### PR TITLE
handle alt text overflow on broken avatar images

### DIFF
--- a/assets/styles/components/_comment.scss
+++ b/assets/styles/components/_comment.scss
@@ -86,11 +86,13 @@ $comment-margin-sm: .3rem;
     grid-area: avatar;
     display: none;
     margin: 0;
-   
+
 
     img{
       width: 30px;
       height: 30px;
+      display: inline-block;
+      overflow: hidden;
     }
 
     @include media-breakpoint-up(sm) {

--- a/assets/styles/components/_comment.scss
+++ b/assets/styles/components/_comment.scss
@@ -92,6 +92,8 @@ $comment-margin-sm: .3rem;
       width: 30px;
       height: 30px;
       display: inline-block;
+      text-indent: 100%;
+      white-space: nowrap;
       overflow: hidden;
     }
 

--- a/assets/styles/components/_comment.scss
+++ b/assets/styles/components/_comment.scss
@@ -91,10 +91,6 @@ $comment-margin-sm: .3rem;
     img{
       width: 30px;
       height: 30px;
-      display: inline-block;
-      text-indent: 100%;
-      white-space: nowrap;
-      overflow: hidden;
     }
 
     @include media-breakpoint-up(sm) {

--- a/assets/styles/components/_user.scss
+++ b/assets/styles/components/_user.scss
@@ -41,6 +41,11 @@
   }
 }
 
+.user-avatar {
+  display: inline-block;
+  overflow: hidden;
+}
+
 .user-inline {
   img {
     border-radius: 50%;

--- a/assets/styles/components/_user.scss
+++ b/assets/styles/components/_user.scss
@@ -51,6 +51,8 @@
     border-radius: 50%;
     vertical-align: middle;
     margin-right: 0.25rem;
+    display: inline-block;
+    overflow: hidden;
 
     @include media-breakpoint-down(sm) {
       width: 25px;

--- a/assets/styles/components/_user.scss
+++ b/assets/styles/components/_user.scss
@@ -51,8 +51,6 @@
     border-radius: 50%;
     vertical-align: middle;
     margin-right: 0.25rem;
-    display: inline-block;
-    overflow: hidden;
 
     @include media-breakpoint-down(sm) {
       width: 25px;

--- a/templates/components/user_avatar.html.twig
+++ b/templates/components/user_avatar.html.twig
@@ -4,7 +4,8 @@
        href="{{ path('user_overview', {username: user.username}) }}">
         {% endif %}
         {% if user.avatar %}
-            <img width="{{ width }}" height="{{ height }}"
+            <img class="user-avatar"
+                 width="{{ width }}" height="{{ height }}"
                  style="max-width: {{ width }}px; max-height: {{ height }}px;"
                  src="{{ asset(user.avatar.filePath) | imagine_filter('avatar_thumb') }}"
                  alt="{{ user.username ~' '~ 'avatar'|trans|lower }}">

--- a/templates/components/user_inline.html.twig
+++ b/templates/components/user_inline.html.twig
@@ -4,7 +4,8 @@
    class="user-inline"
    title="{{ user.username|username(true) }}">
     {% if user.avatar and showAvatar %}
-        <img width="30" height="30"
+        <img class="user-avatar"
+             width="30" height="30"
              src="{{ asset(user.avatar.filePath) | imagine_filter('avatar_thumb') }}"
              alt="{{ user.username ~' '~ 'avatar'|trans|lower }}">
     {% endif %}

--- a/templates/components/user_inline.html.twig
+++ b/templates/components/user_inline.html.twig
@@ -6,7 +6,7 @@
     {% if user.avatar and showAvatar %}
         <img width="30" height="30"
              src="{{ asset(user.avatar.filePath) | imagine_filter('avatar_thumb') }}"
-             alt="{{ user.username ~ ' avatar' }}">
+             alt="{{ user.username ~' '~ 'avatar'|trans|lower }}">
     {% endif %}
     {{ user.apPreferredUsername ?? user.username|username -}}
 </a>

--- a/templates/entry/_info.html.twig
+++ b/templates/entry/_info.html.twig
@@ -3,7 +3,8 @@
     <div class="row">
         {% if entry.user.avatar %}
             <figure>
-                <img width="100" height="100"
+                <img class="user-avatar"
+                     width="100" height="100"
                      src="{{ asset(entry.user.avatar.filePath) | imagine_filter('avatar_thumb') }}"
                      alt="{{ entry.user.username ~' '~ 'avatar'|trans|lower }}">
             </figure>

--- a/templates/magazine/_moderators_sidebar.html.twig
+++ b/templates/magazine/_moderators_sidebar.html.twig
@@ -4,7 +4,8 @@
         {% for moderator in magazine.moderators|slice(0, 5) %}
             <li>
                 {% if moderator.user.avatar %}
-                    <img width="30"
+                    <img class="user-avatar"
+                         width="30"
                          height="30"
                          src="{{ asset(moderator.user.avatar.filePath) | imagine_filter('avatar_thumb') }}"
                          alt="{{ moderator.user.username ~ ' ' ~ 'avatar'|trans|lower }}">

--- a/templates/post/_info.html.twig
+++ b/templates/post/_info.html.twig
@@ -3,7 +3,8 @@
     <div class="row">
         {% if post.user.avatar %}
             <figure>
-                <img width="100" height="100"
+                <img class="user-avatar"
+                     width="100" height="100"
                      src="{{ asset(post.user.avatar.filePath) | imagine_filter('avatar_thumb') }}"
                      alt="{{ post.user.username ~' '~ 'avatar'|trans|lower }}">
             </figure>

--- a/templates/user/_info.html.twig
+++ b/templates/user/_info.html.twig
@@ -4,7 +4,8 @@
         <div class="row">
             {% if user.avatar %}
                 <figure>
-                    <img width="100" height="100"
+                    <img class="user-avatar"
+                         width="100" height="100"
                          src="{{ asset(user.avatar.filePath) | imagine_filter('avatar_thumb') }}"
                          alt="{{ user.username ~' '~ 'avatar'|trans|lower }}">
                 </figure>

--- a/templates/user/_list.html.twig
+++ b/templates/user/_list.html.twig
@@ -13,7 +13,8 @@
                         <li>
                             {% if user.avatar %}
                                 <figure>
-                                    <img width="32" height="32"
+                                    <img class="user-avatar"
+                                         width="32" height="32"
                                          src="{{ asset(user.avatar.filePath) | imagine_filter('avatar_thumb') }}"
                                          alt="{{ user.username ~' '~ 'avatar'|trans|lower }}">
                                 </figure>


### PR DESCRIPTION
mainly in firefox, if mbin was unable to fetch the avatar image and it displays a broken image, a single letter column spans the entire length of the alt text.

left chromium, right firefox:

![before_img_overflow](https://github.com/MbinOrg/mbin/assets/146029455/0c1b79ce-e303-4ef7-a0db-6935d111d568)

I found out this was because `max-width/max-height/width/height` aren't used on `display: inline` elements

following some answers [here](https://stackoverflow.com/a/6701345) and [here](https://stackoverflow.com/a/46109943), changed it to `inline-block` and hide the alt text, which shouldn't effect screenreaders to my understanding of the answers

left chromium, right firefox:

![after_img_overflow](https://github.com/MbinOrg/mbin/assets/146029455/b97864ca-9b3c-412b-8081-38015cb82b93)

might need more testing on mobile / other browsers if this makes sense