### PR TITLE
nsfw - add blurring of nsfw magazine icons

### DIFF
--- a/assets/controllers/subject_controller.js
+++ b/assets/controllers/subject_controller.js
@@ -36,9 +36,8 @@ export default class extends Controller {
         }
 
         this.checkHeight();
-        this.handleAdultThumbs()
     }
-    
+
     async getForm(event) {
         event.preventDefault();
 
@@ -74,7 +73,7 @@ export default class extends Controller {
                         textarea.selectionEnd = firstLineEnd + 1;
                     }
                 }
-                
+
                 textarea.focus();
             }
         } catch (e) {
@@ -407,23 +406,6 @@ export default class extends Controller {
     expand() {
         if (!this.isExpandedValue) {
             this.moreBtn.click();
-        }
-    }
-
-    handleAdultThumbs() {
-        // @todo temporary fix
-        const adultBadge = this.element.querySelector('.danger');
-        if (adultBadge && (adultBadge.textContent.includes('18') || adultBadge.textContent.toLowerCase().includes('nsfw'))) {
-            const image = this.element.querySelector('.thumb-subject');
-            if (image) {
-                image.style.filter = 'blur(8px)';
-                image.addEventListener('mouseenter', () => {
-                    image.style.filter = 'none';
-                });
-                image.addEventListener('mouseleave', () => {
-                    image.style.filter = 'blur(8px)';
-                });
-            }
         }
     }
 }

--- a/assets/controllers/thumb_controller.js
+++ b/assets/controllers/thumb_controller.js
@@ -1,0 +1,29 @@
+import {Controller} from '@hotwired/stimulus';
+import {fetch, ok} from "../utils/http";
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    /**
+     * Called on mouseover
+     * @param {*} event
+     * @returns
+     */
+    async adult_image_hover(event) {
+
+        if (false === event.target.matches(':hover')) {
+            return;
+        }
+
+        event.target.style.filter = 'none';
+    }
+
+    /**
+     * Called on mouseout
+     * @param {*} event
+     */
+    async adult_image_hover_out(event) {
+
+        event.target.style.filter = 'blur(8px)';
+
+    }
+}

--- a/assets/styles/layout/_images.scss
+++ b/assets/styles/layout/_images.scss
@@ -1,4 +1,16 @@
 .image-inline {
     display: inline-block;
     overflow: hidden;
+
+    // inline icons/avatars that are nsfw
+    // likely are used with .stretched-link,
+    // so this is to get the mouse events above the link
+    &.image-adult {
+      position: relative;
+      z-index: 2;
+    }
+}
+
+.image-adult {
+  filter: blur(8px);
 }

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -86,9 +86,9 @@
                                  aria-hidden="true"></div>
                             <a href="{{ is_route_name('entry_single') ? entry.url : entry_url(entry) }}"
                                rel="{{ get_rel(is_route_name('entry_single') ? entry.url : entry_url(entry)) }}">
-                                <img class="thumb-subject"
+                                <img class="thumb-subject {{ entry.isAdult ? 'image-adult' : '' }}"
                                      src="{{ asset(entry.image.filePath) |imagine_filter('entry_thumb') }}"
-                                     {% if entry.isAdult %}style="filter: blur(8px)"{% endif %}
+                                     {% if entry.isAdult %}data-controller="thumb" data-action="mouseover->thumb#adult_image_hover mouseout->thumb#adult_image_hover_out"{% endif %}
                                      alt="{{ entry.image.altText }}">
                             </a>
                         </figure>
@@ -99,9 +99,9 @@
                                  aria-hidden="true"></div>
                             <a href="{{ is_route_name('entry_single') ? uploaded_asset(entry.image.filePath) : entry_url(entry) }}"
                                class="{{ html_classes({'thumb': is_route_name('entry_single')}) }}">
-                                <img class="thumb-subject"
+                                <img class="thumb-subject {{ entry.isAdult ? 'image-adult' : '' }}"
                                      src="{{ asset(entry.image.filePath) |imagine_filter('entry_thumb') }}"
-                                     {% if entry.isAdult %}style="filter: blur(8px)"{% endif %}
+                                     {% if entry.isAdult %}data-controller="thumb" data-action="mouseover->thumb#adult_image_hover mouseout->thumb#adult_image_hover_out"{% endif %}
                                      alt="{{ entry.image.altText }}">
                             </a>
                         </figure>

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -70,9 +70,9 @@
                     <figure>
                         <a href="{{ uploaded_asset(comment.image.filePath) }}"
                            class="thumb">
-                            <img class="thumb-subject"
+                            <img class="thumb-subject {{ comment.isAdult ? 'image-adult' : '' }}"
                                  src="{{ asset(comment.image.filePath) |imagine_filter('post_thumb') }}"
