### PR TITLE
fix page width not affecting header and footer

### DIFF
--- a/assets/styles/layout/_layout.scss
+++ b/assets/styles/layout/_layout.scss
@@ -15,8 +15,10 @@ body {
     max-width: 100%;
   }
 
-  &.width--auto {
-    max-width: 85%;
+  @include media-breakpoint-up(lg) {
+    &.width--auto {
+      max-width: 85%;
+    }
   }
 }
 

--- a/templates/layout/_footer.html.twig
+++ b/templates/layout/_footer.html.twig
@@ -1,5 +1,8 @@
 <footer {{ (inSidebar is defined) ? 'id="footer"' : 'class="footer-sidebar"' }}>
-    <div class="kbin-container">
+    <div class="kbin-container
+          {{ html_classes(app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH'))
+            ? 'width--'~app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH'))
+            : '') }}">
         <section>
             <h5>{{ kbin_domain() }}</h5>
             <menu>
@@ -34,7 +37,7 @@
                 <li><a href="{{ path('page_faq') }}">{{ 'faq'|trans }}</a></li>
                 <li><a href="{{ path('page_terms') }}">{{ 'terms'|trans }}</a></li>
                 <li><a href="{{ path('page_privacy_policy') }}">{{ 'privacy_policy'|trans }}</a></li>
-                {% if kbin_federation_page_enabled() %}<li><a href="{{ path('page_federation') }}">{{ 'federation'|trans }}</a></li>{% endif %} 
+                {% if kbin_federation_page_enabled() %}<li><a href="{{ path('page_federation') }}">{{ 'federation'|trans }}</a></li>{% endif %}
             </menu>
         </section>
         <section>
@@ -78,4 +81,3 @@
         </section>
     </div>
 </footer>
-

--- a/templates/layout/_header.html.twig
+++ b/templates/layout/_header.html.twig
@@ -1,5 +1,8 @@
 <header id="header" class="header">
-    <div class="kbin-container">
+    <div class="kbin-container
+          {{ html_classes(app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH'))
+            ? 'width--'~app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH'))
+            : '') }}">
         <div class="sr-nav">
             <a href="#content">{{ 'go_to_content'|trans }}</a>
             <a href="#options">{{ 'go_to_filters'|trans }}</a>


### PR DESCRIPTION
missed adding the user setting to these templates
also do not allow the 85% setting on mobile. should not happen as the option does not show on mobile but when going from large view to small it was being kept, which was not intended

fixes #175