### PR TITLE
Remove the translations to lower.

### DIFF
--- a/templates/admin/_options.html.twig
+++ b/templates/admin/_options.html.twig
@@ -8,37 +8,37 @@
         <li>
             <a href="{{ path('admin_dashboard') }}"
                class="{{ html_classes({'active': is_route_name('admin_dashboard')}) }}">
-                {{ 'dashboard'|trans|lower }}
+                {{ 'dashboard'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('admin_settings') }}"
                class="{{ html_classes({'active': is_route_name('admin_settings')}) }}">
-                {{ 'settings'|trans|lower }}
+                {{ 'settings'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('admin_users') }}"
                class="{{ html_classes({'active': is_route_name('admin_users')}) }}">
-                {{ 'users'|trans|lower }}
+                {{ 'users'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('admin_reports') }}"
                class="{{ html_classes({'active': is_route_name('admin_reports')}) }}">
-                {{ 'reports'|trans|lower }}
+                {{ 'reports'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('admin_pages', {page: 'about'}) }}"
                class="{{ html_classes({'active': is_route_name('admin_pages')}) }}">
-                {{ 'pages'|trans|lower }}
+                {{ 'pages'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('admin_federation') }}"
                class="{{ html_classes({'active': is_route_name('admin_federation')}) }}">
-                {{ 'federation'|trans|lower }}
+                {{ 'federation'|trans }}
             </a>
         </li>
     </menu>

--- a/templates/admin/users.html.twig
+++ b/templates/admin/users.html.twig
@@ -18,8 +18,8 @@
         <div class="flex">
             <label class="select">
                 <select onchange="location = this.value;">
-                    <option value="{{ options_url('withFederated', false) }}">{{ 'local'|trans|lower }}</option>
-                    <option value="{{ options_url('withFederated', true) }}" {{ withFederated is same as true ? 'selected' : '' }}>{{ 'federated'|trans|lower }}</option>
+                    <option value="{{ options_url('withFederated', false) }}">{{ 'local'|trans }}</option>
+                    <option value="{{ options_url('withFederated', true) }}" {{ withFederated is same as true ? 'selected' : '' }}>{{ 'federated'|trans }}</option>
                 </select>
             </label>
         </div>

--- a/templates/awards/_options.html.twig
+++ b/templates/awards/_options.html.twig
@@ -4,19 +4,19 @@
         <li>
             <a href="#"
                class="">
-                <span class="dot" style="background: gold"></span> {{ 'gold'|trans|lower }}
+                <span class="dot" style="background: gold"></span> {{ 'gold'|trans }}
             </a>
         </li>
         <li>
             <a href="#"
                class="">
-                <span class="dot" style="background: silver"></span> {{ 'silver'|trans|lower }}
+                <span class="dot" style="background: silver"></span> {{ 'silver'|trans }}
             </a>
         </li>
         <li>
             <a href="#"
                class="">
-                <span class="dot" style="background: brown"></span> {{ 'bronze'|trans|lower }}
+                <span class="dot" style="background: brown"></span> {{ 'bronze'|trans }}
             </a>
         </li>
     </menu>

--- a/templates/components/boost.html.twig
+++ b/templates/components/boost.html.twig
@@ -6,7 +6,7 @@
     <button class="{{ html_classes('boost-link', 'stretched-link', {'active': app.user and user_choice is same as(VOTE_UP) }) }}"
             type="submit"
             data-action="subject#favourite">
-        {{ 'up_vote'|trans|lower }} <span class="{{ html_classes({'hidden': not subject.countUpvotes}) }}"
+        {{ 'up_vote'|trans }} <span class="{{ html_classes({'hidden': not subject.countUpvotes}) }}"
                                           data-subject-target="upvoteCounter">({{ subject.countUpvotes }})</span>
     </button>
 </form>

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -154,43 +154,43 @@
                             }) }}
                         </li>
                         <li class="dropdown">
-                            <button class="stretched-link" data-subject-target="more">{{ 'more'|trans|lower }}</button>
+                            <button class="stretched-link" data-subject-target="more">{{ 'more'|trans }}</button>
                             <ul class="dropdown__menu" data-controller="clipboard">
                                 <li>
                                     <a href="{{ path('entry_report', {id: entry.id}) }}"
                                        class="{{ html_classes({'active': is_route_name('entry_report')}) }}"
                                        data-action="subject#getForm">
-                                        {{ 'report'|trans|lower }}
+                                        {{ 'report'|trans }}
                                     </a>
                                 </li>
                                 <li>
                                     <a href="{{ entry_voters_url(entry, 'up') }}"
                                        class="{{ html_classes({'active': is_route_name('entry_fav') or is_route_name('entry_voters')}) }}">
-                                        {{ 'activity'|trans|lower }}
+                                        {{ 'activity'|trans }}
                                     </a>
                                 </li>
 
                                 {% if entry.domain %}
                                     <li>
-                                        <a href="{{ path('domain_entries', {name: entry.domain.name}) }}">{{ 'more_from_domain'|trans|lower }}</a>
+                                        <a href="{{ path('domain_entries', {name: entry.domain.name}) }}">{{ 'more_from_domain'|trans }}</a>
                                     </li>
                                 {% endif %}
 
                                 <li>
                                     <a data-action="clipboard#copy"
-                                       href="{{ entry_url(entry) }}">{{ 'copy_url'|trans|lower }}</a>
+                                       href="{{ entry_url(entry) }}">{{ 'copy_url'|trans }}</a>
                                 </li>
                                 <li>
                                     <a data-action="clipboard#copy"
                                        href="{{ entry.apId ?? path('ap_entry', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}">
-                                        {{ 'copy_url_to_fediverse'|trans|lower }}
+                                        {{ 'copy_url_to_fediverse'|trans }}
                                     </a>
                                 </li>
                                 {% if is_granted('edit', entry) %}
                                     <li>
                                         <a href="{{ entry_edit_url(entry) }}"
                                            class="{{ html_classes({'active': is_route_name('entry_edit')}) }}">
-                                            {{ 'edit'|trans|lower }}
+                                            {{ 'edit'|trans }}
                                         </a>
                                     </li>
                                 {% endif %}
@@ -200,7 +200,7 @@
                                               action="{{ entry_delete_url(entry) }}"
                                               onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                                             <input type="hidden" name="token" value="{{ csrf_token('entry_delete') }}">
-                                            <button type="submit">{{ 'delete'|trans|lower }}</button>
+                                            <button type="submit">{{ 'delete'|trans }}</button>
                                         </form>
                                     </li>
                                 {% endif %}
@@ -209,7 +209,7 @@
                                         <a href="{{ entry_moderate_url(entry) }}"
                                            class="{{ html_classes({'active': is_route_name('entry_moderate')}) }}"
                                            data-action="subject#showModPanel">
-                                            {{ 'moderate'|trans|lower }}
+                                            {{ 'moderate'|trans }}
                                         </a>
                                     </li>
                                 {% endif %}
@@ -228,7 +228,7 @@
                                   action="{{ path('entry_restore', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}"
                                   onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                                 <input type="hidden" name="token" value="{{ csrf_token('entry_restore') }}">
-                                <button type="submit">{{ 'restore'|trans|lower }}</button>
+                                <button type="submit">{{ 'restore'|trans }}</button>
                             </form>
                         </li>
                         <li data-subject-target="loader" style="display:none">

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -67,37 +67,37 @@
                         <li>
                             <a class="stretched-link"
                                href="{{ entry_comment_create_url(comment) }}#add-comment"
-                               data-action="subject#getForm">{{ 'reply'|trans|lower }}</a>
+                               data-action="subject#getForm">{{ 'reply'|trans }}</a>
                         </li>
                         <li>
                             {{ component('boost', {subject: comment}) }}
                         </li>
                         <li class="dropdown">
-                            <button class="stretched-link" data-subject-target="more">{{ 'more'|trans|lower }}</button>
+                            <button class="stretched-link" data-subject-target="more">{{ 'more'|trans }}</button>
                             <ul class="dropdown__menu" data-controller="clipboard">
                                 <li>
                                     <a href="{{ path('entry_comment_report', {id: comment.id}) }}"
                                        class="{{ html_classes({'active': is_route_name('entry_comment_report')}) }}"
                                        data-action="subject#getForm">
-                                        {{ 'report'|trans|lower }}
+                                        {{ 'report'|trans }}
                                     </a>
                                 </li>
                                 <li>
                                     <a href="{{ entry_comment_voters_url(comment, 'up') }}"
                                        class="{{ html_classes({'active': is_route_name('entry_comment_favourites') or is_route_name('entry_comment_voters')}) }}">
-                                        {{ 'activity'|trans|lower }}
+                                        {{ 'activity'|trans }}
                                     </a>
                                 </li>
                                 <li>
                                     <a data-action="clipboard#copy"
                                        href="{{ entry_url(comment.entry) }}#{{ get_url_fragment(comment) }}">
-                                        {{ 'copy_url'|trans|lower }}
+                                        {{ 'copy_url'|trans }}
                                     </a>
                                 </li>
                                 <li>
                                     <a data-action="clipboard#copy"
                                        href="{{ comment.apId ?? path('ap_entry_comment', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id}) }}">
-                                        {{ 'copy_url_to_fediverse'|trans|lower }}
+                                        {{ 'copy_url_to_fediverse'|trans }}
                                     </a>
                                 </li>
                                 {% if is_granted('edit', comment) %}
@@ -105,7 +105,7 @@
                                         <a href="{{ entry_comment_edit_url(comment) }}"
                                            class="{{ html_classes({'active': is_route_name('entry_comment_edit')}) }}"
                                            data-action="subject#getForm">
-                                            {{ 'edit'|trans|lower }}
+                                            {{ 'edit'|trans }}
                                         </a>
                                     </li>
                                 {% endif %}
@@ -116,7 +116,7 @@
                                               onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                                             <input type="hidden" name="token"
                                                    value="{{ csrf_token('entry_comment_delete') }}">
-                                            <button type="submit">{{ 'delete'|trans|lower }}</button>
+                                            <button type="submit">{{ 'delete'|trans }}</button>
                                         </form>
                                     </li>
                                 {% endif %}
@@ -125,7 +125,7 @@
                                         <a href="{{ entry_comment_moderate_url(comment) }}"
                                            class="{{ html_classes({'active': is_route_name('entry_comment_moderate')}) }}"
                                            data-action="subject#showModPanel">
