### PR TITLE
Update Docker docs/compose.yml file with ghcr.io

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -6,6 +6,8 @@ services:
       context: ../
       dockerfile: docker/Dockerfile
     image: mbin
+    # Or remove the build and image lines above and use the prebuild image:
+    #image: "ghcr.io/mbinorg/mbin:main"
     restart: unless-stopped
     command: caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
     healthcheck:
@@ -29,6 +31,8 @@ services:
       context: ../
       dockerfile: docker/Dockerfile
     image: mbin
+    # Or remove the build and image lines above and use the prebuild image:
+    #image: "ghcr.io/mbinorg/mbin:main"
     restart: unless-stopped
     command: php-fpm
     healthcheck:
@@ -51,6 +55,8 @@ services:
       context: ../
       dockerfile: docker/Dockerfile
     image: mbin
+    # Or remove the build and image lines above and use the prebuild image:
+    #image: "ghcr.io/mbinorg/mbin:main"
     restart: unless-stopped
     command: bin/console messenger:consume async --time-limit=3600
     healthcheck:
@@ -69,6 +75,8 @@ services:
       context: ../
       dockerfile: docker/Dockerfile
     image: mbin
+    # Or remove the build and image lines above and use the prebuild image:
+    #image: "ghcr.io/mbinorg/mbin:main"
     restart: unless-stopped
     command: bin/console messenger:consume async_ap --time-limit=3600
     healthcheck:

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -2,12 +2,14 @@ version: "3.9"
 
 services:
   www:
+    # Builds the Docker image from scratch
     build:
       context: ../
       dockerfile: docker/Dockerfile
     image: mbin
-    # Or remove the build and image lines above and use the prebuild image:
-    #image: "ghcr.io/mbinorg/mbin:main"
+    # Or remove the build, context, dockerfile and image lines above and
+    # use the pre-build image from ghcr.io (you can also a tag eg.: v1.0.0 instead of: latest):
+    #image: "ghcr.io/mbinorg/mbin:latest"
     restart: unless-stopped
     command: caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
     healthcheck:
@@ -27,12 +29,14 @@ services:
       - php
 
   php:
+    # Builds the Docker image from scratch
     build:
       context: ../
       dockerfile: docker/Dockerfile
     image: mbin
-    # Or remove the build and image lines above and use the prebuild image:
-    #image: "ghcr.io/mbinorg/mbin:main"
+    # Or remove the build, context, dockerfile and image lines above and
+    # use the pre-build image from ghcr.io (you can also a tag eg.: v1.0.0 instead of: latest):
+    #image: "ghcr.io/mbinorg/mbin:latest"
     restart: unless-stopped
     command: php-fpm
     healthcheck:
@@ -51,12 +55,14 @@ services:
       - rabbitmq
 
   messenger:
+    # Builds the Docker image from scratch
     build:
       context: ../
       dockerfile: docker/Dockerfile
     image: mbin
-    # Or remove the build and image lines above and use the prebuild image:
-    #image: "ghcr.io/mbinorg/mbin:main"
+    # Or remove the build, context, dockerfile and image lines above and
+    # use the pre-build image from ghcr.io (you can also a tag eg.: v1.0.0 instead of: latest):
+    #image: "ghcr.io/mbinorg/mbin:latest"
     restart: unless-stopped
     command: bin/console messenger:consume async --time-limit=3600
     healthcheck:
@@ -71,12 +77,14 @@ services:
       - rabbitmq
 
   messenger_ap:
+    # Builds the Docker image from scratch
     build:
       context: ../
       dockerfile: docker/Dockerfile
     image: mbin
-    # Or remove the build and image lines above and use the prebuild image:
-    #image: "ghcr.io/mbinorg/mbin:main"
+    # Or remove the build, context, dockerfile and image lines above and
+    # use the pre-build image from ghcr.io (you can also a tag eg.: v1.0.0 instead of: latest):
+    #image: "ghcr.io/mbinorg/mbin:latest"
     restart: unless-stopped
     command: bin/console messenger:consume async_ap --time-limit=3600
     healthcheck:

