### PR TITLE
remove active class addition when too many subscriptions

### DIFF
--- a/templates/layout/sidebar_subscriptions.html.twig
+++ b/templates/layout/sidebar_subscriptions.html.twig
@@ -18,7 +18,7 @@
             </div>
         {% endfor %}
         {% if tooManyMagazines %}
-            <div class="subscription {{ openMagazine and openMagazine.name is same as magazine.name ? 'active' : '' }}">
+            <div class="subscription">
                 <a href="/u/{{ app.user.username }}/subscriptions">
                     <button class="btn btn__secondary">
                         {{ 'show_more'|trans }}


### PR DESCRIPTION
the section for too many subscriptions was checking against the `magazine` iterator which was used above it, but it exists outside the for loop. The active class doesn't need to be added to the show more section of the sidebar