### PR TITLE
Introducing Open URL link to thread/post/comment

### DIFF
--- a/assets/styles/components/_dropdown.scss
+++ b/assets/styles/components/_dropdown.scss
@@ -98,8 +98,8 @@ $transition: 180ms all 120ms ease-out;
   }
 
   .dropdown__separator {
-    border: 1px solid #aaaa;
+    border: var(--kbin-section-border);
     height: 0px;
-    margin: 5px 10px;
+    margin: 2px 5px;
   }
 }

--- a/assets/styles/components/_dropdown.scss
+++ b/assets/styles/components/_dropdown.scss
@@ -96,4 +96,10 @@ $transition: 180ms all 120ms ease-out;
     color: var(--kbin-button-secondary-text-hover-color) !important;
     background: var(--kbin-button-secondary-hover-bg);
   }
+
+  .dropdown__separator {
+    border: 1px solid #aaaa;
+    height: 0px;
+    margin: 5px 10px;
+  }
 }

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -177,8 +177,10 @@
                                 {% endif %}
 
                                 <li>
-                                    <a data-action="clipboard#copy"
-                                       href="{{ entry_url(entry) }}">{{ 'copy_url'|trans }}</a>
+                                    <a target="_blank"
+                                       href="{{ entry.apId ?? path('ap_entry', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}">
+                                        {{ 'open_url_to_fediverse'|trans }}
+                                    </a>
                                 </li>
                                 <li>
                                     <a data-action="clipboard#copy"
@@ -187,10 +189,8 @@
                                     </a>
                                 </li>
                                 <li>
-                                    <a target="_blank"
-                                       href="{{ entry.apId ?? path('ap_entry', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}">
-                                        {{ 'open_url_to_fediverse'|trans }}
-                                    </a>
+                                    <a data-action="clipboard#copy"
+                                       href="{{ entry_url(entry) }}">{{ 'copy_url'|trans }}</a>
                                 </li>
                                 {% if is_granted('edit', entry) %}
                                     <li>

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -193,7 +193,9 @@
                                     <a data-action="clipboard#copy"
                                        href="{{ entry_url(entry) }}">{{ 'copy_url'|trans }}</a>
                                 </li>
-                                <li class="dropdown__separator"></li>
+                                {% if is_granted('edit', entry) or if app.user and entry.isAuthor(app.user) or is_granted('moderate', entry) %}
+                                    <li class="dropdown__separator"></li>
+                                {% endif %}
                                 {% if is_granted('edit', entry) %}
                                     <li>
                                         <a href="{{ entry_edit_url(entry) }}"

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -176,6 +176,7 @@
                                     </li>
                                 {% endif %}
 
+                                <li class="dropdown__separator"></li>
                                 <li>
                                     <a target="_blank"
                                        href="{{ entry.apId ?? path('ap_entry', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}">
@@ -192,6 +193,7 @@
                                     <a data-action="clipboard#copy"
                                        href="{{ entry_url(entry) }}">{{ 'copy_url'|trans }}</a>
                                 </li>
+                                <li class="dropdown__separator"></li>
                                 {% if is_granted('edit', entry) %}
                                     <li>
                                         <a href="{{ entry_edit_url(entry) }}"

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -193,7 +193,7 @@
                                     <a data-action="clipboard#copy"
                                        href="{{ entry_url(entry) }}">{{ 'copy_url'|trans }}</a>
                                 </li>
-                                {% if is_granted('edit', entry) or if app.user and entry.isAuthor(app.user) or is_granted('moderate', entry) %}
+                                {% if is_granted('edit', entry) or (app.user and entry.isAuthor(app.user)) or is_granted('moderate', entry) %}
                                     <li class="dropdown__separator"></li>
                                 {% endif %}
                                 {% if is_granted('edit', entry) %}

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -186,6 +186,12 @@
                                         {{ 'copy_url_to_fediverse'|trans|lower }}
                                     </a>
                                 </li>
+                                <li>
+                                    <a target="_blank"
+                                       href="{{ entry.apId ?? path('ap_entry', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}">
+                                        {{ 'open_url_to_fediverse'|trans }}
+                                    </a>
+                                </li>
                                 {% if is_granted('edit', entry) %}
                                     <li>
                                         <a href="{{ entry_edit_url(entry) }}"

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -107,7 +107,9 @@
                                         {{ 'copy_url'|trans }}
                                     </a>
                                 </li>
-                                <li class="dropdown__separator"></li>
+                                {% if is_granted('edit', comment) or if app.user and comment.isAuthor(app.user) or is_granted('moderate', comment) %}
+                                    <li class="dropdown__separator"></li>
+                                {% endif %}
                                 {% if is_granted('edit', comment) %}
                                     <li>
                                         <a href="{{ entry_comment_edit_url(comment) }}"

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -89,9 +89,9 @@
                                     </a>
                                 </li>
                                 <li>
