### PR TITLE
SubscriptionSidebar: improvements and default changes

### DIFF
--- a/assets/styles/components/_sidebar-subscriptions.scss
+++ b/assets/styles/components/_sidebar-subscriptions.scss
@@ -63,6 +63,9 @@
 
     .subscription {
       padding: 0.5rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
 
       @include media-breakpoint-down(lg) {
         min-width: max-content;
@@ -79,8 +82,11 @@
       }
 
       .magazine-subscription-avatar {
+        margin: 0;
         height: 1.5rem;
+        max-height: 1.5rem;
         width: 1.5rem;
+        max-width: 1.5rem;
         object-fit: scale-down;
         border-radius: 50%;
         display: inline;

--- a/assets/styles/components/_sidebar-subscriptions.scss
+++ b/assets/styles/components/_sidebar-subscriptions.scss
@@ -5,9 +5,28 @@
 .sidebar-subscriptions {
   height: fit-content;
 
+  .sidebar-subscriptions-icons {
+    float: right;
+
+    @include media-breakpoint-down(lg) {
+      display: none;
+    }
+  }
+
   &.inline .subscription-list {
-    max-height: 40em;
+    max-height: 20em;
     overflow: auto;
+    &.lg {
+      max-height: 40em;
+    }
+  }
+
+  &.inline .magazine-subscription-avatar-placeholder {
+    display: inline-block;
+  }
+
+  &:not(.inline) .magazine-subscription-avatar-placeholder {
+    display: none;
   }
 
   &.section {
@@ -70,7 +89,6 @@
 
       .magazine-subscription-avatar-placeholder{
         width: 1.5rem;
-        display: inline-block;
         @include media-breakpoint-down(lg) {
           display: none;
         }
@@ -83,7 +101,8 @@
 
       .magazine-name {
         font-weight: bold;
-        padding: 0.25rem;
+        // padding: 0.25rem;
+        display: inline;
 
         &.has-image {
           @include media-breakpoint-down(lg) {

--- a/assets/styles/components/_sidebar-subscriptions.scss
+++ b/assets/styles/components/_sidebar-subscriptions.scss
@@ -95,7 +95,6 @@
         max-width: 1.5rem;
         object-fit: scale-down;
         border-radius: 50%;
-        display: inline;
         vertical-align: middle;
       }
 

--- a/assets/styles/components/_sidebar-subscriptions.scss
+++ b/assets/styles/components/_sidebar-subscriptions.scss
@@ -2,6 +2,36 @@
   border-radius: 0.5rem;
 }
 
+.kbin-container.width--fixed {
+  .sidebar-subscriptions:not(.inline) .subscription-list .subscription a {
+    max-width: calc(max(305px, 1360px / 6) - 3rem);
+  }
+
+  .sidebar-subscriptions.inline .subscription-list .subscription a {
+    max-width: calc(max(305px, 1360px / 4) - 3rem);
+  }
+}
+
+.kbin-container.width--auto {
+  .sidebar-subscriptions:not(.inline) .subscription-list .subscription a {
+    max-width: calc(max(305px, 85vw / 6) - 3rem);
+  }
+
+  .sidebar-subscriptions.inline .subscription-list .subscription a {
+    max-width: calc(max(305px, 85vw / 4) - 3rem);
+  }
+}
+
+.kbin-container.width--max {
+  .sidebar-subscriptions:not(.inline) .subscription-list .subscription a {
+    max-width: calc(max(305px, 100vw / 6) - 3rem);
+  }
+
+  .sidebar-subscriptions.inline .subscription-list .subscription a {
+    max-width: calc(max(305px, 100vw / 4) - 3rem);
+  }
+}
+
 #sidebar .sidebar-subscriptions,
 .sidebar-subscriptions {
   height: fit-content;

--- a/assets/styles/components/_sidebar-subscriptions.scss
+++ b/assets/styles/components/_sidebar-subscriptions.scss
@@ -96,6 +96,11 @@
         object-fit: scale-down;
         border-radius: 50%;
         vertical-align: middle;
+        &.onlyMobile {
+          @include media-breakpoint-up(lg) {
+            display: none;
+          }
+        }
       }
 
       .magazine-subscription-avatar-placeholder{
@@ -103,12 +108,17 @@
         @include media-breakpoint-down(lg) {
           display: none;
         }
+        &.onlyMobile {
+          @include media-breakpoint-up(lg) {
+            display: none;
+          }
+        }
       }
 
       &.active {
-        border: var(--kbin-header-border);
-
+        background-color: var(--kbin-bg);
       }
+
       a {
         display: inline-block;
         overflow: hidden;
@@ -121,6 +131,11 @@
 
           &.has-image {
             margin-left: .25rem;
+            &.onlyMobile {
+              @include media-breakpoint-up(lg) {
+                margin-left: 0;
+              }
+            }
             @include media-breakpoint-down(lg) {
               display: none;
             }

--- a/assets/styles/components/_sidebar-subscriptions.scss
+++ b/assets/styles/components/_sidebar-subscriptions.scss
@@ -6,6 +6,14 @@
 .sidebar-subscriptions {
   height: fit-content;
 
+  &:not(.inline) {
+    padding: 0 0.5rem;
+  }
+
+  &.inline {
+    padding-bottom: unset;
+  }
+
   .sidebar-subscriptions-icons {
     float: right;
 
@@ -14,7 +22,7 @@
     }
   }
 
-  &.inline .subscription-list {
+  .inline .subscription-list {
     max-height: 20em;
     overflow: auto;
     &.lg {
@@ -22,15 +30,15 @@
     }
   }
 
-  &.inline .magazine-subscription-avatar-placeholder {
+  .inline .magazine-subscription-avatar-placeholder {
     display: inline-block;
   }
 
-  &:not(.inline) .magazine-subscription-avatar-placeholder {
+  :not(.inline) .magazine-subscription-avatar-placeholder {
     display: none;
   }
 
-  &.section {
+  .section {
     padding: 0.5rem 0.5rem 0;
 
     @include media-breakpoint-down(lg) {
@@ -47,7 +55,7 @@
   }
   .subscription-list {
 
-    :first-child {
+    &.meta :first-child {
       border-top: unset;
     }
 

--- a/assets/styles/components/_sidebar-subscriptions.scss
+++ b/assets/styles/components/_sidebar-subscriptions.scss
@@ -2,6 +2,7 @@
   border-radius: 0.5rem;
 }
 
+#sidebar .sidebar-subscriptions,
 .sidebar-subscriptions {
   height: fit-content;
 
@@ -30,29 +31,25 @@
   }
 
   &.section {
-    padding: 0.5rem 0.5rem 1rem;
+    padding: 0.5rem 0.5rem 0;
 
-      &:not(.inline) {
-        @include media-breakpoint-down(lg) {
-          margin: 0.5rem;
-          padding: 0.5rem;
-        }
+    @include media-breakpoint-down(lg) {
+      padding: 0.5rem;
     }
-
   }
 
   h3 {
-    border-bottom: var(--kbin-sidebar-header-border);
-    color: var(--kbin-sidebar-header-text-color);
-    font-size: .8rem;
-    margin: 0;
-    text-transform: uppercase;
+    margin: 0 0 .5rem;
 
     @include media-breakpoint-down(lg) {
       margin: 0;
     }
   }
   .subscription-list {
+
+    :first-child {
+      border-top: unset;
+    }
 
     @include media-breakpoint-down(lg) {
       display: flex;
@@ -63,9 +60,6 @@
 
     .subscription {
       padding: 0.5rem;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
 
       @include media-breakpoint-down(lg) {
         min-width: max-content;
@@ -79,6 +73,10 @@
         @include media-breakpoint-down(lg) {
           border-right: var(--kbin-meta-border);
         }
+      }
+
+      &:last-child {
+        border-bottom: unset;
       }
 
       .magazine-subscription-avatar {
@@ -104,15 +102,21 @@
         border: var(--kbin-header-border);
 
       }
+      a {
+        display: inline-block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
 
-      .magazine-name {
-        font-weight: bold;
-        // padding: 0.25rem;
-        display: inline;
+        .magazine-name {
+          font-weight: bold;
+          display: inline;
 
-        &.has-image {
-          @include media-breakpoint-down(lg) {
-            display: none;
+          &.has-image {
+            margin-left: .25rem;
+            @include media-breakpoint-down(lg) {
+              display: none;
+            }
           }
         }
       }

--- a/assets/styles/components/_sidebar.scss
+++ b/assets/styles/components/_sidebar.scss
@@ -1,4 +1,5 @@
-#sidebar {
+#sidebar,
+.sidebar-subscriptions {
   font-size: .85rem;
   opacity: 1;
   padding-bottom: 1rem;

--- a/assets/styles/layout/_layout.scss
+++ b/assets/styles/layout/_layout.scss
@@ -36,7 +36,7 @@ body {
     @include media-breakpoint-up(lg) {
       .subs-show & {
         grid-template-areas: 'subs main sidebar';
-        grid-template-columns: 1fr 6fr 2fr;
+        grid-template-columns: minmax(305px, 1fr) 4fr minmax(305px, 1fr);
       }
 
       .sidebar-left & {
@@ -46,18 +46,18 @@ body {
 
       .sidebar-left.subs-show & {
         grid-template-areas: 'sidebar main subs';
-        grid-template-columns: 2fr 6fr 1fr;
+        grid-template-columns: minmax(305px, 1fr) 4fr minmax(305px, 1fr);
       }
 
 
       .sidebars-same-side.subs-show & {
         grid-template-areas: 'main sidebar subs ';
-        grid-template-columns: 6fr 2fr 1fr;
+        grid-template-columns: 4fr minmax(305px, 1fr) minmax(305px, 1fr);
       }
 
       .sidebars-same-side.sidebar-left.subs-show & {
         grid-template-areas: 'subs sidebar main';
-        grid-template-columns: 1fr 2fr 6fr;
+        grid-template-columns: minmax(305px, 1fr) minmax(305px, 1fr) 4fr;
       }
     }
 

--- a/assets/styles/layout/_layout.scss
+++ b/assets/styles/layout/_layout.scss
@@ -36,7 +36,7 @@ body {
     @include media-breakpoint-up(lg) {
       .subs-show & {
         grid-template-areas: 'subs main sidebar';
-        grid-template-columns: 1fr 3fr 1fr;
+        grid-template-columns: 1fr 6fr 2fr;
       }
 
       .sidebar-left & {
@@ -46,18 +46,18 @@ body {
 
       .sidebar-left.subs-show & {
         grid-template-areas: 'sidebar main subs';
-        grid-template-columns: 1fr 3fr 1fr;
+        grid-template-columns: 2fr 6fr 1fr;
       }
 
 
       .sidebars-same-side.subs-show & {
         grid-template-areas: 'main sidebar subs ';
-        grid-template-columns: 3fr 1fr 1fr;
+        grid-template-columns: 6fr 2fr 1fr;
       }
 
       .sidebars-same-side.sidebar-left.subs-show & {
         grid-template-areas: 'subs sidebar main';
-        grid-template-columns: 1fr 1fr 3fr;
+        grid-template-columns: 1fr 2fr 6fr;
       }
     }
 

--- a/src/Controller/User/ThemeSettingsController.php
+++ b/src/Controller/User/ThemeSettingsController.php
@@ -35,11 +35,12 @@ class ThemeSettingsController extends AbstractController
     public const KBIN_FEDERATION_ENABLED = 'kbin_federation_enabled';
     public const KBIN_COMMENTS_SHOW_USER_AVATAR = 'kbin_comments_show_user_avatar';
     public const KBIN_COMMENTS_REPLY_POSITION = 'kbin_comments_reply_position';
-    public const KBIN_GENERAL_SHOW_SUBSCRIPTIONS = 'kbin_general_show_subscriptions';
-    public const KBIN_GENERAL_SHOW_SUBSCRIPTIONS_SORT = 'kbin_general_show_subscriptions_sort';
-    public const KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE = 'kbin_general_show_subscriptions_seperate';
-    public const KBIN_GENERAL_SIDEBARS_SAME_SIDE = 'kbin_general_sidebars_same_side';
-    public const KBIN_GENERAL_SHOW_SUBSCRIPTIONS_LARGE = 'kbin_general_show_subscriptions_large';
+    public const KBIN_SUBSCRIPTIONS_SHOW = 'kbin_subscriptions_show';
+    public const KBIN_SUBSCRIPTIONS_SORT = 'kbin_subscriptions_sort';
+    public const KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR = 'kbin_subscriptions_in_separate_sidebar';
+    public const KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE = 'kbin_subscriptions_sidebars_same_side';
+    public const KBIN_SUBSCRIPTIONS_LARGE_PANEL = 'kbin_subscriptions_large_panel';
+    public const KBIN_SUBSCRIPTIONS_SHOW_MAGAZINE_ICON = 'kbin_subscriptions_show_magazine_icon';
 
     public const CLASSIC = 'classic';
     public const CHAT = 'chat';
@@ -87,11 +88,12 @@ class ThemeSettingsController extends AbstractController
         self::KBIN_LANG,
         self::KBIN_COMMENTS_SHOW_USER_AVATAR,
         self::KBIN_COMMENTS_REPLY_POSITION,
-        self::KBIN_GENERAL_SHOW_SUBSCRIPTIONS,
-        self::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_SORT,
-        self::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE,
-        self::KBIN_GENERAL_SIDEBARS_SAME_SIDE,
-        self::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_LARGE,
+        self::KBIN_SUBSCRIPTIONS_SHOW,
+        self::KBIN_SUBSCRIPTIONS_SORT,
+        self::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR,
+        self::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE,
+        self::KBIN_SUBSCRIPTIONS_LARGE_PANEL,
+        self::KBIN_SUBSCRIPTIONS_SHOW_MAGAZINE_ICON,
     ];
 
     public const VALUES = [

--- a/src/Controller/User/ThemeSettingsController.php
+++ b/src/Controller/User/ThemeSettingsController.php
@@ -39,6 +39,7 @@ class ThemeSettingsController extends AbstractController
     public const KBIN_GENERAL_SHOW_SUBSCRIPTIONS_SORT = 'kbin_general_show_subscriptions_sort';
     public const KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE = 'kbin_general_show_subscriptions_seperate';
     public const KBIN_GENERAL_SIDEBARS_SAME_SIDE = 'kbin_general_sidebars_same_side';
+    public const KBIN_GENERAL_SHOW_SUBSCRIPTIONS_LARGE = 'kbin_general_show_subscriptions_large';
 
     public const CLASSIC = 'classic';
     public const CHAT = 'chat';
@@ -90,6 +91,7 @@ class ThemeSettingsController extends AbstractController
         self::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_SORT,
         self::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE,
         self::KBIN_GENERAL_SIDEBARS_SAME_SIDE,
+        self::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_LARGE,
     ];
 
     public const VALUES = [
@@ -109,6 +111,8 @@ class ThemeSettingsController extends AbstractController
         self::RIGHT,
         self::TOP,
         self::BOTTOM,
+        self::ALPHABETICALLY,
+        self::LAST_ACTIVE,
         '80',
         '90',
         '100',

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -24,31 +24,6 @@
 
     {% block stylesheets %}
         {{ encore_entry_link_tags('app') }}
-            <style>
-                {#
-                This is needed so the magazine names in the subscription panel are correctly overflowing.
-                The max width depends on the max-width of the whole container, which is controlled by a setting (KBIN_PAGE_WIDTH)
-                 #}
-                .subscription-list .subscription a {
-                    {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR')) is same as 'true' %}
-                        {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH')) is same as constant('App\\Controller\\User\\ThemeSettingsController::MAX') %}
-                            max-width: calc(100vw / 9 - 3rem);
-                        {% elseif app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH')) is same as constant('App\\Controller\\User\\ThemeSettingsController::AUTO') %}
-                            max-width: calc(85vw / 9 - 3rem);
-                        {% else %}
-                            max-width: calc(1360px / 9 - 3rem);
-                        {% endif%}
-                    {% else %}
-                        {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH')) is same as constant('App\\Controller\\User\\ThemeSettingsController::MAX') %}
-                            max-width: calc(100vw / 4 - 3.5rem);
-                        {% elseif app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH')) is same as constant('App\\Controller\\User\\ThemeSettingsController::AUTO') %}
-                            max-width: calc(85vw / 4 - 3.5rem);
-                        {% else %}
-                            max-width: calc(1360px / 4 - 3.5rem);
-                        {% endif%}
-                    {% endif %}
-                }
-            </style>
     {% endblock %}
 
     {% block javascripts %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -30,13 +30,13 @@
                 The max width depends on the max-width of the whole container, which is controlled by a setting (KBIN_PAGE_WIDTH)
                  #}
                 .subscription-list .subscription a {
-                    {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is same as 'true' %}
+                    {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR')) is same as 'true' %}
                         {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH')) is same as constant('App\\Controller\\User\\ThemeSettingsController::MAX') %}
-                            max-width: calc(100vw / 9);
+                            max-width: calc(100vw / 9 - 3rem);
                         {% elseif app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH')) is same as constant('App\\Controller\\User\\ThemeSettingsController::AUTO') %}
-                            max-width: calc(85vw / 9);
+                            max-width: calc(85vw / 9 - 3rem);
                         {% else %}
-                            max-width: calc(1360px / 9);
+                            max-width: calc(1360px / 9 - 3rem);
                         {% endif%}
                     {% else %}
                         {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH')) is same as constant('App\\Controller\\User\\ThemeSettingsController::MAX') %}
@@ -93,8 +93,8 @@
         'topbar': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_TOPBAR')) is same as 'true',
         'fixed-navbar': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_FIXED_NAVBAR')) is same as 'true',
         'sidebar-left': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT'),
-        'subs-show': app.user is defined and app.user is not same as null and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS')) is not same as 'false' and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is same as 'true',
-        'sidebars-same-side': app.user is defined and app.user is not same as null and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is same as 'true' and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE')) is same as 'true',
+        'subs-show': app.user is defined and app.user is not same as null and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SHOW')) is not same as 'false' and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR')) is same as 'true',
+        'sidebars-same-side': app.user is defined and app.user is not same as null and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR')) is same as 'true' and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE')) is same as 'true',
     }) }}" data-controller="kbin notifications">
 {% include 'layout/_header.html.twig' with {header_nav: block('header_nav')} %}
 <div id="middle" class="{%- block mainClass -%}page{%- endblock %}">
@@ -112,10 +112,10 @@
                 {% include 'layout/_sidebar.html.twig' with {sidebar_top: block('sidebar_top'), header_nav: block('header_nav')} %}
             {% endblock %}
         </aside>
-        {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::FALSE') and
-            app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') and
+        {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SHOW')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::FALSE') and
+            app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') and
             app.user is defined and app.user is not same as null %}
-            {{ component('sidebar_subscriptions', { openMagazine: magazine is defined ? magazine : null, user: app.user, sort: app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_SORT'))}) }}
+            {{ component('sidebar_subscriptions', { openMagazine: magazine is defined ? magazine : null, user: app.user, sort: app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SORT'))}) }}
         {% endif %}
     </div>
 </div>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -68,7 +68,7 @@
         'topbar': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_TOPBAR')) is same as 'true',
         'fixed-navbar': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_FIXED_NAVBAR')) is same as 'true',
         'sidebar-left': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT'),
-        'subs-show': app.user is defined and app.user is not same as null and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS')) is same as 'true' and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is same as 'true',
+        'subs-show': app.user is defined and app.user is not same as null and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS')) is not same as 'false' and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is same as 'true',
         'sidebars-same-side': app.user is defined and app.user is not same as null and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is same as 'true' and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE')) is same as 'true',
     }) }}" data-controller="kbin notifications">
 {% include 'layout/_header.html.twig' with {header_nav: block('header_nav')} %}
@@ -87,8 +87,8 @@
                 {% include 'layout/_sidebar.html.twig' with {sidebar_top: block('sidebar_top'), header_nav: block('header_nav')} %}
             {% endblock %}
         </aside>
-        {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS')) is same as 'true' and
-            app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is same as 'true' and
+        {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::FALSE') and
+            app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') and
             app.user is defined and app.user is not same as null %}
             {{ component('sidebar_subscriptions', { openMagazine: magazine is defined ? magazine : null, user: app.user, sort: app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_SORT'))}) }}
         {% endif %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -24,21 +24,31 @@
 
     {% block stylesheets %}
         {{ encore_entry_link_tags('app') }}
-        <style>
-            {#
-            This is needed so the magazine names in the subscription panel are correctly overflowing.
-            The max width depends on the max-width of the whole container, which is controlled by a setting (KBIN_PAGE_WIDTH)
-             #}
-            .subscription-list .subscription {
-                {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH')) is same as constant('App\\Controller\\User\\ThemeSettingsController::MAX') %}
-                    max-width: calc(100vw / 9);
-                {% elseif app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH')) is same as constant('App\\Controller\\User\\ThemeSettingsController::AUTO') %}
-                    max-width: calc(85vw / 9);
-                {% else %}
-                    max-width: calc(1360px / 9);
-                {% endif%}
-            }
-        </style>
+            <style>
+                {#
+                This is needed so the magazine names in the subscription panel are correctly overflowing.
+                The max width depends on the max-width of the whole container, which is controlled by a setting (KBIN_PAGE_WIDTH)
+                 #}
+                .subscription-list .subscription a {
+                    {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is same as 'true' %}
+                        {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH')) is same as constant('App\\Controller\\User\\ThemeSettingsController::MAX') %}
+                            max-width: calc(100vw / 9);
+                        {% elseif app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH')) is same as constant('App\\Controller\\User\\ThemeSettingsController::AUTO') %}
+                            max-width: calc(85vw / 9);
+                        {% else %}
+                            max-width: calc(1360px / 9);
+                        {% endif%}
+                    {% else %}
+                        {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH')) is same as constant('App\\Controller\\User\\ThemeSettingsController::MAX') %}
+                            max-width: calc(100vw / 4 - 3.5rem);
+                        {% elseif app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH')) is same as constant('App\\Controller\\User\\ThemeSettingsController::AUTO') %}
+                            max-width: calc(85vw / 4 - 3.5rem);
+                        {% else %}
+                            max-width: calc(1360px / 4 - 3.5rem);
+                        {% endif%}
+                    {% endif %}
+                }
+            </style>
     {% endblock %}
 
     {% block javascripts %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -24,6 +24,21 @@
 
     {% block stylesheets %}
         {{ encore_entry_link_tags('app') }}
+        <style>
+            {#
+            This is needed so the magazine names in the subscription panel are correctly overflowing.
+            The max width depends on the max-width of the whole container, which is controlled by a setting (KBIN_PAGE_WIDTH)
+             #}
+            .subscription-list .subscription {
+                {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH')) is same as constant('App\\Controller\\User\\ThemeSettingsController::MAX') %}
+                    max-width: calc(100vw / 9);
+                {% elseif app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH')) is same as constant('App\\Controller\\User\\ThemeSettingsController::AUTO') %}
+                    max-width: calc(85vw / 9);
+                {% else %}
+                    max-width: calc(1360px / 9);
+                {% endif%}
+            }
+        </style>
     {% endblock %}
 
     {% block javascripts %}

--- a/templates/layout/_options_appearance.html.twig
+++ b/templates/layout/_options_appearance.html.twig
@@ -20,11 +20,7 @@
             {{ component('settings_row_switch', {label: 'show_subscriptions'|trans, settingsKey: 'KBIN_GENERAL_SHOW_SUBSCRIPTIONS', defaultValue: 'true'}) }}
             {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS')) is not same as 'false' %}
                 {{ component('settings_row_enum', {label: 'subscription_sort'|trans, settingsKey: 'KBIN_GENERAL_SHOW_SUBSCRIPTIONS_SORT', values: [ {name: 'alphabetically'|trans , value: 'ALPHABETICALLY'}, {name: 'last_active'|trans , value: 'LAST_ACTIVE' } ], defaultValue: 'LAST_ACTIVE'}) }}
-                {{ component('settings_row_switch', {label: 'subscriptions_in_own_sidebar'|trans, settingsKey: 'KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE'}) }}
-
-                {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is same as 'true' %}
-                    {{ component('settings_row_switch', {label: 'sidebars_same_side'|trans, settingsKey: 'KBIN_GENERAL_SIDEBARS_SAME_SIDE'}) }}
-                {% else %}
+                {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is not same as 'true' %}
                     {{ component('settings_row_switch', {label: 'subscription_panel_large'|trans, settingsKey: 'KBIN_GENERAL_SHOW_SUBSCRIPTIONS_LARGE'}) }}
                 {% endif %}
             {% endif %}

--- a/templates/layout/_options_appearance.html.twig
+++ b/templates/layout/_options_appearance.html.twig
@@ -17,16 +17,16 @@
         {{ component('settings_row_switch', {label: 'show_top_bar'|trans, settingsKey: 'KBIN_GENERAL_TOPBAR'}) }}
 
         {% if app.user is defined and app.user is not same as null %}
-            {{ component('settings_row_switch', {label: 'show_subscriptions'|trans, settingsKey: 'KBIN_GENERAL_SHOW_SUBSCRIPTIONS'}) }}
-            {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS')) is same as 'true' %}
+            {{ component('settings_row_switch', {label: 'show_subscriptions'|trans, settingsKey: 'KBIN_GENERAL_SHOW_SUBSCRIPTIONS', defaultValue: 'true'}) }}
+            {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS')) is not same as 'false' %}
                 {{ component('settings_row_enum', {label: 'subscription_sort'|trans, settingsKey: 'KBIN_GENERAL_SHOW_SUBSCRIPTIONS_SORT', values: [ {name: 'alphabetically'|trans , value: 'ALPHABETICALLY'}, {name: 'last_active'|trans , value: 'LAST_ACTIVE' } ], defaultValue: 'LAST_ACTIVE'}) }}
-            {% endif %}
-            {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS')) is same as 'true' %}
                 {{ component('settings_row_switch', {label: 'subscriptions_in_own_sidebar'|trans, settingsKey: 'KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE'}) }}
-            {% endif %}
-            {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS')) is same as 'true' and
-                app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is same as 'true' %}
-                {{ component('settings_row_switch', {label: 'sidebars_same_side'|trans, settingsKey: 'KBIN_GENERAL_SIDEBARS_SAME_SIDE'}) }}
+
+                {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is same as 'true' %}
+                    {{ component('settings_row_switch', {label: 'sidebars_same_side'|trans, settingsKey: 'KBIN_GENERAL_SIDEBARS_SAME_SIDE'}) }}
+                {% else %}
+                    {{ component('settings_row_switch', {label: 'subscription_panel_large'|trans, settingsKey: 'KBIN_GENERAL_SHOW_SUBSCRIPTIONS_LARGE'}) }}
+                {% endif %}
             {% endif %}
         {% endif %}
     </div>

--- a/templates/layout/_options_appearance.html.twig
+++ b/templates/layout/_options_appearance.html.twig
@@ -15,17 +15,23 @@
         {{ component('settings_row_switch', {label: 'infinite_scroll'|trans, help: 'infinite_scroll_help'|trans ,  settingsKey: 'KBIN_GENERAL_INFINITE_SCROLL'}) }}
         {{ component('settings_row_switch', {label: 'sticky_navbar'|trans, help: 'sticky_navbar_help'|trans,  settingsKey: 'KBIN_GENERAL_FIXED_NAVBAR'}) }}
         {{ component('settings_row_switch', {label: 'show_top_bar'|trans, settingsKey: 'KBIN_GENERAL_TOPBAR'}) }}
-
-        {% if app.user is defined and app.user is not same as null %}
-            {{ component('settings_row_switch', {label: 'show_subscriptions'|trans, settingsKey: 'KBIN_GENERAL_SHOW_SUBSCRIPTIONS', defaultValue: 'true'}) }}
-            {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS')) is not same as 'false' %}
-                {{ component('settings_row_enum', {label: 'subscription_sort'|trans, settingsKey: 'KBIN_GENERAL_SHOW_SUBSCRIPTIONS_SORT', values: [ {name: 'alphabetically'|trans , value: 'ALPHABETICALLY'}, {name: 'last_active'|trans , value: 'LAST_ACTIVE' } ], defaultValue: 'LAST_ACTIVE'}) }}
-                {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is not same as 'true' %}
-                    {{ component('settings_row_switch', {label: 'subscription_panel_large'|trans, settingsKey: 'KBIN_GENERAL_SHOW_SUBSCRIPTIONS_LARGE'}) }}
+    </div>
+    {% if app.user is defined and app.user is not same as null %}
+        <strong>{{ 'subscriptions'|trans }}</strong>
+        <div class="settings-section">
+            {{ component('settings_row_switch', {label: 'show_subscriptions'|trans, settingsKey: 'KBIN_SUBSCRIPTIONS_SHOW', defaultValue: 'true'}) }}
+            {{ component('settings_row_switch', {label: 'show_magazines_icons'|trans, settingsKey: 'KBIN_SUBSCRIPTIONS_SHOW_MAGAZINE_ICON', defaultValue: 'true'}) }}
+            {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SHOW')) is not same as 'false' %}
+                {{ component('settings_row_enum', {label: 'subscription_sort'|trans, settingsKey: 'KBIN_SUBSCRIPTIONS_SORT', values: [ {name: 'alphabetically'|trans , value: 'ALPHABETICALLY'}, {name: 'last_active'|trans , value: 'LAST_ACTIVE' } ], defaultValue: 'LAST_ACTIVE'}) }}
+                {{ component('settings_row_switch', {label: 'subscriptions_in_own_sidebar'|trans, settingsKey: 'KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR'}) }}
+                {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR')) is same as 'true' %}
+                    {{ component('settings_row_switch', {label: 'sidebars_same_side'|trans, settingsKey: 'KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE'}) }}
+                {% else %}
+                    {{ component('settings_row_switch', {label: 'subscription_panel_large'|trans, settingsKey: 'KBIN_SUBSCRIPTIONS_LARGE_PANEL'}) }}
                 {% endif %}
             {% endif %}
-        {% endif %}
-    </div>
+        </div>
+    {% endif %}
     <strong>{{ 'threads'|trans }}</strong>
     <div class="settings-section">
         {{ component('settings_row_switch', {label: 'auto_preview'|trans, help: 'auto_preview_help'|trans,  settingsKey: 'KBIN_ENTRIES_SHOW_PREVIEW'}) }}

--- a/templates/layout/_sidebar.html.twig
+++ b/templates/layout/_sidebar.html.twig
@@ -98,16 +98,16 @@
 {% if user is defined %}
     {% include 'user/_info.html.twig' %}
 {% endif %}
+{% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SHOW')) is not same as 'false' and
+    app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR')) is not same as 'true' and
+    app.user is defined and app.user is not same as null %}
+    {{ component('sidebar_subscriptions', { openMagazine: magazine is defined ? magazine : null, user: app.user, sort: app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SORT')) }) }}
+{% endif %}
 {% if entry is defined and magazine %}
     {% include 'entry/_info.html.twig' %}
 {% endif %}
 {% if post is defined and magazine %}
     {% include 'post/_info.html.twig' %}
-{% endif %}
-{% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS')) is not same as 'false' and
-    app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is not same as 'true' and
-    app.user is defined and app.user is not same as null %}
-    {{ component('sidebar_subscriptions', { openMagazine: magazine is defined ? magazine : null, user: app.user, sort: app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_SORT')) }) }}
 {% endif %}
 {% if magazine is defined and magazine %}
     {{ component('magazine_box', {

--- a/templates/layout/_sidebar.html.twig
+++ b/templates/layout/_sidebar.html.twig
@@ -104,7 +104,7 @@
 {% if post is defined and magazine %}
     {% include 'post/_info.html.twig' %}
 {% endif %}
-{% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS')) is same as 'true' and
+{% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS')) is not same as 'false' and
     app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is not same as 'true' and
     app.user is defined and app.user is not same as null %}
     {{ component('sidebar_subscriptions', { openMagazine: magazine is defined ? magazine : null, user: app.user, sort: app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_SORT')) }) }}

--- a/templates/layout/sidebar_subscriptions.html.twig
+++ b/templates/layout/sidebar_subscriptions.html.twig
@@ -1,6 +1,43 @@
 <div class="sidebar-subscriptions section {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is not same as 'true' ? 'inline' : 'section--top' }}">
-    <h3>{{ 'subscriptions'|trans }}</h3>
-    <div class="subscription-list">
+    <h3>
+        {{ 'subscriptions'|trans }}
+        <span class="sidebar-subscriptions-icons">
+            {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
+                {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT') and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') or
+                    app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT') and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
+                    <a href="#" style="margin-right: .5em;" title="{{ 'subscription_sidebar_move_right'|trans }}" aria-label="{{ 'subscription_sidebar_move_right'|trans }}"
+                        {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
+                            onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
+                        {% else %}
+                            onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}').then(() => document.location.reload())">
+                        {% endif %}
+                        <i class="fa-solid fa-arrow-right"></i>
+                    </a>
+                {% else %}
+                    <a href="#" style="margin-right: .5em;" title="{{ 'subscription_sidebar_move_left'|trans }}" aria-label="{{ 'subscription_sidebar_move_left'|trans }}"
+                        {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
+                            onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
+                        {% else %}
+                            onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}').then(() => document.location.reload())">
+                        {% endif %}
+                        <i class="fa-solid fa-arrow-left"></i>
+                    </a>
+                {% endif %}
+            {% endif %}
+            {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is not same as 'true' %}
+                <a href="#" title="{{ 'subscription_sidebar_pop_out'|trans }}" aria-label="{{ 'subscription_sidebar_pop_out'|trans }}"
+                   onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}').then(() => document.location.reload())">
+                   <i class="fa-solid fa-right-from-bracket"></i>
+                </a>
+            {% else %}
+                <a href="#" title="{{ 'subscription_sidebar_pop_in'|trans }}" aria-label="{{ 'subscription_sidebar_pop_in'|trans }}"
+                   onclick="fetch('{{ path('theme_settings', { key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
+                   <i class="fa-solid fa-right-to-bracket"></i>
+                </a>
+            {% endif %}
+        </span>
+    </h3>
+    <div class="subscription-list {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_LARGE')) is same as 'true' ? 'lg' : '' }}">
         {% for magazine in magazines %}
             <div class="subscription {{ openMagazine and openMagazine.name is same as magazine.name ? 'active' : '' }}">
                 <a href="/m/{{ magazine.name }}">

--- a/templates/layout/sidebar_subscriptions.html.twig
+++ b/templates/layout/sidebar_subscriptions.html.twig
@@ -37,31 +37,33 @@
             {% endif %}
         </span>
     </h3>
-    <div class="subscription-list {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_LARGE')) is same as 'true' ? 'lg' : '' }}">
-        {% for magazine in magazines %}
-            <div class="subscription {{ openMagazine and openMagazine.name is same as magazine.name ? 'active' : '' }}">
-                <a href="/m/{{ magazine.name }}">
+    <div>
+        <ul class="subscription-list meta {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_LARGE')) is same as 'true' ? 'lg' : '' }}">
+            {% for magazine in magazines %}
+                <li class="subscription {{ openMagazine and openMagazine.name is same as magazine.name ? 'active' : '' }}">
+                    <a href="/m/{{ magazine.name }}">
 
-                    {% if magazine.icon %}
-                        <img src="{{ asset(magazine.icon.filePath) | imagine_filter('avatar_thumb') }}" class="image-inline magazine-subscription-avatar" alt="{{ magazine.name }}'s icon" />
-                    {% else %}
-                        <span class="magazine-subscription-avatar-placeholder"></span>
-                    {% endif %}
+                        {% if magazine.icon %}
+                            <img src="{{ asset(magazine.icon.filePath) | imagine_filter('avatar_thumb') }}" class="image-inline magazine-subscription-avatar" alt="{{ magazine.name }}'s icon" />
+                        {% else %}
+                            <span class="magazine-subscription-avatar-placeholder"></span>
+                        {% endif %}
 
-                    <span class="magazine-name {{ magazine.icon ? 'has-image' : '' }}">
-                        {{ magazine.title ?? magazine.name }}
-                    </span>
-                </a>
-            </div>
-        {% endfor %}
-        {% if tooManyMagazines %}
-            <div class="subscription">
-                <a href="/u/{{ app.user.username }}/subscriptions">
-                    <button class="btn btn__secondary">
-                        {{ 'show_more'|trans }}
-                    </button>
-                </a>
-            </div>
-        {% endif %}
+                        <span class="magazine-name {{ magazine.icon ? 'has-image' : '' }}">
+                            {{ magazine.title ?? magazine.name }}
+                        </span>
+                    </a>
+                </li>
+            {% endfor %}
+            {% if tooManyMagazines %}
+                <div class="subscription">
+                    <a href="/u/{{ app.user.username }}/subscriptions">
+                        <button class="btn btn__secondary">
+                            {{ 'show_more'|trans }}
+                        </button>
+                    </a>
+                </div>
+            {% endif %}
+        </ul>
     </div>
 </div>

--- a/templates/layout/sidebar_subscriptions.html.twig
+++ b/templates/layout/sidebar_subscriptions.html.twig
@@ -1,56 +1,57 @@
-<div class="sidebar-subscriptions {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is not same as 'true' ? 'inline' : '' }}">
-    <section class="section {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is not same as 'true' ? 'inline' : 'section--top' }}">
+<aside class="sidebar-subscriptions {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR')) is not same as 'true' ? 'inline' : '' }}">
+    <section class="section {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR')) is not same as 'true' ? 'inline' : 'section--top' }}">
         <h3>
-            {{ 'subscriptions'|trans }}
+            {{ 'subscription_header'|trans }}
             <span class="sidebar-subscriptions-icons">
-                {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
-                    {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT') and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') or
-                        app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT') and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
+                {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
+                    {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT') and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') or
+                        app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT') and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
                         <a href="#" style="margin-right: .5em;" title="{{ 'subscription_sidebar_move_right'|trans }}" aria-label="{{ 'subscription_sidebar_move_right'|trans }}"
-                            {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
-                                onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
+                            {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
+                                onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
                             {% else %}
-                                onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}').then(() => document.location.reload())">
+                                onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}').then(() => document.location.reload())">
                             {% endif %}
                             <i class="fa-solid fa-arrow-right"></i>
                         </a>
                     {% else %}
                         <a href="#" style="margin-right: .5em;" title="{{ 'subscription_sidebar_move_left'|trans }}" aria-label="{{ 'subscription_sidebar_move_left'|trans }}"
-                            {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
-                                onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
+                            {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
+                                onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
                             {% else %}
-                                onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}').then(() => document.location.reload())">
+                                onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}').then(() => document.location.reload())">
                             {% endif %}
                             <i class="fa-solid fa-arrow-left"></i>
                         </a>
                     {% endif %}
                 {% endif %}
-                {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is not same as 'true' %}
+                {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR')) is not same as 'true' %}
                     <a href="#" title="{{ 'subscription_sidebar_pop_out'|trans }}" aria-label="{{ 'subscription_sidebar_pop_out'|trans }}"
-                       onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}').then(() => document.location.reload())">
+                       onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}').then(() => document.location.reload())">
                        <i class="fa-solid fa-right-from-bracket"></i>
                     </a>
                 {% else %}
                     <a href="#" title="{{ 'subscription_sidebar_pop_in'|trans }}" aria-label="{{ 'subscription_sidebar_pop_in'|trans }}"
-                       onclick="fetch('{{ path('theme_settings', { key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
+                       onclick="fetch('{{ path('theme_settings', { key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
                        <i class="fa-solid fa-right-to-bracket"></i>
                     </a>
                 {% endif %}
             </span>
         </h3>
         <div>
-            <ul class="subscription-list meta {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_LARGE')) is same as 'true' ? 'lg' : '' }}">
+            <ul class="subscription-list meta {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_LARGE_PANEL')) is same as 'true' ? 'lg' : '' }}">
                 {% for magazine in magazines %}
                     <li class="subscription {{ openMagazine and openMagazine.name is same as magazine.name ? 'active' : '' }}">
                         <a href="/m/{{ magazine.name }}">
 
                             {% if magazine.icon %}
-                                <img src="{{ asset(magazine.icon.filePath) | imagine_filter('avatar_thumb') }}" class="image-inline magazine-subscription-avatar" alt="{{ magazine.name }}'s icon" />
+                                <img src="{{ asset(magazine.icon.filePath) | imagine_filter('avatar_thumb') }}" alt="{{ magazine.name }}'s icon"
+                                     class="image-inline magazine-subscription-avatar {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SHOW_MAGAZINE_ICON')) is same as 'false' ? 'onlyMobile' : '' }}"  />
                             {% else %}
-                                <span class="magazine-subscription-avatar-placeholder"></span>
+                                <span class="magazine-subscription-avatar-placeholder {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SHOW_MAGAZINE_ICON')) is same as 'false' ? 'onlyMobile' : '' }}"></span>
                             {% endif %}
 
-                            <span class="magazine-name {{ magazine.icon ? 'has-image' : '' }}">
+                            <span class="magazine-name {{ magazine.icon ? 'has-image' : '' }}  {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SHOW_MAGAZINE_ICON')) is same as 'false' ? 'onlyMobile' : '' }}">
                                 {{ magazine.title ?? magazine.name }}
                             </span>
                         </a>
@@ -68,4 +69,4 @@
             </ul>
         </div>
     </section>
-</div>
+</aside>

--- a/templates/layout/sidebar_subscriptions.html.twig
+++ b/templates/layout/sidebar_subscriptions.html.twig
@@ -4,36 +4,42 @@
             {{ 'subscription_header'|trans }}
             <span class="sidebar-subscriptions-icons">
                 {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
-                    {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT') and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') or
-                        app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT') and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
-                        <a href="#" style="margin-right: .5em;" title="{{ 'subscription_sidebar_move_right'|trans }}" aria-label="{{ 'subscription_sidebar_move_right'|trans }}"
-                            {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
-                                onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
-                            {% else %}
-                                onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}').then(() => document.location.reload())">
-                            {% endif %}
+                    <a href="#" style="margin-right: .5em;" title="{{ 'subscription_sidebar_pop_in'|trans }}" aria-label="{{ 'subscription_sidebar_pop_in'|trans }}"
+                        onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
+                        {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT') and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') or
+                            app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT') and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
                             <i class="fa-solid fa-arrow-right"></i>
-                        </a>
-                    {% else %}
-                        <a href="#" style="margin-right: .5em;" title="{{ 'subscription_sidebar_move_left'|trans }}" aria-label="{{ 'subscription_sidebar_move_left'|trans }}"
-                            {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
-                                onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
-                            {% else %}
-                                onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}').then(() => document.location.reload())">
-                            {% endif %}
+                        {% else %}
                             <i class="fa-solid fa-arrow-left"></i>
-                        </a>
-                    {% endif %}
+                        {% endif %}
+                    </a>
                 {% endif %}
                 {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR')) is not same as 'true' %}
-                    <a href="#" title="{{ 'subscription_sidebar_pop_out'|trans }}" aria-label="{{ 'subscription_sidebar_pop_out'|trans }}"
-                       onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}').then(() => document.location.reload())">
-                       <i class="fa-solid fa-right-from-bracket"></i>
+                    <a href="#" title="{{ 'subscription_sidebar_pop_out_left'|trans }}" aria-label="{{ 'subscription_sidebar_pop_out'|trans }}"
+                       onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}')
+                               .then(() => fetch(
+                       {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT') %}
+                           '{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}'
+                       {% else %}
+                           '{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}'
+                       {% endif %}
+                               )
+                               .then(() => document.location.reload())
+                               )">
+                       <i class="fa-solid fa-arrow-left"></i>
                     </a>
-                {% else %}
-                    <a href="#" title="{{ 'subscription_sidebar_pop_in'|trans }}" aria-label="{{ 'subscription_sidebar_pop_in'|trans }}"
-                       onclick="fetch('{{ path('theme_settings', { key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
-                       <i class="fa-solid fa-right-to-bracket"></i>
+                    <a href="#" title="{{ 'subscription_sidebar_pop_out_right'|trans }}" aria-label="{{ 'subscription_sidebar_pop_out'|trans }}"
+                        onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}')
+                           .then(() => fetch(
+                                {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT') %}
+                                    '{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}'
+                                {% else %}
+                                    '{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}'
+                                {% endif %}
+                                )
+                                .then(() => document.location.reload())
+                           )">
+                        <i class="fa-solid fa-arrow-right"></i>
                     </a>
                 {% endif %}
             </span>

--- a/templates/layout/sidebar_subscriptions.html.twig
+++ b/templates/layout/sidebar_subscriptions.html.twig
@@ -1,4 +1,4 @@
-<div class="sidebar-subscriptions section {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is not same as 'true' ? 'inline' : 'section--top' }}">
+<div class="sidebar-subscriptions meta section {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is not same as 'true' ? 'inline' : 'section--top' }}">
     <h3>
         {{ 'subscriptions'|trans }}
         <span class="sidebar-subscriptions-icons">
@@ -43,7 +43,7 @@
                 <a href="/m/{{ magazine.name }}">
 
                     {% if magazine.icon %}
-                        <img src="{{ asset(magazine.icon.filePath) | imagine_filter('avatar_thumb') }}" class="magazine-subscription-avatar" alt="{{ magazine.name }}'s icon" />
+                        <img src="{{ asset(magazine.icon.filePath) | imagine_filter('avatar_thumb') }}" class="image-inline magazine-subscription-avatar" alt="{{ magazine.name }}'s icon" />
                     {% else %}
                         <span class="magazine-subscription-avatar-placeholder"></span>
                     {% endif %}

--- a/templates/layout/sidebar_subscriptions.html.twig
+++ b/templates/layout/sidebar_subscriptions.html.twig
@@ -1,69 +1,71 @@
-<div class="sidebar-subscriptions meta section {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is not same as 'true' ? 'inline' : 'section--top' }}">
-    <h3>
-        {{ 'subscriptions'|trans }}
-        <span class="sidebar-subscriptions-icons">
-            {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
-                {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT') and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') or
-                    app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT') and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
-                    <a href="#" style="margin-right: .5em;" title="{{ 'subscription_sidebar_move_right'|trans }}" aria-label="{{ 'subscription_sidebar_move_right'|trans }}"
-                        {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
-                            onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
-                        {% else %}
-                            onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}').then(() => document.location.reload())">
-                        {% endif %}
-                        <i class="fa-solid fa-arrow-right"></i>
+<div class="sidebar-subscriptions {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is not same as 'true' ? 'inline' : '' }}">
+    <section class="section {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is not same as 'true' ? 'inline' : 'section--top' }}">
+        <h3>
+            {{ 'subscriptions'|trans }}
+            <span class="sidebar-subscriptions-icons">
+                {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
+                    {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT') and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') or
+                        app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT') and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
+                        <a href="#" style="margin-right: .5em;" title="{{ 'subscription_sidebar_move_right'|trans }}" aria-label="{{ 'subscription_sidebar_move_right'|trans }}"
+                            {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
+                                onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
+                            {% else %}
+                                onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}').then(() => document.location.reload())">
+                            {% endif %}
+                            <i class="fa-solid fa-arrow-right"></i>
+                        </a>
+                    {% else %}
+                        <a href="#" style="margin-right: .5em;" title="{{ 'subscription_sidebar_move_left'|trans }}" aria-label="{{ 'subscription_sidebar_move_left'|trans }}"
+                            {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
+                                onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
+                            {% else %}
+                                onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}').then(() => document.location.reload())">
+                            {% endif %}
+                            <i class="fa-solid fa-arrow-left"></i>
+                        </a>
+                    {% endif %}
+                {% endif %}
+                {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is not same as 'true' %}
+                    <a href="#" title="{{ 'subscription_sidebar_pop_out'|trans }}" aria-label="{{ 'subscription_sidebar_pop_out'|trans }}"
+                       onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}').then(() => document.location.reload())">
+                       <i class="fa-solid fa-right-from-bracket"></i>
                     </a>
                 {% else %}
-                    <a href="#" style="margin-right: .5em;" title="{{ 'subscription_sidebar_move_left'|trans }}" aria-label="{{ 'subscription_sidebar_move_left'|trans }}"
-                        {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
-                            onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
-                        {% else %}
-                            onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBARS_SAME_SIDE'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}').then(() => document.location.reload())">
-                        {% endif %}
-                        <i class="fa-solid fa-arrow-left"></i>
+                    <a href="#" title="{{ 'subscription_sidebar_pop_in'|trans }}" aria-label="{{ 'subscription_sidebar_pop_in'|trans }}"
+                       onclick="fetch('{{ path('theme_settings', { key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
+                       <i class="fa-solid fa-right-to-bracket"></i>
                     </a>
                 {% endif %}
-            {% endif %}
-            {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE')) is not same as 'true' %}
-                <a href="#" title="{{ 'subscription_sidebar_pop_out'|trans }}" aria-label="{{ 'subscription_sidebar_pop_out'|trans }}"
-                   onclick="fetch('{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE'), value: constant('App\\Controller\\User\\ThemeSettingsController::TRUE')}) }}').then(() => document.location.reload())">
-                   <i class="fa-solid fa-right-from-bracket"></i>
-                </a>
-            {% else %}
-                <a href="#" title="{{ 'subscription_sidebar_pop_in'|trans }}" aria-label="{{ 'subscription_sidebar_pop_in'|trans }}"
-                   onclick="fetch('{{ path('theme_settings', { key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_IN_SEPARATE'), value: constant('App\\Controller\\User\\ThemeSettingsController::FALSE')}) }}').then(() => document.location.reload())">
-                   <i class="fa-solid fa-right-to-bracket"></i>
-                </a>
-            {% endif %}
-        </span>
-    </h3>
-    <div>
-        <ul class="subscription-list meta {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_LARGE')) is same as 'true' ? 'lg' : '' }}">
-            {% for magazine in magazines %}
-                <li class="subscription {{ openMagazine and openMagazine.name is same as magazine.name ? 'active' : '' }}">
-                    <a href="/m/{{ magazine.name }}">
+            </span>
+        </h3>
+        <div>
+            <ul class="subscription-list meta {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SHOW_SUBSCRIPTIONS_LARGE')) is same as 'true' ? 'lg' : '' }}">
+                {% for magazine in magazines %}
+                    <li class="subscription {{ openMagazine and openMagazine.name is same as magazine.name ? 'active' : '' }}">
+                        <a href="/m/{{ magazine.name }}">
 
-                        {% if magazine.icon %}
-                            <img src="{{ asset(magazine.icon.filePath) | imagine_filter('avatar_thumb') }}" class="image-inline magazine-subscription-avatar" alt="{{ magazine.name }}'s icon" />
-                        {% else %}
-                            <span class="magazine-subscription-avatar-placeholder"></span>
-                        {% endif %}
+                            {% if magazine.icon %}
+                                <img src="{{ asset(magazine.icon.filePath) | imagine_filter('avatar_thumb') }}" class="image-inline magazine-subscription-avatar" alt="{{ magazine.name }}'s icon" />
+                            {% else %}
+                                <span class="magazine-subscription-avatar-placeholder"></span>
+                            {% endif %}
 
-                        <span class="magazine-name {{ magazine.icon ? 'has-image' : '' }}">
-                            {{ magazine.title ?? magazine.name }}
-                        </span>
-                    </a>
-                </li>
-            {% endfor %}
-            {% if tooManyMagazines %}
-                <div class="subscription">
-                    <a href="/u/{{ app.user.username }}/subscriptions">
-                        <button class="btn btn__secondary">
-                            {{ 'show_more'|trans }}
-                        </button>
-                    </a>
-                </div>
-            {% endif %}
-        </ul>
-    </div>
+                            <span class="magazine-name {{ magazine.icon ? 'has-image' : '' }}">
+                                {{ magazine.title ?? magazine.name }}
+                            </span>
+                        </a>
+                    </li>
+                {% endfor %}
+                {% if tooManyMagazines %}
+                    <div class="subscription">
+                        <a href="/u/{{ app.user.username }}/subscriptions">
+                            <button class="btn btn__secondary">
+                                {{ 'show_more'|trans }}
+                            </button>
+                        </a>
+                    </div>
+                {% endif %}
+            </ul>
+        </div>
+    </section>
 </div>

--- a/translations/messages.de.yaml
+++ b/translations/messages.de.yaml
@@ -574,10 +574,9 @@ oauth.consent.grant_permissions: Gebe Berechtigungen
 oauth2.grant.moderate.magazine.ban.delete: Nutzer in deinen moderierten Magazinen
   entbannen.
 subscriptions_in_own_sidebar: In eigener Seitenleiste
-subscription_sidebar_pop_out: In eigene Seitenleiste verschieben
+subscription_sidebar_pop_out_left: Nach links in eigene Seitenleiste verschieben
+subscription_sidebar_pop_out_right: Nach rechts in eigene Seitenleiste verschieben
 subscription_sidebar_pop_in: In andere Seitenleiste verschieben
-subscription_sidebar_move_left: Nach links verschieben
-subscription_sidebar_move_right: Nach rechts verschieben
 subscription_panel_large: Großes Panel
 subscription_header: Abos
 oauth.client_identifier.invalid: Ungültige OAuth Client ID!

--- a/translations/messages.de.yaml
+++ b/translations/messages.de.yaml
@@ -568,12 +568,18 @@ errors.server500.description: Es tut uns leid, etwas ist schiefgelaufen. Wir arb
 oauth.client_not_granted_message_read_permission: Diese App hat keine Berechtigung
   erhalten deine Nachrichten zu lesen.
 restrict_oauth_clients: Beschränke OAuth2 Client Erstellung auf Admins
-subscription_sort: Abonnements Sortierung
+subscription_sort: Sortierung
 unblock: Entblockieren
 oauth.consent.grant_permissions: Gebe Berechtigungen
 oauth2.grant.moderate.magazine.ban.delete: Nutzer in deinen moderierten Magazinen
   entbannen.
-subscriptions_in_own_sidebar: Abonnements Separat
+subscriptions_in_own_sidebar: In eigener Seitenleiste
+subscription_sidebar_pop_out: In eigene Seitenleiste verschieben
+subscription_sidebar_pop_in: In andere Seitenleiste verschieben
+subscription_sidebar_move_left: Nach links verschieben
+subscription_sidebar_move_right: Nach rechts verschieben
+subscription_panel_large: Großes Panel
+subscription_header: Abos
 oauth.client_identifier.invalid: Ungültige OAuth Client ID!
 oauth.consent.app_has_permissions: kann bereits die folgenden Aktionen ausführen
 email.delete.title: Nutzeraccount Löschanfrage

--- a/translations/messages.de.yaml
+++ b/translations/messages.de.yaml
@@ -578,7 +578,7 @@ subscription_sidebar_pop_out_left: Nach links in eigene Seitenleiste verschieben
 subscription_sidebar_pop_out_right: Nach rechts in eigene Seitenleiste verschieben
 subscription_sidebar_pop_in: In andere Seitenleiste verschieben
 subscription_panel_large: Großes Panel
-subscription_header: Abos
+subscription_header: Abonnierte Magazine
 oauth.client_identifier.invalid: Ungültige OAuth Client ID!
 oauth.consent.app_has_permissions: kann bereits die folgenden Aktionen ausführen
 email.delete.title: Nutzeraccount Löschanfrage

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -794,6 +794,11 @@ subscription_sort: Subscription sort
 alphabetically: Alphabetically
 subscriptions_in_own_sidebar: Subscriptions separate
 sidebars_same_side: Sidebars on the same side
+subscription_sidebar_pop_out: Move subscriptions to separate sidebar
+subscription_sidebar_pop_in: Move subscriptions to the inline panel
+subscription_sidebar_move_left: Move left
+subscription_sidebar_move_right: Move right
+subscription_panel_large: Large subscription panel
 close: Close
 position_bottom: Bottom
 position_top: Top

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -790,15 +790,16 @@ password_and_2fa: Password & 2fa
 flash_account_settings_changed: Your account settings have been successfully changed.
   You will need to login again.
 show_subscriptions: Show subscriptions
-subscription_sort: Subscription sort
+subscription_sort: Sort
 alphabetically: Alphabetically
-subscriptions_in_own_sidebar: Subscriptions separate
+subscriptions_in_own_sidebar: In separate sidebar
 sidebars_same_side: Sidebars on the same side
-subscription_sidebar_pop_out: Move subscriptions to separate sidebar
+subscription_sidebar_pop_out: Move to separate sidebar
 subscription_sidebar_pop_in: Move subscriptions to the inline panel
 subscription_sidebar_move_left: Move left
 subscription_sidebar_move_right: Move right
-subscription_panel_large: Large subscription panel
+subscription_panel_large: Large panel
+subscription_header: Subs
 close: Close
 position_bottom: Bottom
 position_top: Top

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -794,10 +794,9 @@ subscription_sort: Sort
 alphabetically: Alphabetically
 subscriptions_in_own_sidebar: In separate sidebar
 sidebars_same_side: Sidebars on the same side
-subscription_sidebar_pop_out: Move to separate sidebar
+subscription_sidebar_pop_out_right: Move to separate sidebar on the right
+subscription_sidebar_pop_out_left: Move to separate sidebar on the left
 subscription_sidebar_pop_in: Move subscriptions to the inline panel
-subscription_sidebar_move_left: Move left
-subscription_sidebar_move_right: Move right
 subscription_panel_large: Large panel
 subscription_header: Subs
 close: Close

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -798,7 +798,7 @@ subscription_sidebar_pop_out_right: Move to separate sidebar on the right
 subscription_sidebar_pop_out_left: Move to separate sidebar on the left
 subscription_sidebar_pop_in: Move subscriptions to the inline panel
 subscription_panel_large: Large panel
-subscription_header: Subs
+subscription_header: Subscribed Magazines
 close: Close
 position_bottom: Bottom
 position_top: Top


### PR DESCRIPTION
- show subs by default
- add icons in the header of the panel to pop it in and out and, if popped out, to change the side the panel is on
- add a setting to make the inline sub panel larger (the former size)
- set the default `max-height` of the inline panel to `20em` which is half the size
- make the popped out panel smaller (half of the sidebar and a 6th of the main content -> double the ratio on everything except the sub sidebar
- hide the placeholder div in popped out state so no space is wasted
- add the sort values to the `VALUES` array in `ThemeSettingsController`

Fix #154

A lot of this is up for debate. I just implemented it in a way that should satisfy @TheVillageGuy and the way I'd want it myself.

# Images

1. Freshly logged in: 
![grafik](https://github.com/MbinOrg/mbin/assets/25664458/7de48715-8f19-4f85-bebf-7ef3b8b7c0a6)

2. After clicking the left arrow:
![grafik](https://github.com/MbinOrg/mbin/assets/25664458/3369b206-be4a-4426-9f32-0f7517d073e5)

3.After clicking the right arrow:
![grafik](https://github.com/MbinOrg/mbin/assets/25664458/23ae89dc-a016-48dd-a9bf-71d2434b89dd)

4. After clicking the right arrow again:
![grafik](https://github.com/MbinOrg/mbin/assets/25664458/49d855ba-6182-4697-aaf5-9dc5db0f07a8)

4. After clicking the left arrow:
![grafik](https://github.com/MbinOrg/mbin/assets/25664458/585d09ee-51b7-4c24-a0c9-03f75dc2d091)

6. After changing the "Subscriptions panel large" setting to true:
![grafik](https://github.com/MbinOrg/mbin/assets/25664458/466362eb-f6d3-4d50-84f9-fdd765ecf4a7)

7. After changing the "Page width" to "Auto":
![grafik](https://github.com/MbinOrg/mbin/assets/25664458/3a11a5b6-3a3b-46d7-982e-8fa58b07fe77)

8. After changing the "Page width" to "Max":
![grafik](https://github.com/MbinOrg/mbin/assets/25664458/fef44cb3-0a89-4dd9-a544-021911b61ed5)

9. After clicking the left arrow again:
![grafik](https://github.com/MbinOrg/mbin/assets/25664458/7cad6632-8dec-435d-bfed-73141947a926)

10. After clicking the right arrow:
![grafik](https://github.com/MbinOrg/mbin/assets/25664458/2894ffdc-8326-4ffa-9b14-45333285d7af)