-                                            {{ 'moderate'|trans|lower }}
+                                            {{ 'moderate'|trans }}
                                         </a>
                                     </li>
                                 {% endif %}
@@ -144,7 +144,7 @@
                                   action="{{ path('entry_comment_restore', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id}) }}"
                                   onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                                 <input type="hidden" name="token" value="{{ csrf_token('entry_comment_restore') }}">
-                                <button type="submit">{{ 'restore'|trans|lower }}</button>
+                                <button type="submit">{{ 'restore'|trans }}</button>
                             </form>
                         </li>
                         <li data-subject-target="loader" style="display:none">

--- a/templates/components/favourite.html.twig
+++ b/templates/components/favourite.html.twig
@@ -4,7 +4,7 @@
     <button class="{{ html_classes('stretched-link', {'active': app.user and subject.isFavored(app.user) }) }}"
             type="submit"
             data-action="subject#favourite">
-        {{ 'favourites'|trans|lower }} <span class="{{ html_classes({'hidden': not subject.favouriteCount}) }}">
+        {{ 'favourites'|trans }} <span class="{{ html_classes({'hidden': not subject.favouriteCount}) }}">
             (<span data-subject-target="favCounter">{{ subject.favouriteCount }}</span>)
         </span>
     </button>

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -69,20 +69,20 @@
                         <li>
                             <a class="stretched-link"
                                href="{{ path('post_comment_create', {magazine_name: post.magazine.name, post_id: post.id, slug: post.slug|length ? post.slug : '-'}) }}"
-                               data-action="subject#getForm">{{ 'reply'|trans|lower }}</a>
+                               data-action="subject#getForm">{{ 'reply'|trans }}</a>
                         </li>
                         {% if not is_route_name('post_single', true) and ((not showCommentsPreview and post.commentCount > 0) or post.commentCount > 2) %}
                             <li data-post-target="expand">
                                 <a class="stretched-link"
                                    href="#{{ get_url_fragment(post) }}"
-                                   data-action="post#expandComments">{{ 'expand'|trans|lower }} (<span
+                                   data-action="post#expandComments">{{ 'expand'|trans }} (<span
                                             data-subject-target="commentsCounter">{{ post.commentCount }}</span>)</a>
                             </li>
                             <li data-post-target="collapse"
                                 style="display: none">
                                 <a class="stretched-link"
                                    href="#{{ get_url_fragment(post) }}"
-                                   data-action="post#collapseComments">{{ 'collapse'|trans|lower }}
+                                   data-action="post#collapseComments">{{ 'collapse'|trans }}
                                     ({{ post.commentCount }})
                                 </a>
                             </li>
@@ -93,30 +93,30 @@
                             }) }}
                         </li>
                         <li class="dropdown">
-                            <button class="stretched-link" data-subject-target="more">{{ 'more'|trans|lower }}</button>
+                            <button class="stretched-link" data-subject-target="more">{{ 'more'|trans }}</button>
                             <ul class="dropdown__menu" data-controller="clipboard">
                                 <li>
                                     <a href="{{ path('post_report', {id: post.id}) }}"
                                        class="{{ html_classes({'active': is_route_name('post_report')}) }}"
                                        data-action="subject#getForm">
-                                        {{ 'report'|trans|lower }}
+                                        {{ 'report'|trans }}
                                     </a>
                                 </li>
                                 <li>
                                     <a href="{{ post_voters_url(post, 'up') }}"
                                        class="{{ html_classes({'active': is_route_name('post_favourites') or is_route_name('post_voters')}) }}">
-                                        {{ 'activity'|trans|lower }}
+                                        {{ 'activity'|trans }}
                                     </a>
                                 </li>
                                 <li>
                                     <a data-action="clipboard#copy" href="{{ post_url(post) }}">
-                                        {{ 'copy_url'|trans|lower }}
+                                        {{ 'copy_url'|trans }}
                                     </a>
                                 </li>
                                 <li>
                                     <a data-action="clipboard#copy"
                                        href="{{ post.apId ?? path('ap_post', {magazine_name: post.magazine.name, post_id: post.id}) }}">
-                                        {{ 'copy_url_to_fediverse'|trans|lower }}
+                                        {{ 'copy_url_to_fediverse'|trans }}
                                     </a>
                                 </li>
                                 {% if is_granted('edit', post) %}
@@ -124,7 +124,7 @@
                                         <a href="{{ post_edit_url(post) }}"
                                            class="{{ html_classes({'active': is_route_name('post_edit')}) }}"
                                            data-action="subject#getForm">
-                                            {{ 'edit'|trans|lower }}
+                                            {{ 'edit'|trans }}
                                         </a>
                                     </li>
                                 {% endif %}
@@ -134,7 +134,7 @@
                                               action="{{ post_delete_url(post) }}"
                                               onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                                             <input type="hidden" name="token" value="{{ csrf_token('post_delete') }}">
-                                            <button type="submit">{{ 'delete'|trans|lower }}</button>
+                                            <button type="submit">{{ 'delete'|trans }}</button>
                                         </form>
                                     </li>
                                 {% endif %}
@@ -143,7 +143,7 @@
                                         <a href="{{ post_moderate_url(post) }}"
                                            class="{{ html_classes({'active': is_route_name('post_moderate')}) }}"
                                            data-action="subject#showModPanel">
-                                            {{ 'moderate'|trans|lower }}
+                                            {{ 'moderate'|trans }}
                                         </a>
                                     </li>
                                 {% endif %}
@@ -167,7 +167,7 @@
                                   action="{{ path('post_restore', {magazine_name: post.magazine.name, post_id: post.id}) }}"
                                   onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                                 <input type="hidden" name="token" value="{{ csrf_token('post_restore') }}">
-                                <button type="submit">{{ 'restore'|trans|lower }}</button>
+                                <button type="submit">{{ 'restore'|trans }}</button>
                             </form>
                         </li>
                         <li data-subject-target="loader" style="display:none">

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -69,7 +69,7 @@
                         <li>
                             <a class="stretched-link"
                                href="{{ post_comment_create_url(comment) }}#add-comment"
-                               data-action="subject#getForm">{{ 'reply'|trans|lower }}</a>
+                               data-action="subject#getForm">{{ 'reply'|trans }}</a>
                         </li>
                         <li>
                             {{ component('boost', {
@@ -77,31 +77,31 @@
                             }) }}
                         </li>
                         <li class="dropdown">
-                            <button class="stretched-link" data-subject-target="more">{{ 'more'|trans|lower }}</button>
+                            <button class="stretched-link" data-subject-target="more">{{ 'more'|trans }}</button>
                             <ul class="dropdown__menu" data-controller="clipboard">
                                 <li>
                                     <a href="{{ path('post_comment_report', {id: comment.id}) }}"
                                        class="{{ html_classes({'active': is_route_name('post_comment_report')}) }}"
                                        data-action="subject#getForm">
-                                        {{ 'report'|trans|lower }}
+                                        {{ 'report'|trans }}
                                     </a>
                                 </li>
                                 <li>
                                     <a href="{{ post_comment_voters_url(comment) }}"
                                        class="{{ html_classes({'active': is_route_name('post_comment_favourites') or is_route_name('post_comment_voters')}) }}">
-                                        {{ 'activity'|trans|lower }}
+                                        {{ 'activity'|trans }}
                                     </a>
                                 </li>
                                 <li>
                                     <a data-action="clipboard#copy"
                                        href="{{ post_url(comment.post) }}#{{ get_url_fragment(comment) }}">
-                                        {{ 'copy_url'|trans|lower }}
+                                        {{ 'copy_url'|trans }}
                                     </a>
                                 </li>
                                 <li>
                                     <a data-action="clipboard#copy"
                                        href="{{ comment.apId ?? path('ap_post_comment', {magazine_name: comment.magazine.name, post_id: comment.post.id, comment_id: comment.id}) }}">
-                                        {{ 'copy_url_to_fediverse'|trans|lower }}
+                                        {{ 'copy_url_to_fediverse'|trans }}
                                     </a>
                                 </li>
                                 {% if is_granted('edit', comment) %}
@@ -109,7 +109,7 @@
                                         <a href="{{ post_comment_edit_url(comment) }}"
                                            class="{{ html_classes({'active': is_route_name('post_comment_edit')}) }}"
                                            data-action="subject#getForm">
-                                            {{ 'edit'|trans|lower }}
+                                            {{ 'edit'|trans }}
                                         </a>
                                     </li>
                                 {% endif %}
@@ -120,7 +120,7 @@
                                               onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                                             <input type="hidden" name="token"
                                                    value="{{ csrf_token('post_comment_delete') }}">
-                                            <button type="submit">{{ 'delete'|trans|lower }}</button>
+                                            <button type="submit">{{ 'delete'|trans }}</button>
                                         </form>
                                     </li>
                                 {% endif %}
@@ -129,7 +129,7 @@
                                         <a href="{{ post_comment_moderate_url(comment) }}"
                                            class="{{ html_classes({'active': is_route_name('post_comment_moderate')}) }}"
                                            data-action="subject#showModPanel">
-                                            {{ 'moderate'|trans|lower }}
+                                            {{ 'moderate'|trans }}
                                         </a>
                                     </li>
                                 {% endif %}
@@ -148,7 +148,7 @@
                                   action="{{ path('post_comment_restore', {magazine_name: comment.magazine.name, post_id: comment.post.id, comment_id: comment.id}) }}"
                                   onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                                 <input type="hidden" name="token" value="{{ csrf_token('post_comment_restore') }}">
-                                <button type="submit">{{ 'restore'|trans|lower }}</button>
+                                <button type="submit">{{ 'restore'|trans }}</button>
                             </form>
                         </li>
                         <li data-subject-target="loader" style="display:none">

--- a/templates/components/voters_inline.html.twig
+++ b/templates/components/voters_inline.html.twig
@@ -6,7 +6,7 @@
             {%- if not loop.last %},{% endif %}
         {% endfor %}
         {% if count > 4 %}
-            <a data-action="post#expandVoters" href="{{ url }}">+{{ count - 4 }} {{ 'more'|trans|lower }}</a>
+            <a data-action="post#expandVoters" href="{{ url }}">+{{ count - 4 }} {{ 'more'|trans }}</a>
         {% endif %}
     </div>
 {% endif %}

