### PR TITLE
Disable deprecation towards terminal console

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -7,13 +7,13 @@ when@dev:
         handlers:
             main:
                 type: rotating_file
-                path: "%kernel.logs_dir%/%kernel.environment%.log"
-                # Or use: "debug" instead of "info" for more log (debug) messages
+                path: '%kernel.logs_dir%/%kernel.environment%.log'
+                # Or use: "debug" instead of "info" for more verbose log (debug) messages
                 level: info
-                # Enable full stacktrace, set this to false, to disable stacktraces
+                # Enable full stacktrace, set this to false to disable stacktraces
                 include_stacktraces: true
                 max_files: 10
-                channels: ["!event"]
+                channels: ['!event']
             # uncomment to get logging in your browser
             # you may have to allow bigger header sizes in your Web server configuration
             #firephp:
@@ -25,11 +25,13 @@ when@dev:
             console:
                 type: console
                 process_psr_3_messages: false
-                channels: ["!event", "!doctrine", "!console"]
-            deprecation:
-                type: stream
-                channels: [deprecation]
-                path: php://stderr
+                channels: ['!event', '!doctrine', '!console']
+            # uncomment if you wish to see depreciation messages to console
+            # by default it's already logged to the log file
+            #deprecation:
+            #    type: stream
+            #    channels: [deprecation]
+            #    path: php://stderr
 
 when@test:
     monolog:
@@ -39,10 +41,10 @@ when@test:
                 action_level: error
                 handler: nested
                 excluded_http_codes: [404, 405]
-                channels: ["!event"]
+                channels: ['!event']
             nested:
                 type: stream
-                path: "%kernel.logs_dir%/%kernel.environment%.log"
+                path: '%kernel.logs_dir%/%kernel.environment%.log'
                 level: debug
 
 when@prod:
@@ -57,10 +59,10 @@ when@prod:
             nested:
                 type: rotating_file
                 max_files: 7
-                path: "%kernel.logs_dir%/%kernel.environment%.log"
+                path: '%kernel.logs_dir%/%kernel.environment%.log'
                 level: debug
                 formatter: monolog.formatter.json
             console:
                 type: console
                 process_psr_3_messages: false
-                channels: ["!event", "!doctrine"]
+                channels: ['!event', '!doctrine']


### PR DESCRIPTION
- Disable deprecation towards console when in development mode (the messages already appear in the `dev-xxxx-xx-xx.log` file anyway).
- Auto format ran (complying with the new `.editconfig` config for yaml files)