### PR TITLE
Prepare for tombstone support

### DIFF
--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -58,13 +58,16 @@ class ApHttpClient
                 'headers' => $this->getInstanceHeaders($url),
             ]);
 
-            if (!str_starts_with((string) $r->getStatusCode(), '2')) {
-                throw new InvalidApPostException("Get fail: {$url}, ".$r->getContent(false));
+            $statusCode = $r->getStatusCode();
+            // Accepted status code are 2xx or 410 (used Tombstone types)
+            if (!str_starts_with((string) $statusCode, '2') && 410 !== $statusCode) {
+                throw new InvalidApPostException("Invalid status code while getting: {$url}, ".$r->getContent(false));
             }
 
             $item->expiresAt(new \DateTime('+1 hour'));
 
-            return $r->getContent();
+            // Read also non-OK responses (like 410) by passing 'false'
+            return $r->getContent(false);
         });
 
         if (!$resp) {


### PR DESCRIPTION
- Do not fail on 410 status code (used for [Tombstone](https://www.w3.org/TR/activitypub/#delete-activity-outbox))
- Read also 410 error status HTTP content (which contains the tombstone object), passing `false` to `getContent()`
- Do **not** throw error / 500 error message
