### PR TITLE
fix user declaration on blocked domains page

### DIFF
--- a/src/Controller/User/Profile/UserBlockController.php
+++ b/src/Controller/User/Profile/UserBlockController.php
@@ -51,7 +51,7 @@ class UserBlockController extends AbstractController
             'user/settings/block_domains.html.twig',
             [
                 'user' => $user,
-                'domains' => $repository->findBlockedDomains($this->getPageNb($request), $ $user),
+                'domains' => $repository->findBlockedDomains($this->getPageNb($request), $user),
             ]
         );
     }


### PR DESCRIPTION
looking at `/settings/blocked/domains` currently 500s with `Object of class App\Entity\User could not be converted to string`