### PR TITLE
add delay to firefox mercure reconnection that I changed in #78

### DIFF
--- a/assets/controllers/notifications_controller.js
+++ b/assets/controllers/notifications_controller.js
@@ -45,8 +45,10 @@ export default class extends Controller {
         if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
             let resubscribe = (e) => {
                 window.es.close();
-                window.es = Subscribe(topics, cb);
-                window.es.onerror = resubscribe;
+                setTimeout(() => {
+                    window.es = Subscribe(topics, cb);
+                    window.es.onerror = resubscribe;
+                }, 1000);
             };
             window.es.onerror = resubscribe;
         }


### PR DESCRIPTION
thanks to @melroy89 for [pointing this out](https://github.com/MbinOrg/mbin/pull/78#issuecomment-1778062907)

add delay in reconnect function that's in use when in firefox that I changed in #78 (and arguably made it worse as I have traded one untracked connection to reconnection spam)