### PR TITLE
Add CSRF token to logout

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -37,6 +37,7 @@ security:
                 - App\Security\GithubAuthenticator
                 - App\Security\KeycloakAuthenticator
             logout:
+                enable_csrf: true
                 path: app_logout
             user_checker: App\Security\UserChecker
             remember_me:

--- a/templates/layout/_header.html.twig
+++ b/templates/layout/_header.html.twig
@@ -180,7 +180,7 @@
                                 </a>
                             </li>
                         {% endif %}
-                        <li><a href="{{ path('app_logout') }}">{{ 'logout'|trans }}</a></li>
+                        <li><a href="{{ logout_path() }}">{{ 'logout'|trans }}</a></li>
                     </ul>
                 </li>
             {% else %}

--- a/templates/user/2fa.html.twig
+++ b/templates/user/2fa.html.twig
@@ -32,7 +32,7 @@
                 </div>
                 <input type="hidden" name="{{ csrfParameterName }}" value="{{ csrf_token(csrfTokenId) }}">
                 <div class="row actions">
-                    <div><span class="cancel"><a href="{{ path('app_logout') }}">{{ 'cancel'|trans }}</a></span></div>
+                    <div><span class="cancel"><a href="{{ logout_path() }}">{{ 'cancel'|trans }}</a></span></div>
                     <div><button class="btn btn__primary" type="submit">{{ '2fa.verify'|trans }}</button></div>
                 </div>
             </form>


### PR DESCRIPTION
PR adds CSRF token to logout to prevent it from being used as part of phishing or other malicious actions.

Purpose: kbin sync -> security enhancement
Author: @SzymonKaminski 
Reviewed: https://codeberg.org/Kbin/kbin-core/pulls/1205