### PR TITLE
do not translate language options on post box

### DIFF
--- a/templates/form/lang_select.html.twig
+++ b/templates/form/lang_select.html.twig
@@ -2,12 +2,12 @@
 {%- block choice_widget_options -%}
     {% for group_label, choice in options %}
         {%- if choice is iterable -%}
-            <optgroup label="{{ choice_translation_domain is same as(false) ? group_label : group_label|trans({}, choice_translation_domain) }}">
+            <optgroup label="{{ group_label }}">
                 {% set options = choice %}
                 {{- block('choice_widget_options') -}}
             </optgroup>
         {%- elseif render_preferred_choices|default(false) or (not render_preferred_choices|default(false) and choice not in preferred_choices) -%}
-            <option value="{{ choice.value }}"{% if choice.attr %}{% with { attr: choice.attr } %}{{ block('attributes') }}{% endwith %}{% endif %}{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice_translation_domain is same as(false) ? choice.label : choice.label|trans(choice.labelTranslationParameters, choice_translation_domain) }}</option>
+            <option value="{{ choice.value }}"{% if choice.attr %}{% with { attr: choice.attr } %}{{ block('attributes') }}{% endwith %}{% endif %}{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice.label }}</option>
         {%- endif -%}
     {% endfor %}
 {%- endblock choice_widget_options -%}


### PR DESCRIPTION
pages that loaded the reply/comment/post box had 634 translation misses (and likely each time it was added to the page). this was because it attempted to translate the language labels, but languages should not be translated but spelled using their own language

~~I'm still not quite sure I fixed this properly, as I'm not sure what the ternary if was trying to accomplish~~