### PR TITLE
Prepare for magzine removal Mbin (partial kbin sync)

### DIFF
--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -123,7 +123,7 @@ class Entry implements VotableInterface, CommentInterface, DomainInterface, Visi
     public ?array $mentions = null;
     #[OneToMany(mappedBy: 'entry', targetEntity: EntryComment::class, fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     public Collection $comments;
-    #[OneToMany(mappedBy: 'entry', targetEntity: EntryVote::class, cascade: ['persist'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
+    #[OneToMany(mappedBy: 'entry', targetEntity: EntryVote::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     #[OrderBy(['createdAt' => 'DESC'])]
     public Collection $votes;
     #[OneToMany(mappedBy: 'entry', targetEntity: EntryReport::class, cascade: ['remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -6,7 +6,6 @@ namespace App\Entity;
 
 use App\Entity\Contracts\ActivityPubActivityInterface;
 use App\Entity\Contracts\CommentInterface;
-use App\Entity\Contracts\ContentInterface;
 use App\Entity\Contracts\ContentVisibilityInterface;
 use App\Entity\Contracts\DomainInterface;
 use App\Entity\Contracts\FavouriteInterface;
@@ -48,7 +47,7 @@ use Webmozart\Assert\Assert;
 #[Index(columns: ['last_active'], name: 'entry_last_active_at_idx')]
 #[Index(columns: ['body_ts'], name: 'entry_body_ts_idx')]
 #[Index(columns: ['title_ts'], name: 'entry_title_ts_idx')]
