### PR TITLE
cleanup from sync 8

### DIFF
--- a/templates/admin/magazine_ownership.html.twig
+++ b/templates/admin/magazine_ownership.html.twig
@@ -19,10 +19,10 @@
             <table>
                 <thead>
                 <tr>
-                    <td>{{ 'magazine'|trans }}</td>
-                    <td>{{ 'user'|trans }}</td>
-                    <td>{{ 'reputation_points'|trans }}</td>
-                    <td>{{ 'action'|trans }}</td>
+                    <th>{{ 'magazine'|trans }}</th>
+                    <th>{{ 'user'|trans }}</th>
+                    <th>{{ 'reputation_points'|trans }}</th>
+                    <th>{{ 'action'|trans }}</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -51,7 +51,7 @@
                                     <button type="submit"
                                             class="btn btn__secondary"
                                             title="{{ 'reject'|trans }}">
-                                        <i class="fa-solid fa-ban"></i> 
+                                        <i class="fa-solid fa-ban"></i>
                                             <span>{{ 'reject'|trans }}</span>
                                     </button>
                                     <input type="hidden" name="token"

--- a/templates/admin/users.html.twig
+++ b/templates/admin/users.html.twig
@@ -26,11 +26,11 @@
         <table>
             <thead>
             <tr>
-                <td>{{ 'username'|trans }}</td>
-                <td>{{ 'email'|trans }}</td>
-                <td>{{ 'created_at'|trans }}</td>
-                <td>{{ 'last_active'|trans }}</td>
-                <td></td>
+                <th>{{ 'username'|trans }}</th>
+                <th>{{ 'email'|trans }}</th>
+                <th>{{ 'created_at'|trans }}</th>
+                <th>{{ 'last_active'|trans }}</th>
+                <th></th>
             </tr>
             </thead>
             <tbody>

--- a/templates/magazine/_options.html.twig
+++ b/templates/magazine/_options.html.twig
@@ -18,12 +18,14 @@
                 {{ 'active'|trans }}
             </a>
         </li>
+        {% if app.user %}
         <li>
             <a href="{{ path('magazine_abandoned') }}"
                class="{{ html_classes({'active': is_route_name('magazine_abandoned')}) }}">
                 {{ 'abandoned'|trans }}
             </a>
         </li>
+        {% endif %}
     </menu>
     <menu class="options__layout">
         <li class="dropdown">

--- a/templates/magazine/list_abandoned.html.twig
+++ b/templates/magazine/list_abandoned.html.twig
@@ -44,7 +44,7 @@
                                         <div class='action'>
                                             <i class="fa-solid fa-users"></i><span>{{ magazine.subscriptionsCount }}</span>
                                         </div>
-                                        {% if not app.user or not magazine.userIsOwner(app.user) %}
+                                        {% if not app.user or (not magazine.userIsOwner(app.user) and app.user.visibility is same as 'visible') %}
                                             <form action="{{ path('magazine_ownership_request', {name: magazine.name}) }}"
                                                   name="magazine_request_ownership"
                                                   method="post">

--- a/templates/magazine/panel/_options.html.twig
+++ b/templates/magazine/panel/_options.html.twig
@@ -24,7 +24,7 @@
         <li>
             <a href="{{ path('magazine_panel_moderator_requests', {name: magazine.name}) }}"
                class="{{ html_classes({'active': is_route_name('magazine_panel_moderator_requests')}) }}">
-                {{ 'moderator_requests'|trans|lower }}
+                {{ 'moderator_requests'|trans }}
             </a>
         </li>
         <li>

--- a/templates/notifications/front.html.twig
+++ b/templates/notifications/front.html.twig
@@ -28,7 +28,7 @@
                   onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                 <input type="hidden" name="token" value="{{ csrf_token('clear_notifications') }}">
                 <button class="btn btn__secondary" type="submit">
-                    <span>{{ 'purge'|trans }}</span>
+                    <i class="fa-solid fa-dumpster"></i> <span>{{ 'purge'|trans }}</span>
                 </button>
             </form>
         </menu>

--- a/templates/user/overview.html.twig
+++ b/templates/user/overview.html.twig
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block sidebar_top %}
-    {% if (is_granted('ROLE_ADMIN') or is_granted('ROLE_MODERATOR')) and app.user != user and 'ROLE_ADMIN' not in user.roles %}
+    {% if (is_granted('ROLE_ADMIN') or is_granted('ROLE_MODERATOR')) and app.user != user and not user.admin() %}
         <div class="section magazine">
             <h3>{{ 'admin_panel'|trans }}</h3>
             <div class="panel">

--- a/templates/user/overview.html.twig
+++ b/templates/user/overview.html.twig
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block sidebar_top %}
-    {% if (is_granted('ROLE_ADMIN') or is_granted('ROLE_MODERATOR')) and app.user != user %}
+    {% if (is_granted('ROLE_ADMIN') or is_granted('ROLE_MODERATOR')) and app.user != user and 'ROLE_ADMIN' not in user.roles %}
         <div class="section magazine">
             <h3>{{ 'admin_panel'|trans }}</h3>
             <div class="panel">


### PR DESCRIPTION
- hide abandoned magazine link while logged out
- hide request ownership from non visible accounts (marked for deletion, suspended)
- `th` tag usage in `thead` for admin panels
- unlower new "mod requests" panel entry
- add dumpster icon to purge to fix spacing
- disallow admin panel (ban / suspend user) when viewing the admin by either the global mods or another admin