### PR TITLE
fix inconsistent first/last rounding edges for settings row

### DIFF
--- a/assets/styles/components/_settings_row.scss
+++ b/assets/styles/components/_settings_row.scss
@@ -6,13 +6,17 @@
   width: 100%;
   background: var(--kbin-sidebar-settings-row-bg);
 
-  &:nth-child(7),
-  &:nth-child(13),
-  &:nth-child(15) {
-    .rounded-edges & {
-    border-bottom-left-radius: .375rem;
-    border-bottom-right-radius: .375rem;
-    overflow: clip;
+  .rounded-edges & {
+    &:first-child {
+      border-top-left-radius: .375rem;
+      border-top-right-radius: .375rem;
+      overflow: clip;
+    }
+
+    &:last-child {
+      border-bottom-left-radius: .375rem;
+      border-bottom-right-radius: .375rem;
+      overflow: clip;
     }
   }
 

--- a/assets/styles/components/_sidebar.scss
+++ b/assets/styles/components/_sidebar.scss
@@ -432,14 +432,14 @@
       margin-left: .3125rem;
       color: var(--kbin-meta-text-color);
       opacity: .5;
+    }
 
-      & + .settings-row {
-        .rounded-edges & {
-          border-top-left-radius: .375rem;
-          border-top-right-radius: .375rem;
-          overflow: clip;
-        }
-      }
+    .settings-section {
+      display: flex;
+      flex: auto;
+      flex-flow: column wrap;
+      gap: 1px;
+      align-items: center;
     }
 
     .row {

--- a/templates/layout/_options_appearance.html.twig
+++ b/templates/layout/_options_appearance.html.twig
@@ -1,27 +1,36 @@
 <div class="settings-list">
     <div class="reload-required-section">
         <button onclick="window.location.reload(); this.classList.add('spin');" class="btn btn-link">
-            <i class="fa fa-refresh"></i>{{ 'reload_to_apply'|trans }}</button>
+            <i class="fa fa-refresh"></i>{{ 'reload_to_apply'|trans }}
+        </button>
     </div>
     <strong>{{ 'general'|trans }}</strong>
-    {{ component('settings_row_enum', {label: 'sidebar_position'|trans, settingsKey: 'KBIN_GENERAL_SIDEBAR_POSITION', values: [ {name: 'left'|trans , value: 'LEFT'}, {name: 'right'|trans , value: 'RIGHT' } ], defaultValue: 'RIGHT' } ) }}
-    {% if kbin_mercure_enabled() %}
-        {{ component('settings_row_switch', {label: 'dynamic_lists'|trans, settingsKey: 'KBIN_GENERAL_DYNAMIC_LISTS'}) }}
-    {% endif %}
-    {{ component('settings_row_switch', {label: 'rounded_edges'|trans, settingsKey: 'KBIN_GENERAL_ROUNDED_EDGES', defaultValue: true}) }}
-    {{ component('settings_row_switch', {label: 'infinite_scroll'|trans, help: 'infinite_scroll_help'|trans ,  settingsKey: 'KBIN_GENERAL_INFINITE_SCROLL'}) }}
-    {{ component('settings_row_switch', {label: 'sticky_navbar'|trans, help: 'sticky_navbar_help'|trans,  settingsKey: 'KBIN_GENERAL_FIXED_NAVBAR'}) }}
-    {{ component('settings_row_switch', {label: 'show_top_bar'|trans, settingsKey: 'KBIN_GENERAL_TOPBAR'}) }}
+    <div class="settings-section">
+        {{ component('settings_row_enum', {label: 'sidebar_position'|trans, settingsKey: 'KBIN_GENERAL_SIDEBAR_POSITION', values: [ {name: 'left'|trans , value: 'LEFT'}, {name: 'right'|trans , value: 'RIGHT' } ], defaultValue: 'RIGHT' } ) }}
+        {% if kbin_mercure_enabled() %}
+            {{ component('settings_row_switch', {label: 'dynamic_lists'|trans, settingsKey: 'KBIN_GENERAL_DYNAMIC_LISTS'}) }}
+        {% endif %}
+        {{ component('settings_row_switch', {label: 'rounded_edges'|trans, settingsKey: 'KBIN_GENERAL_ROUNDED_EDGES', defaultValue: true}) }}
+        {{ component('settings_row_switch', {label: 'infinite_scroll'|trans, help: 'infinite_scroll_help'|trans ,  settingsKey: 'KBIN_GENERAL_INFINITE_SCROLL'}) }}
+        {{ component('settings_row_switch', {label: 'sticky_navbar'|trans, help: 'sticky_navbar_help'|trans,  settingsKey: 'KBIN_GENERAL_FIXED_NAVBAR'}) }}
+        {{ component('settings_row_switch', {label: 'show_top_bar'|trans, settingsKey: 'KBIN_GENERAL_TOPBAR'}) }}
+    </div>
     <strong>{{ 'threads'|trans }}</strong>
-    {{ component('settings_row_switch', {label: 'auto_preview'|trans, help: 'auto_preview_help'|trans,  settingsKey: 'KBIN_ENTRIES_SHOW_PREVIEW'}) }}
-    {{ component('settings_row_switch', {label: 'compact_view'|trans, settingsKey: 'KBIN_ENTRIES_COMPACT'}) }}
-    {{ component('settings_row_switch', {label: 'show_users_avatars'|trans, settingsKey: 'KBIN_ENTRIES_SHOW_USERS_AVATARS'}) }}
-    {{ component('settings_row_switch', {label: 'show_magazines_icons'|trans, settingsKey: 'KBIN_ENTRIES_SHOW_MAGAZINES_ICONS'}) }}
-    {{ component('settings_row_switch', {label: 'show_thumbnails'|trans, settingsKey: 'KBIN_ENTRIES_SHOW_THUMBNAILS', defaultValue: true}) }}
+    <div class="settings-section">
+        {{ component('settings_row_switch', {label: 'auto_preview'|trans, help: 'auto_preview_help'|trans,  settingsKey: 'KBIN_ENTRIES_SHOW_PREVIEW'}) }}
+        {{ component('settings_row_switch', {label: 'compact_view'|trans, settingsKey: 'KBIN_ENTRIES_COMPACT'}) }}
+        {{ component('settings_row_switch', {label: 'show_users_avatars'|trans, settingsKey: 'KBIN_ENTRIES_SHOW_USERS_AVATARS'}) }}
+        {{ component('settings_row_switch', {label: 'show_magazines_icons'|trans, settingsKey: 'KBIN_ENTRIES_SHOW_MAGAZINES_ICONS'}) }}
+        {{ component('settings_row_switch', {label: 'show_thumbnails'|trans, settingsKey: 'KBIN_ENTRIES_SHOW_THUMBNAILS', defaultValue: true}) }}
+    </div>
     <strong>{{ 'microblog'|trans }}</strong>
-    {{ component('settings_row_switch', {label: 'auto_preview'|trans, help: 'auto_preview_help'|trans,  settingsKey: 'KBIN_POSTS_SHOW_PREVIEW'}) }}
-    {{ component('settings_row_switch', {label: 'show_users_avatars'|trans, settingsKey: 'KBIN_POSTS_SHOW_USERS_AVATARS', defaultValue: true}) }}
+    <div class="settings-section">
+        {{ component('settings_row_switch', {label: 'auto_preview'|trans, help: 'auto_preview_help'|trans,  settingsKey: 'KBIN_POSTS_SHOW_PREVIEW'}) }}
+        {{ component('settings_row_switch', {label: 'show_users_avatars'|trans, settingsKey: 'KBIN_POSTS_SHOW_USERS_AVATARS', defaultValue: true}) }}
+    </div>
     <strong>{{ 'single_settings'|trans }}</strong>
-    {{ component('settings_row_enum', {label: 'comment_reply_position'|trans, help: 'comment_reply_position_help'|trans, settingsKey: 'KBIN_COMMENTS_REPLY_POSITION', values: [ {name: 'top' , value: 'TOP'}, {name: 'bottom'|trans , value: 'BOTTOM' } ], defaultValue: 'TOP' } ) }}
-    {{ component('settings_row_switch', {label: 'show_avatars_on_comments'|trans, help: 'show_avatars_on_comments_help'|trans, settingsKey: 'KBIN_COMMENTS_SHOW_USER_AVATAR', defaultValue: true}) }}
+    <div class="settings-section">
+        {{ component('settings_row_enum', {label: 'comment_reply_position'|trans, help: 'comment_reply_position_help'|trans, settingsKey: 'KBIN_COMMENTS_REPLY_POSITION', values: [ {name: 'top' , value: 'TOP'}, {name: 'bottom'|trans , value: 'BOTTOM' } ], defaultValue: 'TOP' } ) }}
+        {{ component('settings_row_switch', {label: 'show_avatars_on_comments'|trans, help: 'show_avatars_on_comments_help'|trans, settingsKey: 'KBIN_COMMENTS_SHOW_USER_AVATAR', defaultValue: true}) }}
+    </div>
 </div>


### PR DESCRIPTION
saw cooperaj mentioned back in kbin matrix room and decided to investigate

turns out the rounded bottom styling rules of setting row is hardcoded by its position, and it's possible to have this index be out of sync: there's an extra checkbox row for enabling dynamic list if mercure is enabled.

I wrapped the settings rows in a container by its section and changed styling rules to be based on `:first-child`/`:last-child` instead, which should be more robust against adding/removing setting rows.  
also I moved these rules to be in one place/file (previously the rule that define rounded top and bottom were in a separate files).

before:
![image](https://github.com/MbinOrg/mbin/assets/20770492/85459398-65c5-445b-bb7a-e686321ebc6e)

after:
![image](https://github.com/MbinOrg/mbin/assets/20770492/4316474a-268c-46a8-accc-7f8a1a8772a2)
