### PR TITLE
Change federation setting to match other enum styling

### DIFF
--- a/assets/controllers/settings_row_enum_controller.js
+++ b/assets/controllers/settings_row_enum_controller.js
@@ -9,7 +9,10 @@ export default class extends Controller {
     change({params: {actionPath, reloadRequired}}) {
         return fetch(actionPath).then(() => {
             if (reloadRequired) {
-                document.querySelector('.settings-list').classList.add('reload-required');
+                document.querySelectorAll('.settings-list')
+                  .forEach((el) => {
+                    el.classList.add('reload-required');
+                });
             }
         });
     }

--- a/templates/layout/_sidebar.html.twig
+++ b/templates/layout/_sidebar.html.twig
@@ -52,19 +52,8 @@
     <div id="federation" class="section" data-options-target="federation">
         <h3>{{ 'federation'|trans }}</h3>
         <div class="settings-list">
-            <div class="row">
-                <span>{{ 'status'|trans }}:</span>
-                <div>
-                    <a href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_FEDERATION_ENABLED'), value: 'true'}) }}"
-                       class="{{ html_classes('link-muted', {'active': not app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_FEDERATION_ENABLED')) or app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_FEDERATION_ENABLED')) is same as 'true'}) }}">
-                        {{ 'on'|trans }}
-                    </a>
-                    |
-                    <a href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_FEDERATION_ENABLED'), value: 'false'}) }}"
-                       class="{{ html_classes('link-muted', {'active': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_FEDERATION_ENABLED')) is same as 'false'}) }}">
-                        {{ 'off'|trans }}
-                    </a>
-                </div>
+            <div class="settings-section">
+              {{ component('settings_row_enum', {label: 'status'|trans, settingsKey: 'KBIN_FEDERATION_ENABLED', values: [ {name: 'local'|trans , value: 'FALSE'}, {name: 'local_and_federated'|trans , value: 'TRUE' } ], defaultValue: 'TRUE' } ) }}
             </div>
         </div>
     </div>

--- a/templates/layout/_sidebar.html.twig
+++ b/templates/layout/_sidebar.html.twig
@@ -52,8 +52,13 @@
     <div id="federation" class="section" data-options-target="federation">
         <h3>{{ 'federation'|trans }}</h3>
         <div class="settings-list">
+            <div class="reload-required-section">
+                <button onclick="window.location.reload(); this.classList.add('spin');" class="btn btn-link">
+                    <i class="fa fa-refresh"></i>{{ 'reload_to_apply'|trans }}
+                </button>
+            </div>
             <div class="settings-section">
-              {{ component('settings_row_enum', {label: 'status'|trans, settingsKey: 'KBIN_FEDERATION_ENABLED', values: [ {name: 'local'|trans , value: 'FALSE'}, {name: 'local_and_federated'|trans , value: 'TRUE' } ], defaultValue: 'TRUE' } ) }}
+                {{ component('settings_row_enum', {label: 'status'|trans, settingsKey: 'KBIN_FEDERATION_ENABLED', values: [ {name: 'local'|trans , value: 'FALSE'}, {name: 'local_and_federated'|trans , value: 'TRUE' } ], defaultValue: 'TRUE' } ) }}
             </div>
         </div>
     </div>


### PR DESCRIPTION
Personally, I found the federation status setting to be difficult to read. Was it on or off? What does on or off even mean?

This PR changes it to have a consistent style matching the settings panel. It also changes "On" and "Off" to terms used elsewhere (in magazine search): "Local" and "Local and federated". It does switch the option sides (enabled now appears on right rather than left), that felt more natural to the words being used and matches the current defaults of the other setting enums, don't think it has a big effect on usability.

Before:

![image](https://github.com/MbinOrg/mbin/assets/146029455/b65d8268-ade4-4143-85b7-a7e4f86197cc)

After:

![image](https://github.com/MbinOrg/mbin/assets/146029455/5394c049-bc48-4c40-a113-76853c0e83ab)

when changing settings (changed themes to give a different example) reload appears on both settings tab, but that seemed accurate to me as it's still true:

![image](https://github.com/MbinOrg/mbin/assets/146029455/537109c3-64b2-4ebd-9d05-a28f46a45d2b)

Conversely, these terms might not be a perfect fit as well. "Local" will still show posts from local users but to remote magazines, as your local users posts to the local copies of the magazines your instance has.

(As an aside, the enums don't seem quite readable to me in dark theme, it's probably the worst, it looks much better in the other themes, but at least now it matches either way)

<details>
<summary>screenshot in tokyo night</summary>

![image](https://github.com/MbinOrg/mbin/assets/146029455/a20ea149-9411-4a9e-a557-a9622f2a7f9c)

</details>