### PR TITLE
Check if ENABLE_ACL is set before variable access

### DIFF
--- a/docker/docker-entrypoint
+++ b/docker/docker-entrypoint
@@ -51,8 +51,8 @@ if [ "$1" == "php-fpm" ] || [ "$1" == "php" ] || [ "$1" == "bin/console" ]; then
         bin/console doctrine:migrations:migrate --no-interaction
     fi
 
-    if [ -n "${ENABLE_ACL+1}" ]; then
-        if [ $ENABLE_ACL = 1 ]; then
+    if [ -n "$ENABLE_ACL" ]; then
+        if [ "$ENABLE_ACL" -eq 1 ]; then
             setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var
             setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var
         else

--- a/docker/docker-entrypoint
+++ b/docker/docker-entrypoint
@@ -51,9 +51,15 @@ if [ "$1" == "php-fpm" ] || [ "$1" == "php" ] || [ "$1" == "bin/console" ]; then
         bin/console doctrine:migrations:migrate --no-interaction
     fi
 
-    if [ $ENABLE_ACL = 1 ]; then
-        setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var
-        setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var
+    if [ -n "${ENABLE_ACL+1}" ]; then
+        if [ $ENABLE_ACL = 1 ]; then
+            setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var
+            setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var
+        else
+            echo "Filesystem ACL is disabled."
+        fi
+    else
+        echo "ENABLE_ACL is not set!"
     fi
 fi
 


### PR DESCRIPTION
$ENABLE_ACL is read even when it's not set, leading to shell error (sh: 1: unknown operand) during docker entry. PR checks to see if $ENABLE_ACL exists before evaluation.