### PR TITLE
Valuation: combine up votes and favourites

### DIFF
--- a/migrations/Version20231103004800.php
+++ b/migrations/Version20231103004800.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;

--- a/migrations/Version20231103004800.php
+++ b/migrations/Version20231103004800.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20231103004800 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Change the scoring of entry and post tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE entry SET score=favourite_count + up_votes - down_votes');
+        $this->addSql('UPDATE post SET score=favourite_count + up_votes - down_votes');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('UPDATE entry SET score=up_votes - down_votes');
+        $this->addSql('UPDATE post SET score=up_votes - down_votes');
+    }
+}

--- a/src/Entity/Contracts/FavouriteInterface.php
+++ b/src/Entity/Contracts/FavouriteInterface.php
@@ -17,4 +17,6 @@ interface FavouriteInterface extends ContentInterface
     public function isFavored(User $user): bool;
 
     public function updateRanking(): void;
+
+    public function updateScore(): self;
 }

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -290,6 +290,7 @@ class Entry implements VotableInterface, CommentInterface, DomainInterface, Visi
     public function updateScore(): self
     {
         $this->score = $this->getUpVotes()->count() + $this->favouriteCount - $this->getDownVotes()->count();
+
         return $this;
     }
 

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -281,9 +281,15 @@ class Entry implements VotableInterface, CommentInterface, DomainInterface, Visi
             $vote->entry = $this;
         }
 
-        $this->score = $this->getUpVotes()->count() - $this->getDownVotes()->count();
+        $this->updateScore();
         $this->updateRanking();
 
+        return $this;
+    }
+
+    public function updateScore(): self
+    {
+        $this->score = $this->getUpVotes()->count() + $this->favouriteCount - $this->getDownVotes()->count();
         return $this;
     }
 
@@ -297,7 +303,7 @@ class Entry implements VotableInterface, CommentInterface, DomainInterface, Visi
             }
         }
 
-        $this->score = $this->getUpVotes()->count() - $this->getDownVotes()->count();
+        $this->updateScore();
         $this->updateRanking();
 
         return $this;

--- a/src/Entity/EntryComment.php
+++ b/src/Entity/EntryComment.php
@@ -244,6 +244,11 @@ class EntryComment implements VotableInterface, VisibilityInterface, ReportInter
     {
     }
 
+    public function updateScore(): self
+    {
+        return $this;
+    }
+
     public function getParentSubject(): ?ContentInterface
     {
         return $this->entry;

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -249,6 +249,12 @@ class Post implements VotableInterface, CommentInterface, VisibilityInterface, R
         $this->visibility = VisibilityInterface::VISIBILITY_VISIBLE;
     }
 
+    public function updateScore(): self
+    {
+        $this->score = $this->favouriteCount + $this->getUpVotes()->count() - $this->getDownVotes()->count();
+        return $this;
+    }
+
     public function addVote(Vote $vote): self
     {
         Assert::isInstanceOf($vote, PostVote::class);
@@ -258,7 +264,7 @@ class Post implements VotableInterface, CommentInterface, VisibilityInterface, R
             $vote->post = $this;
         }
 
-        $this->score = $this->getUpVotes()->count() - $this->getDownVotes()->count();
+        $this->updateScore();
         $this->updateRanking();
 
         return $this;
@@ -274,7 +280,7 @@ class Post implements VotableInterface, CommentInterface, VisibilityInterface, R
             }
         }
 
-        $this->score = $this->getUpVotes()->count() - $this->getDownVotes()->count();
+        $this->updateScore();
         $this->updateRanking();
 
         return $this;

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -252,6 +252,7 @@ class Post implements VotableInterface, CommentInterface, VisibilityInterface, R
     public function updateScore(): self
     {
         $this->score = $this->favouriteCount + $this->getUpVotes()->count() - $this->getDownVotes()->count();
+
         return $this;
     }
 

--- a/src/Entity/PostComment.php
+++ b/src/Entity/PostComment.php
@@ -236,6 +236,11 @@ class PostComment implements VotableInterface, VisibilityInterface, ReportInterf
     {
     }
 
+    public function updateScore(): self
+    {
+        return $this;
+    }
+
     public function getParentSubject(): ?ContentInterface
     {
         return $this->post;

--- a/src/Entity/Traits/RankingTrait.php
+++ b/src/Entity/Traits/RankingTrait.php
@@ -13,7 +13,7 @@ trait RankingTrait
 
     public function updateRanking(): void
     {
-        $score = $this->getScore() + \intval($this->favouriteCount * .5);
+        $score = $this->getScore();
         $scoreAdvantage = $score * self::NETSCORE_MULTIPLIER;
 
         if ($score > self::DOWNVOTED_CUTOFF) {

--- a/src/Repository/EntryCommentRepository.php
+++ b/src/Repository/EntryCommentRepository.php
@@ -225,7 +225,7 @@ class EntryCommentRepository extends ServiceEntityRepository implements TagRepos
                 $qb->orderBy('c.upVotes', 'DESC');
                 break;
             case Criteria::SORT_TOP:
-                $qb->orderBy('c.favouriteCount - c.downVotes', 'DESC');
+                $qb->orderBy('c.upVotes + c.favouriteCount - c.downVotes', 'DESC');
                 break;
             case Criteria::SORT_ACTIVE:
                 $qb->orderBy('c.lastActive', 'DESC');

--- a/src/Repository/PostCommentRepository.php
+++ b/src/Repository/PostCommentRepository.php
@@ -150,7 +150,7 @@ class PostCommentRepository extends ServiceEntityRepository implements TagReposi
         switch ($criteria->sortOption) {
             case Criteria::SORT_HOT:
             case Criteria::SORT_TOP:
-                $qb->orderBy('c.upVotes', 'DESC');
+                $qb->orderBy('c.upVotes + c.favouriteCount', 'DESC');
                 break;
             case Criteria::SORT_ACTIVE:
                 $qb->orderBy('c.lastActive', 'DESC');

--- a/src/Service/FavouriteManager.php
+++ b/src/Service/FavouriteManager.php
@@ -38,6 +38,7 @@ class FavouriteManager
 
             $subject->favourites->add($favourite);
             $subject->updateCounts();
+            $subject->updateScore();
             $subject->updateRanking();
         } else {
             if (self::TYPE_LIKE === $type) {
@@ -46,6 +47,7 @@ class FavouriteManager
 
             $subject->favourites->removeElement($favourite);
             $subject->updateCounts();
+            $subject->updateScore();
             $subject->updateRanking();
             $favourite = null;
         }


### PR DESCRIPTION
- change the way the score is calculated for `Entry` and `Post`. Added a simple addition of the favourites. Add a migration for it.
- Add `updateScore` method to the `FavouriteInterface`, so the score can be updated when one adds or remove a favourite
- The favourite count is no longer used in the `RankingTrait`, because it is used in the score which is the baseline for the ranking
- The "hot" and "top" (same in this case) sorts of `PostComment`s and `EntryComment`s now use the favourites as well

Close #127 