### PR TITLE
Explain Nginx setup for Docker (and bare metal for www)

### DIFF
--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -409,12 +409,12 @@ gzip_types
 sudo nano /etc/nginx/sites-available/kbin.conf
 ```
 
-Content of `kbin.conf`:
+With the content:
 
-```kbin.conf
+```conf
 # Redirect HTTP to HTTPS
 server {
-    server_name domain.tld www.domain.tld;
+    server_name domain.tld;
     listen 80;
 
     return 301 https://$host$request_uri;
@@ -422,7 +422,7 @@ server {
 
 server {
     listen 443 ssl http2;
-    server_name domain.tld www.domain.tld;
+    server_name domain.tld;
 
     root /var/www/kbin/public;
 
@@ -518,6 +518,34 @@ server {
     location ~ \.php$ {
         return 404;
     }
+}
+```
+
+**Important:** If also want to also configure your `www.domain.tld` subdomain; our advise is to use a HTTP 301 redirect from the `www` subdomain towards the root domain. Do _NOT_ try to setup a double instance (you want to _avoid_ that ActivityPub will see `www` as a separate instance). See Nginx example below:
+
+```conf
+# Example of a 301 redirect response for the www subdomain
+server {
+    listen 80;
+    server_name www.domain.tld;
+    if ($host = www.domain.tld) {
+        return 301 https://domain.tld$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name www.domain.tld;
+
+    # TLS
+    ssl_certificate /etc/letsencrypt/live/domain.tld/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/domain.tld/privkey.pem;
+
+    # Don't leak powered-by
+    fastcgi_hide_header X-Powered-By;
+
+    return 301 https://domain.tld$request_uri;
 }
 ```
 

--- a/docs/docker_deployment_guide.md
+++ b/docs/docker_deployment_guide.md
@@ -181,11 +181,6 @@ files.
 NGINX reverse proxy example for the Mbin Docker instance:
 
 ```conf
-map $http_upgrade $connection_upgrade {
-    default upgrade;
-    ''      close;
-}
-
 # Redirect HTTP to HTTPS
 server {
     server_name domain.tld;
@@ -225,9 +220,6 @@ server {
     access_log /var/log/nginx/mbin_access.log;
 
     location / {
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
         proxy_set_header HOST $host;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/docs/docker_deployment_guide.md
+++ b/docs/docker_deployment_guide.md
@@ -237,7 +237,7 @@ server {
     }
 
     location /.well-known/mercure {
-        proxy_pass http://127.0.0.1:8080$request_uri;
+        proxy_pass http://127.0.0.1:8008$request_uri;
         proxy_read_timeout 24h;
         proxy_http_version 1.1;
         proxy_set_header Connection "";

--- a/docs/docker_deployment_guide.md
+++ b/docs/docker_deployment_guide.md
@@ -176,7 +176,7 @@ If you want to deploy your app on a cluster of machines, you can
 use [Docker Swarm](https://docs.docker.com/engine/swarm/stack-deploy/), which is compatible with the provided Compose
 files.
 
-### NGINX
+### Mbin NGINX Server Block
 
 NGINX reverse proxy example for the Mbin Docker instance:
 

--- a/docs/docker_deployment_guide.md
+++ b/docs/docker_deployment_guide.md
@@ -193,8 +193,6 @@ server {
     listen 443 ssl http2;
     server_name domain.tld;
 
-    index index.php;
-
     charset utf-8;
 
     # TLS


### PR DESCRIPTION
- Explain how to use Nginx if you are running the Docker setup
- Add missing section about the `www` subdomain, remove `www` from the server section, this caused a lot of issues for @Jerry-infosecexchange I think.. Sorry.