### PR TITLE
Add PCNTL PHP extension to Docker environment

### DIFF
--- a/docker/v2/Dockerfile
+++ b/docker/v2/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.2-fpm-alpine as base
 
 # Install php extensions, by docker-php-extension-installer
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
-RUN install-php-extensions amqp pgsql pdo_pgsql gd curl simplexml dom xml redis intl opcache apcu
+RUN install-php-extensions amqp pgsql pdo_pgsql gd curl simplexml dom xml redis intl opcache apcu pcntl
 
 # Install composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
Recent version bump to Symfony messenger requires the `pcntl` extension to handle POSIX signals.

https://stackoverflow.com/questions/77327373/symfony-messenger-undefined-constant-sigterm