### PR TITLE
Kbin sync 9

### DIFF
--- a/src/Controller/Entry/EntrySingleController.php
+++ b/src/Controller/Entry/EntrySingleController.php
@@ -15,7 +15,6 @@ use App\Form\EntryCommentType;
 use App\PageView\EntryCommentPageView;
 use App\Repository\Criteria;
 use App\Repository\EntryCommentRepository;
-use App\Repository\EntryRepository;
 use App\Service\MentionManager;
 use Pagerfanta\PagerfantaInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -34,7 +33,6 @@ class EntrySingleController extends AbstractController
         #[MapEntity(id: 'entry_id')]
         Entry $entry,
         ?string $sortBy,
-        EntryRepository $entryRepository,
         EntryCommentRepository $repository,
         EventDispatcherInterface $dispatcher,
         MentionManager $mentionManager,
@@ -89,7 +87,6 @@ class EntrySingleController extends AbstractController
                 'magazine' => $magazine,
                 'comments' => $comments,
                 'entry' => $entry,
-                'crossPosts' => $entryRepository->findCross($entry),
                 'form' => $this->createForm(EntryCommentType::class, $dto, [
                     'action' => $this->generateUrl(
                         'entry_comment_create',

--- a/src/Controller/Magazine/Panel/MagazineModeratorRequestsController.php
+++ b/src/Controller/Magazine/Panel/MagazineModeratorRequestsController.php
@@ -26,7 +26,7 @@ class MagazineModeratorRequestsController extends AbstractController
     {
         return $this->render('magazine/panel/moderator_requests.html.twig', [
             'magazine' => $magazine,
-            'requests' => $this->repository->findAllPaginated($request->get('page', 1)),
+            'requests' => $this->repository->findAllPaginated($magazine, $request->get('page', 1)),
         ]);
     }
 

--- a/src/Entity/Magazine.php
+++ b/src/Entity/Magazine.php
@@ -181,6 +181,11 @@ class Magazine implements VisibilityInterface, ActivityPubActorInterface, ApiRes
         return !$user->moderatorTokens->matching($criteria)->isEmpty();
     }
 
+    public function isAbandoned(): bool
+    {
+        return $this->getOwner()->lastActive < new \DateTime('-1 month');
+    }
+
     public function getOwnerModerator(): Moderator
     {
         $criteria = Criteria::create()

--- a/src/EventSubscriber/VoteHandleSubscriber.php
+++ b/src/EventSubscriber/VoteHandleSubscriber.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\EventSubscriber;
 
 use App\Entity\Contracts\VotableInterface;
+use App\Entity\Entry;
 use App\Entity\EntryComment;
 use App\Entity\PostComment;
 use App\Event\VoteEvent;
@@ -65,6 +66,12 @@ class VoteHandleSubscriber implements EventSubscriberInterface
     public function clearCache(VotableInterface $votable)
     {
         $this->cache->delete($this->cacheService->getVotersCacheKey($votable));
+
+        if ($votable instanceof Entry) {
+            $this->cache->invalidateTags([
+                'entry_'.$votable->getId(),
+            ]);
+        }
 
         if ($votable instanceof PostComment) {
             $this->cache->invalidateTags([

--- a/src/Repository/EntryRepository.php
+++ b/src/Repository/EntryRepository.php
@@ -420,18 +420,18 @@ class EntryRepository extends ServiceEntityRepository implements TagRepositoryIn
             return [];
         }
 
-        if (\strlen($entry->title) > 10) {
+        if ($entry->url) {
+            $qb->where('e.url = :url')
+                ->setParameter('url', $entry->url);
+        } else {
             $qb->where('e.title = :title')
                 ->setParameter('title', $entry->title);
         }
 
-        if ($entry->url) {
-            $qb->orWhere('e.url = :url')
-                ->setParameter('url', $entry->url);
-        }
-
         $qb->andWhere('e.id != :id')
+            ->andWhere('m.visibility = :visibility')
             ->andWhere('e.visibility = :visibility')
+            ->join('e.magazine', 'm')
             ->setParameter('visibility', VisibilityInterface::VISIBILITY_VISIBLE)
             ->setParameter('id', $entry->getId())
             ->orderBy('e.createdAt', 'DESC')

--- a/src/Repository/ModeratorRequestRepository.php
+++ b/src/Repository/ModeratorRequestRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\Entity\Magazine;
 use App\Entity\ModeratorRequest;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -29,10 +30,12 @@ class ModeratorRequestRepository extends ServiceEntityRepository
         parent::__construct($registry, ModeratorRequest::class);
     }
 
-    public function findAllPaginated(?int $page): PagerfantaInterface
+    public function findAllPaginated(Magazine $magazine, ?int $page): PagerfantaInterface
     {
         $qb = $this->createQueryBuilder('r')
-            ->orderBy('r.createdAt', 'ASC');
+            ->where('r.magazine = :magazine')
+            ->orderBy('r.createdAt', 'ASC')
+            ->setParameter('magazine', $magazine);
 
         $pagerfanta = new Pagerfanta(
             new QueryAdapter(

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -265,7 +265,7 @@ class PostRepository extends ServiceEntityRepository implements TagRepositoryInt
         );
     }
 
-    public function countPostCommentsByMagazine(Magazine $magazine)
+    public function countPostCommentsByMagazine(Magazine $magazine): int
     {
         return \intval(
             $this->createQueryBuilder('p')
@@ -282,7 +282,7 @@ class PostRepository extends ServiceEntityRepository implements TagRepositoryInt
         return $this->createQueryBuilder('p')
             ->where('p.visibility != :visibility')
             ->andWhere('p.user = :user')
-            ->setParameters(['visibility' => Post::VISIBILITY_SOFT_DELETED, 'user' => $user])
+            ->setParameters(['visibility' => VisibilityInterface::VISIBILITY_SOFT_DELETED, 'user' => $user])
             ->orderBy('p.id', 'DESC')
             ->setMaxResults($limit)
             ->getQuery()

--- a/src/Twig/Components/EntriesCrossComponent.php
+++ b/src/Twig/Components/EntriesCrossComponent.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig\Components;
+
+use App\Entity\Entry;
+use App\Repository\EntryRepository;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Twig\Environment;
+
+#[AsTwigComponent('entries_cross', template: 'components/_cached.html.twig')]
+final class EntriesCrossComponent
+{
+    public ?Entry $entry = null;
+
+    public function __construct(
+        private readonly EntryRepository $repository,
+        private readonly CacheInterface $cache,
+        private readonly Environment $twig,
+        private readonly RequestStack $requestStack,
+        private readonly Security $security
+    ) {
+    }
+
+    public function getHtml(): string
+    {
+        return $this->cache->get(
+            "entries_cross_{$this->entry->getId()}_{$this->security->getUser()?->getId()}_{$this->requestStack->getCurrentRequest()?->getLocale()}",
+            function (ItemInterface $item) {
+                $item->expiresAfter(60);
+                $entries = $this->repository->findCross($this->entry);
+
+                $item->tag(['entry_'.$this->entry->getId()]);
+                foreach ($entries as $entry) {
+                    $item->tag(['entry_'.$entry->getId()]);
+                }
+
+                return $this->twig->render(
+                    'components/entries_cross.html.twig',
+                    [
+                        'entries' => $this->repository->findCross($this->entry),
+                    ]
+                );
+            }
+        );
+    }
+}

--- a/templates/components/entries_cross.html.twig
+++ b/templates/components/entries_cross.html.twig
@@ -1,0 +1,3 @@
+{% for entry in entries %}
+    {{ component('entry_cross', {entry: entry}) }}
+{% endfor %}

--- a/templates/entry/single.html.twig
+++ b/templates/entry/single.html.twig
@@ -34,9 +34,7 @@
             showShortSentence: false,
             showBody:true
         }) }}
-        {% for cross in crossPosts %}
-            {{ component('entry_cross', {entry: cross}) }}
-        {% endfor %}
+        {{ component('entries_cross', {entry: entry}) }}
         {% include 'layout/_flash.html.twig' %}
         {% include 'entry/comment/_options.html.twig' %}
         {% include('user/_visibility_info.html.twig') %}

--- a/templates/magazine/moderators.html.twig
+++ b/templates/magazine/moderators.html.twig
@@ -14,22 +14,42 @@
 
 {% block body %}
     <h1>{{ 'moderators'|trans }}</h1>
-    {% if not app.user or not magazine.userIsModerator(app.user) %}
-        <form action="{{ path('magazine_moderator_request', {name: magazine.name}) }}"
-              method="POST"
-              class="float-end mb-2"
-              onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
-            <input type="hidden" name="token" value="{{ csrf_token('moderator_request') }}">
-            <button type="submit" class="btn btn__secondary">
-                <i class="fa-solid fa-hand-point-up"></i>
-                {% if not app.user or not app.user.hasModeratorRequest(magazine) %}
-                    <span>{{ 'apply_for_moderator'|trans }}</span>
-                {% else %}
-                    <span>{{ 'cancel_request'|trans }}</span>
-                {% endif %}
-            </button>
-        </form>
-    {% endif %}
+    <div class="flex">
+        {% if not app.user or not magazine.userIsModerator(app.user) %}
+            <form action="{{ path('magazine_moderator_request', {name: magazine.name}) }}"
+                  method="POST"
+                  class="float-end mb-2"
+                  onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                <input type="hidden" name="token" value="{{ csrf_token('moderator_request') }}">
+                <button type="submit" class="btn btn__secondary">
+                    <i class="fa-solid fa-hand-point-up"></i>
+                    {% if not app.user or not app.user.hasModeratorRequest(magazine) %}
+                        <span>{{ 'apply_for_moderator'|trans }}</span>
+                    {% else %}
+                        <span>{{ 'cancel_request'|trans }}</span>
+                    {% endif %}
+                </button>
+            </form>
+        {% endif %}
+        {% if not app.user or not magazine.userIsOwner(app.user) and magazine.isAbandoned() %}
+            <form action="{{ path('magazine_ownership_request', {name: magazine.name}) }}"
+                  name="magazine_request_ownership"
+                  class="float-end mb-2"
+                  method="post">
+                <button type="submit"
+                        class="btn btn__secondary">
+                    <i class="fa-sharp fa-solid fa-hand-point-up"></i>
+                    {% if not app.user or not app.user.hasMagazineOwnershipRequest(magazine) %}
+                        <span>{{ 'request_magazine_ownership'|trans }}</span>
+                    {% else %}
+                        <span>{{ 'cancel_request'|trans }}</span>
+                    {% endif %}
+                </button>
+                <input type="hidden" name="token"
+                       value="{{ csrf_token('magazine_ownership_request') }}">
+            </form>
+        {% endif %}
+    </div>
     {% include 'magazine/_moderators_list.html.twig' %}
     {% if(moderators.haveToPaginate is defined and moderators.haveToPaginate) %}
         {{ pagerfanta(moderators, null, {'pageParameter':'[p]'}) }}

--- a/templates/magazine/moderators.html.twig
+++ b/templates/magazine/moderators.html.twig
@@ -15,7 +15,7 @@
 {% block body %}
     <h1>{{ 'moderators'|trans }}</h1>
     <div class="flex">
-        {% if not app.user or not magazine.userIsModerator(app.user) %}
+        {% if app.user and not magazine.userIsModerator(app.user) and app.user.visibility is same as 'visible' %}
             <form action="{{ path('magazine_moderator_request', {name: magazine.name}) }}"
                   method="POST"
                   class="float-end mb-2"
@@ -31,7 +31,7 @@
                 </button>
             </form>
         {% endif %}
-        {% if not app.user or not magazine.userIsOwner(app.user) and magazine.isAbandoned() %}
+        {% if magazine.isAbandoned() and app.user and not magazine.userIsOwner(app.user) and app.user.visibility is same as 'visible' %}
             <form action="{{ path('magazine_ownership_request', {name: magazine.name}) }}"
                   name="magazine_request_ownership"
                   class="float-end mb-2"


### PR DESCRIPTION
- Introduce HTML Twig cache for cross-posting threads
- Improve request magazine ownership buttons (for none-magazine owners)
- Only check on thread url (`e.url`) if present otherwise use the thread title (`e.title`)
- Change template regarding cross-posts
- Filter on magazine on moderator_requests page

_Note:_ For now still skipping the user visibility where clauses.  

PR:
- https://codeberg.org/Kbin/kbin-core/pulls/1227
- https://codeberg.org/Kbin/kbin-core/pulls/1229


OUT OF SCOPE:
- https://codeberg.org/Kbin/kbin-core/pulls/1224
- https://codeberg.org/Kbin/kbin-core/pulls/1225

Co-committed-by: Ernest Wiśniewski <ernestwisniewski2@gmail.com>