--- a/templates/entry/_create_options.html.twig
+++ b/templates/entry/_create_options.html.twig
@@ -7,55 +7,55 @@
              <li>
                 <a href="{{ path('magazine_entry_create', {name: magazine.name}) }}"
                    class="{{ html_classes({'active': route_has_param('type', 'link')}) }}">
-                    {{ 'type.link'|trans|lower }}
+                    {{ 'type.link'|trans }}
                 </a>
             </li>
             <li>
                 <a href="{{ path('magazine_entry_create', {name: magazine.name, type: 'article'}) }}"
                    class="{{ html_classes({'active': route_has_param('type', 'article')}) }}">
-                    {{ 'type.article'|trans|lower }}
+                    {{ 'type.article'|trans }}
                 </a>
             </li>  
             <li>
                 <a href="{{ path('magazine_entry_create', {name: magazine.name, type: 'photo'}) }}"
                    class="{{ html_classes({'active': route_has_param('type', 'photo')}) }}">
-                    {{ 'type.photo'|trans|lower }}
+                    {{ 'type.photo'|trans }}
                 </a>
             </li>
             <li>
                 <a href="{{ path('magazine_create') }}"
                    class="{{ html_classes({'active': is_route_name('magazine_create')}) }}">
-                    {{ 'type.magazine'|trans|lower }}
+                    {{ 'type.magazine'|trans }}
                 </a>
             </li>
         {% else %}
             <li>
                 <a href="{{ path('entry_create') }}"
                    class="{{ html_classes({'active': route_has_param('type', 'link')}) }}">
-                    {{ 'type.link'|trans|lower }}
+                    {{ 'type.link'|trans }}
                 </a>
             </li>
             <li>
                 <a href="{{ path('entry_create', {type: 'article'}) }}"
                    class="{{ html_classes({'active': route_has_param('type', 'article')}) }}">
-                    {{ 'type.article'|trans|lower }}
+                    {{ 'type.article'|trans }}
                 </a>
             </li>    
             <li>
                 <a href="{{ path('entry_create', {type: 'photo'}) }}"
                    class="{{ html_classes({'active': route_has_param('type', 'photo')}) }}">
-                    {{ 'type.photo'|trans|lower }}
+                    {{ 'type.photo'|trans }}
                 </a>
             </li>
             <li>
                 <a href="{{ path('posts_front') }}">
-                    {{ 'post'|trans|lower }}
+                    {{ 'post'|trans }}
                 </a>
             </li>
             <li>
                 <a href="{{ path('magazine_create') }}"
                    class="{{ html_classes({'active': is_route_name('magazine_create')}) }}">
-                    {{ 'type.magazine'|trans|lower }}
+                    {{ 'type.magazine'|trans }}
                 </a>
             </li>
         {% endif %}

--- a/templates/entry/_options.html.twig
+++ b/templates/entry/_options.html.twig
@@ -4,31 +4,31 @@
         <li>
             <a href="{{ options_url('sortBy', 'top') }}"
                class="{{ html_classes({'active': route_has_param('sortBy', 'top')}) }}">
-                {{ 'top'|trans|lower }}
+                {{ 'top'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ options_url('sortBy', 'hot') }}"
                class="{{ html_classes({'active': route_has_param('sortBy', 'hot')}) }}">
-                {{ 'hot'|trans|lower }}
+                {{ 'hot'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ options_url('sortBy', 'newest') }}"
                class="{{ html_classes({'active': route_has_param('sortBy', 'newest')}) }}">
-                {{ 'newest'|trans|lower }}
+                {{ 'newest'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ options_url('sortBy', 'active') }}"
                class="{{ html_classes({'active': route_has_param('sortBy', 'active')}) }}">
-                {{ 'active'|trans|lower }}
+                {{ 'active'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ options_url('sortBy', 'commented') }}"
                class="{{ html_classes({'active': route_has_param('sortBy', 'commented')}) }}">
-                {{ 'commented'|trans|lower }}
+                {{ 'commented'|trans }}
             </a>
         </li>
     </menu>
@@ -41,13 +41,13 @@
                 <li>
                     <a class="{{ html_classes({'active': not app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT')) or app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT')) is same as 'false'}) }}"
                        href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT'), value: 'false'}) }}">
-                        {{ 'classic_view'|trans|lower }}
+                        {{ 'classic_view'|trans }}
                     </a>
                 </li>
                 <li>
                     <a class="{{ html_classes({'active': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT')) is same as 'true'}) }}"
                        href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT'), value: 'true'}) }}">
-                        {{ 'compact_view'|trans|lower }}
+                        {{ 'compact_view'|trans }}
                     </a>
                 </li>
             </ul>
@@ -68,42 +68,42 @@
                 <li>
                     <a href="{{ options_url('time', '3h') }}"
                        class="{{ html_classes({'active': route_has_param('time', '3h')}) }}">
-                        {{ '3h'|trans|lower }}
+                        {{ '3h'|trans }}
                     </a></li>
                 <li>
                     <a href="{{ options_url('time', '6h') }}"
                        class="{{ html_classes({'active': route_has_param('time', '6h')}) }}">
-                        {{ '6h'|trans|lower }}
+                        {{ '6h'|trans }}
                     </a>
                 </li>
                 <li>
                     <a href="{{ options_url('time', '12h') }}"
                        class="{{ html_classes({'active': route_has_param('time', '12h')}) }}">
-                        {{ '12h'|trans|lower }}
+                        {{ '12h'|trans }}
                     </a>
                 </li>
                 <li>
                     <a href="{{ options_url('time', '1d') }}"
                        class="{{ html_classes({'active': route_has_param('time', '1d')}) }}">
-                        {{ '1d'|trans|lower }}
+                        {{ '1d'|trans }}
                     </a>
                 </li>
                 <li>
                     <a href="{{ options_url('time', '1w') }}"
                        class="{{ html_classes({'active': route_has_param('time', '1w')}) }}">
-                        {{ '1w'|trans|lower }}
+                        {{ '1w'|trans }}
                     </a>
                 </li>
                 <li>
                     <a href="{{ options_url('time', '1m') }}"
                        class="{{ html_classes({'active': route_has_param('time', '1m')}) }}">
-                        {{ '1m'|trans|lower }}
+                        {{ '1m'|trans }}
                     </a>
                 </li>
                 <li>
                     <a href="{{ options_url('time', '1y') }}"
                        class="{{ html_classes({'active': route_has_param('time', '1y')}) }}">
-                        {{ '1y'|trans|lower }}
+                        {{ '1y'|trans }}
                     </a>
                 </li>
             </ul>
@@ -117,31 +117,31 @@
                 <li>
                     <a href="{{ options_url('type', 'all') }}"
                        class="{{ html_classes({'active': not get_route_param('type') or route_has_param('type', 'all')}) }}">
-                        {{ 'all'|trans|lower }}
+                        {{ 'all'|trans }}
                     </a>
                 </li>
                 <li>
                     <a href="{{ options_url('type', 'links') }}"
                        class="{{ html_classes({'active': route_has_param('type', 'links')}) }}">
-                        {{ 'links'|trans|lower }}
+                        {{ 'links'|trans }}
                     </a>
                 </li>
                 <li>
                     <a href="{{ options_url('type', 'articles') }}"
                        class="{{ html_classes({'active': route_has_param('type', 'articles')}) }}">
-                        {{ 'articles'|trans|lower }}
+                        {{ 'articles'|trans }}
                     </a>
                 </li>
                 <li>
                     <a href="{{ options_url('type', 'photos') }}"
                        class="{{ html_classes({'active': route_has_param('type', 'photos')}) }}">
-                        {{ 'photos'|trans|lower }}
+                        {{ 'photos'|trans }}
                     </a>
                 </li>
                 <li>
                     <a href="{{ options_url('type', 'videos') }}"
                        class="{{ html_classes({'active': route_has_param('type', 'videos')}) }}">
-                        {{ 'videos'|trans|lower }}
+                        {{ 'videos'|trans }}
                     </a>
                 </li>
             </ul>

--- a/templates/entry/_options_activity.html.twig
+++ b/templates/entry/_options_activity.html.twig
@@ -6,19 +6,19 @@
         <li>
             <a href="{{ entry_voters_url(entry, 'up') }}"
                class="{{ html_classes({'active': is_route_name('entry_voters') and route_has_param('type', 'up')}) }}">
-                {{ 'up_votes'|trans|lower }} ({{ entry.countUpVotes }})
+                {{ 'up_votes'|trans }} ({{ entry.countUpVotes }})
             </a>
         </li>
         <li>
             <a href="{{ entry_voters_url(entry, 'down') }}"
                class="{{ html_classes({'active': is_route_name('entry_voters') and route_has_param('type', 'down')}) }}">
-                {{ 'down_votes'|trans|lower }} ({{ entry.countDownVotes }})
+                {{ 'down_votes'|trans }} ({{ entry.countDownVotes }})
             </a>
         </li>
         <li>
             <a href="{{ entry_favourites_url(entry) }}"
                class="{{ html_classes({'active': is_route_name('entry_fav')}) }}">
-                {{ 'favourites'|trans|lower }} ({{ entry.favouriteCount }})
+                {{ 'favourites'|trans }} ({{ entry.favouriteCount }})
             </a>
         </li>
     </menu>

--- a/templates/entry/comment/_moderate_panel.html.twig
+++ b/templates/entry/comment/_moderate_panel.html.twig
@@ -2,7 +2,7 @@
     <menu>
         <li>
             <a class="stretched-link"
-               href="{{ path('magazine_panel_ban', {'name': comment.magazine.name, 'username': comment.user.username}) }}">{{ 'ban'|trans|lower }}</a>
+               href="{{ path('magazine_panel_ban', {'name': comment.magazine.name, 'username': comment.user.username}) }}">{{ 'ban'|trans }}</a>
         </li>
         <li>
             <form action="{{ entry_comment_delete_url(comment) }}"
@@ -10,7 +10,7 @@
                   onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                 <input type="hidden" name="token" value="{{ csrf_token('entry_comment_delete') }}">
                 <button type="submit">
-                    <span>{{ 'delete'|trans|lower }}</span>
+                    <span>{{ 'delete'|trans }}</span>
                 </button>
             </form>
         </li>
@@ -21,7 +21,7 @@
                       onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                     <input type="hidden" name="token" value="{{ csrf_token('entry_comment_purge') }}">
                     <button type="submit">
