### PR TITLE
Remove Nginx referrer policy setting from admin guide

### DIFF
--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -437,7 +437,6 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "no-referrer" always;
     add_header X-Download-Options "noopen" always;
     add_header X-Permitted-Cross-Domain-Policies "none" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;


### PR DESCRIPTION
The controller code requires the referrer header to be set for submission redirects to process correctly. This will close https://github.com/MbinOrg/mbin/issues/35.