### PR TITLE
Fix frontend message enumeration when purged users threads are encountered

### DIFF
--- a/templates/messages/front.html.twig
+++ b/templates/messages/front.html.twig
@@ -14,15 +14,26 @@
 
 {% block body %}
     <h1>{{ 'messages'|trans }}</h1>
+    {% set purgedUsers = 0 %}
     {% for thread in threads %}
-        <div class="{{ html_classes('section section--small thread', {'opacity-50': not thread.countNewMessages(app.user) }) }}">
-            <div>
-                {{ (thread.messages|length - 1)|format_number }} {{ 'replies'|trans }}
-                - {{ component('user_inline', {user: thread.otherParticipants(app.user)[0]}) }} - <a
-                        href="{{ path('messages_single', {'id': thread.id}) }}">{{ thread.title }}</a>
+        {% if thread.otherParticipants(app.user)[0] is defined %}
+            <div class="{{ html_classes('section section--small thread', {'opacity-50': not thread.countNewMessages(app.user) }) }}">
+                <div>
+                    {{ (thread.messages|length - 1)|format_number }} {{ 'replies'|trans }}
+                    - {{ component('user_inline', {user: thread.otherParticipants(app.user)[0]}) }} - <a
+                            href="{{ path('messages_single', {'id': thread.id}) }}">{{ thread.title }}</a>
+                </div>
+                <span>{{ component('date', {date: thread.updatedAt}) }}</span>
             </div>
-            <span>{{ component('date', {date: thread.updatedAt}) }}</span>
-        </div>
+        {% else %}
+            {% set purgedUsers = purgedUsers + 1 %}
+        {% endif %}
+
+        {% if threads|length == purgedUsers %}
+            <aside class="section section--muted">
+                <p>{{ 'empty'|trans }}</p>
+            </aside>
+        {% endif %}
     {% endfor %}
     {% if(threads.haveToPaginate is defined and threads.haveToPaginate) %}
         {{ pagerfanta(threads, null, {'pageParameter':'[p]'}) }}


### PR DESCRIPTION
The frontend message center will throw a 500 if it tries to reference messages of recipient users that have been purged from the database. The entire DM messaging system uses 3 different tables in the database, so ultimately I think the _"more robust"_ solution is to replace/restructure the entire thing especially since it doesn't support federation right now; however, this will fix the 500 and allow the user to see the remainder of their other messages.

**Bug replication steps prior to PR**: create a user, message the user, then purge the user... then try to visit the message center.