### PR TITLE
fix inline link preview basically imploded when trying open preview

### DIFF
--- a/assets/controllers/preview_controller.js
+++ b/assets/controllers/preview_controller.js
@@ -18,28 +18,21 @@ export default class extends Controller {
     async show(event) {
         event.preventDefault();
 
-        let element = this.element;
+        let container = this.element.nextElementSibling && this.element.nextElementSibling.classList.contains('js-container')
+            ? this.element.nextElementSibling : null;
 
-        if (element.classList.contains('preview')) {
-            element = element.parentElement.previousElementSibling;
-            this.element.remove();
+        if (null === container) {
+            container = document.createElement('div');
+            container.classList.add('js-container');
+            container.style.display = 'none';
+            this.element.insertAdjacentHTML('afterend', container.outerHTML);
         } else {
-            let container = this.element.nextElementSibling && this.element.nextElementSibling.classList.contains('js-container')
-                ? this.element.nextElementSibling : null;
-
-            if (null === container) {
-                container = document.createElement('div');
-                container.classList.add('js-container');
-                container.style.display = 'none';
-                this.element.insertAdjacentHTML('afterend', container.outerHTML);
-            } else {
-                if (container.querySelector('.preview')) {
-                    container.querySelector('.preview').remove();
-                    if (0 === container.children.length) {
-                        container.remove();
-                    }
-                    return;
+            if (container.querySelector('.preview')) {
+                container.querySelector('.preview').remove();
+                if (0 === container.children.length) {
+                    container.remove();
                 }
+                return;
             }
         }
 
@@ -51,20 +44,14 @@ export default class extends Controller {
             response = await ok(response);
             response = await response.json();
 
-            element.nextElementSibling.insertAdjacentHTML('afterbegin', response.html);
-            element.nextElementSibling.style.display = 'block';
+            this.element.nextElementSibling.insertAdjacentHTML('afterbegin', response.html);
+            this.element.nextElementSibling.style.display = 'block';
             if (event.params.ratio) {
-                element.nextElementSibling.querySelector('.preview').classList.add('ratio');
+                this.element.nextElementSibling.querySelector('.preview').classList.add('ratio');
             }
             this.loadScripts(response.html);
         } catch (e) {
-            const failedHtml = '<div class="preview" data-controller="preview">' + 
-                                '<a class="retry-failed" href="#" ' + 
-                                    'data-action="preview#show" data-preview-url-param="' + event.params.url +
-                                    '" data-preview-ratio-param="' + event.params.ratio + '">' +
-                                'Failed to load. Click to retry.</a></div>';
-            element.nextElementSibling.insertAdjacentHTML('afterbegin', failedHtml);
-            element.nextElementSibling.style.display = 'block';
+            window.location.href = event.target.href;
         } finally {
             this.loadingValue = false;
         }

--- a/assets/controllers/preview_controller.js
+++ b/assets/controllers/preview_controller.js
@@ -18,7 +18,8 @@ export default class extends Controller {
     async show(event) {
         event.preventDefault();
 
-        let container = this.element.nextElementSibling && this.element.nextElementSibling.classList.contains('js-container')
+        let container = this.element.nextElementSibling
+                && this.element.nextElementSibling.classList.contains('js-container')
             ? this.element.nextElementSibling : null;
 
         if (null === container) {
@@ -51,7 +52,18 @@ export default class extends Controller {
             }
             this.loadScripts(response.html);
         } catch (e) {
-            window.location.href = event.target.href;
+            console.error('preview failed: ', e);
+            let failedHtml =
+                `<div class="preview">
+                    <a class="retry-failed" href="#"
+                        data-action="preview#show"
+                        data-preview-url-param="${event.params.url}"
+                        data-preview-ratio-param="${event.params.ratio}">
+                            Failed to load. Click to retry.
+                    </a>
+                </div>`
+            this.element.nextElementSibling.insertAdjacentHTML('afterbegin', failedHtml);
+            this.element.nextElementSibling.style.display = 'block';
         } finally {
             this.loadingValue = false;
         }

--- a/assets/controllers/preview_controller.js
+++ b/assets/controllers/preview_controller.js
@@ -18,7 +18,7 @@ export default class extends Controller {
         // workaround: give itself a container if it couldn't find one
         // I am not happy with this
         if (!this.hasContainerTarget && this.element.matches('span.preview')) {
-            let container = this.createContainerTarget();
+            let container = this.createContainerTarget('preview-target');
             this.element.insertAdjacentElement('beforeend', container);
             console.warn('unable to find container target, creating one for itself at', this.element.lastChild);
         }

--- a/assets/controllers/preview_controller.js
+++ b/assets/controllers/preview_controller.js
@@ -14,6 +14,24 @@ export default class extends Controller {
 
     connect() {
         useThrottle(this, {wait: 1000});
+
+        // workaround: give itself a container if it couldn't find one
+        // I am not happy with this
+        if (!this.hasContainerTarget && this.element.matches('span.preview')) {
+            let container = this.createContainerTarget();
+            this.element.insertAdjacentElement('beforeend', container);
+            console.warn('unable to find container target, creating one for itself at', this.element.lastChild);
+        }
+    }
+
+    createContainerTarget(extraClasses) {
+        let classes = [].concat(extraClasses ?? []);
+
+        let div = document.createElement('div');
+        div.classList.add(...classes, 'hidden');
+        div.dataset.previewTarget = 'container';
+
+        return div;
     }
 
     async retry(event) {

--- a/assets/controllers/preview_controller.js
+++ b/assets/controllers/preview_controller.js
@@ -16,13 +16,17 @@ export default class extends Controller {
         useThrottle(this, {wait: 1000});
     }
 
-    async show(event) {
+    async retry(event) {
         event.preventDefault();
 
-        if (!this.hasContainerTarget) {
-            console.warn('display target not found, bailing out');
-            return;
-        }
+        this.containerTarget.replaceChildren();
+        this.containerTarget.classList.add('hidden');
+
+        await this.show(event);
+    }
+
+    async show(event) {
+        event.preventDefault();
 
         if (this.containerTarget.hasChildNodes()) {
             this.containerTarget.replaceChildren();
@@ -51,7 +55,7 @@ export default class extends Controller {
             let failedHtml =
                 `<div class="preview">
                     <a class="retry-failed" href="#"
-                        data-action="preview#show"
+                        data-action="preview#retry"
                         data-preview-url-param="${event.params.url}"
                         data-preview-ratio-param="${event.params.ratio}">
                             Failed to load. Click to retry.

--- a/assets/styles/components/_entry.scss
+++ b/assets/styles/components/_entry.scss
@@ -348,8 +348,8 @@
       h1,h2,h3,h4,h5,h6{
         margin: 1rem auto;
       }
-      h1{       
-        font-size: 1.25rem;      
+      h1{
+        font-size: 1.25rem;
       }
       h2{
         font-size: 1.20rem;
@@ -366,7 +366,6 @@
       h6{
         font-size: 1rem;
       }
-      
     }
 
     .no-image-placeholder {
@@ -374,17 +373,12 @@
     }
 
     .rounded-edges .view-compact & figure {
-      border-top-right-radius: 0 !important;
+      border-bottom-right-radius: 0;
     }
 
     @include media-breakpoint-down(sm) {
-      .rounded-edges & figure {
-        border-top-left-radius: 0 !important;
-        border-top-right-radius: 0 !important;
-      }
-
       .rounded-edges .view-compact & figure {
-        border-top-right-radius: var(--kbin-rounded-edges-radius);
+        border-bottom-right-radius: var(--kbin-rounded-edges-radius);
       }
     }
   }

--- a/assets/styles/components/_entry.scss
+++ b/assets/styles/components/_entry.scss
@@ -8,6 +8,7 @@
                        "vote image shortDesc"
                        "vote image meta"
                        "vote image footer"
+                       "preview preview preview"
                        "body body body";
   grid-template-columns: min-content min-content 1fr;
   grid-template-rows: 1fr min-content;
@@ -40,6 +41,7 @@
                          "shortDesc shortDesc"
                          "meta meta"
                          "footer footer"
+                         "preview preview"
                          "body body";
     grid-template-columns: min-content 1fr;
 
@@ -64,6 +66,7 @@
       grid-template-areas: "title title vote"
                        "meta meta image"
                        "footer footer image"
+                       "preview preview preview"
                        "body body body";
       grid-template-columns: 1fr min-content min-content;
 
@@ -93,6 +96,7 @@
       grid-template-areas: "vote title image"
                        "vote meta image"
                        "vote footer image"
+                       "preview preview preview"
                        "body body body";
       grid-template-columns: min-content 1fr min-content;
 
@@ -250,6 +254,11 @@
       font-size: .85rem;
       margin: 0 var(--kbin-entry-element-spacing) 1rem 0;
     }
+  }
+
+  &__preview {
+    grid-area: preview;
+    margin: 0.5rem;
   }
 
   &__body {

--- a/assets/styles/components/_preview.scss
+++ b/assets/styles/components/_preview.scss
@@ -25,6 +25,14 @@
   }
 }
 
+.preview-target {
+  margin: 0.5rem 0;
+
+  &:not(.hidden) {
+    display: block;
+  }
+}
+
 // Credit: Nicolas Gallagher and SUIT CSS.
 .ratio {
   --aspect-ratio: 16 / 9;

--- a/src/Controller/AjaxController.php
+++ b/src/Controller/AjaxController.php
@@ -17,6 +17,7 @@ use App\Repository\EntryRepository;
 use App\Repository\NotificationRepository;
 use App\Repository\PostCommentRepository;
 use App\Repository\UserRepository;
+use App\Service\ImageManager;
 use App\Service\UserNoteManager;
 use App\Utils\Embed;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -60,10 +61,20 @@ class AjaxController extends AbstractController
     public function fetchEmbed(Embed $embed, Request $request): JsonResponse
     {
         $data = $embed->fetch($request->get('url'));
+        // only wrap embed link for image embed as it doesn't make much sense for any other type for embed
+        if ($data->isImageUrl()) {
+            $html = sprintf(
+                '<a href="%s" class="embed-link">%s</a>',
+                $data->url,
+                $data->html
+            );
+        } else {
+            $html = $data->html;
+        }
 
         return new JsonResponse(
             [
-                'html' => sprintf('<a href="%s" class="embed-link"><div class="preview">%s</div></a>', $data->url, $data->html),
+                'html' => sprintf('<div class="preview">%s</div>', $html),
             ]
         );
     }

--- a/src/Controller/AjaxController.php
+++ b/src/Controller/AjaxController.php
@@ -17,7 +17,6 @@ use App\Repository\EntryRepository;
 use App\Repository\NotificationRepository;
 use App\Repository\PostCommentRepository;
 use App\Repository\UserRepository;
-use App\Service\ImageManager;
 use App\Service\UserNoteManager;
 use App\Utils\Embed;
 use Symfony\Component\HttpFoundation\JsonResponse;

--- a/src/Markdown/CommonMark/EmbedElement.php
+++ b/src/Markdown/CommonMark/EmbedElement.php
@@ -46,7 +46,7 @@ class EmbedElement
                 new HtmlElement(
                     'span',
                     [
-                        'class' => 'hidden',
+                        'class' => 'preview-target hidden',
                         'data-preview-target' => 'container',
                     ]
                 ),

--- a/src/Markdown/CommonMark/EmbedElement.php
+++ b/src/Markdown/CommonMark/EmbedElement.php
@@ -32,13 +32,23 @@ class EmbedElement
                         [
                             'class' => 'fas fa-photo-video',
                         ],
-                        ''
                     ),
                 ),
                 new HtmlElement(
                     'a',
-                    ['href' => $url, 'rel' => 'nofollow noopener noreferrer', 'target' => '_blank'],
+                    [
+                        'href' => $url,
+                        'rel' => 'nofollow noopener noreferrer',
+                        'target' => '_blank',
+                    ],
                     $label
+                ),
+                new HtmlElement(
+                    'span',
+                    [
+                        'class' => 'hidden',
+                        'data-preview-target' => 'container',
+                    ]
                 ),
             ]
         );

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -116,6 +116,7 @@
                     subject: entry,
                 }) }}
             {% endif %}
+            <aside class="entry__preview hidden" data-preview-target="container"></aside>
             <footer>
                 {% if entry.visibility in ['visible', 'private'] %}
                     <menu>


### PR DESCRIPTION
so basically this is a revert/reimplementation of #109, plus some of my personal touches.

the merged changes probably worked nicely when previewing from an entry listing/card, but it seems to cause regression in inline link preview as it basically made the link implodes when trying to open the preview

![link-implode-demo](https://github.com/MbinOrg/mbin/assets/20770492/0af6eeab-e69c-491d-ab8b-0279151a30b6)

- revert/reimplement changes that #109 set out to do (or at least how I understand what it should do)
- fix inline link preview self destruct when trying to open preview
- change the preview container selection/manipulation to be stimulus target based instead of the old sibling node dancing, which should be more robust and simpler work with, though this does come with some tradeoff: the entry preview is now inside the entry itself instead of after or between the entry card.
- when fetching embed, only wrap embed link when it's image embed as it doesn't make much sense for other type for embed, and can cause some usability issues like suddenly being able to drag a `<video>` element when trying to drag its seek bar.

![image](https://github.com/MbinOrg/mbin/assets/20770492/acf13987-b71b-4fa2-ab1e-17015d24ca54)  
(the preview is now inside the entry card)

![image](https://github.com/MbinOrg/mbin/assets/20770492/c812a296-26c8-4d09-ae10-37a8bcd16997)  
(both entry preview (top) and inline preview (middle, bottom) expanded)