### PR TITLE
exiftool based image exif cleaner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,16 @@ OAUTH_KEYCLOAK_VERSION=
 # If true, sign ins and sign ups will only be possible through the OAuth providers configured above
 SSO_ONLY_MODE=
 
+# image exif cleaning options
+# available value: none, sanitize, scrub
+# can be set differently for user uploaded and external media
+EXIF_CLEAN_MODE_UPLOADED=sanitize
+EXIF_CLEAN_MODE_EXTERNAL=none
+# path to exiftool binary, leave blank for auto PATH search
+EXIF_EXIFTOOL_PATH=
+# max execution time for exiftool in seconds, defaults to 10 seconds
+EXIF_EXIFTOOL_TIMEOUT=10
+
 ###> symfony/framework-bundle ###
 APP_ENV=prod
 APP_SECRET=!CHANGE_SECRET!

--- a/.env.example_docker
+++ b/.env.example_docker
@@ -66,6 +66,16 @@ OAUTH_GITHUB_SECRET=
 # If true, sign ins and sign ups will only be possible through the OAuth providers configured above
 SSO_ONLY_MODE=
 
+# image exif cleaning options
+# available value: none, sanitize, scrub
+# can be set differently for user uploaded and external media
+EXIF_CLEAN_MODE_UPLOADED=sanitize
+EXIF_CLEAN_MODE_EXTERNAL=none
+# path to exiftool binary, leave blank for auto PATH search
+EXIF_EXIFTOOL_PATH=
+# max execution time for exiftool in seconds, defaults to 10 seconds
+EXIF_EXIFTOOL_TIMEOUT=10
+
 ###> symfony/framework-bundle ###
 APP_ENV=prod
 APP_SECRET=!CHANGE_SECRET!

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -69,6 +69,14 @@ parameters:
 
     sso_only_mode: "%env(bool:default::SSO_ONLY_MODE)%"
 
+    exif_default_uploaded: 'sanitize'
+    exif_default_external: 'none'
+
+    exif_clean_mode_uploaded: '%env(enum:\App\Utils\ExifCleanMode:default:exif_default_uploaded:EXIF_CLEAN_MODE_UPLOADED)%'
+    exif_clean_mode_external: '%env(enum:\App\Utils\ExifCleanMode:default:exif_default_external:EXIF_CLEAN_MODE_EXTERNAL)%'
+    exif_exiftool_path: '%env(default::EXIF_EXIFTOOL_PATH)%'
+    exif_exiftool_timeout: '%env(int:default::EXIF_EXIFTOOL_TIMEOUT)%'
+
 services:
     # default configuration for services in *this* file
     _defaults:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN install-php-extensions amqp pgsql pdo_pgsql gd curl simplexml dom xml redis 
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
 # Install caddy
