### PR TITLE
Update Dockerfile v2 to use lts-alpine image for yarn builder

### DIFF
--- a/docker/v2/Dockerfile
+++ b/docker/v2/Dockerfile
@@ -66,7 +66,7 @@ RUN composer run-script --no-dev post-install-cmd && \
 
 ####################
 
-FROM node:alpine as builder-yarn
+FROM node:lts-alpine as builder-yarn
 
 # Setup environment
 ENV KBIN_HOME=/var/www/kbin


### PR DESCRIPTION
Recent updates to the node:alpine image used for the yarn builder in the v2 dockerfile cause the docker build to fail. This PR updates the dockerfile to use the LTS release of the node:alpine image, resolving docker build failure.