### PR TITLE
Add footer to sidebar on mobile

### DIFF
--- a/assets/styles/components/_footer.scss
+++ b/assets/styles/components/_footer.scss
@@ -1,4 +1,4 @@
-#footer {
+#footer, .footer-sidebar{
   background: var(--kbin-footer-bg);
   color: var(--kbin-footer-text-color);
   padding: 0;

--- a/assets/styles/components/_sidebar.scss
+++ b/assets/styles/components/_sidebar.scss
@@ -3,7 +3,7 @@
   opacity: 1;
   padding-bottom: 1rem;
 
-  h3 {
+  h3, h5 {
     border-bottom: var(--kbin-sidebar-header-border);
     color: var(--kbin-sidebar-header-text-color);
     font-size: .8rem;
@@ -614,6 +614,29 @@
         display: none;
       }
     }
+  }
+
+  .footer-sidebar{
+    background-color: unset;
+    padding: 0px;
+
+    .kbin-container {
+      grid-template-areas: none;
+      grid-template-columns: none;
+    }
+
+    section{
+      background-color: var(--kbin-section-bg);
+      border: var(--kbin-section-border);
+      color: var(--kbin-section-text-color);
+      margin-bottom: 0.5rem;
+      padding: 0.5rem 0.5rem 1rem;
+    }
+
+    @include media-breakpoint-up(sm){
+      display: none;
+    }
+
   }
 }
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -84,7 +84,8 @@
         </aside>
     </div>
 </div>
-{% include 'layout/_footer.html.twig' %}
+
+{% include 'layout/_footer.html.twig' with {inSidebar: true} %}
 {% include 'layout/_topbar.html.twig' %}
 <div id="popover" class="popover js-popover section section--small" role="dialog"></div>
 <div id="scroll-top" data-controller="scroll-top" style="display: none;" data-action="click->scroll-top#scrollTop">

--- a/templates/layout/_footer.html.twig
+++ b/templates/layout/_footer.html.twig
@@ -1,4 +1,4 @@
-<footer id="footer">
+<footer {{ (inSidebar is defined) ? 'id="footer"' : 'class="footer-sidebar"' }}>
     <div class="kbin-container">
         <section>
             <h5>{{ kbin_domain() }}</h5>

--- a/templates/layout/_sidebar.html.twig
+++ b/templates/layout/_sidebar.html.twig
@@ -131,3 +131,6 @@
             })|raw }}</p>
     </div>
 </div>
+
+{% include 'layout/_topbar.html.twig' %}
+{% include 'layout/_footer.html.twig' %}

--- a/templates/layout/_sidebar.html.twig
+++ b/templates/layout/_sidebar.html.twig
@@ -132,5 +132,4 @@
     </div>
 </div>
 
-{% include 'layout/_topbar.html.twig' %}
 {% include 'layout/_footer.html.twig' %}


### PR DESCRIPTION
Add footer to sidebar on mobile. This fixed the issue with infinite scrolling on mobile! 

This is a good solution for now, we are agile, so if we find a better way of showing the footer on mobile with infinite scrolling we can always improve further I think.

Once again thank you @simonrcodrington for the contribution. This PR is for you!