### PR TITLE
update sidebar subscription links to stretch across row

### DIFF
--- a/templates/layout/sidebar_subscriptions.html.twig
+++ b/templates/layout/sidebar_subscriptions.html.twig
@@ -48,7 +48,7 @@
             <ul class="subscription-list meta {{ app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_LARGE_PANEL')) is same as 'true' ? 'lg' : '' }}">
                 {% for magazine in magazines %}
                     <li class="subscription {{ openMagazine and openMagazine.name is same as magazine.name ? 'active' : '' }}">
-                        <a href="/m/{{ magazine.name }}">
+                        <a class="stretched-link" href="/m/{{ magazine.name }}">
 
                             {% if magazine.icon %}
                                 <img src="{{ asset(magazine.icon.filePath) | imagine_filter('avatar_thumb') }}" alt="{{ magazine.name }}'s icon"


### PR DESCRIPTION
this changes the clickable area of the subscription sidebar to stretch across the entire row (similar to random magazines). when on mobile and only the icons show, the clickable area is unaffected (I had a little concern it would make the entire row of icons a single link or something but that doesn't happen :laughing: )

before:

![image](https://github.com/MbinOrg/mbin/assets/146029455/6f751f3d-da88-4297-ae8b-0db45dadb78a)

after:

![image](https://github.com/MbinOrg/mbin/assets/146029455/9a9c1f0c-e05f-424e-bfb8-34211ab73bbe)
