### PR TITLE
Fix consistenty with VisibilityInterface code

### DIFF
--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -223,12 +223,12 @@ class Entry implements VotableInterface, CommentInterface, DomainInterface, Visi
 
     public function softDelete(): void
     {
-        $this->visibility = self::VISIBILITY_SOFT_DELETED;
+        $this->visibility = VisibilityInterface::VISIBILITY_SOFT_DELETED;
     }
 
     public function trash(): void
     {
-        $this->visibility = self::VISIBILITY_TRASHED;
+        $this->visibility = VisibilityInterface::VISIBILITY_TRASHED;
     }
 
     public function restore(): void

--- a/src/Entity/EntryComment.php
+++ b/src/Entity/EntryComment.php
@@ -179,12 +179,12 @@ class EntryComment implements VotableInterface, VisibilityInterface, ReportInter
 
     public function softDelete(): void
     {
-        $this->visibility = self::VISIBILITY_SOFT_DELETED;
+        $this->visibility = VisibilityInterface::VISIBILITY_SOFT_DELETED;
     }
 
     public function trash(): void
     {
-        $this->visibility = self::VISIBILITY_TRASHED;
+        $this->visibility = VisibilityInterface::VISIBILITY_TRASHED;
     }
 
     public function restore(): void

--- a/src/Entity/Magazine.php
+++ b/src/Entity/Magazine.php
@@ -295,12 +295,12 @@ class Magazine implements VisibilityInterface, ActivityPubActorInterface, ApiRes
 
     public function softDelete(): void
     {
-        $this->visibility = self::VISIBILITY_SOFT_DELETED;
+        $this->visibility = VisibilityInterface::VISIBILITY_SOFT_DELETED;
     }
 
     public function trash(): void
     {
-        $this->visibility = self::VISIBILITY_TRASHED;
+        $this->visibility = VisibilityInterface::VISIBILITY_TRASHED;
     }
 
     public function restore(): void

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -174,11 +174,11 @@ class Post implements VotableInterface, CommentInterface, VisibilityInterface, R
     private function handlePrivateComments(ArrayCollection $comments, ?User $user): ArrayCollection
     {
         return $comments->filter(function (PostComment $val) use ($user) {
-            if ($user && self::VISIBILITY_PRIVATE === $val->visibility) {
+            if ($user && VisibilityInterface::VISIBILITY_PRIVATE === $val->visibility) {
                 return $user->isFollower($val->user);
             }
 
-            return self::VISIBILITY_VISIBLE === $val->visibility;
+            return VisibilityInterface::VISIBILITY_VISIBLE === $val->visibility;
         });
     }
 
@@ -236,12 +236,12 @@ class Post implements VotableInterface, CommentInterface, VisibilityInterface, R
 
     public function softDelete(): void
     {
-        $this->visibility = self::VISIBILITY_SOFT_DELETED;
+        $this->visibility = VisibilityInterface::VISIBILITY_SOFT_DELETED;
     }
 
     public function trash(): void
     {
-        $this->visibility = self::VISIBILITY_TRASHED;
+        $this->visibility = VisibilityInterface::VISIBILITY_TRASHED;
     }
 
     public function restore(): void

--- a/src/Entity/PostComment.php
+++ b/src/Entity/PostComment.php
@@ -171,12 +171,12 @@ class PostComment implements VotableInterface, VisibilityInterface, ReportInterf
 
     public function softDelete(): void
     {
-        $this->visibility = self::VISIBILITY_SOFT_DELETED;
+        $this->visibility = VisibilityInterface::VISIBILITY_SOFT_DELETED;
     }
 
     public function trash(): void
     {
-        $this->visibility = self::VISIBILITY_TRASHED;
+        $this->visibility = VisibilityInterface::VISIBILITY_TRASHED;
     }
 
     public function restore(): void


### PR DESCRIPTION
Let's avoid using `self::` where possible, so it's much more clear what kind of interface these enums belong to. Just like the rest of the PHP.

This was most likely introduced with this API PRs, but the code is now no longer consistent with the existing code (see `restore()` method below for example). Hence my PR.