### PR TITLE
Adjust User class constructor to support type field during object instantiation

### DIFF
--- a/src/DataFixtures/UserFixtures.php
+++ b/src/DataFixtures/UserFixtures.php
@@ -29,7 +29,8 @@ class UserFixtures extends BaseFixture
             $newUser = new User(
                 $user['email'],
                 $user['username'],
-                $user['password']
+                $user['password'],
+                $user['type']
             );
 
             $newUser->setPassword(
@@ -74,6 +75,7 @@ class UserFixtures extends BaseFixture
                 'email' => 'demo@karab.in',
                 'username' => 'demo',
                 'password' => 'demo',
+                'type' => 'Person',
             ];
         }
 
@@ -82,6 +84,7 @@ class UserFixtures extends BaseFixture
                 'email' => $this->faker->email,
                 'username' => str_replace('.', '_', $this->faker->userName),
                 'password' => 'secret',
+                'type' => 'Person',
             ];
         }
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -233,12 +233,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
         string $email,
         string $username,
         string $password,
+        string $type,
         string $apProfileId = null,
         string $apId = null
     ) {
         $this->email = $email;
         $this->password = $password;
         $this->username = $username;
+        $this->type = $type;
         $this->apProfileId = $apProfileId;
         $this->apId = $apId;
         $this->moderatorTokens = new ArrayCollection();

--- a/src/Service/UserManager.php
+++ b/src/Service/UserManager.php
@@ -138,8 +138,7 @@ class UserManager
             }
         }
 
-        $user = new User($dto->email, $dto->username, '', $dto->apProfileId, $dto->apId);
-        $user->type = ($dto->isBot) ? 'Service' : 'Person'; // Set type "Service" when it's a bot
+        $user = new User($dto->email, $dto->username, '', ($dto->isBot) ? 'Service' : 'Person', $dto->apProfileId, $dto->apId);
         $user->setPassword($this->passwordHasher->hashPassword($user, $dto->plainPassword));
 
         if (!$dto->apId) {

--- a/tests/FactoryTrait.php
+++ b/tests/FactoryTrait.php
@@ -84,20 +84,22 @@ trait FactoryTrait
             'username' => 'adminUser',
             'password' => 'adminUser123',
             'email' => 'adminUser@example.com',
+            'type' => 'Person',
         ];
 
         yield [
             'username' => 'JohnDoe',
             'password' => 'JohnDoe123',
             'email' => 'JohnDoe@example.com',
+            'type' => 'Person',
         ];
     }
 
-    private function createUser(string $username, string $email = null, string $password = null, $active = true, $hideAdult = true, $about = null): User
+    private function createUser(string $username, string $email = null, string $password = null, string $type, $active = true, $hideAdult = true, $about = null): User
     {
         $manager = $this->getService(EntityManagerInterface::class);
 
-        $user = new User($email ?: $username.'@example.com', $username, $password ?: 'secret');
+        $user = new User($email ?: $username.'@example.com', $username, $password ?: 'secret', $type ?: 'Person');
 
         $user->isVerified = $active;
         $user->notifyOnNewEntry = true;

--- a/tests/FactoryTrait.php
+++ b/tests/FactoryTrait.php
@@ -95,11 +95,11 @@ trait FactoryTrait
         ];
     }
 
-    private function createUser(string $username, string $email = null, string $password = null, string $type, $active = true, $hideAdult = true, $about = null): User
+    private function createUser(string $username, string $email = null, string $password = null, string $type = 'Person', $active = true, $hideAdult = true, $about = null): User
     {
         $manager = $this->getService(EntityManagerInterface::class);
 
-        $user = new User($email ?: $username.'@example.com', $username, $password ?: 'secret', $type ?: 'Person');
+        $user = new User($email ?: $username.'@example.com', $username, $password ?: 'secret', $type);
 
         $user->isVerified = $active;
         $user->notifyOnNewEntry = true;


### PR DESCRIPTION
This PR adjusts/updates the `User` class constructor for cleaner code when instantiating a `User` object. This was motivated by updating the user fixture code to support the new user `type` field requirement that cannot be set to null. This will fix the regression currently present in the user fixture code that is used to generate random data during development and functional testing.