### PR TITLE
fix mercure eventsource (re)connection explosion in firefox

### DIFF
--- a/assets/controllers/notifications_controller.js
+++ b/assets/controllers/notifications_controller.js
@@ -43,9 +43,12 @@ export default class extends Controller {
         window.es = Subscribe(topics, cb);
         // firefox bug: https://github.com/dunglas/mercure/issues/339#issuecomment-650978605
         if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
-            window.es.onerror = (e) => {
-                Subscribe(topics, cb);
+            let resubscribe = (e) => {
+                window.es.close();
+                window.es = Subscribe(topics, cb);
+                window.es.onerror = resubscribe;
             };
+            window.es.onerror = resubscribe;
         }
     }
 


### PR DESCRIPTION
previously, the firefox bug workaround in eventsource mercure connection code would results in a new untracked connection to mercure and there would be a new untracked connection everytime the initial mercure eventsource connection onerror handler is triggered.

try idling on any page while using dev tools open to track network requests to mercure and observe an additional request to mercure everytime the current one terminates approx. every 10m

although from some quick testing against newer/current firefox version, it looks like this workaround might not be needed and perhaps can be removed entirely? (last I checked was with FF 116 and it seemed to work fine)