### PR TITLE
Introducing stale github action workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: "Close stale issues and PRs"
+on:
+  schedule:
+    - cron: "46 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: "This issue is stale because it has been open 50 days with no activity. Remove stale label or comment or this will be closed in 6 days."
+          stale-pr-message: "This PR is stale because it has been open 40 days with no activity."
+          close-issue-message: "This issue was closed because it has been stalled for 6 days with no activity."
+          exempt-issue-labels: "high priority"
+          days-before-issue-stale: 50
+          days-before-pr-stale: 40
+          days-before-issue-close: 6
+          days-before-pr-close: -1


### PR DESCRIPTION
Introducing [stale github action workflow](https://github.com/actions/stale). With custom settings, I don't want to end-up with the issue lists we had in Codeberg. `-1` on the PRs means it will never close the PRs automatically. 