### PR TITLE
user box template - fix losing cover class

### DIFF
--- a/templates/components/user_box.html.twig
+++ b/templates/components/user_box.html.twig
@@ -1,10 +1,9 @@
 <div{{ attributes.defaults({class: 'user-box'}) }}>
     <div class="{{ html_classes({'with-cover': user.cover, 'with-avatar': user.avatar }) }}">
         {% if user.cover %}
-            <img class="image-inline"
+            <img class="cover image-inline"
                  height="220"
                  width="100%"
-                 class="cover"
                  src="{{ asset(user.cover.filePath)|imagine_filter('user_cover') }}"
                  alt="{{ user.username ~' '~ 'cover'|trans|lower  }}">
         {% endif %}


### PR DESCRIPTION
thanks to @nobodyatroot for noticing this, was declaring the class field twice after #113 so it was losing some styling

before:

![image](https://github.com/MbinOrg/mbin/assets/146029455/726c3e08-fc01-4914-804a-228fce9c59a9)

after:

![image](https://github.com/MbinOrg/mbin/assets/146029455/bd91eb96-094a-47ac-ac32-11b070288304)
