### PR TITLE
nsfw entries - blur by default, unblur via JS hover event

### DIFF
--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -88,6 +88,7 @@
                                rel="{{ get_rel(is_route_name('entry_single') ? entry.url : entry_url(entry)) }}">
                                 <img class="thumb-subject"
                                      src="{{ asset(entry.image.filePath) |imagine_filter('entry_thumb') }}"
+                                     {% if entry.isAdult %}style="filter: blur(8px)"{% endif %}
                                      alt="{{ entry.image.altText }}">
                             </a>
                         </figure>
@@ -100,6 +101,7 @@
                                class="{{ html_classes({'thumb': is_route_name('entry_single')}) }}">
                                 <img class="thumb-subject"
                                      src="{{ asset(entry.image.filePath) |imagine_filter('entry_thumb') }}"
+                                     {% if entry.isAdult %}style="filter: blur(8px)"{% endif %}
                                      alt="{{ entry.image.altText }}">
                             </a>
                         </figure>

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -72,7 +72,7 @@
                            class="thumb">
                             <img class="thumb-subject"
                                  src="{{ asset(comment.image.filePath) |imagine_filter('post_thumb') }}"
-                                 {% if entry.isAdult %}style="filter: blur(8px)"{% endif %}
+                                 {% if comment.isAdult %}style="filter: blur(8px)"{% endif %}
                                  alt="{{ comment.image.altText }}">
                         </a>
                     </figure>

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -58,6 +58,7 @@
                            class="thumb">
                             <img class="thumb-subject"
                                  src="{{ asset(comment.image.filePath) |imagine_filter('post_thumb') }}"
+                                 {% if entry.isAdult %}style="filter: blur(8px)"{% endif %}
                                  alt="{{ comment.image.altText }}">
                         </a>
                     </figure>

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -55,6 +55,7 @@
                         <a class="thumb" href="{{ uploaded_asset(post.image.filePath) }}">
                             <img class="thumb-subject"
                                  src="{{ asset(post.image.filePath) |imagine_filter('post_thumb') }}"
+                                 {% if entry.isAdult %}style="filter: blur(8px)"{% endif %}
                                  alt="{{ post.image.altText }}">
                         </a>
                     </figure>

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -55,7 +55,7 @@
                         <a class="thumb" href="{{ uploaded_asset(post.image.filePath) }}">
                             <img class="thumb-subject"
                                  src="{{ asset(post.image.filePath) |imagine_filter('post_thumb') }}"
-                                 {% if entry.isAdult %}style="filter: blur(8px)"{% endif %}
+                                 {% if post.isAdult %}style="filter: blur(8px)"{% endif %}
                                  alt="{{ post.image.altText }}">
                         </a>
                     </figure>

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -60,6 +60,7 @@
                            class="thumb">
                             <img class="thumb-subject"
                                  src="{{ asset(comment.image.filePath) |imagine_filter('post_thumb') }}"
+                                 {% if entry.isAdult %}style="filter: blur(8px)"{% endif %}
                                  alt="{{ comment.image.altText }}">
                         </a>
                     </figure>

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -74,7 +74,7 @@
                            class="thumb">
                             <img class="thumb-subject"
                                  src="{{ asset(comment.image.filePath) |imagine_filter('post_thumb') }}"
-                                 {% if entry.isAdult %}style="filter: blur(8px)"{% endif %}
+                                 {% if comment.isAdult %}style="filter: blur(8px)"{% endif %}
                                  alt="{{ comment.image.altText }}">
                         </a>
                     </figure>


### PR DESCRIPTION
This blurs nsfw threads, microblogs, and comments by setting the blur on the html element

currently this is only done in https://github.com/MbinOrg/mbin/blob/main/assets/controllers/subject_controller.js#L419
this means if JS is slow to load for any reason, the user gets to see all nsfw images until JS finishes loading and then blurs the images (technically, this always happens to some extent, the js tags are `defer` so wait until the DOM is finished loading before executing, how long that takes seems to vary)

potential downsides:
if the user has JS disabled, hovering over the image won't unblur it, it will be stuck in a blurred state rather than the current always unblurred with JS disabled, but expanding the preview or, of course, going to the image url would produce the unblurred image