### PR TITLE
Display maximum character limit on form elements (#1193)

### DIFF
--- a/assets/controllers/autogrow_controller.js
+++ b/assets/controllers/autogrow_controller.js
@@ -1,0 +1,9 @@
+import TextareaAutoGrow from 'stimulus-textarea-autogrow';
+
+/* stimulusFetch: 'lazy' */
+export default class extends TextareaAutoGrow {
+
+    connect(){      
+        super.connect();
+    }
+}

--- a/assets/controllers/entry_link_create_controller.js
+++ b/assets/controllers/entry_link_create_controller.js
@@ -30,7 +30,6 @@ export default class extends ApplicationController {
         }
 
         try {
-
             this.loadingValue = true;
 
             await this.fetchTitleAndDescription(event);
@@ -57,8 +56,6 @@ export default class extends ApplicationController {
             return;
         }
 
-
-
         const url = router().generate('ajax_fetch_title');
         let response = await fetch(url, {
             method: 'POST',
@@ -72,5 +69,9 @@ export default class extends ApplicationController {
 
         this.titleTarget.value = response.title;
         this.descriptionTarget.value = response.description;
+
+        // required for input length indicator
+        this.titleTarget.dispatchEvent(new Event('input'));
+        this.descriptionTarget.dispatchEvent(new Event('input'));
     }
 }

--- a/assets/controllers/input_length_controller.js
+++ b/assets/controllers/input_length_controller.js
@@ -1,0 +1,42 @@
+import {Controller} from '@hotwired/stimulus';
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    static values = {
+        max: Number
+    }
+
+    /** DOM element that will hold the current/max text */
+    lengthIndicator
+
+    connect(){
+        if(!this.hasMaxValue){
+            return;
+        }
+
+        //create a html element to display the current/max text
+        let indicator = document.createElement('div');
+
+        indicator.classList.add('length-indicator');
+
+        this.element.insertAdjacentElement('afterend', indicator);
+
+        this.lengthIndicator = indicator;
+
+        this.updateDisplay();
+    }
+
+    updateDisplay(){
+        if (!this.lengthIndicator) {
+            return;
+        }
+
+        //trim to max length if needed
+        if(this.element.value.length >= this.maxValue){
+            this.element.value = this.element.value.substring(0, this.maxValue);
+        }
+
+        //display to user
+        this.lengthIndicator.innerHTML = `${this.element.value.length}/${this.maxValue}`;
+    }
+}

--- a/assets/controllers/rich_textarea_controller.js
+++ b/assets/controllers/rich_textarea_controller.js
@@ -1,10 +1,8 @@
-import TextareaAutoGrow from 'stimulus-textarea-autogrow';
+import {Controller} from '@hotwired/stimulus';
 
 /* stimulusFetch: 'lazy' */
-export default class extends TextareaAutoGrow {
+export default class extends Controller {
     connect() {
-        super.connect();
-
         this.element.addEventListener('keydown',
             this.handleInput.bind(this));
     }

--- a/assets/styles/layout/_forms.scss
+++ b/assets/styles/layout/_forms.scss
@@ -212,6 +212,10 @@ form {
   .help-text{
     font-size: 0.8rem;
   }
+
+  .length-indicator{
+    font-size: 0.8rem;
+  }
 }
 
 .checkbox {

--- a/src/DTO/EntryCommentDto.php
+++ b/src/DTO/EntryCommentDto.php
@@ -16,6 +16,8 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 class EntryCommentDto
 {
+    public const MAX_BODY_LENGTH = 5000;
+
     public Magazine|MagazineDto|null $magazine = null;
     public User|UserDto|null $user = null;
     public Entry|EntryDto|null $entry = null;
@@ -24,7 +26,7 @@ class EntryCommentDto
     public ?ImageDto $image = null;
     public ?string $imageUrl = null;
     public ?string $imageAlt = null;
-    #[Assert\Length(max: 5000)]
+    #[Assert\Length(max: self::MAX_BODY_LENGTH)]
     public ?string $body = null;
     public ?string $lang = null;
     public bool $isAdult = false;

--- a/src/DTO/EntryDto.php
+++ b/src/DTO/EntryDto.php
@@ -28,7 +28,7 @@ class EntryDto implements ContentVisibilityInterface
     public ?string $title = null;
     #[Assert\Url]
     public ?string $url = null;
-    #[Assert\Length(max: 35000)]
+    #[Assert\Length(max: Entry::MAX_BODY_LENGTH)]
     public ?string $body = null;
     public ?string $lang = null;
     public string $type = Entry::ENTRY_TYPE_ARTICLE;

--- a/src/DTO/MagazineDto.php
+++ b/src/DTO/MagazineDto.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\DTO;
 
 use App\Entity\Image;
+use App\Entity\Magazine;
 use App\Entity\User;
 use App\Utils\RegPatterns;
 use App\Validator\Unique;
@@ -16,18 +17,21 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 class MagazineDto
 {
+    public const MAX_NAME_LENGTH = 25;
+    public const MAX_TITLE_LENGTH = 50;
+
     private User|UserDto|null $owner = null;
     public Image|ImageDto|null $icon = null;
     #[Assert\NotBlank]
-    #[Assert\Length(min: 2, max: 25)]
+    #[Assert\Length(min: 2, max: self::MAX_NAME_LENGTH)]
     #[Assert\Regex(pattern: RegPatterns::MAGAZINE_NAME, match: true)]
     public ?string $name = null;
     #[Assert\NotBlank]
-    #[Assert\Length(min: 3, max: 50)]
+    #[Assert\Length(min: 3, max: self::MAX_TITLE_LENGTH)]
     public ?string $title = null;
-    #[Assert\Length(min: 3, max: 10000)]
+    #[Assert\Length(min: 3, max: Magazine::MAX_DESCRIPTION_LENGTH)]
     public ?string $description = null;
-    #[Assert\Length(min: 3, max: 10000)]
+    #[Assert\Length(min: 3, max: Magazine::MAX_RULES_LENGTH)]
     public ?string $rules = null;
     public ?string $visibility = null;
     public int $subscriptionsCount = 0;

--- a/src/DTO/PostCommentDto.php
+++ b/src/DTO/PostCommentDto.php
@@ -16,6 +16,8 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 class PostCommentDto implements ContentVisibilityInterface
 {
+    public const MAX_BODY_LENGTH = 5000;
+
     public Magazine|MagazineDto|null $magazine = null;
     public User|UserDto|null $user = null;
     public Post|PostDto|null $post = null;
@@ -24,7 +26,7 @@ class PostCommentDto implements ContentVisibilityInterface
     public ?ImageDto $image = null;
     public ?string $imageUrl = null;
     public ?string $imageAlt = null;
-    #[Assert\Length(max: 5000)]
+    #[Assert\Length(max: self::MAX_BODY_LENGTH)]
     public ?string $body = null;
     public ?string $lang = null;
     public bool $isAdult = false;

--- a/src/DTO/PostDto.php
+++ b/src/DTO/PostDto.php
@@ -15,12 +15,14 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 class PostDto implements ContentVisibilityInterface
 {
+    public const MAX_BODY_LENGTH = 5000;
+
     public Magazine|MagazineDto|null $magazine = null;
     public User|UserDto|null $user = null;
     public ?ImageDto $image = null;
     public ?string $imageUrl = null;
     public ?string $imageAlt = null;
-    #[Assert\Length(max: 5000)]
+    #[Assert\Length(max: self::MAX_BODY_LENGTH)]
     public ?string $body = null;
     public ?string $lang = null;
     public bool $isAdult = false;

--- a/src/DTO/UserDto.php
+++ b/src/DTO/UserDto.php
@@ -17,8 +17,11 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  */
 class UserDto implements UserDtoInterface
 {
+    public const MAX_USERNAME_LENGTH = 30;
+    public const MAX_ABOUT_LENGTH = 512;
+
     #[Assert\NotBlank]
-    #[Assert\Length(min: 2, max: 30)]
+    #[Assert\Length(min: 2, max: self::MAX_USERNAME_LENGTH)]
     #[Assert\Regex(pattern: RegPatterns::USERNAME, match: true)]
     public ?string $username = null;
     #[Assert\NotBlank]
@@ -26,7 +29,7 @@ class UserDto implements UserDtoInterface
     public ?string $email = null;
     #[Assert\Length(min: 6, max: 4096)]
     public ?string $plainPassword = null; // @todo move password and agreeTerms to RegisterDto
-    #[Assert\Length(min: 2, max: 512)]
+    #[Assert\Length(min: 2, max: self::MAX_ABOUT_LENGTH)]
     public ?string $about = null;
     public ?\DateTimeImmutable $createdAt = null;
     public ?string $fields = null;

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -69,6 +69,9 @@ class Entry implements VotableInterface, CommentInterface, DomainInterface, Visi
         self::ENTRY_TYPE_IMAGE,
         self::ENTRY_TYPE_VIDEO,
     ];
+    public const MAX_TITLE_LENGTH = 255;
+    public const MAX_BODY_LENGTH = 35000;
+
     #[ManyToOne(targetEntity: User::class, inversedBy: 'entries')]
     #[JoinColumn(nullable: false)]
     public User $user;
@@ -83,11 +86,11 @@ class Entry implements VotableInterface, CommentInterface, DomainInterface, Visi
     public ?Domain $domain = null;
     #[Column(type: 'string', nullable: true)]
     public ?string $slug = null;
-    #[Column(type: 'string', nullable: false)]
+    #[Column(type: 'string', length: self::MAX_TITLE_LENGTH, nullable: false)]
     public string $title;
     #[Column(type: 'string', length: 2048, nullable: true)]
     public ?string $url = null;
-    #[Column(type: 'text', length: 35000, nullable: true)]
+    #[Column(type: 'text', length: self::MAX_BODY_LENGTH, nullable: true)]
     public ?string $body = null;
     #[Column(type: 'string', nullable: false)]
     public string $type = self::ENTRY_TYPE_ARTICLE;

--- a/src/Entity/Magazine.php
+++ b/src/Entity/Magazine.php
@@ -38,6 +38,9 @@ class Magazine implements VisibilityInterface, ActivityPubActorInterface, ApiRes
         CreatedAtTrait::__construct as createdAtTraitConstruct;
     }
 
+    public const MAX_DESCRIPTION_LENGTH = 10000;
+    public const MAX_RULES_LENGTH = 10000;
+
     #[ManyToOne(targetEntity: Image::class, cascade: ['persist'])]
     #[JoinColumn(nullable: true)]
     public ?Image $icon = null;
@@ -45,9 +48,9 @@ class Magazine implements VisibilityInterface, ActivityPubActorInterface, ApiRes
     public string $name;
     #[Column(type: 'string')]
     public ?string $title;
-    #[Column(type: 'text', length: 10000, nullable: true)]
+    #[Column(type: 'text', length: self::MAX_DESCRIPTION_LENGTH, nullable: true)]
     public ?string $description = null;
-    #[Column(type: 'text', length: 10000, nullable: true)]
+    #[Column(type: 'text', length: self::MAX_RULES_LENGTH, nullable: true)]
     public ?string $rules = null;
     #[Column(type: 'integer', nullable: false)]
     public int $subscriptionsCount = 0;

--- a/templates/admin/pages.html.twig
+++ b/templates/admin/pages.html.twig
@@ -52,7 +52,7 @@
         <div class="container">
             {{ form_start(form) }}
             {{ component('editor_toolbar', {id: 'page_body'}) }}
-            {{ form_row(form.body, {label: false, attr: {placeholder: 'body', 'data-controller': 'rich-textarea', 'data-entry-link-create-target': 'admin_pages'}}) }}
+            {{ form_row(form.body, {label: false, attr: {placeholder: 'body', 'data-controller': 'rich-textarea autogrow', 'data-entry-link-create-target': 'admin_pages'}}) }}
             <div class="row actions">
                 {{ form_row(form.submit, {label: 'save', attr: {class: 'btn btn__primary'}}) }}
             </div>

--- a/templates/entry/_form_article.html.twig
+++ b/templates/entry/_form_article.html.twig
@@ -6,10 +6,22 @@
 {% elseif entry.image %}
     {% set hasImage = true %}
 {% endif %}
+
 {{ form_start(form, {attr: {class: edit ? 'entry_edit' : 'entry-create'}}) }}
-    {{ form_row(form.title, {label: 'title'}) }}
+    {{ form_row(form.title, {
+        label: 'title', attr: {
+            'data-controller' : "input-length autogrow", 
+            'data-action' : 'input-length#updateDisplay',
+            'data-input-length-max-value' : constant('App\\Entity\\Entry::MAX_TITLE_LENGTH')
+            }}) }}
     {{ component('editor_toolbar', {id: 'entry_article_body'}) }}
-    {{ form_row(form.body, {label: false, attr: {placeholder: 'body', 'data-controller': 'rich-textarea'}}) }}
+    {{ form_row(form.body, {
+        label: false, attr: {
+            placeholder: 'body', 
+            'data-controller': 'rich-textarea input-length autogrow',
+            'data-action' : 'input-length#updateDisplay',
+            'data-input-length-max-value' : constant('App\\Entity\\Entry::MAX_BODY_LENGTH')
+            }}) }}
     {{ form_row(form.magazine, {label: false}) }}
     {{ form_row(form.tags, {label: 'tags'}) }}
     {{ form_row(form.badges, {label: 'badges'}) }}

--- a/templates/entry/_form_image.html.twig
+++ b/templates/entry/_form_image.html.twig
@@ -7,7 +7,11 @@
     {% set hasImage = true %}
 {% endif %}
 {{ form_start(form, {attr: {class: edit ? 'entry_edit' : 'entry-create'}}) }}
-    {{ form_row(form.title, {label: 'title'}) }}
+    {{ form_row(form.title, {label: 'title', attr: {
+        'data-controller' : "input-length autogrow", 
+        'data-action' : 'input-length#updateDisplay',
+        'data-input-length-max-value' : constant('App\\Entity\\Entry::MAX_TITLE_LENGTH')
+    }}) }}
     {{ form_row(form.magazine, {label: false}) }}
     {{ form_row(form.tags, {label: 'tags'}) }}
     {{ form_row(form.badges, {label: 'badges'}) }}

--- a/templates/entry/_form_link.html.twig
+++ b/templates/entry/_form_link.html.twig
@@ -7,10 +7,10 @@
     {% set hasImage = true %}
 {% endif %}
 {{ form_start(form, {attr: {class: edit ? 'entry-edit' : 'entry-create'}}) }}
-   
+
     <div>
         {% set label %}
-            URL       
+            URL
             <div data-entry-link-create-target='loader' class="loader small" role="status">
                 <span class="visually-hidden">Loading...</span>
             </div>
@@ -18,9 +18,20 @@
         {{ form_label(form.url, label, {'label_html': true}) }}
         {{ form_widget(form.url, {attr: {'data-action': 'entry-link-create#fetchLink', 'data-entry-link-create-target': 'url'}}) }}
     </div>
-    {{ form_row(form.title, {label: 'title', attr: {'data-entry-link-create-target': 'title'}}) }}
+    {{ form_row(form.title, {label: 'title', attr: {
+        'data-controller': 'input-length autogrow',
+        'data-entry-link-create-target': 'title',
+        'data-action': 'input-length#updateDisplay',
+        'data-input-length-max-value' : constant('App\\Entity\\Entry::MAX_TITLE_LENGTH')}
+    }) }}
     {{ component('editor_toolbar', {id: 'entry_link_body'}) }}
-    {{ form_row(form.body, {label: false, attr: {placeholder: 'body', 'data-controller': 'rich-textarea', 'data-entry-link-create-target': 'description'}}) }}
+    {{ form_row(form.body, {label: false, attr: {
+        placeholder: 'body',
+        'data-controller': 'input-length rich-textarea autogrow',
+        'data-entry-link-create-target': 'description',
+        'data-action': 'input-length#updateDisplay',
+        'data-input-length-max-value': constant('App\\Entity\\Entry::MAX_BODY_LENGTH')
+        }}) }}
     {{ form_row(form.magazine, {label: false}) }}
     {{ form_row(form.tags, {label: 'tags'}) }}
     {{ form_row(form.badges, {label: 'badges'}) }}

--- a/templates/entry/comment/_form_comment.html.twig
+++ b/templates/entry/comment/_form_comment.html.twig
@@ -18,8 +18,11 @@
 <h3 hidden>{{ title }}</h3>
 {{ form_start(form, {action: action, attr: {class: edit ? 'comment-edit replace' : 'comment-add'}}) }}
 {{ component('editor_toolbar', {id: form.body.vars.id}) }}
-{{ form_row(form.body, {label: false, attr: {'data-controller': 'rich-textarea'}}) }}
-<div class="row actions">
+{{ form_row(form.body, {label: false, attr: {
+    'data-controller': 'input-length rich-textarea autogrow',
+    'data-action' : 'input-length#updateDisplay',
+    'data-input-length-max-value': constant('App\\DTO\\EntryCommentDto::MAX_BODY_LENGTH')
+}}) }}<div class="row actions">
     <ul>
         {% if hasImage %}
             <img width="40"

--- a/templates/magazine/create.html.twig
+++ b/templates/magazine/create.html.twig
@@ -19,12 +19,31 @@
     <div id="content" class="section">
         <div class="container">
             {{ form_start(form) }}
-            {{ form_row(form.name, {label: 'name', attr: {placeholder: '/m/'}}) }}
-            {{ form_row(form.title, {label: 'title'}) }}
+            {{ form_row(form.name, {label: 'name', attr: {
+                placeholder: '/m/',
+                'data-controller': 'input-length',
+                'data-action' : 'input-length#updateDisplay',
+                'data-input-length-max-value': constant('App\\DTO\\MagazineDto::MAX_NAME_LENGTH')
+                }}) }}
+            {{ form_row(form.title, {label: 'title', attr: {
+                'data-controller': 'input-length autogrow',
+                'data-action' : 'input-length#updateDisplay',
+                'data-input-length-max-value': constant('App\\DTO\\MagazineDto::MAX_TITLE_LENGTH')
+            }}) }}
             {{ component('editor_toolbar', {id: 'magazine_description'}) }}
-            {{ form_row(form.description, {label: false, attr: {placeholder: 'description'}}) }}
+            {{ form_row(form.description, {label: false, attr: {
+                placeholder: 'description',
+                'data-controller': 'input-length rich-textarea autogrow',
+                'data-action' : 'input-length#updateDisplay',
+                'data-input-length-max-value': constant('App\\Entity\\Magazine::MAX_DESCRIPTION_LENGTH')
+                }}) }}
             {{ component('editor_toolbar', {id: 'magazine_rules'}) }}
-            {{ form_row(form.rules, {label: false, attr: {placeholder: 'rules'}}) }}
+            {{ form_row(form.rules, {label: false, attr: {
+                placeholder: 'rules',
+                'data-controller': 'input-length rich-textarea autogrow',
+                'data-action' : 'input-length#updateDisplay',
+                'data-input-length-max-value': constant('App\\Entity\\Magazine::MAX_RULES_LENGTH')
+                }}) }}
             {{ form_row(form.isAdult, {label:'is_adult', row_attr: {class: 'checkbox'}}) }}
             <div class="row actions">
                 {{ form_row(form.submit, {label: 'create_new_magazine', attr: {class: 'btn btn__primary'}, row_attr: {class: 'float-end'}}) }}

--- a/templates/messages/_form_create.html.twig
+++ b/templates/messages/_form_create.html.twig
@@ -1,5 +1,5 @@
 {{ form_start(form) }}
-{{ form_row(form.body, {attr: {'data-controller': 'rich-textarea'}}) }}
+{{ form_row(form.body, {attr: {'data-controller': 'rich-textarea autogrow'}}) }}
 <div class="row actions">
     {{ form_row(form.submit, {attr: {class: 'btn btn__primary'}}) }}
 </div>

--- a/templates/post/_form_post.html.twig
+++ b/templates/post/_form_post.html.twig
@@ -23,7 +23,11 @@
 {{ form_start(form, {action: action, attr: {class: edit ? 'post-edit replace' : 'post-add'}|merge(attributes)}) }}
 <div class="row">
     {{ component('editor_toolbar', {id: 'post_body'}) }}
-    {{ form_row(form.body, {label: false, attr: {'data-controller': 'rich-textarea'}}) }}
+    {{ form_row(form.body, {label: false, attr: {
+        'data-controller': 'input-length rich-textarea autogrow',
+        'data-action' : 'input-length#updateDisplay',
+        'data-input-length-max-value': constant('App\\DTO\\PostDto::MAX_BODY_LENGTH')
+        }}) }}
 </div>
 <div class="row params">
     {{ form_row(form.isAdult, {label:'is_adult'}) }}

--- a/templates/post/comment/_form_comment.html.twig
+++ b/templates/post/comment/_form_comment.html.twig
@@ -19,7 +19,11 @@
 {{ form_start(form, {action: action, attr: {class: edit ? 'comment-edit replace' : 'comment-add'}}) }}
 <div class="row">
     {{ component('editor_toolbar', {id: form.body.vars.id}) }}
-    {{ form_row(form.body, {label: false, attr: {'data-controller': 'rich-textarea'}}) }}
+    {{ form_row(form.body, {label: false, attr: {
+        'data-controller': 'input-length rich-textarea autogrow',
+        'data-action' : 'input-length#updateDisplay',
+        'data-input-length-max-value': constant('App\\DTO\\PostCommentDto::MAX_BODY_LENGTH')
+    }}) }}
 </div>
 <div class="row actions">
     <ul>

--- a/templates/user/settings/profile.html.twig
+++ b/templates/user/settings/profile.html.twig
@@ -26,8 +26,19 @@
             <h1 hidden>{{ 'profile'|trans }}</h1>
             {{ form_start(form) }}
             {{ component('editor_toolbar', {id: 'user_basic_about'}) }}
-            {{ form_row(form.about, {label: false, attr: {placeholder: 'about', 'data-controller': 'rich-textarea', 'data-entry-link-create-target': 'user_about'}}) }}
-            {{ form_row(form.username, {label: 'username'}) }}
+            {{ form_row(form.about, {label: false, attr: {
+                placeholder: 'about', 
+                'data-controller': 'input-length rich-textarea autogrow', 
+                'data-entry-link-create-target': 'user_about',
+                'data-action' : 'input-length#updateDisplay',
+                'data-input-length-max-value' : constant('App\\DTO\\UserDto::MAX_ABOUT_LENGTH')
+                }}) }}
+            {{ form_row(form.username, {label: 'username', attr: {
+                'data-controller': 'input-length autogrow', 
+                'data-entry-link-create-target': 'user_about',
+                'data-action' : 'input-length#updateDisplay',
+                'data-input-length-max-value' : constant('App\\DTO\\UserDto::MAX_USERNAME_LENGTH')
+            }}) }}
             {{ form_row(form.avatar, {label: 'avatar'}) }}
             {{ form_row(form.cover, {label: 'cover'}) }}
             <div class="row actions">


### PR DESCRIPTION
PR is continuation of great work of [AnonymousLlama](https://github.com/simonrcodrington) in #911, check it for more details and gifs of the functionality.

Changes in comparison to that PR:
- resolved merge conflicts
- added and used `MAX_<FIELD>_LENGTH` constants in all places
- when adding new link, after the title and body are fetched the char counters are now updated properly
- used [Stimulus values](https://stimulus.hotwired.dev/reference/values) to simplify JS controller a bit


Reviewed-on: https://codeberg.org/Kbin/kbin-core/pulls/1193

Co-committed-by: Szymon Kamiński <kaminskisj@gmail.com>