### PR TITLE
hide nsfw magazine icons for logged out users, blur on mag sub/block pages

### DIFF
--- a/assets/styles/components/_magazine.scss
+++ b/assets/styles/components/_magazine.scss
@@ -171,6 +171,14 @@
     color: var(--kbin-meta-text-color);
     font-size: .85rem;
   }
+
+  .stretched-link {
+    small {
+      &.badge.danger {
+        color: var(--kbin-danger-color);
+      }
+    }
+  }
 }
 
 td {
@@ -272,7 +280,7 @@ td {
     }
 
     &__sub{
-      
+
     }
 
     &__information{
@@ -299,7 +307,7 @@ td {
       flex-direction: column;
       justify-content: center;
       align-items: center;
-      
+
       .value{
         font-weight: bold;
       }

--- a/templates/components/magazine_box.html.twig
+++ b/templates/components/magazine_box.html.twig
@@ -8,7 +8,7 @@
         </div>
     {% endif %}
     <div class="row">
-        {% if computed.magazine.icon and showCover %}
+        {% if computed.magazine.icon and showCover and (app.user or magazine.isAdult is same as false) %}
             <figure>
                 <img class="image-inline {{ magazine.isAdult ? 'image-adult' : '' }}"
                      src="{{ asset(computed.magazine.icon.filePath) | imagine_filter('post_thumb') }}"

--- a/templates/components/magazine_inline.html.twig
+++ b/templates/components/magazine_inline.html.twig
@@ -1,7 +1,7 @@
 <a href="{{ path('front_magazine', {name: magazine.name}) }}"
    class="{{ html_classes('magazine-inline', {'stretched-link': stretchedLink }) }}"
    title="{{ ('@'~magazine.name)|username(true) }}">
-    {% if magazine.icon and showAvatar %}
+    {% if magazine.icon and showAvatar and (app.user or magazine.isAdult is same as false) %}
         <img class="image-inline {{ magazine.isAdult ? 'image-adult' : '' }}"
              width="30" height="30"
              style="max-width: 30px; max-height: 30px;"

--- a/templates/layout/_magazine_activity_list.html.twig
+++ b/templates/layout/_magazine_activity_list.html.twig
@@ -7,16 +7,18 @@
         <ul>
             {% for subject in list %}
                 <li>
-                    {% if attribute(subject, actor).icon %}
+                    {% if attribute(subject, actor).icon and (app.user or attribute(subject, actor).isAdult is same as false) %}
                         <figure>
                             <img width="32" height="32"
+                                 class="image-inline {{ attribute(subject, actor).isAdult ? 'image-adult' : '' }}"
                                  src="{{ asset(attribute(subject, actor).icon.filePath) | imagine_filter('avatar_thumb') }}"
-                                 alt="{{ attribute(subject, actor).name ~' '~ 'cover'|trans|lower }}">
+                                 {% if attribute(subject, actor).isAdult %}data-controller="thumb" data-action="mouseover->thumb#adult_image_hover mouseout->thumb#adult_image_hover_out"{% endif %}
+                                 alt="{{ attribute(subject, actor).name ~' '~ 'icon'|trans|lower }}">
                         </figure>
                     {% endif %}
                     <div>
                         <a href="{{ path('front_magazine', {name: attribute(subject, actor).name}) }}"
-                           class="stretched-link">{{ attribute(subject, actor).name }}</a>
+                           class="stretched-link">{{ attribute(subject, actor).name }} {% if attribute(subject, actor).isAdult %}<small class="badge danger">18+</small>{% endif %}</a>
                         <small>{{ component('date', {date: subject.createdAt}) }}</small>
                     </div>
                 </li>

--- a/templates/magazine/_list.html.twig
+++ b/templates/magazine/_list.html.twig
@@ -11,7 +11,7 @@
                 <ul>
                     {% for magazine in magazines %}
                         <li>
-                            {% if magazine.icon %}
+                            {% if magazine.icon and (app.user or magazine.isAdult is same as false) %}
                                 <figure>
                                     <img width="32" height="32"
                                          class="image-inline {{ magazine.isAdult ? 'image-adult' : '' }}"
@@ -22,7 +22,7 @@
                             {% endif %}
                             <div>
                                 <a href="{{ path('front_magazine', {name: magazine.name}) }}"
-                                   class="stretched-link">{{ magazine.name }}</a>
+                                   class="stretched-link">{{ magazine.name }} {% if magazine.isAdult %}<small class="badge danger">18+</small>{% endif %}</a>
                                 <small>{{ component('date', {date: magazine.createdAt}) }}</small>
                             </div>
                         </li>


### PR DESCRIPTION
hide nsfw magazine icons for logged out users, this is consistent with how we currently handle entries. we discussed adding an admin option to allow enabling nsfw for logged out users, but that would require a bunch more work, so seemed like it could be, once again, another followup

blur magazine subscriptions (in user page or user settings page) and magazine blocks (in user settings)

this also adds the `18+` danger badge to subscription and block pages. opinions welcome if this is bad. The information isn't really hidden if you just go to the magazine, but if users make their subs public and there are nsfw mags in there, it's obvious now

another nsfw followup for #254

in my previous PR I had said the sub/block components didn't have nsfw info. Then I slept on it and realized, wait, how the heck would it have icon, there's no way that's in the sub/block table surely. I just misread the components, they have the info

<details>
<summary>magazine icon being hidden while logged out images</summary>

![image](https://github.com/MbinOrg/mbin/assets/146029455/3c280036-8251-4846-8463-fdc31e7a24c0)
![image](https://github.com/MbinOrg/mbin/assets/146029455/fd707497-b0e0-4d9f-ad66-4408000c2569)
![image](https://github.com/MbinOrg/mbin/assets/146029455/f0bdb20e-4d13-45b9-834f-5ce07c64fa9a)
![image](https://github.com/MbinOrg/mbin/assets/146029455/1199470f-05f2-4fc8-8a68-16c441f18e0f)
![image](https://github.com/MbinOrg/mbin/assets/146029455/0194e556-9cfe-48a0-b905-57867b539869)

</details>

<details>
<summary>magazine sub and block icon being blurred out for user while logged in</summary>

![image](https://github.com/MbinOrg/mbin/assets/146029455/07fb7137-1060-4334-aebe-a859876d2369)
![image](https://github.com/MbinOrg/mbin/assets/146029455/21532279-6c29-4635-ad77-f4d72fd7adfb)

</details>