### PR TITLE
Allow admins to create a sitewide notification below the header

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -14,6 +14,7 @@
 @import 'layout/alerts';
 @import 'layout/forms';
 @import 'layout/images';
+@import 'components/announcement';
 @import 'components/topbar';
 @import 'components/header';
 @import 'components/sidebar';

--- a/assets/styles/components/_announcement.scss
+++ b/assets/styles/components/_announcement.scss
@@ -1,0 +1,24 @@
+.announcement {
+  padding: 0.75rem;
+  position: relative;
+
+  p {
+    margin: 0;
+    text-align: center;
+  }
+
+  a{
+    font-weight: bold;
+  }
+
+  &__info {
+    background: var(--kbin-alert-info-bg);
+    border: var(--kbin-alert-info-border);
+    color: var(--kbin-alert-info-text-color);
+
+    a {
+      color: var(--kbin-alert-info-link-color);    
+    }
+  }
+
+}

--- a/migrations/Version20231113165549.php
+++ b/migrations/Version20231113165549.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20231113165549 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE site ADD announcement TEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE site DROP announcement');
+    }
+}

--- a/src/Entity/Site.php
+++ b/src/Entity/Site.php
@@ -21,6 +21,8 @@ class Site
     #[Column(type: 'text', nullable: true)]
     public ?string $about = null;
     #[Column(type: 'text', nullable: true)]
+    public ?string $announcement = null;
+    #[Column(type: 'text', nullable: true)]
     public ?string $contact = null;
     #[Column(type: 'text', nullable: true)]
     public ?string $privateKey = null;

--- a/src/Twig/Components/AnnouncementComponent.php
+++ b/src/Twig/Components/AnnouncementComponent.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig\Components;
+
+use App\Repository\SiteRepository;
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Symfony\UX\TwigComponent\ComponentAttributes;
+use Twig\Environment;
+
+#[AsTwigComponent('announcement', template: 'components/_cached.html.twig')]
+final class AnnouncementComponent
+{
+    public function __construct(
+        private readonly Environment $twig,
+        private readonly SiteRepository $repository
+    ) {
+    }
+
+    public function getHtml(ComponentAttributes $attributes): string
+    {
+        return $this->twig->render(
+            'components/announcement.html.twig',
+            [
+                'content' => $this->repository->findAll()[0]->announcement ?? '',
+            ]
+        );
+    }
+}

--- a/templates/admin/_options.html.twig
+++ b/templates/admin/_options.html.twig
@@ -42,7 +42,7 @@
             </a>
         </li>
         <li>
-            <a href="{{ path('admin_pages', {page: 'about'}) }}"
+            <a href="{{ path('admin_pages', {page: 'announcement'}) }}"
                class="{{ html_classes({'active': is_route_name('admin_pages')}) }}">
                 {{ 'pages'|trans }}
             </a>

--- a/templates/admin/pages.html.twig
+++ b/templates/admin/pages.html.twig
@@ -17,6 +17,12 @@
     <div class="pills">
         <menu>
             <li>
+                <a href="{{ path('admin_pages', {page: 'announcement'}) }}"
+                   class="{{ html_classes({'active': route_has_param('page', 'announcement')}) }}">
+                    {{ 'announcement'|trans }}
+                </a>
+            </li>
+            <li>
                 <a href="{{ path('admin_pages', {page: 'about'}) }}"
                    class="{{ html_classes({'active': route_has_param('page', 'about')}) }}">
                     {{ 'about_instance'|trans }}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -72,6 +72,7 @@
         'sidebars-same-side': app.user is defined and app.user is not same as null and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR')) is same as 'true' and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE')) is same as 'true',
     }) }}" data-controller="kbin notifications">
 {% include 'layout/_header.html.twig' with {header_nav: block('header_nav')} %}
+{{ component('announcement') }}
 <div id="middle" class="{%- block mainClass -%}page{%- endblock %}">
     <div class="kbin-container
       {{ html_classes(app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH'))

--- a/templates/components/announcement.html.twig
+++ b/templates/components/announcement.html.twig
@@ -1,0 +1,5 @@
+{% if content is not empty %}
+<div class="announcement announcement__info">
+    {{ content|markdown|raw }}
+</div>
+{% endif %}

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -864,3 +864,4 @@ user_badge_op: OP
 user_badge_admin: Admin
 user_badge_global_moderator: Global Mod
 user_badge_moderator: Mod
+announcement: Announcement


### PR DESCRIPTION
Until now there hasn't been a way for admins to make site wide announcements to notify users of system maintenance or other serious news. This PR adds a notification bar below the header only if an announcement message has been set.

![Screenshot 2023-11-13 150225](https://github.com/MbinOrg/mbin/assets/35878315/c338a2ae-ebbc-4353-bf5f-e1682ee7a555)

I didn't want to make a separate admin panel tab for it, so it's under the pages tab for now... our admin panel needs some serious TLC anyway.

I've also fixed a bug in the other the admin pages where once something is set you were unable to clear it/set it to null again without a 500 error being generated.