### PR TITLE
Decrease proxy read timeout on Mercure

### DIFF
--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -559,7 +559,8 @@ server {
 
     location /.well-known/mercure {
         proxy_pass http://127.0.0.1:3000$request_uri;
-        proxy_read_timeout 24h;
+        # Increase this time-out if you want clients have a Mercure connection open for longer (eg. 24h)
+        proxy_read_timeout 2h;
         proxy_http_version 1.1;
         proxy_set_header Connection "";
 


### PR DESCRIPTION
Decrease from 24h to just 2 hours timeout on the Mercure connection (Nginx), which I think is long enough. Server owners are free to increase this timeout to any value they like.

The benefit of reducing this time-out is that you also reduce long open connections. Which is especially problematic on large instances. 