--- a/docs/docker_deployment_guide.md
+++ b/docs/docker_deployment_guide.md
@@ -53,7 +53,15 @@ cd mbin
 cd docker
 ```
 
-2. Build the docker image (from the root-directory of the repository):
+2. Use the existing Docker image or build the docker image (from the root-directory of the repository).
+
+Fetch the latest Docker image from the `main` branch:
+
+```bash
+docker pull ghcr.io/mbinorg/mbin:main
+```
+
+_OR_ build the image yourself (if you wish):
 
 ```bash
 docker build --no-cache -t mbin -f Dockerfile  ..

--- a/docs/docker_deployment_guide.md
+++ b/docs/docker_deployment_guide.md
@@ -53,7 +53,7 @@ cd mbin
 cd docker
 ```
 
-2. Use the existing Docker image _OR_ build the docker image (from the root-directory of the repository).
+2. Use the existing Docker image _OR_ build the docker image. Select one of the two options.
 
 #### Build our own Docker image
 

--- a/docs/docker_deployment_guide.md
+++ b/docs/docker_deployment_guide.md
@@ -57,7 +57,7 @@ cd docker
 
 #### Build our own Docker image
 
-If you want to build our own image use (_No_ need to update the `compose.yml` file):
+If you want to build our own image, run  (_no_ need to update the `compose.yml` file):
 
 ```bash
 docker build --no-cache -t mbin -f Dockerfile  ..

--- a/docs/docker_deployment_guide.md
+++ b/docs/docker_deployment_guide.md
@@ -86,7 +86,7 @@ And instead use the following line on all places (`www`, `php`, `messenger` and 
 image: "ghcr.io/mbinorg/mbin:latest"
 ```
 
-**Important:** Do _NOT_ forget to change **ALL LINES** in that matches `image: mbin` to: `image: "ghcr.io/mbinorg/mbin:latest"` in the `compose.yml` file (should 4 matches in total).
+**Important:** Do _NOT_ forget to change **ALL LINES** in that matches `image: mbin` to: `image: "ghcr.io/mbinorg/mbin:latest"` in the `compose.yml` file (should be 4 matches in total).
 
 3. Create config files and storage directories:
 

--- a/docs/docker_deployment_guide.md
+++ b/docs/docker_deployment_guide.md
@@ -53,19 +53,40 @@ cd mbin
 cd docker
 ```
 
-2. Use the existing Docker image or build the docker image (from the root-directory of the repository).
+2. Use the existing Docker image _OR_ build the docker image (from the root-directory of the repository).
 
-Fetch the latest Docker image from the `main` branch:
+#### Build our own Docker image
 
-```bash
-docker pull ghcr.io/mbinorg/mbin:main
-```
-
-_OR_ build the image yourself (if you wish):
+If you want to build our own image use (_No_ need to update the `compose.yml` file):
 
 ```bash
 docker build --no-cache -t mbin -f Dockerfile  ..
 ```
+
+#### Use Mbin pre-build image
+
+_OR_ use our pre-build images from [ghcr.io](https://ghcr.io). In this case you need to update the `compose.yml` file:
+
+```bash
+nano compose.yml
+```
+
+Find and replace or comment-out the following 4 lines:
+
+```yml
+build:
+  context: ../
+  dockerfile: docker/Dockerfile
+image: mbin
+```
+
+And instead use the following line on all places (`www`, `php`, `messenger` and `messenger_ap` services):
+
+```yml
+image: "ghcr.io/mbinorg/mbin:latest"
+```
+
+**Important:** Do _NOT_ forget to change **ALL LINES** in that matches `image: mbin` to: `image: "ghcr.io/mbinorg/mbin:latest"` in the `compose.yml` file (should 4 matches in total).
 
 3. Create config files and storage directories:
 

--- a/docs/docker_deployment_guide.md
+++ b/docs/docker_deployment_guide.md
@@ -42,7 +42,7 @@ git clone https://github.com/MbinOrg/mbin.git
 cd mbin
 ```
 
-### Prepare and build Docker image
+### Docker image preparation
 
 > **Note**
 > If you're using a version of Docker Engine earlier than 23.0, run `export DOCKER_BUILDKIT=1`, prior to building the image. This does not apply to users running Docker Desktop. More info can be found [here](https://docs.docker.com/build/buildkit/#getting-started)


### PR DESCRIPTION
Update the docker documentation and `compose.yml`, explain how to use our pre-build Docker **tagged** images.

I didn't see any package data transfer quota limits or issues, hence I think it's safe to update the docs:

![image](https://github.com/MbinOrg/mbin/assets/628926/c8d8145e-365e-41bd-9348-b4f665a3dffa)
