### PR TITLE
Do not allowed spaces in tags

### DIFF
--- a/src/Form/DataTransformer/TagTransformer.php
+++ b/src/Form/DataTransformer/TagTransformer.php
@@ -10,7 +10,7 @@ class TagTransformer implements DataTransformerInterface
 {
     public function transform($value): ?string
     {
-        return $value ? implode(',', $value) : null;
+        return $value ? implode(' ', $value) : null;
     }
 
     public function reverseTransform($value): ?array
@@ -19,6 +19,6 @@ class TagTransformer implements DataTransformerInterface
             return null;
         }
 
-        return explode(',', strtolower($value));
+        return explode(' ', strtolower($value));
     }
 }

--- a/src/Form/EntryArticleType.php
+++ b/src/Form/EntryArticleType.php
@@ -44,7 +44,7 @@ class EntryArticleType extends AbstractType
                 'tom_select_options' => [
                     'create' => true,
                     'createOnBlur' => true,
-                    'delimiter' => ',',
+                    'delimiter' => ' ',
                 ],
             ])
             ->add(

--- a/src/Form/EntryImageType.php
+++ b/src/Form/EntryImageType.php
@@ -45,7 +45,7 @@ class EntryImageType extends AbstractType
                 'tom_select_options' => [
                     'create' => true,
                     'createOnBlur' => true,
-                    'delimiter' => ',',
+                    'delimiter' => ' ',
                 ],
             ])
             ->add(

--- a/src/Form/EntryLinkType.php
+++ b/src/Form/EntryLinkType.php
@@ -45,7 +45,7 @@ class EntryLinkType extends AbstractType
                 'tom_select_options' => [
                     'create' => true,
                     'createOnBlur' => true,
-                    'delimiter' => ',',
+                    'delimiter' => ' ',
                 ],
             ])
             ->add('body', TextareaType::class, [

--- a/src/Form/InstancesType.php
+++ b/src/Form/InstancesType.php
@@ -24,7 +24,7 @@ class InstancesType extends AbstractType
                 'tom_select_options' => [
                     'create' => true,
                     'createOnBlur' => true,
-                    'delimiter' => ',',
+                    'delimiter' => ' ',
                 ],
             ]);
 

--- a/src/Form/MagazineTagsType.php
+++ b/src/Form/MagazineTagsType.php
@@ -24,7 +24,7 @@ class MagazineTagsType extends AbstractType
                 'tom_select_options' => [
                     'create' => true,
                     'createOnBlur' => true,
-                    'delimiter' => ',',
+                    'delimiter' => ' ',
                 ],
             ]);
 


### PR DESCRIPTION
Do not allow spaces in tags.

It's currently possible to add tags with spaces, these tags are eventually ignored and actually not allowed by AP protocol. Most of the cases users can use `camelCase` or `PascalCase` to add tags with multiple words in the same tag. This PR will trigger on a space and insert the tag.

Thank you @simonrcodrington for the contribution. I know you are currently busy, so here is my PR using your code ;).