### PR TITLE
Improve error warning log pollution + dev setup + composer update (part 5)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,30 @@ There are three levels of tests that we distinguish between:
 
 For more info read: [Symfony Testing guide](https://symfony.com/doc/current/testing.html).
 
+#### Unit Tests
+
+- First increase execution time in your PHP config file: `/etc/php/8.2/fpm/php.ini`:
+
+```ini
+max_execution_time = 120
+```
+
+- Increase/set max_nesting_level in `/etc/php/8.2/fpm/conf.d/20-xdebug.ini`:
+
+```ini
+xdebug.max_nesting_level=512
+```
+
+- Restart the PHP-FPM service: `sudo systemctl restart php8.2-fpm.service`
+- Copy the dot env file: `cp .env.example .env`
+- Install composer packages: `composer install --no-scripts`
+
+Running the unit tests by executing:
+
+```bash
+SYMFONY_DEPRECATIONS_HELPER=disabled ./bin/phpunit tests/Unit
+```
+
 ### Fixtures
 
 You might want to load random data to database instead of manually adding magazines, users, posts, comments etc.  

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Requirements:
 - Increase execution time in PHP config file: `/etc/php/8.2/fpm/php.ini`:
 
 ```ini
-max_execution_time = 60
+max_execution_time = 120
 ```
 
 - Restart the PHP-FPM service: `sudo systemctl restart php8.2-fpm.service`

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ sudo -u postgres createuser --createdb --createrole --pwprompt mbin
 - Correctly configured `.env` file (`cp .env.example .env`), these are only the changes you need to pay attention to:
 
 ```env
+# Set domain to 127.0.0.1:8000
+SERVER_NAME=127.0.0.1:8000
+KBIN_DOMAIN=127.0.0.1:8000
+KBIN_STORAGE_URL=http://127.0.0.1:8000/media
+
 #Redis (without password)
 REDIS_DNS=redis://127.0.0.1:6379
 
@@ -138,7 +143,7 @@ local   mbin            mbin                                    md5
 - Restart the PostgreSQL server: `sudo systemctl restart postgresql`
 - Create database: `php bin/console doctrine:database:create`
 - Create tables and database structure: `php bin/console doctrine:migrations:migrate`
-- Build frontend assets: `yarn && yarn build`
+- Build frontend assets: `yarn && yarn dev`
 
 Starting the server:
 
@@ -155,7 +160,7 @@ This will give you a minimal working frontend with PostgreSQL setup. Keep in min
 
 _Optionally:_ you could also setup RabbitMQ, but the Doctrine messenger configuration will be sufficient for local development.
 
-More info: [Symfony Local Web Server](https://symfony.com/doc/current/setup/symfony_server.html)
+More info: [Admin guide](docs/admin_guide.md) and [Symfony Local Web Server](https://symfony.com/doc/current/setup/symfony_server.html)
 
 ### Linting
 

--- a/assets/controllers/notifications_controller.js
+++ b/assets/controllers/notifications_controller.js
@@ -40,17 +40,23 @@ export default class extends Controller {
             //
         }
 
-        window.es = Subscribe(topics, cb);
-        // firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1803431
-        if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
-            let resubscribe = (e) => {
-                window.es.close();
-                setTimeout(() => {
-                    window.es = Subscribe(topics, cb);
-                    window.es.onerror = resubscribe;
-                }, 1000);
-            };
-            window.es.onerror = resubscribe;
+        const eventSource = Subscribe(topics, cb);
+        if (eventSource) {
+            window.es = eventSource;
+            // firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1803431
+            if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
+                let resubscribe = (e) => {
+                    window.es.close();
+                    setTimeout(() => {
+                        const eventSource = Subscribe(topics, cb);
+                        if (eventSource) {
+                            window.es = Subscribe(topics, cb);
+                            window.es.onerror = resubscribe;
+                        }
+                    }, 10000);
+                };
+                window.es.onerror = resubscribe;
+            }
         }
     }
 

--- a/assets/utils/event-source.js
+++ b/assets/utils/event-source.js
@@ -1,13 +1,17 @@
 export default function
     subscribe(topics, cb) {
-    const url = new URL(document.getElementById("mercure-url").textContent.trim());
+    const mercureElem = document.getElementById("mercure-url");
+    if (mercureElem) {
+        const url = new URL(mercureElem.textContent.trim());
 
-    topics.forEach(topic => {
-        url.searchParams.append('topic', topic);
-    })
+        topics.forEach(topic => {
+            url.searchParams.append('topic', topic);
+        })
 
-    const eventSource = new EventSource(url);
-    eventSource.onmessage = e => cb(e);
+        const eventSource = new EventSource(url);
+        eventSource.onmessage = e => cb(e);
 
-    return eventSource;
+        return eventSource;
+    }
+    return null;
 }

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "aws/aws-crt-php",
-            "version": "v1.2.2",
+            "version": "v1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/awslabs/aws-crt-php.git",
-                "reference": "2f1dc7b7eda080498be96a4a6d683a41583030e9"
+                "reference": "5545a4fa310aec39f54279fdacebcce33b3ff382"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/2f1dc7b7eda080498be96a4a6d683a41583030e9",
-                "reference": "2f1dc7b7eda080498be96a4a6d683a41583030e9",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/5545a4fa310aec39f54279fdacebcce33b3ff382",
+                "reference": "5545a4fa310aec39f54279fdacebcce33b3ff382",
                 "shasum": ""
             },
             "require": {
@@ -56,26 +56,26 @@
             ],
             "support": {
                 "issues": "https://github.com/awslabs/aws-crt-php/issues",
-                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.2"
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.3"
             },
-            "time": "2023-07-20T16:49:55+00:00"
+            "time": "2023-10-16T20:10:06+00:00"
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.283.10",
+            "version": "3.283.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "ae611a2d1d32bb2d14c1653e3d2c309cfed42883"
+                "reference": "853eecfb21e8d623fa1b32e597b0a75912e8a404"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/ae611a2d1d32bb2d14c1653e3d2c309cfed42883",
-                "reference": "ae611a2d1d32bb2d14c1653e3d2c309cfed42883",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/853eecfb21e8d623fa1b32e597b0a75912e8a404",
+                "reference": "853eecfb21e8d623fa1b32e597b0a75912e8a404",
                 "shasum": ""
             },
             "require": {
-                "aws/aws-crt-php": "^1.0.4",
+                "aws/aws-crt-php": "^1.2.3",
                 "ext-json": "*",
                 "ext-pcre": "*",
                 "ext-simplexml": "*",
@@ -151,9 +151,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.283.10"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.283.13"
             },
-            "time": "2023-10-23T18:08:46+00:00"
+            "time": "2023-10-26T18:14:40+00:00"
         },
         {
             "name": "babdev/pagerfanta-bundle",
@@ -497,16 +497,16 @@
         },
         {
             "name": "debril/feed-io",
-            "version": "v5.3.1",
+            "version": "v5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/alexdebril/feed-io.git",
-                "reference": "b1237713ae174fc4dd57aff1e472303a1162ccfc"
+                "reference": "7c206ea5f07a65e7ccccdcdfbe0803806d54caa5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/alexdebril/feed-io/zipball/b1237713ae174fc4dd57aff1e472303a1162ccfc",
-                "reference": "b1237713ae174fc4dd57aff1e472303a1162ccfc",
+                "url": "https://api.github.com/repos/alexdebril/feed-io/zipball/7c206ea5f07a65e7ccccdcdfbe0803806d54caa5",
+                "reference": "7c206ea5f07a65e7ccccdcdfbe0803806d54caa5",
                 "shasum": ""
             },
             "require": {
@@ -558,9 +558,9 @@
             ],
             "support": {
                 "issues": "https://github.com/alexdebril/feed-io/issues",
-                "source": "https://github.com/alexdebril/feed-io/tree/v5.3.1"
+                "source": "https://github.com/alexdebril/feed-io/tree/v5.3.2"
             },
-            "time": "2022-10-26T20:20:14+00:00"
+            "time": "2023-10-24T15:16:47+00:00"
         },
         {
             "name": "debril/rss-atom-bundle",
@@ -3919,16 +3919,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.17.0",
+            "version": "3.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "bd4c9b26849d82364119c68429541f1631fba94b"
+                "reference": "015633a05aee22490495159237a5944091d8281e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/bd4c9b26849d82364119c68429541f1631fba94b",
-                "reference": "bd4c9b26849d82364119c68429541f1631fba94b",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/015633a05aee22490495159237a5944091d8281e",
+                "reference": "015633a05aee22490495159237a5944091d8281e",
                 "shasum": ""
             },
             "require": {
@@ -3957,7 +3957,7 @@
                 "google/cloud-storage": "^1.23",
                 "microsoft/azure-storage-blob": "^1.1",
                 "phpseclib/phpseclib": "^3.0.14",
-                "phpstan/phpstan": "^0.12.26",
+                "phpstan/phpstan": "^1.10",
                 "phpunit/phpunit": "^9.5.11|^10.0",
                 "sabre/dav": "^4.3.1"
             },
@@ -3993,7 +3993,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.17.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.18.0"
             },
             "funding": [
                 {
@@ -4005,7 +4005,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-05T20:15:05+00:00"
+            "time": "2023-10-20T17:59:40+00:00"
         },
         {
             "name": "league/flysystem-aws-s3-v3",
@@ -4075,16 +4075,16 @@
         },
         {
             "name": "league/flysystem-local",
-            "version": "3.16.0",
+            "version": "3.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem-local.git",
-                "reference": "ec7383f25642e6fd4bb0c9554fc2311245391781"
+                "reference": "e7381ef7643f658b87efb7dbe98fe538fb1bbf32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/ec7383f25642e6fd4bb0c9554fc2311245391781",
-                "reference": "ec7383f25642e6fd4bb0c9554fc2311245391781",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/e7381ef7643f658b87efb7dbe98fe538fb1bbf32",
+                "reference": "e7381ef7643f658b87efb7dbe98fe538fb1bbf32",
                 "shasum": ""
             },
             "require": {
@@ -4119,7 +4119,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem-local/issues",
-                "source": "https://github.com/thephpleague/flysystem-local/tree/3.16.0"
+                "source": "https://github.com/thephpleague/flysystem-local/tree/3.18.0"
             },
             "funding": [
                 {
@@ -4131,7 +4131,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-30T10:23:59+00:00"
+            "time": "2023-10-19T20:07:13+00:00"
         },
         {
             "name": "league/html-to-markdown",
@@ -6479,16 +6479,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.23",
+            "version": "3.0.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "866cc78fbd82462ffd880e3f65692afe928bed50"
+                "reference": "33fa69b2514a61138dd48e7a49f99445711e0ad0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/866cc78fbd82462ffd880e3f65692afe928bed50",
-                "reference": "866cc78fbd82462ffd880e3f65692afe928bed50",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/33fa69b2514a61138dd48e7a49f99445711e0ad0",
+                "reference": "33fa69b2514a61138dd48e7a49f99445711e0ad0",
                 "shasum": ""
             },
             "require": {
@@ -6569,7 +6569,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.23"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.33"
             },
             "funding": [
                 {
@@ -6585,7 +6585,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-18T17:22:01+00:00"
+            "time": "2023-10-21T14:00:39+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",

--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -60,7 +60,3 @@ when@prod:
                 type: console
                 process_psr_3_messages: false
                 channels: ["!event", "!doctrine"]
-            deprecation:
-                type: stream
-                channels: [deprecation]
-                path: php://stderr

--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -26,6 +26,10 @@ when@dev:
                 type: console
                 process_psr_3_messages: false
                 channels: ["!event", "!doctrine", "!console"]
+            deprecation:
+                type: stream
+                channels: [deprecation]
+                path: php://stderr
 
 when@test:
     monolog:

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -10,8 +10,6 @@ security:
             entity:
                 class: App\Entity\User
 
-    enable_authenticator_manager: true
-
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/

--- a/docs/docker_deployment_guide.md
+++ b/docs/docker_deployment_guide.md
@@ -197,7 +197,7 @@ docker compose down
 docker compose up -d
 ```
 
-4. Clear the caches, see section below "Clear cache".
+4. Clear the caches, see section below "Clear caches".
 
 ## Clear caches
 

--- a/src/Security/OAuth/ClientCredentialsGrant.php
+++ b/src/Security/OAuth/ClientCredentialsGrant.php
@@ -65,7 +65,7 @@ class ClientCredentialsGrant extends AbstractGrant
         ServerRequestInterface $request,
         ResponseTypeInterface $responseType,
         \DateInterval $accessTokenTTL
-    ) {
+    ): ResponseTypeInterface {
         list($clientId) = $this->getClientCredentials($request);
 
         $client = $this->getKbinClientEntityOrFail($clientId, $request);
@@ -96,7 +96,7 @@ class ClientCredentialsGrant extends AbstractGrant
         return $responseType;
     }
 
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return 'client_credentials';
     }

