### PR TITLE
subscription sidebar - add back link hover style

### DIFF
--- a/assets/styles/components/_sidebar.scss
+++ b/assets/styles/components/_sidebar.scss
@@ -175,10 +175,6 @@
         border-top: var(--kbin-meta-border);
       }
 
-      span {
-        color: var(--kbin-meta-text-color);
-      }
-
       a {
         font-weight: bold;
         padding: 0;


### PR DESCRIPTION
very minor change to bring back the hover styling for links in the sidebar subscription. it looks like it was present in the first iteration but might've gotten shuffled around during the tweaking from `div` -> `ul`

right now the subscription sidebar links are one text color and hovering over them doesn't change like other links, this removes a property that was overriding it, the links are the same color but now get the hover styling applied

before:

![image](https://github.com/MbinOrg/mbin/assets/146029455/2067b119-b24a-4008-8dd7-672caef1317e)


after:

![image](https://github.com/MbinOrg/mbin/assets/146029455/aeba96b4-5aef-4aaa-bdc8-8527855c5d67)
