### PR TITLE
add bot badges, add admin and global mod badges to user pages

### DIFF
--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -29,6 +29,8 @@
                     <span class="user-badge">{{ 'user_badge_global_moderator'|trans }}</span>
                 {% elseif comment.magazine.userIsModerator(comment.user) %}
                     <span class="user-badge">{{ 'user_badge_moderator'|trans }}</span>
+                {% elseif (comment.user.type) == "Service" %}
+                    <span class="user-badge">{{ 'user_badge_bot'|trans }}</span>
                 {% endif %}
                 <span>, </span>
 

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -32,6 +32,8 @@
                     <span class="user-badge">{{ 'user_badge_global_moderator'|trans }}</span>
                 {% elseif comment.magazine.userIsModerator(comment.user) %}
                     <span class="user-badge">{{ 'user_badge_moderator'|trans }}</span>
+                {% elseif (comment.user.type) == "Service" %}
+                    <span class="user-badge">{{ 'user_badge_bot'|trans }}</span>
                 {% endif %}
                 <span>, </span>
 

--- a/templates/components/user_box.html.twig
+++ b/templates/components/user_box.html.twig
@@ -32,16 +32,24 @@
                     {% if stretchedLink %}
                         <h1>
                             <a class="link-muted stretched-link"
-                               href="{{ path('user_overview', {'username': user.username}) }}">{{ user.username|username(false) }}</a>
-                            {% if (user.type) == "Service" %}
-                                <code title="Bot Account">Robot</code>
+                              href="{{ path('user_overview', {'username': user.username}) }}">{{ user.username|username(false) }}</a>
+                            {% if user.admin() %}
+                              <code title="{{ 'user_badge_admin'|trans }}">{{ 'user_badge_admin'|trans }}</code>
+                            {% elseif user.moderator() %}
+                              <code title="{{ 'user_badge_global_moderator'|trans }}">{{ 'user_badge_global_moderator'|trans }}</code>
+                            {% elseif (user.type) == "Service" %}
+                              <code title="{{ 'user_badge_bot'|trans }}">{{ 'user_badge_bot'|trans }}</code>
                             {% endif %}
                         </h1>
                     {% else %}
                         <h1>
                             {{ user.apPreferredUsername ?? user.username|username(false) }}
-                            {% if (user.type) == "Service" %}
-                                <code title="Bot Account">Robot</code>
+                            {% if user.admin() %}
+                                <code title="{{ 'user_badge_admin'|trans }}">{{ 'user_badge_admin'|trans }}</code>
+                            {% elseif user.moderator() %}
+                                <code title="{{ 'user_badge_global_moderator'|trans }}">{{ 'user_badge_global_moderator'|trans }}</code>
+                            {% elseif (user.type) == "Service" %}
+                                <code title="{{ 'user_badge_bot'|trans }}">{{ 'user_badge_bot'|trans }}</code>
                             {% endif %}
                         </h1>
                     {% endif %}

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -864,4 +864,5 @@ user_badge_op: OP
 user_badge_admin: Admin
 user_badge_global_moderator: Global Mod
 user_badge_moderator: Mod
+user_badge_bot: Bot
 announcement: Announcement


### PR DESCRIPTION
noticed we had the label on user box pages for bot accounts, but think it'd be useful on the comment as well, which made me also think the admin / global mod labels might be useful on the user box pages

![image](https://github.com/MbinOrg/mbin/assets/146029455/11997344-de2c-4874-87cb-b85d5a8db070)

![image](https://github.com/MbinOrg/mbin/assets/146029455/5f8e5db1-a949-4aef-96e4-4b54e4c1fe8d)

![image](https://github.com/MbinOrg/mbin/assets/146029455/e656e61f-63be-497e-95c7-c1c7736f3458)