-                        <span>{{ 'purge'|trans|lower }}</span>
+                        <span>{{ 'purge'|trans }}</span>
                     </button>
                 </form>
             </li>
@@ -40,7 +40,7 @@
                     <input type="hidden" name="token" value="{{ csrf_token('change_adult') }}">
                     <input name="adult"
                            type="checkbox" {{ comment.isAdult ? 'checked' : '' }}>
-                    <button type="submit">{{ 'is_adult'|trans|lower }}</button>
+                    <button type="submit">{{ 'is_adult'|trans }}</button>
                 </form>
             </div>
         </li>

--- a/templates/entry/comment/_options.html.twig
+++ b/templates/entry/comment/_options.html.twig
@@ -5,31 +5,31 @@
         <li>
             <a href="{{ options_url('sortBy', 'top') }}"
                class="{{ html_classes({'active': route_has_param('sortBy', 'top')}) }}">
-                {{ 'top'|trans|lower }}
+                {{ 'top'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ options_url('sortBy', 'hot') }}"
                class="{{ html_classes({'active': route_has_param('sortBy', 'hot')}) }}">
-                {{ 'hot'|trans|lower }}
+                {{ 'hot'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ options_url('sortBy', 'active') }}"
                class="{{ html_classes({'active': route_has_param('sortBy', 'active')}) }}">
-                {{ 'active'|trans|lower }}
+                {{ 'active'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ options_url('sortBy', 'newest') }}"
                class="{{ html_classes({'active': route_has_param('sortBy', 'newest')}) }}">
-                {{ 'newest'|trans|lower }}
+                {{ 'newest'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ options_url('sortBy', 'oldest') }}"
                class="{{ html_classes({'active': route_has_param('sortBy', 'oldest')}) }}">
-                {{ 'oldest'|trans|lower }}
+                {{ 'oldest'|trans }}
             </a>
         </li>
     </menu>
@@ -44,15 +44,15 @@
             <ul class="dropdown__menu">
                 <li>
                     <a class="{{ html_classes({'active': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::ENTRY_COMMENTS_VIEW')) is same as constant('App\\Controller\\User\\ThemeSettingsController::CLASSIC')}) }}"
-                       href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::ENTRY_COMMENTS_VIEW'), value: constant('App\\Controller\\User\\ThemeSettingsController::CLASSIC')}) }}">{{ 'classic_view'|trans|lower }}</a>
+                       href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::ENTRY_COMMENTS_VIEW'), value: constant('App\\Controller\\User\\ThemeSettingsController::CLASSIC')}) }}">{{ 'classic_view'|trans }}</a>
                 </li>
                 <li>
                     <a class="{{ html_classes({'active': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::ENTRY_COMMENTS_VIEW')) is same as constant('App\\Controller\\User\\ThemeSettingsController::CHAT')}) }}"
-                       href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::ENTRY_COMMENTS_VIEW'), value: constant('App\\Controller\\User\\ThemeSettingsController::CHAT')}) }}">{{ 'chat_view'|trans|lower }}</a>
+                       href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::ENTRY_COMMENTS_VIEW'), value: constant('App\\Controller\\User\\ThemeSettingsController::CHAT')}) }}">{{ 'chat_view'|trans }}</a>
                 </li>
                 <li>
                     <a class="{{ html_classes({'active': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::ENTRY_COMMENTS_VIEW')) is same as null or app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::ENTRY_COMMENTS_VIEW')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TREE')}) }}"
-                       href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::ENTRY_COMMENTS_VIEW'), value: constant('App\\Controller\\User\\ThemeSettingsController::TREE')}) }}">{{ 'tree_view'|trans|lower }}</a>
+                       href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::ENTRY_COMMENTS_VIEW'), value: constant('App\\Controller\\User\\ThemeSettingsController::TREE')}) }}">{{ 'tree_view'|trans }}</a>
                 </li>
             </ul>
         </li>

--- a/templates/entry/comment/_options_activity.html.twig
+++ b/templates/entry/comment/_options_activity.html.twig
@@ -6,19 +6,19 @@
         <li>
             <a href="{{ entry_comment_voters_url(comment, 'up') }}"
                class="{{ html_classes({'active': is_route_name('entry_comment_voters') and route_has_param('type', 'up')}) }}">
-                {{ 'up_votes'|trans|lower }} ({{ comment.countUpVotes }})
+                {{ 'up_votes'|trans }} ({{ comment.countUpVotes }})
             </a>
         </li>
         <li>
             <a href="{{ entry_comment_voters_url(comment, 'down') }}"
                class="{{ html_classes({'active': is_route_name('entry_comment_voters') and route_has_param('type', 'down')}) }}">
-                {{ 'down_votes'|trans|lower }} ({{ comment.countDownVotes }})
+                {{ 'down_votes'|trans }} ({{ comment.countDownVotes }})
             </a>
         </li>
         <li>
             <a href="{{ entry_comment_favourites_url(comment) }}"
                class="{{ html_classes({'active': is_route_name('entry_comment_favourites')}) }}">
-                {{ 'favourites'|trans|lower }} ({{ comment.favouriteCount }})
+                {{ 'favourites'|trans }} ({{ comment.favouriteCount }})
             </a>
         </li>
     </menu>

--- a/templates/magazine/_moderators_sidebar.html.twig
+++ b/templates/magazine/_moderators_sidebar.html.twig
@@ -18,7 +18,7 @@
     {% if magazine.moderators|length > 5 %}
         <footer>
             <a href="{{ path('magazine_moderators', {name: magazine.name}) }}"
-               class="stretched-link">{{ 'show_more'|trans|lower }}</a>
+               class="stretched-link">{{ 'show_more'|trans }}</a>
         </footer>
     {% endif %}
 </section>

--- a/templates/magazine/_options.html.twig
+++ b/templates/magazine/_options.html.twig
@@ -3,19 +3,19 @@
         <li>
             <a href="{{ options_url('sortBy', 'newest') }}"
                class="{{ html_classes({'active': route_has_param('sortBy', 'newest')}) }}">
-                {{ 'newest'|trans|lower }}
+                {{ 'newest'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ options_url('sortBy', 'hot') }}"
                class="{{ html_classes({'active': route_has_param('sortBy', 'hot')}) }}">
-                {{ 'hot'|trans|lower }}
+                {{ 'hot'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ options_url('sortBy', 'active') }}"
                class="{{ html_classes({'active': route_has_param('sortBy', 'active')}) }}">
-                {{ 'active'|trans|lower }}
+                {{ 'active'|trans }}
             </a>
         </li>
     </menu>
@@ -26,10 +26,10 @@
                         class="fa-solid fa-layer-group"></i> {{ 'change_view'|trans }}</button>
             <ul class="dropdown__menu">
                 <li><a class="{{ html_classes({'active': route_has_param('view', 'table')}) }}"
-                       href="{{ options_url('view', 'table') }}">{{ 'table_view'|trans|lower }}</a></li>
+                       href="{{ options_url('view', 'table') }}">{{ 'table_view'|trans }}</a></li>
                 <li>
                     <a class="{{ html_classes({'active': route_has_param('view', 'cards')}) }}"
-                       href="{{ options_url('view', 'cards') }}">{{ 'cards_view'|trans|lower }}</a>
+                       href="{{ options_url('view', 'cards') }}">{{ 'cards_view'|trans }}</a>
                 </li>
             </ul>
         </li>

--- a/templates/magazine/panel/_options.html.twig
+++ b/templates/magazine/panel/_options.html.twig
@@ -6,55 +6,55 @@
         <li>
             <a href="{{ path('magazine_panel_general', {name: magazine.name}) }}"
                class="{{ html_classes({'active': is_route_name('magazine_panel_general')}) }}">
-                {{ 'general'|trans|lower }}
+                {{ 'general'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('magazine_panel_reports', {name: magazine.name}) }}"
                class="{{ html_classes({'active': is_route_name('magazine_panel_reports')}) }}">
-                {{ 'reports'|trans|lower }}
+                {{ 'reports'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('magazine_panel_moderators', {name: magazine.name}) }}"
                class="{{ html_classes({'active': is_route_name('magazine_panel_moderators')}) }}">
-                {{ 'moderators'|trans|lower }}
+                {{ 'moderators'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('magazine_panel_badges', {name: magazine.name}) }}"
                class="{{ html_classes({'active': is_route_name('magazine_panel_badges')}) }}">
-                {{ 'badges'|trans|lower }}
+                {{ 'badges'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('magazine_panel_tags', {name: magazine.name}) }}"
                class="{{ html_classes({'active': is_route_name('magazine_panel_tags')}) }}">
-                {{ 'tags'|trans|lower }}
+                {{ 'tags'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('magazine_panel_bans', {name: magazine.name}) }}"
                class="{{ html_classes({'active': is_route_name_contains('_ban')}) }}">
-                {{ 'bans'|trans|lower }}
+                {{ 'bans'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('magazine_panel_trash', {name: magazine.name}) }}"
                class="{{ html_classes({'active': is_route_name('magazine_panel_trash')}) }}">
-                {{ 'trash'|trans|lower }}
+                {{ 'trash'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('magazine_panel_theme', {name: magazine.name}) }}"
                class="{{ html_classes({'active': is_route_name('magazine_panel_theme')}) }}">
-                {{ 'appearance'|trans|lower }}
+                {{ 'appearance'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('magazine_panel_stats', {name: magazine.name}) }}"
                class="{{ html_classes({'active': is_route_name('magazine_panel_stats')}) }}">
-                {{ 'stats'|trans|lower }}
+                {{ 'stats'|trans }}
             </a>
         </li>
     </menu>

--- a/templates/notifications/_blocks.html.twig
+++ b/templates/notifications/_blocks.html.twig
@@ -1,101 +1,101 @@
 {% block entry_created_notification %}
-    {{ component('user_inline', {user: notification.entry.user}) }} {{ 'added_new_thread'|trans }} - <a
+    {{ component('user_inline', {user: notification.entry.user}) }} {{ 'added_new_thread'|trans|lower }} - <a
         href="{{ entry_url(notification.entry) }}">{{ notification.entry.shortTitle }}</a>
 {% endblock entry_created_notification %}
 
 {% block entry_edited_notification %}
