### PR TITLE
update s3 adapter docs for not using ACL

### DIFF
--- a/config/packages/oneup_flysystem.yaml
+++ b/config/packages/oneup_flysystem.yaml
@@ -11,6 +11,9 @@ oneup_flysystem:
     #    bucket: "%amazon.s3.bucket%"
     #    options:
     #      ACL: public-read
+    ## If using an s3 bucket with owner-full-control and no ACL, the following may work:
+    ##    options:
+    ##      ACL: ''
 
   filesystems:
     public_uploads_filesystem:


### PR DESCRIPTION
this came out of the resolution for s3 writing on originalucifer's instance