### PR TITLE
HTTPS update to production compose override and docker deployment guide

### DIFF
--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -18,3 +18,19 @@ services:
       - RABBITMQ_PASSWORD=!ChangeThisRabbitPass!
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_PASSWORD}
 
+  # Set the following HTTPS variables to TRUE if your environment is using a 
+  # valid certificate behind a reverse proxy. This is most likely true for most
+  # production environments and is required for proper federation, that is, this
+  # will ensure the webfinger responses include `https:` in the URLs generated.
+
+  php:
+    environment:
+      - HTTPS=TRUE
+
+  messenger:
+    environment:
+      - HTTPS=TRUE
+
+  messenger_ap:
+    environment:
+      - HTTPS=TRUE

--- a/docs/docker_deployment_guide.md
+++ b/docs/docker_deployment_guide.md
@@ -66,6 +66,9 @@ sudo chown $USER:$USER storage/media storage/caddy_config storage/caddy_data
 1. Choose your Redis password, PostgreSQL password, RabbitMQ password, and Mercure password.
 2. Place them in the corresponding variables in both `.env` and `compose.override.yml`.
 
+> **Note**
+> Ensure the `HTTPS` environmental variable is set to `TRUE` in `compose.override.yml` for the `php`, `messenger`, and `messenger_ap` containers **if your environment is using a valid certificate behind a reverse proxy**. This is most likely true for most production environments and is required for proper federation, that is, this will ensure the webfinger responses include `https:` in the URLs generated.
+
 ### Configure OAuth2 keys
 
 1. Create an RSA key pair using OpenSSL:


### PR DESCRIPTION
HTTPS is required for proper federation, webfinger does not return valid `https` URLs without these environmental variables set.

Reference related kbin issue: https://codeberg.org/Kbin/kbin-core/issues/851