-    {{ component('user_inline', {user: notification.entry.user}) }} {{ 'edited_thread'|trans }} - <a
+    {{ component('user_inline', {user: notification.entry.user}) }} {{ 'edited_thread'|trans|lower }} - <a
         href="{{ entry_url(notification.entry) }}">{{ notification.entry.shortTitle }}</a>
 {% endblock entry_edited_notification %}
 
 {% block entry_deleted_notification %}
     <a href="{{ entry_url(notification.entry) }}">{{ notification.entry.shortTitle }}</a>
-    {% if notification.entry.isTrashed %}{{ 'removed'|trans }}{% else %}{{ 'deleted'|trans }}{% endif %}
+    {% if notification.entry.isTrashed %}{{ 'removed'|trans|lower }}{% else %}{{ 'deleted'|trans|lower }}{% endif %}
 {% endblock entry_deleted_notification %}
 
 {% block entry_mentioned_notification %}
-    {{ component('user_inline', {user: notification.entry.user}) }} {{ 'mentioned_you'|trans }} - <a
+    {{ component('user_inline', {user: notification.entry.user}) }} {{ 'mentioned_you'|trans|lower }} - <a
         href="{{ entry_url(notification.entry) }}">{{ notification.entry.shortTitle }}</a>
 {% endblock entry_mentioned_notification %}
 
 {% block entry_comment_created_notification %}
-    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'added_new_comment'|trans }} - <a
+    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'added_new_comment'|trans|lower }} - <a
         href="{{ entry_url(notification.comment.entry) }}#{{ get_url_fragment(notification.comment) }}">{{ notification.comment.shortTitle }}</a>
 {% endblock entry_comment_created_notification %}
 
 {% block entry_comment_edited_notification %}
-    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'edited_comment'|trans }} - <a
+    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'edited_comment'|trans|lower }} - <a
         href="{{ entry_url(notification.comment.entry) }}#{{ get_url_fragment(notification.comment) }}">{{ notification.comment.shortTitle }}</a>
 {% endblock entry_comment_edited_notification %}
 
 {% block entry_comment_reply_notification %}
-    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'replied_to_your_comment'|trans }} - <a
+    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'replied_to_your_comment'|trans|lower }} - <a
         href="{{ entry_url(notification.comment.entry) }}#{{ get_url_fragment(notification.comment) }}">{{ notification.comment.shortTitle }}</a>
 {% endblock entry_comment_reply_notification %}
 
 {% block entry_comment_deleted_notification %}
     {{ 'comment'|trans }} <a
         href="{{ entry_url(notification.comment.entry) }}">{{ notification.comment.shortTitle }}</a> -
-    {% if notification.comment.isTrashed %}{{ 'removed'|trans }}{% else %}{{ 'deleted'|trans }}{% endif %}
+    {% if notification.comment.isTrashed %}{{ 'removed'|trans|lower }}{% else %}{{ 'deleted'|trans|lower }}{% endif %}
 {% endblock entry_comment_deleted_notification %}
 
 {% block entry_comment_mentioned_notification %}
-    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'mentioned_you'|trans }} - <a
+    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'mentioned_you'|trans|lower }} - <a
         href="{{ entry_url(notification.comment.entry) }}#{{ get_url_fragment(notification.comment) }}">{{ notification.comment.shortTitle }}</a>
 {% endblock entry_comment_mentioned_notification %}
 
 {% block post_created_notification %}
-    {{ component('user_inline', {user: notification.post.user}) }} {{ 'added_new_post'|trans }} - <a
+    {{ component('user_inline', {user: notification.post.user}) }} {{ 'added_new_post'|trans|lower }} - <a
         href="{{ post_url(notification.post) }}">{{ notification.post.shortTitle }}</a>
 {% endblock post_created_notification %}
 
 {% block post_edited_notification %}
-    {{ component('user_inline', {user: notification.post.user}) }} {{ 'edit_post'|trans }} - <a
+    {{ component('user_inline', {user: notification.post.user}) }} {{ 'edit_post'|trans|lower }} - <a
         href="{{ post_url(notification.post) }}">{{ notification.post.shortTitle }}</a>
 {% endblock post_edited_notification %}
 
 {% block post_deleted_notification %}
     {{ 'post'|trans }} <a
         href="{{ post_url(notification.post) }}">{{ notification.post.shortTitle }}</a> -
-    {% if notification.comment.isTrashed %}{{ 'removed'|trans }}{% else %}{{ 'deleted'|trans }}{% endif %}
+    {% if notification.comment.isTrashed %}{{ 'removed'|trans|lower }}{% else %}{{ 'deleted'|trans|lower }}{% endif %}
 {% endblock post_deleted_notification %}
 
 {% block post_mentioned_notification %}
-    {{ component('user_inline', {user: notification.post.user}) }} {{ 'mentioned_you'|trans }} - <a
+    {{ component('user_inline', {user: notification.post.user}) }} {{ 'mentioned_you'|trans|lower }} - <a
         href="{{ post_url(notification.post) }}">{{ notification.post.shortTitle }}</a>
 {% endblock post_mentioned_notification %}
 
 {% block post_comment_created_notification %}
-    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'added_new_comment'|trans }} - <a
+    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'added_new_comment'|trans|lower }} - <a
         href="{{ post_url(notification.comment.post) }}#{{ get_url_fragment(notification.comment) }}">{{ notification.comment.shortTitle }}</a>
 {% endblock post_comment_created_notification %}
 
 {% block post_comment_edited_notification %}
-    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'edited_comment'|trans }} - <a
+    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'edited_comment'|trans|lower }} - <a
         href="{{ post_url(notification.comment.post) }}#{{ get_url_fragment(notification.comment) }}">{{ notification.comment.shortTitle }}</a>
 {% endblock post_comment_edited_notification %}
 
 {% block post_comment_reply_notification %}
-    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'replied_to_your_comment'|trans }} - <a
+    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'replied_to_your_comment'|trans|lower }} - <a
         href="{{ post_url(notification.comment.post) }}#{{ get_url_fragment(notification.comment) }}">{{ notification.comment.shortTitle }}</a>
 {% endblock post_comment_reply_notification %}
 
 {% block post_comment_deleted_notification %}
     {{ 'comment'|trans }} <a
         href="{{ post_url(notification.comment.post) }}">{{ notification.comment.shortTitle }}</a> -
-    {% if notification.comment.isTrashed %}{{ 'removed'|trans }}{% else %}{{ 'deleted'|trans }}{% endif %}
+    {% if notification.comment.isTrashed %}{{ 'removed'|trans|lower }}{% else %}{{ 'deleted'|trans|lower }}{% endif %}
 {% endblock post_comment_deleted_notification %}
 
 {% block post_comment_mentioned_notification %}
-    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'mentioned_you'|trans }} - <a
+    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'mentioned_you'|trans|lower }} - <a
         href="{{ post_url(notification.comment.post) }}#{{ get_url_fragment(notification.comment) }}">{{ notification.comment.shortTitle }}</a>
 {% endblock post_comment_mentioned_notification %}
 
 {% block message_notification %}
-    {{ component('user_inline', {user: notification.message.sender}) }} {{ 'wrote_message'|trans }} <a
+    {{ component('user_inline', {user: notification.message.sender}) }} {{ 'wrote_message'|trans|lower }} <a
         href="{{ path('messages_front', {'id': notification.message.thread.id}) }}">{{ notification.message.thread.title }}</a>
 {% endblock message_notification %}
 
 {% block magazine_ban_notification %}
-    {{ component('user_inline', {user: notification.ban.bannedBy}) }} {{ 'banned'|trans }}. {{ 'ban_expired'|trans }} {{ component('date', {date: notification.ban.expiredAt}) }}. {{ notification.ban.reason }}
+    {{ component('user_inline', {user: notification.ban.bannedBy}) }} {{ 'banned'|trans|lower }}. {{ 'ban_expired'|trans }} {{ component('date', {date: notification.ban.expiredAt}) }}. {{ notification.ban.reason }}
 {% endblock magazine_ban_notification %}

--- a/templates/notifications/_blocks.html.twig
+++ b/templates/notifications/_blocks.html.twig
@@ -1,101 +1,101 @@
 {% block entry_created_notification %}
-    {{ component('user_inline', {user: notification.entry.user}) }} {{ 'added_new_thread'|trans|lower }} - <a
+    {{ component('user_inline', {user: notification.entry.user}) }} {{ 'added_new_thread'|trans }} - <a
         href="{{ entry_url(notification.entry) }}">{{ notification.entry.shortTitle }}</a>
 {% endblock entry_created_notification %}
 
 {% block entry_edited_notification %}
-    {{ component('user_inline', {user: notification.entry.user}) }} {{ 'edited_thread'|trans|lower }} - <a
+    {{ component('user_inline', {user: notification.entry.user}) }} {{ 'edited_thread'|trans }} - <a
         href="{{ entry_url(notification.entry) }}">{{ notification.entry.shortTitle }}</a>
 {% endblock entry_edited_notification %}
 
 {% block entry_deleted_notification %}
     <a href="{{ entry_url(notification.entry) }}">{{ notification.entry.shortTitle }}</a>
-    {% if notification.entry.isTrashed %}{{ 'removed'|trans|lower }}{% else %}{{ 'deleted'|trans|lower }}{% endif %}
+    {% if notification.entry.isTrashed %}{{ 'removed'|trans }}{% else %}{{ 'deleted'|trans }}{% endif %}
 {% endblock entry_deleted_notification %}
 
 {% block entry_mentioned_notification %}
-    {{ component('user_inline', {user: notification.entry.user}) }} {{ 'mentioned_you'|trans|lower }} - <a
+    {{ component('user_inline', {user: notification.entry.user}) }} {{ 'mentioned_you'|trans }} - <a
         href="{{ entry_url(notification.entry) }}">{{ notification.entry.shortTitle }}</a>
 {% endblock entry_mentioned_notification %}
 
 {% block entry_comment_created_notification %}
-    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'added_new_comment'|trans|lower }} - <a
+    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'added_new_comment'|trans }} - <a
         href="{{ entry_url(notification.comment.entry) }}#{{ get_url_fragment(notification.comment) }}">{{ notification.comment.shortTitle }}</a>
 {% endblock entry_comment_created_notification %}
 
 {% block entry_comment_edited_notification %}
