### PR TITLE
Fix undefined $entity variable message and more

### DIFF
--- a/src/MessageHandler/ActivityPub/Inbox/AnnounceHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/AnnounceHandler.php
@@ -40,7 +40,9 @@ class AnnounceHandler
             } else {
                 $object = $this->apHttpClient->getActivityObject($message->payload['object']);
 
-                $this->bus->dispatch(new ChainActivityMessage([$object], null, $message->payload));
+                if (!empty($object)) {
+                    $this->bus->dispatch(new ChainActivityMessage([$object], null, $message->payload));
+                }
 
                 return;
             }
@@ -51,6 +53,9 @@ class AnnounceHandler
                 $this->manager->upvote($entity, $actor);
                 $this->voteHandleSubscriber->clearCache($entity);
 
+                // Dead-code introduced by Ernest "Temp disable handler dispatch", in commit:
+                // 4573e87f91923b9a5758e0dfacb3870d55ef1166
+                //
                 //                if (null === $entity->magazine->apId) {
                 //                    $this->bus->dispatch(
                 //                        new \App\Message\ActivityPub\Outbox\AnnounceMessage(

--- a/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
@@ -73,12 +73,14 @@ class ChainActivityHandler
             array_pop($message->chain);
         }
 
-        $this->bus->dispatch(
-            new ChainActivityMessage($message->chain, [
-                'id' => $entity->getId(),
-                'type' => \get_class($entity),
-            ], $message->announce, $message->like)
-        );
+        if (!empty($entity)) {
+            $this->bus->dispatch(
+                new ChainActivityMessage($message->chain, [
+                    'id' => $entity->getId(),
+                    'type' => \get_class($entity),
+                ], $message->announce, $message->like)
+            );
+        }
     }
 
     private function unloadStack(array $chain, array $parent, array $announce = null, array $like = null): void

--- a/src/MessageHandler/ActivityPub/Inbox/LikeHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/LikeHandler.php
@@ -37,14 +37,16 @@ class LikeHandler
             } else {
                 $object = $this->apHttpClient->getActivityObject($message->payload['object']);
 
-                $this->bus->dispatch(new ChainActivityMessage([$object], null, null, $message->payload));
+                if (!empty($object)) {
+                    $this->bus->dispatch(new ChainActivityMessage([$object], null, null, $message->payload));
+                }
 
                 return;
             }
 
             $actor = $this->activityPubManager->findActorOrCreate($message->payload['actor']);
-            // Check if actor isn't empty
-            if (!empty($actor)) {
+            // Check if actor and entity aren't empty
+            if (!empty($actor) && !empty($entity)) {
                 $this->manager->toggle($actor, $entity, FavouriteManager::TYPE_LIKE);
             }
         } elseif ('Undo' === $message->payload['type']) {
@@ -52,13 +54,16 @@ class LikeHandler
                 $activity = $this->repository->findByObjectId($message->payload['object']['object']);
                 $entity = $this->entityManager->getRepository($activity['type'])->find((int) $activity['id']);
                 $actor = $this->activityPubManager->findActorOrCreate($message->payload['actor']);
-                // Check if actor isn't empty
-                if (!empty($actor)) {
+                // Check if actor and entity aren't empty
+                if (!empty($actor) && !empty($entity)) {
                     $this->manager->toggle($actor, $entity, FavouriteManager::TYPE_UNLIKE);
                 }
             }
         }
 
+        // Dead-code introduced by Ernest "Temp disable handler dispatch", in commit:
+        // 4573e87f91923b9a5758e0dfacb3870d55ef1166
+        //
         //        if (null === $entity->magazine->apId) {
         //            $this->bus->dispatch(
         //                new \App\Message\ActivityPub\Outbox\LikeMessage(

--- a/src/MessageHandler/ActivityPub/Inbox/UpdateHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/UpdateHandler.php
@@ -82,8 +82,13 @@ class UpdateHandler
             $fn = 'editPostComment';
         }
 
-        $this->$fn($object, $actor);
+        if (isset($fn, $object, $actor)) {
+            $this->$fn($object, $actor);
+        }
 
+        // Dead-code introduced by Ernest "Temp disable handler dispatch", in commit:
+        // 4573e87f91923b9a5758e0dfacb3870d55ef1166
+        //
         //        if (null === $object->magazine->apId) {
         //            $this->bus->dispatch(
         //                new \App\Message\ActivityPub\Outbox\UpdateMessage(


### PR DESCRIPTION
This should hopefully "solve" (hide) the error messages in the log (causing log pollution):

```
[2023-10-31T21:51:23.881536+00:00] messenger.CRITICAL: Error thrown while handling message App\Message\ActivityPub\Inbox\ChainActivityMessage. Removing from transport after 0 retries. Error: "Handling "App\Message\ActivityPub\Inbox\ChainActivityMessage" failed: Warning: Undefined variable $entity" {"class":"App\\Message\\ActivityPub\\Inbox\\ChainActivityMessage","retryCount":0,"error":"Handling \"App\\Message\\ActivityPub\\Inbox\\ChainActivityMessage\" failed: Warning: Undefined variable $entity","exception":"[object] (Symfony\\Component\\Messenger\\Exception\\HandlerFailedException(code: 0): Handling \"App\\Message\\ActivityPub\\Inbox\\ChainActivityMessage\" failed: Warning: Undefined variable $entity at /var/www/kbin.melroy.org/html/vendor/symfony/messenger/Middleware/HandleMessageMiddleware.php:129)
```