### PR TITLE
remove copy pasted vote up class on downvote button

### DIFF
--- a/templates/components/vote.html.twig
+++ b/templates/components/vote.html.twig
@@ -42,8 +42,7 @@
             <button type="submit"
                     title="{{ 'down_vote'|trans }}"
                     aria-label="{{ 'down_vote'|trans }}"
-                    data-action="subject#vote"
-                    class="vote__up">
+                    data-action="subject#vote">
                 <span data-subject-target="downvoteCounter">{{ subject.countDownvotes }}</span> <span><i class="fa-solid fa-arrow-down"></i></span>
             </button>
             <input type="hidden" name="token" value="{{ csrf_token('vote') }}">


### PR DESCRIPTION
was browsing the DOM, as one does, and noticed the downvote buttons have the class `vote__up`. don't think it does anything, the rules are on `.vote__up button` and `.vote__down button` (this would be `button.vote__up`) so looks like it was just erroneously copy pasted (the upvote button has no classes)