-    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'edited_comment'|trans|lower }} - <a
+    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'edited_comment'|trans }} - <a
         href="{{ entry_url(notification.comment.entry) }}#{{ get_url_fragment(notification.comment) }}">{{ notification.comment.shortTitle }}</a>
 {% endblock entry_comment_edited_notification %}
 
 {% block entry_comment_reply_notification %}
-    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'replied_to_your_comment'|trans|lower }} - <a
+    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'replied_to_your_comment'|trans }} - <a
         href="{{ entry_url(notification.comment.entry) }}#{{ get_url_fragment(notification.comment) }}">{{ notification.comment.shortTitle }}</a>
 {% endblock entry_comment_reply_notification %}
 
 {% block entry_comment_deleted_notification %}
     {{ 'comment'|trans }} <a
         href="{{ entry_url(notification.comment.entry) }}">{{ notification.comment.shortTitle }}</a> -
-    {% if notification.comment.isTrashed %}{{ 'removed'|trans|lower }}{% else %}{{ 'deleted'|trans|lower }}{% endif %}
+    {% if notification.comment.isTrashed %}{{ 'removed'|trans }}{% else %}{{ 'deleted'|trans }}{% endif %}
 {% endblock entry_comment_deleted_notification %}
 
 {% block entry_comment_mentioned_notification %}
-    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'mentioned_you'|trans|lower }} - <a
+    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'mentioned_you'|trans }} - <a
         href="{{ entry_url(notification.comment.entry) }}#{{ get_url_fragment(notification.comment) }}">{{ notification.comment.shortTitle }}</a>
 {% endblock entry_comment_mentioned_notification %}
 
 {% block post_created_notification %}
-    {{ component('user_inline', {user: notification.post.user}) }} {{ 'added_new_post'|trans|lower }} - <a
+    {{ component('user_inline', {user: notification.post.user}) }} {{ 'added_new_post'|trans }} - <a
         href="{{ post_url(notification.post) }}">{{ notification.post.shortTitle }}</a>
 {% endblock post_created_notification %}
 
 {% block post_edited_notification %}
-    {{ component('user_inline', {user: notification.post.user}) }} {{ 'edit_post'|trans|lower }} - <a
+    {{ component('user_inline', {user: notification.post.user}) }} {{ 'edit_post'|trans }} - <a
         href="{{ post_url(notification.post) }}">{{ notification.post.shortTitle }}</a>
 {% endblock post_edited_notification %}
 
 {% block post_deleted_notification %}
     {{ 'post'|trans }} <a
         href="{{ post_url(notification.post) }}">{{ notification.post.shortTitle }}</a> -
-    {% if notification.comment.isTrashed %}{{ 'removed'|trans|lower }}{% else %}{{ 'deleted'|trans|lower }}{% endif %}
+    {% if notification.comment.isTrashed %}{{ 'removed'|trans }}{% else %}{{ 'deleted'|trans }}{% endif %}
 {% endblock post_deleted_notification %}
 
 {% block post_mentioned_notification %}
-    {{ component('user_inline', {user: notification.post.user}) }} {{ 'mentioned_you'|trans|lower }} - <a
+    {{ component('user_inline', {user: notification.post.user}) }} {{ 'mentioned_you'|trans }} - <a
         href="{{ post_url(notification.post) }}">{{ notification.post.shortTitle }}</a>
 {% endblock post_mentioned_notification %}
 
 {% block post_comment_created_notification %}
-    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'added_new_comment'|trans|lower }} - <a
+    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'added_new_comment'|trans }} - <a
         href="{{ post_url(notification.comment.post) }}#{{ get_url_fragment(notification.comment) }}">{{ notification.comment.shortTitle }}</a>
 {% endblock post_comment_created_notification %}
 
 {% block post_comment_edited_notification %}
-    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'edited_comment'|trans|lower }} - <a
+    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'edited_comment'|trans }} - <a
         href="{{ post_url(notification.comment.post) }}#{{ get_url_fragment(notification.comment) }}">{{ notification.comment.shortTitle }}</a>
 {% endblock post_comment_edited_notification %}
 
 {% block post_comment_reply_notification %}
-    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'replied_to_your_comment'|trans|lower }} - <a
+    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'replied_to_your_comment'|trans }} - <a
         href="{{ post_url(notification.comment.post) }}#{{ get_url_fragment(notification.comment) }}">{{ notification.comment.shortTitle }}</a>
 {% endblock post_comment_reply_notification %}
 
 {% block post_comment_deleted_notification %}
     {{ 'comment'|trans }} <a
         href="{{ post_url(notification.comment.post) }}">{{ notification.comment.shortTitle }}</a> -
-    {% if notification.comment.isTrashed %}{{ 'removed'|trans|lower }}{% else %}{{ 'deleted'|trans|lower }}{% endif %}
+    {% if notification.comment.isTrashed %}{{ 'removed'|trans }}{% else %}{{ 'deleted'|trans }}{% endif %}
 {% endblock post_comment_deleted_notification %}
 
 {% block post_comment_mentioned_notification %}
-    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'mentioned_you'|trans|lower }} - <a
+    {{ component('user_inline', {user: notification.comment.user}) }} {{ 'mentioned_you'|trans }} - <a
         href="{{ post_url(notification.comment.post) }}#{{ get_url_fragment(notification.comment) }}">{{ notification.comment.shortTitle }}</a>
 {% endblock post_comment_mentioned_notification %}
 
 {% block message_notification %}
-    {{ component('user_inline', {user: notification.message.sender}) }} {{ 'wrote_message'|trans|lower }} <a
+    {{ component('user_inline', {user: notification.message.sender}) }} {{ 'wrote_message'|trans }} <a
         href="{{ path('messages_front', {'id': notification.message.thread.id}) }}">{{ notification.message.thread.title }}</a>
 {% endblock message_notification %}
 
 {% block magazine_ban_notification %}
-    {{ component('user_inline', {user: notification.ban.bannedBy}) }} {{ 'banned'|trans|lower }}. {{ 'ban_expired'|trans }} {{ component('date', {date: notification.ban.expiredAt}) }}. {{ notification.ban.reason }}
+    {{ component('user_inline', {user: notification.ban.bannedBy}) }} {{ 'banned'|trans }}. {{ 'ban_expired'|trans }} {{ component('date', {date: notification.ban.expiredAt}) }}. {{ notification.ban.reason }}
 {% endblock magazine_ban_notification %}

--- a/templates/post/_moderate_panel.html.twig
+++ b/templates/post/_moderate_panel.html.twig
@@ -52,7 +52,7 @@
         <li class="actions">
             {{ form_start(form, {action: path('post_change_lang', {magazine_name: magazine.name, post_id: post.id})}) }}
             {{ form_row(form.lang, {label: false, row_attr: {class: 'checkbox'}}) }}
-            {{ form_row(form.submit, {label: 'change_language'|trans, attr: {class: 'btn btn__secondary'}}) }}
+            {{ form_row(form.submit, {label: 'change_language'|trans|lower, attr: {class: 'btn btn__secondary'}}) }}
             {{ form_end(form) }}
         </li>
         <li class="actions">

--- a/templates/post/_moderate_panel.html.twig
+++ b/templates/post/_moderate_panel.html.twig
@@ -2,14 +2,14 @@
     <menu>
         <li>
             <a class="stretched-link"
-               href="{{ path('magazine_panel_ban', {'name': post.magazine.name, 'username': post.user.username}) }}">{{ 'ban'|trans|lower }}</a>
+               href="{{ path('magazine_panel_ban', {'name': post.magazine.name, 'username': post.user.username}) }}">{{ 'ban'|trans }}</a>
         </li>
         <li>
             <form action="{{ path('post_pin', {'magazine_name': post.magazine.name, 'post_id': post.id}) }}"
                   method="post">
                 <input type="hidden" name="token" value="{{ csrf_token('post_pin') }}">
                 <button type="submit">
-                    <span>{{ post.sticky ? 'unpin'|trans|lower : 'pin'|trans|lower }}</span>
+                    <span>{{ post.sticky ? 'unpin'|trans : 'pin'|trans }}</span>
                 </button>
             </form>
         </li>
@@ -19,7 +19,7 @@
                   onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                 <input type="hidden" name="token" value="{{ csrf_token('post_delete') }}">
                 <button type="submit">
-                    <span>{{ 'delete'|trans|lower }}</span>
+                    <span>{{ 'delete'|trans }}</span>
                 </button>
             </form>
         </li>
@@ -30,7 +30,7 @@
                       onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                     <input type="hidden" name="token" value="{{ csrf_token('post_purge') }}">
                     <button type="submit">
-                        <span>{{ 'purge'|trans|lower }}</span>
+                        <span>{{ 'purge'|trans }}</span>
                     </button>
                 </form>
             </li>
@@ -44,7 +44,7 @@
                     <input type="hidden" name="token" value="{{ csrf_token('change_magazine') }}">
                     <input id="change_magazine_new_magazine" name="change_magazine[new_magazine]">
                     <button type="submit" class="btn btn__secondary">
-                        {{ 'change_magazine'|trans|lower }}
+                        {{ 'change_magazine'|trans }}
                     </button>
                 </form>
             </li>
@@ -52,7 +52,7 @@
         <li class="actions">
             {{ form_start(form, {action: path('post_change_lang', {magazine_name: magazine.name, post_id: post.id})}) }}
             {{ form_row(form.lang, {label: false, row_attr: {class: 'checkbox'}}) }}
-            {{ form_row(form.submit, {label: 'change_language'|trans|lower, attr: {class: 'btn btn__secondary'}}) }}
+            {{ form_row(form.submit, {label: 'change_language'|trans, attr: {class: 'btn btn__secondary'}}) }}
             {{ form_end(form) }}
         </li>
         <li class="actions">
@@ -63,7 +63,7 @@
                     <input type="hidden" name="token" value="{{ csrf_token('change_adult') }}">
                     <input name="adult"
                            type="checkbox" {{ post.isAdult ? 'checked' : '' }}>
-                    <button type="submit">{{ 'is_adult'|trans|lower }}</button>
+                    <button type="submit">{{ 'is_adult'|trans }}</button>
                 </form>
             </div>
         </li>

--- a/templates/post/_options.html.twig
+++ b/templates/post/_options.html.twig
@@ -4,31 +4,31 @@
         <li>
             <a href="{{ options_url('sortBy', 'top') }}"
                class="{{ html_classes({'active': route_has_param('sortBy', 'top')}) }}">
