### PR TITLE
fix type mismatch when querying AP user follower/following list

### DIFF
--- a/src/Controller/ActivityPub/User/UserFollowersController.php
+++ b/src/Controller/ActivityPub/User/UserFollowersController.php
@@ -65,26 +65,28 @@ class UserFollowersController
     }
 
     #[ArrayShape([
-     '@context' => 'string',
-     'type' => 'string',
-     'partOf' => 'string',
-     'id' => 'string',
-     'totalItems' => 'int',
-     'orderedItems' => 'array',
- ])]
+        '@context' => 'string',
+        'type' => 'string',
+        'partOf' => 'string',
+        'id' => 'string',
+        'totalItems' => 'int',
+        'orderedItems' => 'array',
+    ])]
     private function getCollectionItems(User $user, int $page, string $type): array
     {
         $routeName = "ap_user_{$type}";
+        $items = [];
 
         if (ActivityPubActivityInterface::FOLLOWING === $type) {
             $actors = $this->userRepository->findFollowing($page, $user);
+            foreach ($actors as $actor) {
+                $items[] = $this->manager->getActorProfileId($actor->following);
+            }
         } else {
             $actors = $this->userRepository->findFollowers($page, $user);
-        }
-
-        $items = [];
-        foreach ($actors as $actor) {
-            $items[] = $this->manager->getActorProfileId($actor);
+            foreach ($actors as $actor) {
+                $items[] = $this->manager->getActorProfileId($actor->follower);
+            }
         }
 
         return $this->collectionItemsWrapper->build(


### PR DESCRIPTION
fix type mismatch when querying user follower/following list at any specific page from AP endpoint, right now attempting to query would results in a 5xx error and the following log lines.

```sh
curl -vL 'https://instance.tld/u/someone/followers?page=1' -H 'Accept: application/activity+json, application/ld+json'
```

```
[2023-10-23T21:50:39.299373+07:00] php.CRITICAL: Uncaught Error: App\Service\ActivityPubManager::getActorProfileId(): Argument #1 ($actor) must be of type App\Entity\Contracts\ActivityPubActorInterface, App\Entity\UserFollow given, called in /usr/local/www/kbin/src/Controller/ActivityPub/User/UserFollowersController.php on line 87 {"exception":"[object] (TypeError(code: 0): App\\Service\\ActivityPubManager::getActorProfileId(): Argument #1 ($actor) must be of type App\\Entity\\Contracts\\ActivityPubActorInterface, App\\Entity\\UserFollow given, called in /usr/local/www/kbin/src/Controller/ActivityPub/User/UserFollowersController.php on line 87 at /usr/local/www/kbin/src/Service/ActivityPubManager.php:61)"} []
[2023-10-23T21:50:39.301022+07:00] request.CRITICAL: Uncaught PHP Exception TypeError: "App\Service\ActivityPubManager::getActorProfileId(): Argument #1 ($actor) must be of type App\Entity\Contracts\ActivityPubActorInterface, App\Entity\UserFollow given, called in /usr/local/www/kbin/src/Controller/ActivityPub/User/UserFollowersController.php on line 87" at /usr/local/www/kbin/src/Service/ActivityPubManager.php line 61 {"exception":"[object] (TypeError(code: 0): App\\Service\\ActivityPubManager::getActorProfileId(): Argument #1 ($actor) must be of type App\\Entity\\Contracts\\ActivityPubActorInterface, App\\Entity\\UserFollow given, called in /usr/local/www/kbin/src/Controller/ActivityPub/User/UserFollowersController.php on line 87 at /usr/local/www/kbin/src/Service/ActivityPubManager.php:61)"} []
```