### PR TITLE
Fix composer dev mode bug in docker-entrypoint

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,7 +56,7 @@ RUN composer install --prefer-dist --no-dev --no-autoloader --no-scripts --no-pr
 
 # Copy repository
 COPY --link ./ $KBIN_HOME
-RUN cp .env.example .env
+RUN cp .env.example_docker .env
 
 # Dump-autoload and run post-install script
 RUN composer dump-autoload --classmap-authoritative --no-dev
@@ -89,7 +89,7 @@ RUN yarn build --mode production
 FROM base as runner
 
 COPY --chown=$USER:$GROUP --link ./ $KBIN_HOME
-RUN cp .env.example .env
+RUN cp .env.example_docker .env
 
 COPY --from=builder-caddy --link /usr/bin/caddy /usr/sbin/caddy
 COPY --from=builder-composer --chown=$USER:$GROUP $KBIN_HOME/vendor $KBIN_HOME/vendor

--- a/docker/docker-entrypoint
+++ b/docker/docker-entrypoint
@@ -8,26 +8,24 @@ fi
 
 if [ "$1" == "php-fpm" ] || [ "$1" == "php" ] || [ "$1" == "bin/console" ]; then
     # if running as a service install assets
-    if [ "$1" == "php-fpm" ]; then
-        echo "Starting as servce..."
+    echo "Starting as servce..."
 
-        # In production: dump the production PHP config files,
-        # validate the installed packages (no dev) and dump prod config
-        if [ "$APP_ENV" == "prod" ]; then
-            cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
-            cp "$PHP_INI_DIR/conf.d/app.ini-production" "$PHP_INI_DIR/conf.d/app.prod.or.dev.ini"
-            composer install --prefer-dist --no-dev --no-autoloader --no-scripts --no-progress
-            composer dump-env prod
-        fi
+    # In production: dump the production PHP config files,
+    # validate the installed packages (no dev) and dump prod config
+    if [ "$APP_ENV" == "prod" ]; then
+        cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+        cp "$PHP_INI_DIR/conf.d/app.ini-production" "$PHP_INI_DIR/conf.d/app.prod.or.dev.ini"
+        composer install --prefer-dist --no-dev --no-autoloader --no-scripts --no-progress
+        composer dump-env prod
+    fi
 
-        # In development: dump the development PHP config files,
-        # validate the installed packages (including dev dependencies) and dump dev config
-        if [ "$APP_ENV" == "dev" ]; then
-            cp "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
-            cp "$PHP_INI_DIR/conf.d/app.ini-development" "$PHP_INI_DIR/conf.d/app.prod.or.dev.ini"
-            composer install --prefer-dist --no-scripts --no-progress
-            composer dump-env dev
-        fi
+    # In development: dump the development PHP config files,
+    # validate the installed packages (including dev dependencies) and dump dev config
+    if [ "$APP_ENV" == "dev" ]; then
+        cp "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+        cp "$PHP_INI_DIR/conf.d/app.ini-development" "$PHP_INI_DIR/conf.d/app.prod.or.dev.ini"
+        composer install --prefer-dist --no-scripts --no-progress
+        composer dump-env dev
     fi
 
     echo "Waiting for db to be ready..." 


### PR DESCRIPTION
The composer `dev` mode environment wasn't being properly installed on all relevant containers (specifically `messenger` and `messenger_ap`) due to extra `if` statement in `docker-entrypoint`. Also fixed `Dockerfile` to actually copy `.env.example_docker` file.