### PR TITLE
Show always the magazine name

### DIFF
--- a/assets/styles/components/_entry.scss
+++ b/assets/styles/components/_entry.scss
@@ -260,6 +260,9 @@
   &__meta {
     grid-area: meta;
     align-self: flex-end;
+    justify-content: flex-start;
+    align-items: center;
+    column-gap: 0.25rem;
 
     .edited{
       font-style: italic;

--- a/src/Twig/Components/EntryComponent.php
+++ b/src/Twig/Components/EntryComponent.php
@@ -30,8 +30,6 @@ final class EntryComponent
         $this->canSeeTrashed();
 
         if ($this->isSingle) {
-            $this->showMagazineName = false;
-
             if (isset($attr['class'])) {
                 $attr['class'] = trim('entry--single section--top '.$attr['class']);
             } else {

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -67,11 +67,13 @@
                 {% endif %}
             {% endif %}
             <aside class="meta entry__meta">
-                {{ component('user_inline', {user: entry.user, showAvatar: app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_USERS_AVATARS')) is same as 'true'}) -}}
-                ,
-                {{ component('date', {date: entry.createdAt}) }}
-                {{ component('date_edited', {createdAt: entry.createdAt, editedAt: entry.editedAt}) }}
-                {% if showMagazineName %}{{ 'to'|trans }} {{ component('magazine_inline', {magazine: entry.magazine, showAvatar: app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_MAGAZINES_ICONS')) is same as 'true'}) }}{% endif %}
+                <span>{{ component('user_inline', {user: entry.user, showAvatar: app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_USERS_AVATARS')) is same as 'true'}) -}}</span>
+                <span>,</span>
+                <span>{{ component('date', {date: entry.createdAt}) }}</span>
+                <span>{{ component('date_edited', {createdAt: entry.createdAt, editedAt: entry.editedAt}) }}</span>
+                {% if showMagazineName %}
+                    <span>{{ 'to'|trans }} {{ component('magazine_inline', {magazine: entry.magazine, showAvatar: app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_MAGAZINES_ICONS')) is same as 'true'}) }}</span>
+                {% endif %}
             </aside>
             {% if not app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_THUMBNAILS')) or app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_THUMBNAILS')) is same as 'true' %}
                 {% if entry.image %}


### PR DESCRIPTION
- Show always the magazine name where the thread is posted into
- This is really helpful when using a mobile phone, and you do not want to scroll-down
- Style improvements