### PR TITLE
Fix comment URL twig render, missing user object

### DIFF
--- a/src/Controller/Entry/Comment/EntryCommentEditController.php
+++ b/src/Controller/Entry/Comment/EntryCommentEditController.php
@@ -68,10 +68,11 @@ class EntryCommentEditController extends AbstractController
             );
         }
 
+        $user = $this->getUserOrThrow();
         $criteria = new EntryCommentPageView($this->getPageNb($request));
         $criteria->entry = $entry;
 
-        return $this->getEntryCommentPageResponse('entry/comment/edit.html.twig', $criteria, $form, $request, $comment);
+        return $this->getEntryCommentPageResponse('entry/comment/edit.html.twig', $user, $criteria, $form, $request, $comment);
     }
 
     private function getForm(EntryCommentDto $dto, EntryComment $comment): FormInterface

--- a/src/Controller/Entry/Comment/EntryCommentResponseTrait.php
+++ b/src/Controller/Entry/Comment/EntryCommentResponseTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller\Entry\Comment;
 
 use App\Entity\EntryComment;
+use App\Entity\User;
 use App\PageView\EntryCommentPageView;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -19,6 +20,7 @@ trait EntryCommentResponseTrait
 {
     private function getEntryCommentPageResponse(
         string $template,
+        User $user,
         EntryCommentPageView $criteria,
         FormInterface $form,
         Request $request,
@@ -31,6 +33,7 @@ trait EntryCommentResponseTrait
         return $this->render(
             $template,
             [
+                'user' => $user,
                 'magazine' => $criteria->entry->magazine,
                 'entry' => $criteria->entry,
                 'parent' => $parent,


### PR DESCRIPTION
Attempts to open comment URL directly results in 500 because twig render was not being passed user object, PR adds user object


![image](https://github.com/MbinOrg/mbin/assets/35878315/e66ad528-a7cb-464d-95f5-0d019c882302)

![image](https://github.com/MbinOrg/mbin/assets/35878315/07f598bd-7089-419c-854e-3817c109548f)
