### PR TITLE
add quick links to change avatar and cover when viewing your own profile

### DIFF
--- a/templates/components/user_box.html.twig
+++ b/templates/components/user_box.html.twig
@@ -1,7 +1,7 @@
 <div{{ attributes.defaults({class: 'user-box'}) }}>
     <div class="{{ html_classes({'with-cover': user.cover, 'with-avatar': user.avatar }) }}">
         {% if user.cover %}
-          {% if app.user is same as user %}
+          {% if app.user is same as user and is_route_name('user_overview') %}
             <a href="{{ path('user_settings_profile') }}" title="{{ 'change_my_cover'|trans }}" aria-label="{{ 'change_my_cover'|trans }}">
           {% endif %}
             <img class="cover image-inline"
@@ -9,7 +9,7 @@
                  width="100%"
                  src="{{ asset(user.cover.filePath)|imagine_filter('user_cover') }}"
                  alt="{{ user.username ~' '~ 'cover'|trans|lower  }}">
-          {% if app.user is same as user %}
+          {% if app.user is same as user and is_route_name('user_overview') %}
             </a>
           {% endif %}
         {% endif %}
@@ -17,7 +17,7 @@
             <div>
                 <div class="row">
                     {% if user.avatar %}
-                      {% if app.user is same as user %}
+                      {% if app.user is same as user and is_route_name('user_overview') %}
                         <a href="{{ path('user_settings_profile') }}" title="{{ 'change_my_avatar'|trans }}" aria-label="{{ 'change_my_avatar'|trans }}">
                       {% endif %}
                         {{ component('user_avatar', {
@@ -25,7 +25,7 @@
                             width: 100,
                             height: 100
                         }) }}
-                      {% if app.user is same as user %}
+                      {% if app.user is same as user and is_route_name('user_overview') %}
                         </a>
                       {% endif %}
                     {% endif %}

--- a/templates/components/user_box.html.twig
+++ b/templates/components/user_box.html.twig
@@ -1,21 +1,33 @@
 <div{{ attributes.defaults({class: 'user-box'}) }}>
     <div class="{{ html_classes({'with-cover': user.cover, 'with-avatar': user.avatar }) }}">
         {% if user.cover %}
+          {% if app.user is same as user %}
+            <a href="{{ path('user_settings_profile') }}" title="{{ 'change_my_cover'|trans }}" aria-label="{{ 'change_my_cover'|trans }}">
+          {% endif %}
             <img class="cover image-inline"
                  height="220"
                  width="100%"
                  src="{{ asset(user.cover.filePath)|imagine_filter('user_cover') }}"
                  alt="{{ user.username ~' '~ 'cover'|trans|lower  }}">
+          {% if app.user is same as user %}
+            </a>
+          {% endif %}
         {% endif %}
         <div class="user-main" id="content">
             <div>
                 <div class="row">
                     {% if user.avatar %}
+                      {% if app.user is same as user %}
+                        <a href="{{ path('user_settings_profile') }}" title="{{ 'change_my_avatar'|trans }}" aria-label="{{ 'change_my_avatar'|trans }}">
+                      {% endif %}
                         {{ component('user_avatar', {
                             user: user,
                             width: 100,
                             height: 100
                         }) }}
+                      {% if app.user is same as user %}
+                        </a>
+                      {% endif %}
                     {% endif %}
                     {% if stretchedLink %}
                         <h1>

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -823,3 +823,5 @@ page_width_max: Max
 page_width_auto: Auto
 page_width_fixed: Fixed
 open_url_to_fediverse: Open original URL
+change_my_avatar: Change my avatar
+change_my_cover: Change my cover


### PR DESCRIPTION
if viewing your own profile, clicking on your avatar or cover will bring you to the page to change them

viewing someone else's profile does not show this link

![image](https://github.com/MbinOrg/mbin/assets/146029455/9c07f944-5d77-406c-af0b-07e0912f1a49)
![image](https://github.com/MbinOrg/mbin/assets/146029455/7413df0a-a6f5-47d9-bb4c-66c2ec8279ac)

(if I do show pointer, it won't show labels, if I do selection, it won't show pointer... just trust me the pointer is over avatar and cover where the label appears. there is a slight no-click zone to the right of the avatar due to the HTML element spacing, but I feel like the cover is a large enough target that users can click anywhere else)

related #69

not sure if it completely solves what @TheVillageGuy wanted to see, but this was one of my suggestions to help, as I feel it's fairly common to have this flow (you can see it here on github if you go to your profile, hovering over your avatar if you have one says "Change your avatar" (I wonder why they went with your rather than my :thinking: ) and clicking that just directs you to the settings page