### PR TITLE
Ensure doctrine migration (and ACL set if enabled) only happens once when php-fpm is started

### DIFF
--- a/docker/docker-entrypoint
+++ b/docker/docker-entrypoint
@@ -28,28 +28,28 @@ if [ "$1" == "php-fpm" ] || [ "$1" == "php" ] || [ "$1" == "bin/console" ]; then
         composer dump-env dev
     fi
 
-    if [ "$1" == "php-fpm" ]; then
-        echo "Waiting for db to be ready..."
-        ATTEMPTS_LEFT_TO_REACH_DATABASE=60
-        until [ $ATTEMPTS_LEFT_TO_REACH_DATABASE -eq 0 ] || DATABASE_ERROR=$(bin/console dbal:run-sql "SELECT 1" 2>&1); do
-            if [ $? -eq 255 ]; then
-                # If the Doctrine command exits with 255, an unrecoverable error occurred
-                ATTEMPTS_LEFT_TO_REACH_DATABASE=0
-                break
-            fi
-            sleep 1
-            ATTEMPTS_LEFT_TO_REACH_DATABASE=$((ATTEMPTS_LEFT_TO_REACH_DATABASE - 1))
-            echo "Still waiting for db to be ready... Or maybe the db is not reachable. $ATTEMPTS_LEFT_TO_REACH_DATABASE attempts left"
-        done
-
-        if [ $ATTEMPTS_LEFT_TO_REACH_DATABASE -eq 0 ]; then
-            echo "The database is not up or not reachable:"
-            echo "$DATABASE_ERROR"
-            exit 1
-        else
-            echo "The db is now ready and reachable"
+    echo "Waiting for db to be ready..."
+    ATTEMPTS_LEFT_TO_REACH_DATABASE=60
+    until [ $ATTEMPTS_LEFT_TO_REACH_DATABASE -eq 0 ] || DATABASE_ERROR=$(bin/console dbal:run-sql "SELECT 1" 2>&1); do
+        if [ $? -eq 255 ]; then
+            # If the Doctrine command exits with 255, an unrecoverable error occurred
+            ATTEMPTS_LEFT_TO_REACH_DATABASE=0
+            break
         fi
+        sleep 1
+        ATTEMPTS_LEFT_TO_REACH_DATABASE=$((ATTEMPTS_LEFT_TO_REACH_DATABASE - 1))
+        echo "Still waiting for db to be ready... Or maybe the db is not reachable. $ATTEMPTS_LEFT_TO_REACH_DATABASE attempts left"
+    done
 
+    if [ $ATTEMPTS_LEFT_TO_REACH_DATABASE -eq 0 ]; then
+        echo "The database is not up or not reachable:"
+        echo "$DATABASE_ERROR"
+        exit 1
+    else
+        echo "The db is now ready and reachable"
+    fi
+
+    if [ "$1" == "php-fpm" ]; then
         if [ "$( find ./migrations -iname '*.php' -print -quit )" ]; then
             bin/console doctrine:migrations:migrate --no-interaction
         fi

--- a/docker/docker-entrypoint
+++ b/docker/docker-entrypoint
@@ -28,40 +28,42 @@ if [ "$1" == "php-fpm" ] || [ "$1" == "php" ] || [ "$1" == "bin/console" ]; then
         composer dump-env dev
     fi
 
-    echo "Waiting for db to be ready..." 
-    ATTEMPTS_LEFT_TO_REACH_DATABASE=60
-    until [ $ATTEMPTS_LEFT_TO_REACH_DATABASE -eq 0 ] || DATABASE_ERROR=$(bin/console dbal:run-sql "SELECT 1" 2>&1); do
-        if [ $? -eq 255 ]; then
-            # If the Doctrine command exits with 255, an unrecoverable error occurred
-            ATTEMPTS_LEFT_TO_REACH_DATABASE=0
-            break
-        fi
-        sleep 1
-        ATTEMPTS_LEFT_TO_REACH_DATABASE=$((ATTEMPTS_LEFT_TO_REACH_DATABASE - 1))
-        echo "Still waiting for db to be ready... Or maybe the db is not reachable. $ATTEMPTS_LEFT_TO_REACH_DATABASE attempts left"
-    done
+    if [ "$1" == "php-fpm" ]; then
+        echo "Waiting for db to be ready..."
+        ATTEMPTS_LEFT_TO_REACH_DATABASE=60
+        until [ $ATTEMPTS_LEFT_TO_REACH_DATABASE -eq 0 ] || DATABASE_ERROR=$(bin/console dbal:run-sql "SELECT 1" 2>&1); do
+            if [ $? -eq 255 ]; then
+                # If the Doctrine command exits with 255, an unrecoverable error occurred
+                ATTEMPTS_LEFT_TO_REACH_DATABASE=0
+                break
+            fi
+            sleep 1
+            ATTEMPTS_LEFT_TO_REACH_DATABASE=$((ATTEMPTS_LEFT_TO_REACH_DATABASE - 1))
+            echo "Still waiting for db to be ready... Or maybe the db is not reachable. $ATTEMPTS_LEFT_TO_REACH_DATABASE attempts left"
+        done
 
-    if [ $ATTEMPTS_LEFT_TO_REACH_DATABASE -eq 0 ]; then
-        echo "The database is not up or not reachable:"
-        echo "$DATABASE_ERROR"
-        exit 1
-    else
-        echo "The db is now ready and reachable"
-    fi
-
-    if [ "$( find ./migrations -iname '*.php' -print -quit )" ]; then
-        bin/console doctrine:migrations:migrate --no-interaction
-    fi
-
-    if [ -n "$ENABLE_ACL" ]; then
-        if [ "$ENABLE_ACL" -eq 1 ]; then
-            setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var
-            setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var
+        if [ $ATTEMPTS_LEFT_TO_REACH_DATABASE -eq 0 ]; then
+            echo "The database is not up or not reachable:"
+            echo "$DATABASE_ERROR"
+            exit 1
         else
-            echo "Filesystem ACL is disabled."
+            echo "The db is now ready and reachable"
         fi
-    else
-        echo "ENABLE_ACL is not set!"
+
+        if [ "$( find ./migrations -iname '*.php' -print -quit )" ]; then
+            bin/console doctrine:migrations:migrate --no-interaction
+        fi
+
+        if [ -n "$ENABLE_ACL" ]; then
+            if [ "$ENABLE_ACL" -eq 1 ]; then
+                setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var
+                setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var
+            else
+                echo "Filesystem ACL is disabled."
+            fi
+        else
+            echo "ENABLE_ACL is not set!"
+        fi
     fi
 fi
 


### PR DESCRIPTION
Docker-entrypoint fix to check and make sure doctrine migration only happens when the `php-fpm` command is executed (will only happen once during stack startup). Also moved ACL set/check under same condition since it should only happen once during startup.