### PR TITLE
Fix logic precedence in admin panel sidebar

### DIFF
--- a/templates/user/overview.html.twig
+++ b/templates/user/overview.html.twig
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block sidebar_top %}
-    {% if is_granted('ROLE_ADMIN') or is_granted('ROLE_MODERATOR') and app.user != user %}
+    {% if (is_granted('ROLE_ADMIN') or is_granted('ROLE_MODERATOR')) and app.user != user %}
         <div class="section magazine">
             <h3>{{ 'admin_panel'|trans }}</h3>
             <div class="panel">


### PR DESCRIPTION
Minor fix to admin panel sidebar logic so that admins and moderators don't accidently ban, delete or purge themselves. The bug was introduced after introducing OR logic to check for moderator role.