-                                 {% if comment.isAdult %}style="filter: blur(8px)"{% endif %}
+                                 {% if comment.isAdult %}data-controller="thumb" data-action="mouseover->thumb#adult_image_hover mouseout->thumb#adult_image_hover_out"{% endif %}
                                  alt="{{ comment.image.altText }}">
                         </a>
                     </figure>

--- a/templates/components/magazine_box.html.twig
+++ b/templates/components/magazine_box.html.twig
@@ -10,8 +10,9 @@
     <div class="row">
         {% if computed.magazine.icon and showCover %}
             <figure>
-                <img class="image-inline"
+                <img class="image-inline {{ magazine.isAdult ? 'image-adult' : '' }}"
                      src="{{ asset(computed.magazine.icon.filePath) | imagine_filter('post_thumb') }}"
+                     {% if magazine.isAdult %}data-controller="thumb" data-action="mouseover->thumb#adult_image_hover mouseout->thumb#adult_image_hover_out"{% endif %}
                      alt="{{ computed.magazine.name ~ ' ' ~ 'icon'|trans|lower }}" width="260">
             </figure>
         {% endif %}

--- a/templates/components/magazine_inline.html.twig
+++ b/templates/components/magazine_inline.html.twig
@@ -2,9 +2,10 @@
    class="{{ html_classes('magazine-inline', {'stretched-link': stretchedLink }) }}"
    title="{{ ('@'~magazine.name)|username(true) }}">
     {% if magazine.icon and showAvatar %}
-        <img class="image-inline"
+        <img class="image-inline {{ magazine.isAdult ? 'image-adult' : '' }}"
              width="30" height="30"
              style="max-width: 30px; max-height: 30px;"
+             {% if magazine.isAdult %}data-controller="thumb" data-action="mouseover->thumb#adult_image_hover mouseout->thumb#adult_image_hover_out"{% endif %}
              src="{{ asset(magazine.icon.filePath) | imagine_filter('avatar_thumb') }}"
              alt="{{ magazine.name ~ ' ' ~ 'icon'|trans|lower }}">
     {% endif %}

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -53,9 +53,9 @@
                 {% if post.image %}
                     <figure>
                         <a class="thumb" href="{{ uploaded_asset(post.image.filePath) }}">
-                            <img class="thumb-subject"
+                            <img class="thumb-subject {{ post.isAdult ? 'image-adult' : '' }}"
                                  src="{{ asset(post.image.filePath) |imagine_filter('post_thumb') }}"
-                                 {% if post.isAdult %}style="filter: blur(8px)"{% endif %}
+                                 {% if post.isAdult %}data-controller="thumb" data-action="mouseover->thumb#adult_image_hover mouseout->thumb#adult_image_hover_out"{% endif %}
                                  alt="{{ post.image.altText }}">
                         </a>
                     </figure>

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -72,9 +72,9 @@
                     <figure>
                         <a href="{{ uploaded_asset(comment.image.filePath) }}"
                            class="thumb">
-                            <img class="thumb-subject"
+                            <img class="thumb-subject {{ comment.isAdult ? 'image-adult' : '' }}"
                                  src="{{ asset(comment.image.filePath) |imagine_filter('post_thumb') }}"
-                                 {% if comment.isAdult %}style="filter: blur(8px)"{% endif %}
+                                 {% if comment.isAdult %}data-controller="thumb" data-action="mouseover->thumb#adult_image_hover mouseout->thumb#adult_image_hover_out"{% endif %}
                                  alt="{{ comment.image.altText }}">
                         </a>
                     </figure>

--- a/templates/magazine/_list.html.twig
+++ b/templates/magazine/_list.html.twig
@@ -14,7 +14,7 @@
                             {% if magazine.icon %}
                                 <figure>
                                     <img width="32" height="32"
-                                         class="{{ magazine.isAdult ? 'image-adult' : '' }}"
+                                         class="image-inline {{ magazine.isAdult ? 'image-adult' : '' }}"
                                          src="{{ asset(magazine.icon.filePath) | imagine_filter('avatar_thumb') }}"
                                          {% if magazine.isAdult %}data-controller="thumb" data-action="mouseover->thumb#adult_image_hover mouseout->thumb#adult_image_hover_out"{% endif %}
                                          alt="{{ magazine.name ~' '~ 'avatar'|trans|lower }}">

