### PR TITLE
Simplify language selection in tests (#1204)

### DIFF
--- a/tests/Functional/Controller/Entry/Comment/EntryCommentChangeLangControllerTest.php
+++ b/tests/Functional/Controller/Entry/Comment/EntryCommentChangeLangControllerTest.php
@@ -18,11 +18,10 @@ class EntryCommentChangeLangControllerTest extends WebTestCase
         $crawler = $client->request('GET', "/m/acme/t/{$comment->entry->getId()}/-/comment/{$comment->getId()}/moderate");
 
         $form = $crawler->filter('.moderate-panel')->selectButton('change language')->form();
-        $values = $form['lang']['lang']->availableOptionValues();
 
-        $this->assertSame($values[0], 'en');
+        $this->assertSame($form['lang']['lang']->getValue(), 'en');
 
-        $form['lang']['lang']->select($values[array_search('fr', $values)]);
+        $form['lang']['lang']->select('fr');
 
         $client->submit($form);
         $client->followRedirect();

--- a/tests/Functional/Controller/Entry/EntryChangeLangControllerTest.php
+++ b/tests/Functional/Controller/Entry/EntryChangeLangControllerTest.php
@@ -21,11 +21,10 @@ class EntryChangeLangControllerTest extends WebTestCase
         $crawler = $client->request('GET', "/m/acme/t/{$entry->getId()}/-/moderate");
 
         $form = $crawler->filter('.moderate-panel')->selectButton('change language')->form();
-        $values = $form['lang']['lang']->availableOptionValues();
 
-        $this->assertSame($values[0], 'en');
+        $this->assertSame($form['lang']['lang']->getValue(), 'en');
 
-        $form['lang']['lang']->select($values[array_search('fr', $values)]);
+        $form['lang']['lang']->select('fr');
 
         $client->submit($form);
         $client->followRedirect();

--- a/tests/Functional/Controller/Post/Comment/PostCommentChangeLangControllerTest.php
+++ b/tests/Functional/Controller/Post/Comment/PostCommentChangeLangControllerTest.php
@@ -18,11 +18,10 @@ class PostCommentChangeLangControllerTest extends WebTestCase
         $crawler = $client->request('GET', "/m/acme/p/{$comment->post->getId()}/-/reply/{$comment->getId()}/moderate");
 
         $form = $crawler->filter('.moderate-panel')->selectButton('change language')->form();
-        $values = $form['lang']['lang']->availableOptionValues();
 
-        $this->assertSame($values[0], 'en');
+        $this->assertSame($form['lang']['lang']->getValue(), 'en');
 
-        $form['lang']['lang']->select($values[array_search('fr', $values)]);
+        $form['lang']['lang']->select('fr');
 
         $client->submit($form);
         $client->followRedirect();

--- a/tests/Functional/Controller/Post/PostChangeLangControllerTest.php
+++ b/tests/Functional/Controller/Post/PostChangeLangControllerTest.php
@@ -18,11 +18,10 @@ class PostChangeLangControllerTest extends WebTestCase
         $crawler = $client->request('GET', "/m/acme/p/{$post->getId()}/-/moderate");
 
         $form = $crawler->filter('.moderate-panel')->selectButton('change language')->form();
-        $values = $form['lang']['lang']->availableOptionValues();
 
-        $this->assertSame($values[0], 'en');
+        $this->assertSame($form['lang']['lang']->getValue(), 'en');
 
-        $form['lang']['lang']->select($values[array_search('fr', $values)]);
+        $form['lang']['lang']->select('fr');
 
         $client->submit($form);
         $client->followRedirect();


### PR DESCRIPTION
PR fixes usage of `availableOptionValues` - internal method of DomCrawler component

Reviewed-on: https://codeberg.org/Kbin/kbin-core/pulls/1204
