### PR TITLE
enable auto rotate filter when making thumbnail

### DIFF
--- a/config/packages/liip_imagine.yaml
+++ b/config/packages/liip_imagine.yaml
@@ -8,18 +8,22 @@ liip_imagine:
     entry_thumb:
       quality: 90
       filters:
+        auto_rotate: ~
         thumbnail: { size: [ 380, 380 ], mode: inset }
     avatar_thumb:
       quality: 90
       filters:
+        auto_rotate: ~
         thumbnail: { size: [ 100, 100 ], mode: fixed }
     post_thumb:
       quality: 90
       filters:
+        auto_rotate: ~
         thumbnail: { size: [ 600, 500 ], mode: inset }
     user_cover:
       quality: 90
       filters:
+        auto_rotate: ~
         thumbnail: { size: [ 1500, 500 ], mode: fixed }
 
   data_loader: kbin.liip_loader

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.2-fpm-alpine as base
 
 # Install php extensions, by docker-php-extension-installer
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
-RUN install-php-extensions amqp pgsql pdo_pgsql gd curl simplexml dom xml redis intl opcache apcu pcntl
+RUN install-php-extensions amqp pgsql pdo_pgsql gd curl simplexml dom xml redis intl opcache apcu pcntl exif
 
 # Install composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
enable auto rotate filter to properly make thumbnails for images that have rotation data stored in exif, such as those coming from phones.

note that this required php exif extension for it to work (added extension in docker build, basic php install for bare metal guide should already included exif extension)