### PR TITLE
Remove height 100% from label class in settings

### DIFF
--- a/assets/styles/components/_settings_row.scss
+++ b/assets/styles/components/_settings_row.scss
@@ -27,7 +27,6 @@
   .label {
     grid-area: label;
     line-height: normal;
-    height: 100%;
     align-items: center;
     display: flex;
     margin-left: .375rem;


### PR DESCRIPTION
Fixes: https://github.com/MbinOrg/mbin/issues/148


Before:

![image](https://github.com/MbinOrg/mbin/assets/628926/46576c51-f60a-4be2-8ccb-a220c7f09d3b)


After:

![image](https://github.com/MbinOrg/mbin/assets/628926/8d82f947-1b07-49d2-9bf2-74e003b24a86)


Ps. Yes this is WebKit under Linux.