### PR TITLE
Do not automatically subscribe admin OR users to new federated magazine lookups

### DIFF
--- a/src/Service/MagazineManager.php
+++ b/src/Service/MagazineManager.php
@@ -72,7 +72,7 @@ class MagazineManager
         $this->entityManager->persist($magazine);
         $this->entityManager->flush();
 
-        $this->subscribe($magazine, $user);
+        //$this->subscribe($magazine, $user);
 
         return $magazine;
     }

--- a/src/Service/MagazineManager.php
+++ b/src/Service/MagazineManager.php
@@ -72,7 +72,9 @@ class MagazineManager
         $this->entityManager->persist($magazine);
         $this->entityManager->flush();
 
-        // $this->subscribe($magazine, $user);
+        if (!$dto->apId) {
+            $this->subscribe($magazine, $user);
+        }
 
         return $magazine;
     }

--- a/src/Service/MagazineManager.php
+++ b/src/Service/MagazineManager.php
@@ -72,7 +72,7 @@ class MagazineManager
         $this->entityManager->persist($magazine);
         $this->entityManager->flush();
 
-        //$this->subscribe($magazine, $user);
+        // $this->subscribe($magazine, $user);
 
         return $magazine;
     }


### PR DESCRIPTION
Disables the default /kbin behavior of automatically subscribing the admin to federated magazine lookups. The searching user must explicitly hit the subscribe button in order for the Mbin instance to pull in federated updates.

This change would also seem to remove the need for the admin panel option to explicitly allow only logged in users to search for federated content since you have to be logged in to subscribe anyway, but I left it intact incase we want to modify this behavior in the future.