### PR TITLE
comment reply position - translate top label text

### DIFF
--- a/templates/layout/_options_appearance.html.twig
+++ b/templates/layout/_options_appearance.html.twig
@@ -44,7 +44,7 @@
     </div>
     <strong>{{ 'single_settings'|trans }}</strong>
     <div class="settings-section">
-        {{ component('settings_row_enum', {label: 'comment_reply_position'|trans, help: 'comment_reply_position_help'|trans, settingsKey: 'KBIN_COMMENTS_REPLY_POSITION', values: [ {name: 'top'|trans , value: 'TOP'}, {name: 'bottom'|trans , value: 'BOTTOM' } ], defaultValue: 'TOP' } ) }}
+        {{ component('settings_row_enum', {label: 'comment_reply_position'|trans, help: 'comment_reply_position_help'|trans, settingsKey: 'KBIN_COMMENTS_REPLY_POSITION', values: [ {name: 'position_top'|trans , value: 'TOP'}, {name: 'position_bottom'|trans , value: 'BOTTOM' } ], defaultValue: 'TOP' } ) }}
         {{ component('settings_row_switch', {label: 'show_avatars_on_comments'|trans, help: 'show_avatars_on_comments_help'|trans, settingsKey: 'KBIN_COMMENTS_SHOW_USER_AVATAR', defaultValue: true}) }}
     </div>
 </div>

--- a/templates/layout/_options_appearance.html.twig
+++ b/templates/layout/_options_appearance.html.twig
@@ -44,7 +44,7 @@
     </div>
     <strong>{{ 'single_settings'|trans }}</strong>
     <div class="settings-section">
-        {{ component('settings_row_enum', {label: 'comment_reply_position'|trans, help: 'comment_reply_position_help'|trans, settingsKey: 'KBIN_COMMENTS_REPLY_POSITION', values: [ {name: 'top' , value: 'TOP'}, {name: 'bottom'|trans , value: 'BOTTOM' } ], defaultValue: 'TOP' } ) }}
+        {{ component('settings_row_enum', {label: 'comment_reply_position'|trans, help: 'comment_reply_position_help'|trans, settingsKey: 'KBIN_COMMENTS_REPLY_POSITION', values: [ {name: 'top'|trans , value: 'TOP'}, {name: 'bottom'|trans , value: 'BOTTOM' } ], defaultValue: 'TOP' } ) }}
         {{ component('settings_row_switch', {label: 'show_avatars_on_comments'|trans, help: 'show_avatars_on_comments_help'|trans, settingsKey: 'KBIN_COMMENTS_SHOW_USER_AVATAR', defaultValue: true}) }}
     </div>
 </div>

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -795,5 +795,6 @@ alphabetically: Alphabetically
 subscriptions_in_own_sidebar: Subscriptions separate
 sidebars_same_side: Sidebars on the same side
 close: Close
-bottom: Bottom
+position_bottom: Bottom
+position_top: Top
 pending: Pending

--- a/translations/messages.nl.yaml
+++ b/translations/messages.nl.yaml
@@ -836,7 +836,7 @@ flash_comment_new_success: Reactie is succesvol aangemaakt.
 flash_user_settings_general_error: Kan gebruikersinstellingen niet opslaan.
 alphabetically: Alfabetisch
 flash_email_was_sent: E-mail is succesvol verzonden.
-bottom: Onderkant
+position_bottom: Onderkant
 show_subscriptions: Toon abonnementen
 flash_comment_edit_success: Reactie is succesvol bijgewerkt.
 flash_user_edit_profile_success: Gebruikersprofielinstellingen zijn succesvol opgeslagen.

--- a/translations/messages.nl.yaml
+++ b/translations/messages.nl.yaml
@@ -836,7 +836,7 @@ flash_comment_new_success: Reactie is succesvol aangemaakt.
 flash_user_settings_general_error: Kan gebruikersinstellingen niet opslaan.
 alphabetically: Alfabetisch
 flash_email_was_sent: E-mail is succesvol verzonden.
-position_bottom: Onderkant
+bottom: Onderkant
 show_subscriptions: Toon abonnementen
 flash_comment_edit_success: Reactie is succesvol bijgewerkt.
 flash_user_edit_profile_success: Gebruikersprofielinstellingen zijn succesvol opgeslagen.


### PR DESCRIPTION
focused a bit too much on missing loc entries and missed that top wasn't being translated at all. this translates it, which already existed for "Top" regarding posts. I'm not quite sure if the two usages have the same meanings in all languages so if they don't, we might want to break this out to be a different loc token