### PR TITLE
Fix duplicate key value for url_idx

### DIFF
--- a/src/MessageHandler/LinkEmbedHandler.php
+++ b/src/MessageHandler/LinkEmbedHandler.php
@@ -7,8 +7,6 @@ namespace App\MessageHandler;
 use App\Message\LinkEmbedMessage;
 use App\Repository\EmbedRepository;
 use App\Utils\Embed;
-use Doctrine\DBAL\DriverManager;
-use Doctrine\ORM\EntityManagerInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -18,19 +16,13 @@ class LinkEmbedHandler
     public function __construct(
         private readonly EmbedRepository $embedRepository,
         private readonly Embed $embed,
-        private readonly CacheItemPoolInterface $markdownCache,
-        private EntityManagerInterface $entityManager,
+        private readonly CacheItemPoolInterface $markdownCache
     ) {
     }
 
     public function __invoke(LinkEmbedMessage $message): void
     {
         preg_match_all('#\bhttps?://[^,\s()<>]+(?:\([\w\d]+\)|([^,[:punct:]\s]|/))#', $message->body, $match);
-
-        //DriverManager::getConnection(
-        //    $this->entityManager->getConnection()->getParams(),
-        //    $this->entityManager->getConfiguration()
-        //);
 
         foreach ($match[0] as $url) {
             try {

--- a/src/MessageHandler/LinkEmbedHandler.php
+++ b/src/MessageHandler/LinkEmbedHandler.php
@@ -27,10 +27,10 @@ class LinkEmbedHandler
     {
         preg_match_all('#\bhttps?://[^,\s()<>]+(?:\([\w\d]+\)|([^,[:punct:]\s]|/))#', $message->body, $match);
 
-        DriverManager::getConnection(
-            $this->entityManager->getConnection()->getParams(),
-            $this->entityManager->getConfiguration()
-        );
+        //DriverManager::getConnection(
+        //    $this->entityManager->getConnection()->getParams(),
+        //    $this->entityManager->getConfiguration()
+        //);
 
         foreach ($match[0] as $url) {
             try {

--- a/src/Repository/EmbedRepository.php
+++ b/src/Repository/EmbedRepository.php
@@ -11,7 +11,7 @@ use Doctrine\Persistence\ManagerRegistry;
 /**
  * @method Embed|null find($id, $lockMode = null, $lockVersion = null)
  * @method Embed|null findOneBy(array $criteria, array $orderBy = null)
- * @method Embed|null findOneByName(string $name)
+ * @method Embed|null findOneByUrl(string $url)
  * @method Embed[]    findAll()
  * @method Embed[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
@@ -24,9 +24,13 @@ class EmbedRepository extends ServiceEntityRepository
 
     public function add(Embed $entity, bool $flush = true): void
     {
-        $this->_em->persist($entity);
-        if ($flush) {
-            $this->_em->flush();
+        // Check if embed url does not exists yet (null),
+        // before we try to insert a new DB record
+        if (null === $this->findOneByUrl($entity->url)) {
+            $this->_em->persist($entity);
+            if ($flush) {
+                $this->_em->flush();
+            }
         }
     }
 


### PR DESCRIPTION
- Finally fix those errors: `"message":"Error thrown while handling message App\\Message\\LinkEmbedMessage. Removing from transport after 0 retries. Error: \"Handling \"App\\Message\\LinkEmbedMessage\" failed: An exception occurred while executing a query: SQLSTATE[23505]: Unique violation: 7 ERROR:  duplicate key value violates unique constraint \"url_idx\"\nDETAIL:  Key (url)=(https://www.....) already exists.\"","context":{"class":"App\\Message\\LinkEmbedMessage","retryCount":0,"error":"Handling \"App\\Message\\LinkEmbedMessage\" failed: An exception occurred while executing a query: SQLSTATE[23505]: Unique violation: 7 ERROR:  duplicate key value violates unique constraint \"url_idx\"\nDETAIL:  Key (url)=(https://www.....) already exists.`

- Clean-up dead code? Unnecessary amount of DB connection for each link message event. It doesn't seem to use this DB connection?!?