### PR TITLE
Improve docker-entrypoint for prod & dev

### DIFF
--- a/docker/docker-entrypoint
+++ b/docker/docker-entrypoint
@@ -11,18 +11,22 @@ if [ "$1" == "php-fpm" ] || [ "$1" == "php" ] || [ "$1" == "bin/console" ]; then
     if [ "$1" == "php-fpm" ]; then
         echo "Starting as servce..."
 
-        # dump out a config php file if an environment file is found and we are in production
+        # In production: dump the production PHP config files,
+        # validate the installed packages (no dev) and dump prod config
         if [ "$APP_ENV" == "prod" ]; then
             cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
             cp "$PHP_INI_DIR/conf.d/app.ini-production" "$PHP_INI_DIR/conf.d/app.prod.or.dev.ini"
+            composer install --prefer-dist --no-dev --no-autoloader --no-scripts --no-progress
             composer dump-env prod
         fi
 
-        # install development dependencies if they don't exist
+        # In development: dump the development PHP config files,
+        # validate the installed packages (including dev dependencies) and dump dev config
         if [ "$APP_ENV" == "dev" ]; then
             cp "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
             cp "$PHP_INI_DIR/conf.d/app.ini-development" "$PHP_INI_DIR/conf.d/app.prod.or.dev.ini"
-            composer install --prefer-dist --no-scripts --no-progress
+            composer install --prefer-dist --no-autoloader --no-scripts --no-progress
+            composer dump-env dev
         fi
     fi
 


### PR DESCRIPTION
If the user switch between prod to dev it should install the correct packages and dump the mode correctly to `.env.local.php`. **BUT ALSO** when the user switches back again from dev to prod.