-class Entry implements VotableInterface, CommentInterface, DomainInterface, VisibilityInterface, RankingInterface, ReportInterface, FavouriteInterface, ViewCountable, TagInterface, ActivityPubActivityInterface, ContentInterface, ContentVisibilityInterface
+class Entry implements VotableInterface, CommentInterface, DomainInterface, VisibilityInterface, RankingInterface, ReportInterface, FavouriteInterface, ViewCountable, TagInterface, ActivityPubActivityInterface, ContentVisibilityInterface
 {
     use VotableTrait;
     use RankingTrait;

--- a/src/Entity/EntryComment.php
+++ b/src/Entity/EntryComment.php
@@ -86,7 +86,7 @@ class EntryComment implements VotableInterface, VisibilityInterface, ReportInter
     #[OneToMany(mappedBy: 'root', targetEntity: EntryComment::class, orphanRemoval: true)]
     #[OrderBy(['createdAt' => 'ASC'])]
     public Collection $nested;
-    #[OneToMany(mappedBy: 'comment', targetEntity: EntryCommentVote::class, cascade: ['persist'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
+    #[OneToMany(mappedBy: 'comment', targetEntity: EntryCommentVote::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     public Collection $votes;
     #[OneToMany(mappedBy: 'entryComment', targetEntity: EntryCommentReport::class, cascade: ['remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     public Collection $reports;

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -88,7 +88,7 @@ class Post implements VotableInterface, CommentInterface, VisibilityInterface, R
     public ?array $mentions = null;
     #[OneToMany(mappedBy: 'post', targetEntity: PostComment::class, orphanRemoval: true)]
     public Collection $comments;
-    #[OneToMany(mappedBy: 'post', targetEntity: PostVote::class, cascade: ['persist'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
+    #[OneToMany(mappedBy: 'post', targetEntity: PostVote::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     public Collection $votes;
     #[OneToMany(mappedBy: 'post', targetEntity: PostReport::class, cascade: ['remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     public Collection $reports;

--- a/src/Entity/PostComment.php
+++ b/src/Entity/PostComment.php
@@ -88,7 +88,7 @@ class PostComment implements VotableInterface, VisibilityInterface, ReportInterf
     #[OneToMany(mappedBy: 'root', targetEntity: PostComment::class, orphanRemoval: true)]
     #[OrderBy(['createdAt' => 'ASC'])]
     public Collection $nested;
-    #[OneToMany(mappedBy: 'comment', targetEntity: PostCommentVote::class, cascade: ['persist'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
+    #[OneToMany(mappedBy: 'comment', targetEntity: PostCommentVote::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     public Collection $votes;
     #[OneToMany(mappedBy: 'postComment', targetEntity: PostCommentReport::class, cascade: ['remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     public Collection $reports;

--- a/src/EventListener/MagazineVisibilityListener.php
+++ b/src/EventListener/MagazineVisibilityListener.php
@@ -6,11 +6,16 @@ namespace App\EventListener;
 
 use App\Entity\Contracts\VisibilityInterface;
 use App\Entity\Magazine;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class MagazineVisibilityListener
 {
+    public function __construct(private readonly Security $security)
+    {
+    }
+
     public function onKernelControllerArguments(ControllerArgumentsEvent $event): void
     {
         $magazine = array_filter($event->getArguments(), fn ($argument) => $argument instanceof Magazine);
@@ -19,8 +24,14 @@ class MagazineVisibilityListener
             return;
         }
 
-        if (VisibilityInterface::VISIBILITY_VISIBLE !== array_values($magazine)[0]->visibility) {
-            throw new NotFoundHttpException();
+        $magazine = array_values($magazine)[0];
+
+        if (VisibilityInterface::VISIBILITY_VISIBLE !== $magazine->visibility) {
+            if (null === $this->security->getUser()
+                || false === $magazine->userIsOwner($this->security->getUser())
+                && false === $this->security->isGranted('ROLE_ADMIN')) {
+                throw new NotFoundHttpException();
+            }
         }
     }
 }

--- a/src/Security/Voter/MagazineVoter.php
+++ b/src/Security/Voter/MagazineVoter.php
@@ -69,7 +69,7 @@ class MagazineVoter extends Voter
 
     private function canDelete(Magazine $magazine, User $user): bool
     {
-        return $magazine->userIsOwner($user);
+        return $magazine->userIsOwner($user) || $user->isAdmin();
     }
 
     private function canPurge(Magazine $magazine, User $user): bool

--- a/templates/components/magazine_box.html.twig
+++ b/templates/components/magazine_box.html.twig
@@ -2,7 +2,7 @@
     {% if showSectionTitle %}
         <h3>{{ 'magazine'|trans }}</h3>
     {% endif %}
-    {% if app.user and magazine.userIsOwner(app.user) and not is_route_name_contains('magazine_panel') %}
+    {% if app.user and (magazine.userIsOwner(app.user) or is_granted('ROLE_ADMIN')) and not is_route_name_contains('magazine_panel') %}
         <div class="panel">
             <a href="{{ path('magazine_panel_general', {name: magazine.name}) }}" class="btn btn__primary">Magazine panel</a>
         </div>

--- a/templates/domain/comment/front.html.twig
+++ b/templates/domain/comment/front.html.twig
@@ -18,14 +18,6 @@
     <h1 hidden>{{ domain.name }}</h1>
     <h2 hidden>{{ get_active_sort_option()|trans }}</h2>
     {% include 'entry/comment/_options.html.twig' %}
-    {% if magazine is defined and magazine %}
-        {% if magazine.apId %}
-            <div class="alert alert__info">
-                <p>{{ 'federated_magazine_info'|trans }} <a
-                            href="{{ magazine.apProfileId }}">{{ 'go_to_original_instance'|trans }}</a></p>
-            </div>
-        {% endif %}
-    {% endif %}
     <div id="content" class="comments-tree">
         {% include 'entry/comment/_list.html.twig' %}
     </div>

--- a/templates/domain/front.html.twig
+++ b/templates/domain/front.html.twig
@@ -20,14 +20,6 @@
         <h2 hidden>{{ get_active_sort_option()|trans }}</h2>
     </header>
     {% include 'entry/_options.html.twig' %}
-    {% if magazine is defined and magazine %}
-        {% if magazine.apId %}
-            <div class="alert alert__info">
-                <p>{{ 'federated_magazine_info'|trans }} <a
-                            href="{{ magazine.apProfileId }}">{{ 'go_to_original_instance'|trans }}</a></p>
-            </div>
-        {% endif %}
-    {% endif %}
     <div id="content">
         {% include 'entry/_list.html.twig' %}
     </div>

--- a/templates/entry/comment/front.html.twig
+++ b/templates/entry/comment/front.html.twig
@@ -26,14 +26,6 @@
     {% endif %}
     {% include 'entry/comment/_options.html.twig' %}
     {% include 'layout/_flash.html.twig' %}
-    {% if magazine is defined and magazine %}
-        {% if magazine.apId %}
-            <div class="alert alert__info">
-                <p>{{ 'federated_magazine_info'|trans }} <a
-                            href="{{ magazine.apProfileId }}">{{ 'go_to_original_instance'|trans }}</a></p>
-            </div>
-        {% endif %}
-    {% endif %}
     <div id="content" class="comments-tree">
         {% include 'entry/comment/_list.html.twig' %}
     </div>

--- a/templates/user/overview.html.twig
+++ b/templates/user/overview.html.twig
@@ -53,7 +53,7 @@
                 <form action="{{ path('user_delete_account', {username: user.username}) }}" method="POST"
                       onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                     <input type="hidden" name="token" value="{{ csrf_token('user_delete_account') }}">
-                    <button type="submit" class="btn btn__secondary" title="{{ 'delete_account_desc'|trans }}">
+                    <button type="submit" class="btn btn__danger" title="{{ 'delete_account_desc'|trans }}">
                         <i class="fa fa-dumpster"></i> {{ 'delete_account'|trans }}
                     </button>
                 </form>


### PR DESCRIPTION
Cherry-picked changes from [PR-1207](https://codeberg.org/Kbin/kbin-core/pulls/1207) and [PR-1208](https://codeberg.org/Kbin/kbin-core/pulls/1208) I do want to have in Mbin, but not the changes I don't like (yet). As discussed in Matrix, I would like to have a correct cascading DB schema first. If the database design is correct, the code can be much simpler, easier to understand and thus cleaner. 

- Adding `remove` cascading in Doctrine annotation  
- Prepare for magazine removal by admin role
- This will give the admin already access to local magazines the admin isn't owner of
- Clean-up dead code
- Minor fix; CSS class on delete account button