-                                    <a data-action="clipboard#copy"
-                                       href="{{ entry_url(comment.entry) }}#{{ get_url_fragment(comment) }}">
-                                        {{ 'copy_url'|trans }}
+                                    <a target="_blank"
+                                       href="{{ comment.apId ?? path('ap_entry_comment', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id}) }}">
+                                        {{ 'open_url_to_fediverse'|trans }}
                                     </a>
                                 </li>
                                 <li>
@@ -101,9 +101,9 @@
                                     </a>
                                 </li>
                                 <li>
-                                    <a target="_blank"
-                                       href="{{ comment.apId ?? path('ap_entry_comment', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id}) }}">
-                                        {{ 'open_url_to_fediverse'|trans }}
+                                    <a data-action="clipboard#copy"
+                                       href="{{ entry_url(comment.entry) }}#{{ get_url_fragment(comment) }}">
+                                        {{ 'copy_url'|trans }}
                                     </a>
                                 </li>
                                 {% if is_granted('edit', comment) %}

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -88,6 +88,7 @@
                                         {{ 'activity'|trans }}
                                     </a>
                                 </li>
+                                <li class="dropdown__separator"></li>
                                 <li>
                                     <a target="_blank"
                                        href="{{ comment.apId ?? path('ap_entry_comment', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id}) }}">
@@ -106,6 +107,7 @@
                                         {{ 'copy_url'|trans }}
                                     </a>
                                 </li>
+                                <li class="dropdown__separator"></li>
                                 {% if is_granted('edit', comment) %}
                                     <li>
                                         <a href="{{ entry_comment_edit_url(comment) }}"

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -107,7 +107,7 @@
                                         {{ 'copy_url'|trans }}
                                     </a>
                                 </li>
-                                {% if is_granted('edit', comment) or if app.user and comment.isAuthor(app.user) or is_granted('moderate', comment) %}
+                                {% if is_granted('edit', comment) or (app.user and comment.isAuthor(app.user)) or is_granted('moderate', comment) %}
                                     <li class="dropdown__separator"></li>
                                 {% endif %}
                                 {% if is_granted('edit', comment) %}

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -100,6 +100,12 @@
                                         {{ 'copy_url_to_fediverse'|trans|lower }}
                                     </a>
                                 </li>
+                                <li>
+                                    <a target="_blank"
+                                       href="{{ comment.apId ?? path('ap_entry_comment', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id}) }}">
+                                        {{ 'open_url_to_fediverse'|trans }}
+                                    </a>
+                                </li>
                                 {% if is_granted('edit', comment) %}
                                     <li>
                                         <a href="{{ entry_comment_edit_url(comment) }}"

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -108,6 +108,7 @@
                                         {{ 'activity'|trans }}
                                     </a>
                                 </li>
+                                <li class="dropdown__separator"></li>
                                 <li>
                                     <a target="_blank"
                                        href="{{ post.apId ?? path('ap_post', {magazine_name: post.magazine.name, post_id: post.id}) }}">
@@ -125,6 +126,7 @@
                                         {{ 'copy_url'|trans }}
                                     </a>
                                 </li>
+                                <li class="dropdown__separator"></li>
                                 {% if is_granted('edit', post) %}
                                     <li>
                                         <a href="{{ post_edit_url(post) }}"

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -109,8 +109,9 @@
                                     </a>
                                 </li>
                                 <li>
-                                    <a data-action="clipboard#copy" href="{{ post_url(post) }}">
-                                        {{ 'copy_url'|trans }}
+                                    <a target="_blank"
+                                       href="{{ post.apId ?? path('ap_post', {magazine_name: post.magazine.name, post_id: post.id}) }}">
+                                        {{ 'open_url_to_fediverse'|trans }}
                                     </a>
                                 </li>
                                 <li>
@@ -120,9 +121,8 @@
                                     </a>
                                 </li>
                                 <li>
-                                    <a target="_blank"
-                                       href="{{ post.apId ?? path('ap_post', {magazine_name: post.magazine.name, post_id: post.id}) }}">
-                                        {{ 'open_url_to_fediverse'|trans }}
+                                    <a data-action="clipboard#copy" href="{{ post_url(post) }}">
+                                        {{ 'copy_url'|trans }}
                                     </a>
                                 </li>
                                 {% if is_granted('edit', post) %}

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -126,7 +126,9 @@
                                         {{ 'copy_url'|trans }}
                                     </a>
                                 </li>
-                                <li class="dropdown__separator"></li>
+                                {% if is_granted('edit', post) or if app.user and post.isAuthor(app.user) or is_granted('moderate', post) %}
+                                    <li class="dropdown__separator"></li>
+                                {% endif %}
                                 {% if is_granted('edit', post) %}
                                     <li>
                                         <a href="{{ post_edit_url(post) }}"

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -119,6 +119,12 @@
                                         {{ 'copy_url_to_fediverse'|trans|lower }}
                                     </a>
                                 </li>
+                                <li>
+                                    <a target="_blank"
+                                       href="{{ post.apId ?? path('ap_post', {magazine_name: post.magazine.name, post_id: post.id}) }}">
+                                        {{ 'open_url_to_fediverse'|trans }}
+                                    </a>
+                                </li>
                                 {% if is_granted('edit', post) %}
                                     <li>
                                         <a href="{{ post_edit_url(post) }}"

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -126,7 +126,7 @@
                                         {{ 'copy_url'|trans }}
                                     </a>
                                 </li>
