### PR TITLE
add change my avatar and cover quick links to all user pages

### DIFF
--- a/templates/components/user_box.html.twig
+++ b/templates/components/user_box.html.twig
@@ -1,7 +1,7 @@
 <div{{ attributes.defaults({class: 'user-box'}) }}>
     <div class="{{ html_classes({'with-cover': user.cover, 'with-avatar': user.avatar }) }}">
         {% if user.cover %}
-          {% if app.user is same as user and is_route_name('user_overview') %}
+          {% if app.user is same as user and is_route_name_starts_with('user') and not is_route_name_contains('settings') %}
             <a href="{{ path('user_settings_profile') }}" title="{{ 'change_my_cover'|trans }}" aria-label="{{ 'change_my_cover'|trans }}">
           {% endif %}
             <img class="cover image-inline"
@@ -9,7 +9,7 @@
                  width="100%"
                  src="{{ asset(user.cover.filePath)|imagine_filter('user_cover') }}"
                  alt="{{ user.username ~' '~ 'cover'|trans|lower  }}">
-          {% if app.user is same as user and is_route_name('user_overview') %}
+          {% if app.user is same as user and is_route_name_starts_with('user') and not is_route_name_contains('settings') %}
             </a>
           {% endif %}
         {% endif %}
@@ -17,7 +17,7 @@
             <div>
                 <div class="row">
                     {% if user.avatar %}
-                      {% if app.user is same as user and is_route_name('user_overview') %}
+                      {% if app.user is same as user and is_route_name_starts_with('user') and not is_route_name_contains('settings') %}
                         <a href="{{ path('user_settings_profile') }}" title="{{ 'change_my_avatar'|trans }}" aria-label="{{ 'change_my_avatar'|trans }}">
                       {% endif %}
                         {{ component('user_avatar', {
@@ -25,7 +25,7 @@
                             width: 100,
                             height: 100
                         }) }}
-                      {% if app.user is same as user and is_route_name('user_overview') %}
+                      {% if app.user is same as user and is_route_name_starts_with('user') and not is_route_name_contains('settings') %}
                         </a>
                       {% endif %}
                     {% endif %}


### PR DESCRIPTION
there's nothing fundamentally different in this than #206 but sync 7 added the user avatar / cover to all user non-settings pages (threads, comments, posts, replies, boosts, following, followers, subscriptions, reputation, moderated). this adds the quick links to all those pages when viewing your own profile