--- a/src/Security/UserChecker.php
+++ b/src/Security/UserChecker.php
@@ -19,7 +19,7 @@ class UserChecker implements UserCheckerInterface
     ) {
     }
 
-    public function checkPreAuth(UserInterface $user)
+    public function checkPreAuth(UserInterface $user): void
     {
         if (!$user instanceof AppUser) {
             return;
@@ -35,7 +35,7 @@ class UserChecker implements UserCheckerInterface
         }
     }
 
-    public function checkPostAuth(UserInterface $user)
+    public function checkPostAuth(UserInterface $user): void
     {
         if (!$user instanceof AppUser) {
             return;

--- a/src/Validator/Unique.php
+++ b/src/Validator/Unique.php
@@ -21,7 +21,7 @@ class Unique extends Constraint
 {
     public const NOT_UNIQUE_ERROR = 'eec1b008-c55b-4d91-b5ad-f0b201eb8ada';
 
-    protected static $errorNames = [
+    protected const ERROR_NAMES = [
         self::NOT_UNIQUE_ERROR => 'NOT_UNIQUE_ERROR',
     ];
 

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -38,9 +38,8 @@ abstract class WebTestCase extends BaseWebTestCase
 
     protected string $kibbyPath;
 
-    public function __construct($name = null, array $data = [], $dataName = '')
+    public function setUp(): void
     {
-        parent::__construct($name, $data, $dataName);
         $this->users = new ArrayCollection();
         $this->magazines = new ArrayCollection();
         $this->entries = new ArrayCollection();


### PR DESCRIPTION
We are at part 5 already of fixing errors, warning,  deprecation messages/clean-ups inside our code base:

- Ran: `composer update`
- Remove deprecation channel to stderr from prod completely in `monolog.yaml`
- Introduce deprecation channel to stderr in dev 
- ~~Ran composer recipe `symfony/webpack-encore-bundle`~~ Despite it still "worked".. This recipe upgrade caused some strange page-reload behavior. So I rolled-back.
- Fix various deprecation problems in our code-base
- Null check on mercure-url in `event-source.js` (return `null` otherwise)
- Increase mercure reconnect setTimeout to 10s (10000ms) plus `null` check
- README.md improvements (dev setup)
- Contributing.md improved with unit-testing section

