### PR TITLE
update changes from sync 7

### DIFF
--- a/templates/admin/_options.html.twig
+++ b/templates/admin/_options.html.twig
@@ -26,7 +26,7 @@
         <li>
             <a href="{{ path('admin_moderators') }}"
                class="{{ html_classes({'active': is_route_name('admin_moderators')}) }}">
-                {{ 'moderators'|trans|lower }}
+                {{ 'moderators'|trans }}
             </a>
         </li>
         <li>
@@ -50,7 +50,7 @@
         <li>
             <a href="{{ path('admin_deletion_users') }}"
                class="{{ html_classes({'active': is_route_name('admin_deletion_users') or is_route_name('admin_deletion_magazines')}) }}">
-                {{ 'deletion'|trans|lower }}
+                {{ 'deletion'|trans }}
             </a>
         </li>
     </menu>

--- a/templates/admin/deletion_magazines.html.twig
+++ b/templates/admin/deletion_magazines.html.twig
@@ -33,31 +33,21 @@
     <div class="section" id="content">
         <table>
             <thead>
-            <tr>
-                <td>{{ 'name'|trans }}</td>
-                <td>{{ 'entries'|trans }}</td>
-                <td>{{ 'posts'|trans }}</td>
-                <td></td>
-            </tr>
+              <tr>
+                  <th>{{ 'name'|trans }}</th>
+                  <th>{{ 'threads'|trans }}</th>
+                  <th>{{ 'comments'|trans }}</th>
+                  <th>{{ 'posts'|trans }}</th>
+                  <th></th>
+              </tr>
             </thead>
             <tbody>
             {% for magazine in magazines %}
                 <tr>
-                    <td>
-                        {% if magazine.icon %}
-                            <figure>
-                                <img width="32" height="32"
-                                     src="{{ asset(magazine.icon.filePath) | imagine_filter('avatar_thumb') }}"
-                                     alt="{{ magazine.name ~' '~ 'avatar'|trans|lower }}">
-                            </figure>
-                        {% endif %}
-                        <div>
-                            <a href="{{ path('front_magazine', {name: magazine.name}) }}"
-                               class="stretched-link">{{ magazine.name }}</a>
-                        </div>
-                    </td>
+                    <td>{{ component('magazine_inline', { magazine: magazine, stretchedLink: true, showAvatar: true}) }}</td>
                     <td>{{ magazine.entryCount }}</td>
-                    <td>{{ magazine.postCount }}</td>
+                    <td>{{ magazine.entryCommentCount }}</td>
+                    <td>{{ magazine.postCount + magazine.postCommentCount }}</td>
                     <td>{{ component('date', {date: magazine.markedForDeletionAt}) }}</td>
                 </tr>
             {% endfor %}

--- a/templates/admin/deletion_users.html.twig
+++ b/templates/admin/deletion_users.html.twig
@@ -33,11 +33,11 @@
     <div class="section" id="content">
         <table>
             <thead>
-            <tr>
-                <td>{{ 'username'|trans }}</td>
-                <td>{{ 'reputation_points'|trans }}</td>
-                <td></td>
-            </tr>
+              <tr>
+                  <th>{{ 'username'|trans }}</th>
+                  <th>{{ 'reputation_points'|trans }}</th>
+                  <th></th>
+              </tr>
             </thead>
             <tbody>
             {% for user in users %}

--- a/templates/components/entry_cross.html.twig
+++ b/templates/components/entry_cross.html.twig
@@ -55,43 +55,53 @@
                         }) }}
                     </li>
                     <li class="dropdown">
-                        <button class="stretched-link" data-subject-target="more">{{ 'more'|trans|lower }}</button>
+                        <button class="stretched-link" data-subject-target="more">{{ 'more'|trans }}</button>
                         <ul class="dropdown__menu" data-controller="clipboard">
                             <li>
                                 <a href="{{ path('entry_report', {id: entry.id}) }}"
                                    class="{{ html_classes({'active': is_route_name('entry_report')}) }}"
                                    data-action="subject#getForm">
-                                    {{ 'report'|trans|lower }}
+                                    {{ 'report'|trans }}
                                 </a>
                             </li>
                             <li>
                                 <a href="{{ entry_voters_url(entry, 'up') }}"
                                    class="{{ html_classes({'active': is_route_name('entry_fav') or is_route_name('entry_voters')}) }}">
-                                    {{ 'activity'|trans|lower }}
+                                    {{ 'activity'|trans }}
                                 </a>
                             </li>
 
                             {% if entry.domain %}
                                 <li>
-                                    <a href="{{ path('domain_entries', {name: entry.domain.name}) }}">{{ 'more_from_domain'|trans|lower }}</a>
+                                    <a href="{{ path('domain_entries', {name: entry.domain.name}) }}">{{ 'more_from_domain'|trans }}</a>
                                 </li>
                             {% endif %}
 
+                            <li class="dropdown__separator"></li>
                             <li>
-                                <a data-action="clipboard#copy"
-                                   href="{{ entry_url(entry) }}">{{ 'copy_url'|trans|lower }}</a>
+                                <a target="_blank"
+                                   href="{{ entry.apId ?? path('ap_entry', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}">
+                                    {{ 'open_url_to_fediverse'|trans }}
+                                </a>
                             </li>
                             <li>
                                 <a data-action="clipboard#copy"
                                    href="{{ entry.apId ?? path('ap_entry', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}">
-                                    {{ 'copy_url_to_fediverse'|trans|lower }}
+                                    {{ 'copy_url_to_fediverse'|trans }}
                                 </a>
                             </li>
+                            <li>
+                                <a data-action="clipboard#copy"
+                                   href="{{ entry_url(entry) }}">{{ 'copy_url'|trans }}</a>
+                            </li>
+                            {% if is_granted('edit', entry) or (app.user and entry.isAuthor(app.user)) or is_granted('moderate', entry) %}
+                                <li class="dropdown__separator"></li>
+                            {% endif %}
                             {% if is_granted('edit', entry) %}
                                 <li>
                                     <a href="{{ entry_edit_url(entry) }}"
                                        class="{{ html_classes({'active': is_route_name('entry_edit')}) }}">
-                                        {{ 'edit'|trans|lower }}
+                                        {{ 'edit'|trans }}
                                     </a>
                                 </li>
                             {% endif %}
@@ -101,7 +111,7 @@
                                           action="{{ entry_delete_url(entry) }}"
                                           onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                                         <input type="hidden" name="token" value="{{ csrf_token('entry_delete') }}">
-                                        <button type="submit">{{ 'delete'|trans|lower }}</button>
+                                        <button type="submit">{{ 'delete'|trans }}</button>
                                     </form>
                                 </li>
                             {% endif %}
@@ -110,7 +120,7 @@
                                     <a href="{{ entry_moderate_url(entry) }}"
                                        class="{{ html_classes({'active': is_route_name('entry_moderate')}) }}"
                                        data-action="subject#showModPanel">
-                                        {{ 'moderate'|trans|lower }}
+                                        {{ 'moderate'|trans }}
                                     </a>
                                 </li>
                             {% endif %}


### PR DESCRIPTION
un-lower the menu items
update cross post template "more" menu to match mbin (now that it's copy pasted in two locations it might be worth moving to a component if possible, but that strays further from kbin, wasn't sure on this one)
update tables to use `th` in `thead` sections, match magazine data, use component