### PR TITLE
button changes to request for mod or ownership

### DIFF
--- a/templates/magazine/moderators.html.twig
+++ b/templates/magazine/moderators.html.twig
@@ -15,7 +15,7 @@
 {% block body %}
     <h1>{{ 'moderators'|trans }}</h1>
     <div class="flex">
-        {% if not app.user or not magazine.userIsModerator(app.user) %}
+        {% if app.user and not magazine.userIsModerator(app.user) %}
             <form action="{{ path('magazine_moderator_request', {name: magazine.name}) }}"
                   method="POST"
                   class="float-end mb-2"
@@ -31,7 +31,7 @@
                 </button>
             </form>
         {% endif %}
-        {% if not app.user or not magazine.userIsOwner(app.user) and magazine.isAbandoned() %}
+        {% if magazine.isAbandoned() and app.user and not magazine.userIsOwner(app.user) and app.user.visibility is same as 'visible' %}
             <form action="{{ path('magazine_ownership_request', {name: magazine.name}) }}"
                   name="magazine_request_ownership"
                   class="float-end mb-2"

--- a/templates/magazine/moderators.html.twig
+++ b/templates/magazine/moderators.html.twig
@@ -15,7 +15,7 @@
 {% block body %}
     <h1>{{ 'moderators'|trans }}</h1>
     <div class="flex">
-        {% if app.user and not magazine.userIsModerator(app.user) %}
+        {% if app.user and not magazine.userIsModerator(app.user) and app.user.visibility is same as 'visible' %}
             <form action="{{ path('magazine_moderator_request', {name: magazine.name}) }}"
                   method="POST"
                   class="float-end mb-2"


### PR DESCRIPTION
Right now on `m/{magazine}/moderators`:

Apply for moderator: Appears when logged out, or logged in and not a moderator of the magazine
Request magazine ownership: Appears when logged out (always, regardless of abandoned, it's missing a `()`, likely a bug upstream) or when logged in and magazine is abandoned

After this:

Apply for moderator: Appears only when logged in and not moderator of the magazine and account is visible (not marked for delete, not suspended)
Request magazine ownership: Appears only when magazine is abandoned and logged in and not moderator of the magazine and account is visible (not marked for delete, not suspended)

This PR is pointed at #251 