### PR TITLE
Change from info to debug level

### DIFF
--- a/src/Controller/ActivityPub/Magazine/MagazineInboxController.php
+++ b/src/Controller/ActivityPub/Magazine/MagazineInboxController.php
@@ -27,9 +27,9 @@ class MagazineInboxController
             ]
         );
 
-        $this->logger->info('MagazineInboxController:request: '.$requestInfo['method'].' '.$requestInfo['uri']);
-        $this->logger->info('MagazineInboxController:headers: '.$request->headers);
-        $this->logger->info('MagazineInboxController:content: '.$request->getContent());
+        $this->logger->debug('MagazineInboxController:request: '.$requestInfo['method'].' '.$requestInfo['uri']);
+        $this->logger->debug('MagazineInboxController:headers: '.$request->headers);
+        $this->logger->debug('MagazineInboxController:content: '.$request->getContent());
 
         $this->bus->dispatch(
             new ActivityMessage(

--- a/src/Controller/ActivityPub/SharedInboxController.php
+++ b/src/Controller/ActivityPub/SharedInboxController.php
@@ -29,9 +29,9 @@ class SharedInboxController
             ]
         );
 
-        $this->logger->info('SharedInboxController:request: '.$requestInfo['method'].' '.$requestInfo['uri']);
-        $this->logger->info('SharedInboxController:headers: '.$request->headers);
-        $this->logger->info('SharedInboxController:body: '.$request->getContent());
+        $this->logger->debug('SharedInboxController:request: '.$requestInfo['method'].' '.$requestInfo['uri']);
+        $this->logger->debug('SharedInboxController:headers: '.$request->headers);
+        $this->logger->debug('SharedInboxController:body: '.$request->getContent());
 
         $this->bus->dispatch(
             new ActivityMessage(

--- a/src/Controller/ActivityPub/User/UserInboxController.php
+++ b/src/Controller/ActivityPub/User/UserInboxController.php
@@ -27,9 +27,9 @@ class UserInboxController
             ]
         );
 
-        $this->logger->info('UserInboxController:request: '.$requestInfo['method'].' '.$requestInfo['uri']);
-        $this->logger->info('UserInboxController:headers: '.$request->headers);
-        $this->logger->info('UserInboxController:content: '.$request->getContent());
+        $this->logger->debug('UserInboxController:request: '.$requestInfo['method'].' '.$requestInfo['uri']);
+        $this->logger->debug('UserInboxController:headers: '.$request->headers);
+        $this->logger->debug('UserInboxController:content: '.$request->getContent());
 
         $this->bus->dispatch(
             new ActivityMessage(

--- a/src/Controller/Api/Post/PostsRetrieveApi.php
+++ b/src/Controller/Api/Post/PostsRetrieveApi.php
@@ -512,7 +512,7 @@ class PostsRetrieveApi extends PostsBaseApi
         $criteria->perPage = self::constrainPerPage($request->getCurrentRequest()->get('perPage', PostRepository::PER_PAGE));
         $criteria->favourite = true;
 
-        $this->logger->info(var_export($criteria, true));
+        $this->logger->debug(var_export($criteria, true));
 
         $posts = $repository->findByCriteria($criteria);
 

--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -49,7 +49,7 @@ class ApHttpClient
     public function getActivityObject(string $url, bool $decoded = true): array|string|null
     {
         $resp = $this->cache->get('ap_'.hash('sha256', $url), function (ItemInterface $item) use ($url) {
-            $this->logger->info("ApHttpClient:getActivityObject:url: {$url}");
+            $this->logger->debug("ApHttpClient:getActivityObject:url: {$url}");
 
             $client = new CurlHttpClient();
             $r = $client->request('GET', $url, [
@@ -86,7 +86,7 @@ class ApHttpClient
         $resp = $this->cache->get(
             'wf_'.hash('sha256', $url),
             function (ItemInterface $item) use ($url) {
-                $this->logger->info("ApHttpClient:getWebfingerObject:url: {$url}");
+                $this->logger->debug("ApHttpClient:getWebfingerObject:url: {$url}");
 
                 try {
                     $client = new CurlHttpClient();
@@ -118,7 +118,7 @@ class ApHttpClient
         $resp = $this->cache->get(
             'ap_'.hash('sha256', $apProfileId),
             function (ItemInterface $item) use ($apProfileId) {
-                $this->logger->info("ApHttpClient:getActorObject:url: {$apProfileId}");
+                $this->logger->debug("ApHttpClient:getActorObject:url: {$apProfileId}");
 
                 try {
                     // Set-up request
@@ -171,8 +171,8 @@ class ApHttpClient
             return;
         }
 
-        $this->logger->info("ApHttpClient:post:url: {$url}");
-        $this->logger->info('ApHttpClient:post:body '.json_encode($body ?? []));
+        $this->logger->debug("ApHttpClient:post:url: {$url}");
+        $this->logger->debug('ApHttpClient:post:body '.json_encode($body ?? []));
 
         // Set-up request
         $client = new CurlHttpClient();

--- a/src/Service/ActivityPub/SignatureValidator.php
+++ b/src/Service/ActivityPub/SignatureValidator.php
@@ -126,7 +126,7 @@ readonly class SignatureValidator
             throw new InvalidApSignatureException('Signature of request could not be verified.');
         }
 
-        $this->logger->info('Successfully verified signature of incoming AP request.', ['digest' => $digest]);
+        $this->logger->debug('Successfully verified signature of incoming AP request.', ['digest' => $digest]);
     }
 
     private static function headersToSigningString($headers): string


### PR DESCRIPTION
 Reduce log pollution when running "info" by changing from `info` to `debug` logging.

The reason is that running `info` can help debugging issues in other parts of the code like federation issues of messenger. The current `info` lines in Mbin cause log pollution. If the development wants, you can always enable debug logging.