-                {{ 'top'|trans|lower }}
+                {{ 'top'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ options_url('sortBy', 'hot') }}"
                class="{{ html_classes({'active': route_has_param('sortBy', 'hot')}) }}">
-                {{ 'hot'|trans|lower }}
+                {{ 'hot'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ options_url('sortBy', 'newest') }}"
                class="{{ html_classes({'active': route_has_param('sortBy', 'newest')}) }}">
-                {{ 'newest'|trans|lower }}
+                {{ 'newest'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ options_url('sortBy', 'active') }}"
                class="{{ html_classes({'active': route_has_param('sortBy', 'active')}) }}">
-                {{ 'active'|trans|lower }}
+                {{ 'active'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ options_url('sortBy', 'commented') }}"
                class="{{ html_classes({'active': route_has_param('sortBy', 'commented')}) }}">
-                {{ 'commented'|trans|lower }}
+                {{ 'commented'|trans }}
             </a>
         </li>
     </menu>
@@ -47,44 +47,44 @@
                 <li>
                     <a href="{{ options_url('time', '3h') }}"
                        class="{{ html_classes({'active': route_has_param('time', '3h')}) }}">
-                        {{ '3h'|trans|lower }}
+                        {{ '3h'|trans }}
                     </a>
                 </li>
                 <li>
                     <a href="{{ options_url('time', '6h') }}"
                        class="{{ html_classes({'active': route_has_param('time', '6h')}) }}">
-                        {{ '6h'|trans|lower }}
+                        {{ '6h'|trans }}
                     </a>
                 </li>
                 <li>
                     <a href="{{ options_url('time', '12h') }}"
                        class="{{ html_classes({'active': route_has_param('time', '12h')}) }}">
-                        {{ '12h'|trans|lower }}
+                        {{ '12h'|trans }}
                     </a>
                 </li>
-                {% if get_active_sort_option() is not same as 'hot'|trans|lower %}
+                {% if get_active_sort_option() is not same as 'hot'|trans %}
                     <li>
                         <a href="{{ options_url('time', '1d') }}"
                            class="{{ html_classes({'active': route_has_param('time', '1d')}) }}">
-                            {{ '1d'|trans|lower }}
+                            {{ '1d'|trans }}
                         </a>
                     </li>
                     <li>
                         <a href="{{ options_url('time', '1w') }}"
                            class="{{ html_classes({'active': route_has_param('time', '1w')}) }}">
-                            {{ '1w'|trans|lower }}
+                            {{ '1w'|trans }}
                         </a>
                     </li>
                     <li>
                         <a href="{{ options_url('time', '1m') }}"
                            class="{{ html_classes({'active': route_has_param('time', '1m')}) }}">
-                            {{ '1m'|trans|lower }}
+                            {{ '1m'|trans }}
                         </a>
                     </li>
                     <li>
                         <a href="{{ options_url('time', '1y') }}"
                            class="{{ html_classes({'active': route_has_param('time', '1y')}) }}">
-                            {{ '1y'|trans|lower }}
+                            {{ '1y'|trans }}
                         </a>
                     </li>
                 {% endif %}

--- a/templates/post/_options_activity.html.twig
+++ b/templates/post/_options_activity.html.twig
@@ -6,13 +6,13 @@
         <li>
             <a href="{{ post_voters_url(post, 'up') }}"
                class="{{ html_classes({'active': is_route_name('post_voters') and route_has_param('type', 'up')}) }}">
-                {{ 'up_votes'|trans|lower }} ({{ post.countUpVotes }})
+                {{ 'up_votes'|trans }} ({{ post.countUpVotes }})
             </a>
         </li>
         <li>
             <a href="{{ post_favourites_url(post) }}"
                class="{{ html_classes({'active': is_route_name('post_favourites')}) }}">
-                {{ 'favourites'|trans|lower }} ({{ post.favouriteCount }})
+                {{ 'favourites'|trans }} ({{ post.favouriteCount }})
             </a>
         </li>
     </menu>

--- a/templates/post/comment/_moderate_panel.html.twig
+++ b/templates/post/comment/_moderate_panel.html.twig
@@ -2,7 +2,7 @@
     <menu>
         <li>
             <a class="stretched-link"
-               href="{{ path('magazine_panel_ban', {'name': comment.magazine.name, 'username': comment.user.username}) }}">{{ 'ban'|trans|lower }}</a>
+               href="{{ path('magazine_panel_ban', {'name': comment.magazine.name, 'username': comment.user.username}) }}">{{ 'ban'|trans }}</a>
         </li>
         <li>
             <form action="{{ post_comment_delete_url(comment) }}"
@@ -10,7 +10,7 @@
                   onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                 <input type="hidden" name="token" value="{{ csrf_token('post_comment_delete') }}">
                 <button type="submit">
-                    <span>{{ 'delete'|trans|lower }}</span>
+                    <span>{{ 'delete'|trans }}</span>
                 </button>
             </form>
         </li>
@@ -21,7 +21,7 @@
                       onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                     <input type="hidden" name="token" value="{{ csrf_token('post_comment_purge') }}">
                     <button type="submit">
-                        <span>{{ 'purge'|trans|lower }}</span>
+                        <span>{{ 'purge'|trans }}</span>
                     </button>
                 </form>
             </li>
@@ -40,7 +40,7 @@
                     <input type="hidden" name="token" value="{{ csrf_token('change_adult') }}">
                     <input name="adult"
                            type="checkbox" {{ comment.isAdult ? 'checked' : '' }}>
-                    <button type="submit">{{ 'is_adult'|trans|lower }}</button>
+                    <button type="submit">{{ 'is_adult'|trans }}</button>
                 </form>
             </div>
         </li>

--- a/templates/post/comment/_options.html.twig
+++ b/templates/post/comment/_options.html.twig
@@ -5,25 +5,25 @@
             <li>
                 <a href="{{ options_url('sortBy', 'hot') }}"
                    class="{{ html_classes({'active': route_has_param('sortBy', 'hot')}) }}">
-                    {{ 'hot'|trans|lower }}
+                    {{ 'hot'|trans }}
                 </a>
             </li>
             <li>
                 <a href="{{ options_url('sortBy', 'active') }}"
                    class="{{ html_classes({'active': route_has_param('sortBy', 'active')}) }}">
-                    {{ 'active'|trans|lower }}
+                    {{ 'active'|trans }}
                 </a>
             </li>
             <li>
                 <a href="{{ options_url('sortBy', 'newest') }}"
                    class="{{ html_classes({'active': route_has_param('sortBy', 'newest')}) }}">
-                    {{ 'newest'|trans|lower }}
+                    {{ 'newest'|trans }}
                 </a>
             </li>
             <li>
                 <a href="{{ options_url('sortBy', 'oldest') }}"
                    class="{{ html_classes({'active': route_has_param('sortBy', 'oldest')}) }}">
-                    {{ 'oldest'|trans|lower }}
+                    {{ 'oldest'|trans }}
                 </a>
             </li>
         </menu>
@@ -38,15 +38,15 @@
             <ul class="dropdown__menu">
                 <li>
                     <a class="{{ html_classes({'active': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW')) is same as constant('App\\Controller\\User\\ThemeSettingsController::CLASSIC')}) }}"
-                       href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW'), value: constant('App\\Controller\\User\\ThemeSettingsController::CLASSIC')}) }}">{{ 'classic_view'|trans|lower }}</a>
+                       href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW'), value: constant('App\\Controller\\User\\ThemeSettingsController::CLASSIC')}) }}">{{ 'classic_view'|trans }}</a>
                 </li>
                 <li>
                     <a class="{{ html_classes({'active': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW')) is same as constant('App\\Controller\\User\\ThemeSettingsController::CHAT')}) }}"
-                       href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW'), value: constant('App\\Controller\\User\\ThemeSettingsController::CHAT')}) }}">{{ 'chat_view'|trans|lower }}</a>
+                       href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW'), value: constant('App\\Controller\\User\\ThemeSettingsController::CHAT')}) }}">{{ 'chat_view'|trans }}</a>
                 </li>
                 <li>
                     <a class="{{ html_classes({'active': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW')) is same as null or app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TREE')}) }}"
-                       href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW'), value: constant('App\\Controller\\User\\ThemeSettingsController::TREE')}) }}">{{ 'tree_view'|trans|lower }}</a>
+                       href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW'), value: constant('App\\Controller\\User\\ThemeSettingsController::TREE')}) }}">{{ 'tree_view'|trans }}</a>
                 </li>
             </ul>
         </li>

--- a/templates/post/comment/_options_activity.html.twig
+++ b/templates/post/comment/_options_activity.html.twig
@@ -6,13 +6,13 @@
         <li>
             <a href="{{ post_comment_voters_url(comment, 'up') }}"
                class="{{ html_classes({'active': is_route_name('post_comment_voters')}) }}">
-                {{ 'up_votes'|trans|lower }} ({{ comment.countUpVotes }})
+                {{ 'up_votes'|trans }} ({{ comment.countUpVotes }})
             </a>
         </li>
         <li>
             <a href="{{ post_comment_favourites_url(comment) }}"
                class="{{ html_classes({'active': is_route_name('post_comment_favourites')}) }}">
-                {{ 'favourites'|trans|lower }} ({{ comment.favouriteCount }})
+                {{ 'favourites'|trans }} ({{ comment.favouriteCount }})
             </a>
         </li>
     </menu>

--- a/templates/stats/_filters.html.twig
+++ b/templates/stats/_filters.html.twig
@@ -1,20 +1,20 @@
 <div class="flex">
     <label class="select">
         <select onchange="location = this.value;">
-            <option value="{{ options_url('statsPeriod', -1) }}">{{ 'all'|trans|lower }}</option>
-            <option value="{{ options_url('statsPeriod', 7) }}" {{ period is same as 7 ? 'selected' : '' }}>{{ 'week'|trans|lower }}</option>
+            <option value="{{ options_url('statsPeriod', -1) }}">{{ 'all'|trans }}</option>
+            <option value="{{ options_url('statsPeriod', 7) }}" {{ period is same as 7 ? 'selected' : '' }}>{{ 'week'|trans }}</option>
             <option value="{{ options_url('statsPeriod', 14) }}" {{ period is same as 14 ? 'selected' : '' }}>
