### PR TITLE
point reputation link to reputation path

### DIFF
--- a/templates/user/_info.html.twig
+++ b/templates/user/_info.html.twig
@@ -19,7 +19,7 @@
     <ul class="info">
         <li>{{ 'joined'|trans }}: {{ component('date', {date: user.createdAt}) }}</li>
         {%- set TYPE_ENTRY = constant('App\\Repository\\ReputationRepository::TYPE_ENTRY') -%}
-        <li><a href="#" class="stretched-link">{{ 'reputation_points'|trans }}:</a> {{ get_reputation_total(user) }}</li>
+        <li><a href="{{ path('user_reputation', {username: user.username, reputationType: TYPE_ENTRY}) }}" class="stretched-link">{{ 'reputation_points'|trans }}:</a> {{ get_reputation_total(user) }}</li>
         <li><a href="{{ path('user_moderated', {username: user.username}) }}"
                class="stretched-link">{{ 'moderated'|trans }}:</a> {{ count_user_moderated(user) }}
         </li>


### PR DESCRIPTION
for some reason the "Reputation" field in the user box is a link that does not link anywhere. Not sure if that was intended (even more confusing that it sets up `TYPE_ENTRY` above the link as if it was going to but appears to not use it). This changes it to link to the reputation page for the user (which currently appears public so don't think there's a reason not to)