-RUN apk update && apk add caddy acl fcgi
+RUN apk update && apk add caddy acl fcgi exiftool
 
 # **Environment variables**
 ARG UID=1000

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -1061,6 +1061,31 @@ oneup_flysystem:
       alias: League\Flysystem\Filesystem
 ```
 
+### Image metadata cleaning with `exiftool` (optional)
+
+To use this feature, install `exiftool` (`libimage-exiftool-perl` package for Ubuntu/Debian)
+and make sure `exiftool` executable exist and and visible in PATH
+
+Available options in `.env`:
+
+```sh
+# available modes: none, sanitize, scrub
+# can be set differently for user uploaded and external media
+EXIF_CLEAN_MODE_UPLOADED=sanitize
+EXIF_CLEAN_MODE_EXTERNAL=none
+# path to exiftool binary, leave blank for auto PATH search
+EXIF_EXIFTOOL_PATH=
+# max execution time for exiftool in seconds, defaults to 10 seconds
+EXIF_EXIFTOOL_TIMEOUT=10
+```
+
+Available cleaning modes:
+
+- `none`: no metadata cleaning would be done.
+- `sanitize`: removes GPS and serial number metadata. this is the default for uploaded images.
+- `scrub`: removes most of image metadata save for those needed for proper image rendering
+  and XMP IPTC attribution metadata.
+
 ### Captcha (optional)
 
 Go to [hcaptcha.com](https://www.hcaptcha.com) and create a free account. Make a sitekey and a secret. Add domain.tld to the sitekey.

--- a/src/EventSubscriber/Image/ExifCleanerSubscriber.php
+++ b/src/EventSubscriber/Image/ExifCleanerSubscriber.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber\Image;
+
+use App\Event\ImagePostProcessEvent;
+use App\Utils\ExifCleaner;
+use App\Utils\ExifCleanMode;
+use App\Utils\ImageOrigin;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ExifCleanerSubscriber implements EventSubscriberInterface
+{
+    private ExifCleanMode $uploadedCleanMode;
+    private ExifCleanMode $externalCleanMode;
+
+    public function __construct(
+        private readonly ExifCleaner $cleaner,
+        private readonly ContainerBagInterface $params,
+        private readonly LoggerInterface $logger,
+    ) {
+        $this->uploadedCleanMode = $params->get('exif_clean_mode_uploaded');
+        $this->externalCleanMode = $params->get('exif_clean_mode_external');
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ImagePostProcessEvent::class => ['cleanExif'],
+        ];
+    }
+
+    public function cleanExif(ImagePostProcessEvent $event)
+    {
+        $mode = $this->getCleanMode($event->origin);
+        $this->logger->debug(
+            'ImagePostProcessEvent:ExifCleanerSubscriber: cleaning image:',
+            [
+                'source' => $event->source,
+                'origin' => $event->origin,
+                'sha256' => hash_file('sha256', $event->source, false),
+                'mode' => $mode,
+            ]
+        );
+        $this->cleaner->cleanImage($event->source, $mode);
+    }
+
+    private function getCleanMode(ImageOrigin $origin): ExifCleanMode
+    {
+        return match ($origin) {
+            ImageOrigin::Uploaded => $this->uploadedCleanMode,
+            ImageOrigin::External => $this->externalCleanMode,
+        };
+    }
+}

--- a/src/Repository/ImageRepository.php
+++ b/src/Repository/ImageRepository.php
@@ -145,6 +145,8 @@ class ImageRepository extends ServiceEntityRepository
 
             return Blurhash::encode($pixels, $components_x, $components_y);
         } catch (\Exception $e) {
+            $this->logger->info('Failed to calculate blurhash: '.$e->getMessage());
+
             return null;
         }
     }

--- a/src/Utils/ExifCleanMode.php
+++ b/src/Utils/ExifCleanMode.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Utils;
+
+enum ExifCleanMode: string
+{
+    case None = 'none';
+    case Sanitize = 'sanitize';
+    case Scrub = 'scrub';
+}

--- a/src/Utils/ExifCleaner.php
+++ b/src/Utils/ExifCleaner.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Utils;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Process\Process;
+
+class ExifCleaner
+{
+    protected const EXIFTOOL_COMMAND_NAME = 'exiftool';
+    protected const EXIFTOOL_ARGS_COMMON = [
+        '-overwrite_original', '-ignoreminorerrors',
+    ];
+    protected const EXIFTOOL_ARGS_SANITIZE = [
+        '-GPS*=', '-*Serial*=',
+    ];
+    protected const EXIFTOOL_ARGS_SCRUB = [
+        '-all=',
+        '-tagsfromfile', '@',
+        '-colorspacetags', '-commonifd0', '-orientation', '-icc_profile',
+        '-XMP-dc:all', '-XMP-iptcCore:all', '-XMP-iptcExt:all',
+        '-IPTC:all',
+    ];
+    protected const EXIFTOOL_TIMEOUT_SECONDS = 10;
+
+    private readonly ?string $exiftoolPath;
+    private readonly ?string $exiftool;
+    private readonly int $timeout;
+
+    public function __construct(
+        private readonly ContainerBagInterface $params,
+        private readonly LoggerInterface $logger,
+    ) {
+        $this->exiftoolPath = $params->get('exif_exiftool_path');
+        $this->timeout = $params->get('exif_exiftool_timeout') ?? self::EXIFTOOL_TIMEOUT_SECONDS;
+        $this->exiftool = $this->getExifToolBinary();
+    }
+
+    public function cleanImage(string $filePath, ExifCleanMode $mode)
+    {
+        if (ExifCleanMode::None === $mode) {
+            $this->logger->debug("ExifCleaner:cleanImage: cleaning mode is 'None', nothing will be done.");
+
+            return;
+        }
+
+        if (!$this->exiftool) {
+            $this->logger->info('ExifCleaner:cleanImage: exiftool binary was not found, nothing will be done.');
+
+            return;
+        }
+
+        try {
+            $ps = $this->buildProcess($mode, $filePath, $this->exiftool);
+            $ps->mustRun();
+            $this->logger->debug(
+                'ExifCleaner:cleanImage: exiftool success:',
+                ['stdout' => $ps->getOutput()],
+            );
+        } catch (ProcessFailedException $e) {
+            $this->logger->warning('ExifCleaner:cleanImage: exiftool failed: '.$e->getMessage());
+        }
+    }
+
+    private function getExifToolBinary(): ?string
+    {
+        if ($this->exiftoolPath && is_executable($this->exiftoolPath)) {
+            return $this->exiftoolPath;
+        }
+
+        $which = new ExecutableFinder();
+        $cmdpath = $which->find(self::EXIFTOOL_COMMAND_NAME);
+
+        return $cmdpath;
+    }
+
+    private function getCleaningArguments(ExifCleanMode $mode): array
+    {
+        return match ($mode) {
+            ExifCleanMode::None => [],
+            ExifCleanMode::Sanitize => self::EXIFTOOL_ARGS_SANITIZE,
+            ExifCleanMode::Scrub => self::EXIFTOOL_ARGS_SCRUB,
+        };
+    }
+
+    private function buildProcess(ExifCleanMode $mode, string $filePath, string $exiftool): Process
+    {
+        $ps = new Process(array_merge(
+            [$exiftool, $filePath],
+            self::EXIFTOOL_ARGS_COMMON,
+            $this->getCleaningArguments($mode),
+        ));
+        $ps->setTimeout($this->timeout);
+
+        return $ps;
+    }
+}


### PR DESCRIPTION
something I mentioned to put up [weeks ago](https://github.com/MbinOrg/mbin/pull/107#issuecomment-1775592752)

add an image metadata sanitizer/cleaner based on exiftool, comes with following modes, configurable via env variables:

- `none`: disable image metadata cleaning. default for external images.
- `sanitize`: strips just GPS data and what might looks like serial numbers. default for uploaded images.
- `scrub`: strip most of metadata save for those needed for proper image rendition and some attribution tags.

I tried to rig this up as an optional feature, as in it would only work when a valid `exiftool` binary is found and is executable, and it's effectively a no op when that's not the case without impeding the entire image processing flow.

---

<details><summary>concerns about where to plug the processor</summary>
<p>

now the hard part that I could use some suggestion: right now I plugged the cleaner inside `ImageRepository::findOrCreateFromPath`, right just before storing the image, and I'm not sure if there's more appropiate place to put this:

- putting it here means all image introduced would be cleaned, including federated images, which may not be desired for busy instances
- putting it before `findOrCreateFrom{Path,Upload}` could results in image lookup by hash being less effective because the input image will have to be cleaned before checking for hash although the same, cleaned image might already exists, which means what's supposedly fast path is now slower and the cleaning job is practically wasted
- right now, the function now looks like at least 3 functions stacked together and looks like it could use some refactoring, but I'm not sure how to go with it (and for some inexplicable reasons I feel like event dispatcher could be used here)

</p>
</details> 

ended up refactored/rearranged the `findOrCreateFrom{Path,Upload}` functions, reviewed separately at #287 