### PR TITLE
remove autofocus from 2fa setup page

### DIFF
--- a/src/Form/UserTwoFactorType.php
+++ b/src/Form/UserTwoFactorType.php
@@ -24,7 +24,6 @@ class UserTwoFactorType extends AbstractType
                     'mapped' => false,
                     'attr' => [
                         'autocomplete' => 'one-time-code',
-                        'autofocus' => true,
                         'inputmode' => 'numeric',
                         'pattern' => '[0-9]*',
                     ],


### PR DESCRIPTION
when navigating to the setup 2fa page, the input box to enter the code had autofocus, which scrolls the view down to the bottom of the page. users that are setting up 2fa likely want to start at the top of the page and view the QR code first to get the codes instead