--- a/templates/magazine/_list.html.twig
+++ b/templates/magazine/_list.html.twig
@@ -17,7 +17,7 @@
                                          class="image-inline {{ magazine.isAdult ? 'image-adult' : '' }}"
                                          src="{{ asset(magazine.icon.filePath) | imagine_filter('avatar_thumb') }}"
                                          {% if magazine.isAdult %}data-controller="thumb" data-action="mouseover->thumb#adult_image_hover mouseout->thumb#adult_image_hover_out"{% endif %}
-                                         alt="{{ magazine.name ~' '~ 'avatar'|trans|lower }}">
+                                         alt="{{ magazine.name ~' '~ 'icon'|trans|lower }}">
                                 </figure>
                             {% endif %}
                             <div>

--- a/templates/magazine/_list.html.twig
+++ b/templates/magazine/_list.html.twig
@@ -14,7 +14,9 @@
                             {% if magazine.icon %}
                                 <figure>
                                     <img width="32" height="32"
+                                         class="{{ magazine.isAdult ? 'image-adult' : '' }}"
                                          src="{{ asset(magazine.icon.filePath) | imagine_filter('avatar_thumb') }}"
+                                         {% if magazine.isAdult %}data-controller="thumb" data-action="mouseover->thumb#adult_image_hover mouseout->thumb#adult_image_hover_out"{% endif %}
                                          alt="{{ magazine.name ~' '~ 'avatar'|trans|lower }}">
                                 </figure>
                             {% endif %}
@@ -76,33 +78,33 @@
                     {% for column in ['threads', 'comments', 'posts', 'hot'] %}
                         <span>
                             <a href="{{ options_url('sortBy', column) }}" class="btn {{ (sortBy is same as column) ? 'btn__primary' : 'btn__secondary' }}">
-                                
+
                                 {% if(column is same as 'hot')%}
                                     {{ 'subscriptions'|trans }}
                                 {% else %}
                                     {{ column|trans }}
                                 {% endif %}
-                                
+
                                 {% if sortBy is same as column %}
                                     <i class="fa-solid fa-sort-amount-desc" aria-sort="descending"></i>
                                 {% endif %}
                             </a>
-                            
+
                         </span>
                     {% endfor %}
                 </div>
                 {% for magazine in magazines %}
                         <div class="magazine">
                             <div class="magazine__top">
-                                <div class="magazine__inline">{{ component('magazine_inline', { magazine: magazine, stretchedLink: true, showAvatar: true, fullName: true}) }}</div>         
-                                <div class="magazine__information">                  
+                                <div class="magazine__inline">{{ component('magazine_inline', { magazine: magazine, stretchedLink: true, showAvatar: true, fullName: true}) }}</div>
+                                <div class="magazine__information">
                                     <span class="magazine__info"><span class="value">{{ magazine.entryCount }}</span><span class="label">{{ 'threads'|trans }}</span></span>
                                     <span class="magazine__info"><span class="value">{{ magazine.entryCommentCount }}</span><span class="label">{{ 'comments'|trans }}</span></span>
                                     <span class="magazine__info"><span class="value">{{ magazine.postCount + magazine.postCommentCount }}</span><span class="label">{{ 'posts'|trans }}</span></span>
                                 </div>
                                 <div class="magazine__sub">{{ component('magazine_sub', {magazine: magazine}) }}</div>
                             </div>
-                            
+
                         </div>
                 {% endfor %}
             </div>


### PR DESCRIPTION
add controller for blurring nsfw images
blur nsfw magazine icons, inline icons
replacing blurring of entries, entry comments, posts, post comments

followup to #246 where it was brought up to blur magazine icons

![image](https://github.com/MbinOrg/mbin/assets/146029455/99773f48-2565-465f-8b22-e4bfe51d97a5)
![image](https://github.com/MbinOrg/mbin/assets/146029455/5072a4fc-6a18-457b-b313-5db1657df99d)
![image](https://github.com/MbinOrg/mbin/assets/146029455/4036acd2-3562-47ee-8bf7-0e7b5a5ba7e8)

entry (thread) comment
![image](https://github.com/MbinOrg/mbin/assets/146029455/1ea7c23e-8d26-4041-a0ea-746d945c58a9)

post (microblog) comment
![image](https://github.com/MbinOrg/mbin/assets/146029455/a574bd23-5fb2-4eef-9422-62734af99cb1)

<details>
<summary>hover states of the new mag blurring:</summary>

![image](https://github.com/MbinOrg/mbin/assets/146029455/897c8ed2-6e70-4036-8f67-65e997e368f4)
![image](https://github.com/MbinOrg/mbin/assets/146029455/3cf02dde-ec25-403f-a04e-993db09f62d3)
![image](https://github.com/MbinOrg/mbin/assets/146029455/2e9c3972-b0c8-45dc-89e8-7aa956a6ae2e)

</details>