-                2 {{ 'weeks'|trans|lower }}</option>
-            <option value="{{ options_url('statsPeriod', 31) }}" {{ period is same as 31 ? 'selected' : '' }}>{{ 'month'|trans|lower }}</option>
+                2 {{ 'weeks'|trans }}</option>
+            <option value="{{ options_url('statsPeriod', 31) }}" {{ period is same as 31 ? 'selected' : '' }}>{{ 'month'|trans }}</option>
             <option value="{{ options_url('statsPeriod', 183) }}" {{ period is same as 183 ? 'selected' : '' }}>
-                6 {{ 'months'|trans|lower }}</option>
-            <option value="{{ options_url('statsPeriod', 365) }}" {{ period is same as 365 ? 'selected' : '' }}>{{ 'year'|trans|lower }}</option>
+                6 {{ 'months'|trans }}</option>
+            <option value="{{ options_url('statsPeriod', 365) }}" {{ period is same as 365 ? 'selected' : '' }}>{{ 'year'|trans }}</option>
         </select>
     </label>
     <label class="select">
         <select onchange="location = this.value;">
-            <option value="{{ options_url('withFederated', false) }}">{{ 'local'|trans|lower }}</option>
-            <option value="{{ options_url('withFederated', true) }}" {{ withFederated is same as true ? 'selected' : '' }}>{{ 'federated'|trans|lower }}</option>
+            <option value="{{ options_url('withFederated', false) }}">{{ 'local'|trans }}</option>
+            <option value="{{ options_url('withFederated', true) }}" {{ withFederated is same as true ? 'selected' : '' }}>{{ 'federated'|trans }}</option>
         </select>
     </label>
 </div>

--- a/templates/stats/_options.html.twig
+++ b/templates/stats/_options.html.twig
@@ -8,25 +8,25 @@
         <li>
             <a href="{{ path('stats', {statsType: TYPE_GENERAL}) }}"
                class="{{ html_classes({'active': route_has_param('statsType', TYPE_GENERAL) or get_route_param('statsType') is same as null}) }}">
-                {{ TYPE_GENERAL|trans|lower }}
+                {{ TYPE_GENERAL|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('stats', {statsType: TYPE_CONTENT}) }}"
                class="{{ html_classes({'active': route_has_param('statsType', TYPE_CONTENT)}) }}">
-                {{ TYPE_CONTENT|trans|lower }}
+                {{ TYPE_CONTENT|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('stats', {statsType: TYPE_VOTES}) }}"
                class="{{ html_classes({'active': route_has_param('statsType', TYPE_VOTES)}) }}">
-                {{ TYPE_VOTES|trans|lower }}
+                {{ TYPE_VOTES|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('stats', {statsType: TYPE_VIEWS}) }}"
                class="{{ html_classes({'active': route_has_param('statsType', TYPE_VIEWS)}) }}">
-                {{ TYPE_VIEWS|trans|lower }}
+                {{ TYPE_VIEWS|trans }}
             </a>
         </li>
     </menu>

--- a/templates/user/_options.html.twig
+++ b/templates/user/_options.html.twig
@@ -4,58 +4,58 @@
         <li>
             <a href="{{ path('user_overview', {username: user.username}) }}"
                class="{{ html_classes({'active': is_route_name('user_overview')}) }}">
-                {{ 'overview'|trans|lower }}
+                {{ 'overview'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('user_entries', {username: user.username}) }}"
                class="{{ html_classes({'active': is_route_name('user_entries')}) }}">
-                {{ 'threads'|trans|lower }} ({{ user.entries|length }})
+                {{ 'threads'|trans }} ({{ user.entries|length }})
             </a>
         </li>
         <li>
             <a href="{{ path('user_comments', {username: user.username}) }}"
                class="{{ html_classes({'active': is_route_name('user_comments')}) }}">
-                {{ 'comments'|trans|lower }} ({{ user.entryComments|length }})
+                {{ 'comments'|trans }} ({{ user.entryComments|length }})
             </a>
         </li>
         <li>
             <a href="{{ path('user_posts', {username: user.username}) }}"
                class="{{ html_classes({'active': is_route_name('user_posts')}) }}">
-                {{ 'posts'|trans|lower }} ({{ user.posts|length }})
+                {{ 'posts'|trans }} ({{ user.posts|length }})
             </a>
         </li>
         <li>
             <a href="{{ path('user_replies', {username: user.username}) }}"
                class="{{ html_classes({'active': is_route_name('user_replies')}) }}">
-                {{ 'replies'|trans|lower }} ({{ user.postComments|length }})
+                {{ 'replies'|trans }} ({{ user.postComments|length }})
             </a>
         </li>
         <li>
             <a href="{{ path('user_boosts', {username: user.username}) }}"
                class="{{ html_classes({'active': is_route_name('user_boosts')}) }}">
-                {{ 'boosts'|trans|lower }} ({{ count_user_boosts(user) }})
+                {{ 'boosts'|trans }} ({{ count_user_boosts(user) }})
             </a>
         </li>
         {% if user.getShowProfileFollowings or app.user is same as user %}
             <li>
                 <a href="{{ path('user_following', {username: user.username}) }}"
                    class="{{ html_classes({'active': is_route_name('user_following'), 'opacity-50': not user.getShowProfileFollowings}) }}">
-                    {{ 'following'|trans|lower }} ({{ user.follows|length }})
+                    {{ 'following'|trans }} ({{ user.follows|length }})
                 </a>
             </li>
         {% endif %}
         <li>
             <a href="{{ path('user_followers', {username: user.username}) }}"
                class="{{ html_classes({'active': is_route_name('user_followers')}) }}">
-                {{ 'followers'|trans|lower }} ({{ user.followers|length }})
+                {{ 'followers'|trans }} ({{ user.followers|length }})
             </a>
         </li>
         {% if user.getShowProfileSubscriptions or app.user is same as user %}
             <li>
                 <a href="{{ path('user_subscriptions', {username: user.username}) }}"
                    class="{{ html_classes({'active': is_route_name('user_subscriptions'), 'opacity-50': not user.getShowProfileSubscriptions}) }}">
-                    {{ 'subscriptions'|trans|lower }} ({{ user.subscriptions|length }})
+                    {{ 'subscriptions'|trans }} ({{ user.subscriptions|length }})
                 </a>
             </li>
         {% endif %}
@@ -63,7 +63,7 @@
             {%- set TYPE_ENTRY = constant('App\\Repository\\ReputationRepository::TYPE_ENTRY') -%}
             <a href="{{ path('user_reputation', {username: user.username, reputationType: TYPE_ENTRY}) }}"
                class="{{ html_classes({'active': is_route_name('user_reputation')}) }}">
-                {{ 'reputation'|trans|lower }} ({{ get_reputation_total(user) }})
+                {{ 'reputation'|trans }} ({{ get_reputation_total(user) }})
             </a>
         </li>
     </menu>

--- a/templates/user/settings/_options.html.twig
+++ b/templates/user/settings/_options.html.twig
@@ -4,49 +4,49 @@
         <li>
             <a href="{{ path('user_settings_general') }}"
                class="{{ html_classes({'active': is_route_name('user_settings_general')}) }}">
-                {{ 'general'|trans|lower }}
+                {{ 'general'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('user_settings_profile') }}"
                class="{{ html_classes({'active': is_route_name('user_settings_profile')}) }}">
-                {{ 'profile'|trans|lower }}
+                {{ 'profile'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('user_settings_email') }}"
                class="{{ html_classes({'active': is_route_name('user_settings_email')}) }}">
-                {{ 'email'|trans|lower }}
+                {{ 'email'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('user_settings_password') }}"
                class="{{ html_classes({'active': is_route_name('user_settings_password')}) }}">
-                {{ 'password_and_2fa'|trans|lower }}
+                {{ 'password_and_2fa'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('user_settings_magazine_blocks') }}"
                class="{{ html_classes({'active': is_route_name_contains('_blocks')}) }}">
-                {{ 'blocked'|trans|lower }}
+                {{ 'blocked'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('user_settings_magazine_subscriptions') }}"
                class="{{ html_classes({'active': is_route_name_contains('_subscriptions')}) }}">
-                {{ 'subscriptions'|trans|lower }}
+                {{ 'subscriptions'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('user_settings_reports') }}"
                class="{{ html_classes({'active': is_route_name('user_settings_reports')}) }}">
-                {{ 'reports'|trans|lower }}
+                {{ 'reports'|trans }}
             </a>
         </li>
         <li>
             <a href="{{ path('user_settings_stats') }}"
                class="{{ html_classes({'active': is_route_name('user_settings_stats')}) }}">
-                {{ 'stats'|trans|lower }}
+                {{ 'stats'|trans }}
             </a>
         </li>
     </menu>


### PR DESCRIPTION
I personally never liked the lower-caps in all the text. This will remove the "to lower" twig pipe from the translation strings.

I kept lower caps in notification area however as well as in some special form row segments and alt text on images.

**Before:**

![image](https://github.com/MbinOrg/mbin/assets/628926/554b206a-d744-49f2-b393-341a220ec696)

**After:**
![image](https://github.com/MbinOrg/mbin/assets/628926/3fa063bf-e8ee-4168-a1bf-d54402a74e7a)
![image](https://github.com/MbinOrg/mbin/assets/628926/f691a575-e874-41e9-baf0-233204405e9c)
![image](https://github.com/MbinOrg/mbin/assets/628926/d8af34ef-1186-426b-b926-9fd5752a9d36)


**After:**
![image](https://github.com/MbinOrg/mbin/assets/628926/51518d7d-7c19-4ce1-8ca0-86b3b3f77512)

After:
![image](https://github.com/MbinOrg/mbin/assets/628926/b40bbc3b-9bb6-422c-84f6-b5d536242e82)

After:

![image](https://github.com/MbinOrg/mbin/assets/628926/3e4f2a89-c7a7-4e61-8b24-0faca2bdb134)

After:

![image](https://github.com/MbinOrg/mbin/assets/628926/e5a4e825-731e-471c-81d3-32f9f6d86794)

After:

![image](https://github.com/MbinOrg/mbin/assets/628926/14d683bb-2333-4703-815e-9d14da96cfcb)


Example of UNchanged lower-caps in notification page (I did keep the low caps here):

![image](https://github.com/MbinOrg/mbin/assets/628926/d5da244b-7d9e-4d44-9b59-45da2a9a5b1f)
