### PR TITLE
add cover translation to alt text

### DIFF
--- a/templates/components/user_box.html.twig
+++ b/templates/components/user_box.html.twig
@@ -5,7 +5,7 @@
                  width="100%"
                  class="cover"
                  src="{{ asset(user.cover.filePath)|imagine_filter('user_cover') }}"
-                 alt="{{ user.username }}">
+                 alt="{{ user.username ~' '~ 'cover'|trans|lower  }}">
         {% endif %}
         <div class="user-main" id="content">
             <div>


### PR DESCRIPTION
noticed while working on alt text overflow that the cover alt text was only the username. this adds the translation of "cover" that already exists to make it match user avatars. So before the alt text for a user's cover just said "username", now it says "username cover"