### PR TITLE
Allow CORS requests to nodeinfo endpoint

### DIFF
--- a/config/packages/nelmio_cors.yaml
+++ b/config/packages/nelmio_cors.yaml
@@ -4,11 +4,15 @@ nelmio_cors:
         allow_origin: ['%env(CORS_ALLOW_ORIGIN)%']
         allow_methods: ['GET', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE']
         allow_headers: ['Content-Type', 'Authorization']
-        expose_headers: ['Link']
         max_age: 3600
     paths:
         '^/api/':
             allow_origin: [ '*' ]
             allow_headers: [ 'X-Custom-Auth' ]
             allow_methods: [ 'POST', 'PUT', 'GET', 'DELETE' ]
+            expose_headers: ['Link']
+            max_age: 3600
+        '^/.well-known/|^/nodeinfo/':
+            allow_origin: [ '*' ]
+            allow_methods: [ 'GET' ]
             max_age: 3600


### PR DESCRIPTION
Web applications meant to work with different Fediverse applications need to download `/.well-known/nodeinfo` and `/nodeinfo/2.0` in order to determine what software they are dealing with. Kbin currently doesn’t allow this to happen on the client side, without CORS headers third-party web pages aren’t allowed to do it. I’ve hit this issue myself when implementing “Share to Fediverse” functionality for my website.

Adding CORS headers is trivial and solves this issue. I’ve made the entire `.well-known` directory accessible, matching what most other Fediverse apps are doing. With this info being public information, there is no reason why third-party websites shouldn’t have access to it.


Reviewed-on: https://codeberg.org/Kbin/kbin-core/pulls/1195
Co-committed-by: Wladimir Palant <palant@noreply.codeberg.org>