-                                {% if is_granted('edit', post) or if app.user and post.isAuthor(app.user) or is_granted('moderate', post) %}
+                                {% if is_granted('edit', post) or (app.user and post.isAuthor(app.user)) or is_granted('moderate', post) %}
                                     <li class="dropdown__separator"></li>
                                 {% endif %}
                                 {% if is_granted('edit', post) %}

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -92,6 +92,7 @@
                                         {{ 'activity'|trans }}
                                     </a>
                                 </li>
+                                <li class="dropdown__separator"></li>
                                 <li>
                                     <a target="_blank"
                                        href="{{ comment.apId ?? path('ap_post_comment', {magazine_name: comment.magazine.name, post_id: comment.post.id, comment_id: comment.id}) }}">
@@ -110,6 +111,7 @@
                                         {{ 'copy_url'|trans }}
                                     </a>
                                 </li>
+                                <li class="dropdown__separator"></li>
                                 {% if is_granted('edit', comment) %}
                                     <li>
                                         <a href="{{ post_comment_edit_url(comment) }}"

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -104,6 +104,12 @@
                                         {{ 'copy_url_to_fediverse'|trans|lower }}
                                     </a>
                                 </li>
+                                <li>
+                                    <a target="_blank"
+                                       href="{{ comment.apId ?? path('ap_post_comment', {magazine_name: comment.magazine.name, post_id: comment.post.id, comment_id: comment.id}) }}">
+                                        {{ 'open_url_to_fediverse'|trans }}
+                                    </a>
+                                </li>
                                 {% if is_granted('edit', comment) %}
                                     <li>
                                         <a href="{{ post_comment_edit_url(comment) }}"

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -111,7 +111,7 @@
                                         {{ 'copy_url'|trans }}
                                     </a>
                                 </li>
-                                {% if is_granted('edit', comment) or if app.user and comment.isAuthor(app.user) or is_granted('moderate', comment) %}
+                                {% if is_granted('edit', comment) or (app.user and comment.isAuthor(app.user)) or is_granted('moderate', comment) %}
                                     <li class="dropdown__separator"></li>
                                 {% endif %}
                                 {% if is_granted('edit', comment) %}

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -93,9 +93,9 @@
                                     </a>
                                 </li>
                                 <li>
-                                    <a data-action="clipboard#copy"
-                                       href="{{ post_url(comment.post) }}#{{ get_url_fragment(comment) }}">
-                                        {{ 'copy_url'|trans }}
+                                    <a target="_blank"
+                                       href="{{ comment.apId ?? path('ap_post_comment', {magazine_name: comment.magazine.name, post_id: comment.post.id, comment_id: comment.id}) }}">
+                                        {{ 'open_url_to_fediverse'|trans }}
                                     </a>
                                 </li>
                                 <li>
@@ -105,9 +105,9 @@
                                     </a>
                                 </li>
                                 <li>
-                                    <a target="_blank"
-                                       href="{{ comment.apId ?? path('ap_post_comment', {magazine_name: comment.magazine.name, post_id: comment.post.id, comment_id: comment.id}) }}">
-                                        {{ 'open_url_to_fediverse'|trans }}
+                                    <a data-action="clipboard#copy"
+                                       href="{{ post_url(comment.post) }}#{{ get_url_fragment(comment) }}">
+                                        {{ 'copy_url'|trans }}
                                     </a>
                                 </li>
                                 {% if is_granted('edit', comment) %}

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -111,7 +111,9 @@
                                         {{ 'copy_url'|trans }}
                                     </a>
                                 </li>
-                                <li class="dropdown__separator"></li>
+                                {% if is_granted('edit', comment) or if app.user and comment.isAuthor(app.user) or is_granted('moderate', comment) %}
+                                    <li class="dropdown__separator"></li>
+                                {% endif %}
                                 {% if is_granted('edit', comment) %}
                                     <li>
                                         <a href="{{ post_comment_edit_url(comment) }}"

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -822,3 +822,4 @@ page_width: Page width
 page_width_max: Max
 page_width_auto: Auto
 page_width_fixed: Fixed
+open_url_to_fediverse: Open original URL


### PR DESCRIPTION
The "Copy" link is nice, but users including myself also want to open the original link sometimes directly into a new window (yes you can use middle mouse button click, if you have that). 

- Introducing a Open URL menu item
- Reorder the menu items
- Introducing a separator

![image](https://github.com/MbinOrg/mbin/assets/628926/cd5d06ef-6318-4c7d-8f14-8ea3d7e2a61a)

And when there is no edit, no actor and no moderator, it looks like this:

![image](https://github.com/MbinOrg/mbin/assets/628926/648f67ae-c21a-4236-8bad-193235f63d84)


In another PR I might also want to automatically close the drop-down menu when a user clicked on "Copy ... URL".