### PR TITLE
Add support for user_type enum in Doctrine

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -2,7 +2,7 @@ doctrine:
   dbal:
     url: "%env(resolve:DATABASE_URL)%"
     mapping_types:
-      enum: string
+      user_type: string
 
   orm:
     dql:

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -1,23 +1,25 @@
 doctrine:
-    dbal:
-        url: '%env(resolve:DATABASE_URL)%'
+  dbal:
+    url: "%env(resolve:DATABASE_URL)%"
+    mapping_types:
+      enum: string
 
-    orm:
-        dql:
-            string_functions:
-                JSONB_CONTAINS: Scienta\DoctrineJsonFunctions\Query\AST\Functions\Postgresql\JsonbContains
-        auto_generate_proxy_classes: true
-        naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
-        auto_mapping: true
-        mappings:
-            App:
-                is_bundle: false
-                type: attribute
-                dir: '%kernel.project_dir%/src/Entity'
-                prefix: 'App\Entity'
-                alias: App
-        second_level_cache:
-            enabled: true
-            region_cache_driver:
-                type: pool
-                pool: doctrine.second_level_cache_pool
+  orm:
+    dql:
+      string_functions:
+        JSONB_CONTAINS: Scienta\DoctrineJsonFunctions\Query\AST\Functions\Postgresql\JsonbContains
+    auto_generate_proxy_classes: true
+    naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
+    auto_mapping: true
+    mappings:
+      App:
+        is_bundle: false
+        type: attribute
+        dir: "%kernel.project_dir%/src/Entity"
+        prefix: 'App\Entity'
+        alias: App
+    second_level_cache:
+      enabled: true
+      region_cache_driver:
+        type: pool
+        pool: doctrine.second_level_cache_pool


### PR DESCRIPTION
According to the Symfony docs, enum types are disabled by default (we are using enum for `user_type` in postgresql). Enabling support is possible via: 

```yml
doctrine:
    dbal:
        mapping_types:
            enum: string

#  In your case:

doctrine:
    dbal:
        mapping_types:
            user_type: string
```

See docs: https://symfony.com/doc/current/doctrine/dbal.html#registering-custom-mapping-types-in-the-schematool

This will fix the `./bin/console doctrine:migrations:diff` command again.