### PR TITLE
fix global mod actions on mag panel pages

### DIFF
--- a/src/EventListener/MagazineVisibilityListener.php
+++ b/src/EventListener/MagazineVisibilityListener.php
@@ -28,8 +28,9 @@ class MagazineVisibilityListener
 
         if (VisibilityInterface::VISIBILITY_VISIBLE !== $magazine->visibility) {
             if (null === $this->security->getUser()
-                || false === $magazine->userIsOwner($this->security->getUser())
-                && false === $this->security->isGranted('ROLE_ADMIN')) {
+                || (false === $magazine->userIsOwner($this->security->getUser())
+                && false === $this->security->isGranted('ROLE_ADMIN')
+                && false === $this->security->isGranted('ROLE_MODERATOR'))) {
                 throw new NotFoundHttpException();
             }
         }

--- a/src/Security/Voter/MagazineVoter.php
+++ b/src/Security/Voter/MagazineVoter.php
@@ -69,7 +69,7 @@ class MagazineVoter extends Voter
 
     private function canDelete(Magazine $magazine, User $user): bool
     {
-        return $magazine->userIsOwner($user) || $user->isAdmin();
+        return $magazine->userIsOwner($user) || $user->isAdmin() || $user->isModerator();
     }
 
     private function canPurge(Magazine $magazine, User $user): bool

--- a/templates/magazine/panel/general.html.twig
+++ b/templates/magazine/panel/general.html.twig
@@ -15,7 +15,7 @@
 {% block body %}
     {% include 'magazine/panel/_options.html.twig' %}
     {% include 'magazine/_visibility_info.html.twig' %}
-    
+
     <h1 hidden>{{ 'general'|trans }}</h1>
     {% include 'layout/_flash.html.twig' %}
     <div id="content" class="section theme">
@@ -70,6 +70,7 @@
                         </form>
                     {% endif %}
                 </div>
+                {% if is_granted('ROLE_ADMIN') %}
                 <div class="mb-2">
                     <form action="{{ path('magazine_remove_subscriptions', {name: magazine.name}) }}" method="POST"
                           onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
@@ -79,6 +80,7 @@
                         </button>
                     </form>
                 </div>
+                {% endif %}
                 {% if is_granted('purge', magazine) %}
                     <div class="mb-2">
                         <form action="{{ path('magazine_purge_content', {name: magazine.name}) }}" method="POST"


### PR DESCRIPTION
noticed while testing a recent PR, mods can see the delete mag / remove all subscription buttons but clicking on them 403s

this changes
- global mods can now delete magazines
- global mods can't unsub all subscribers, the button was red so rather than make the button work, I kept things in line with other red buttons that appear to be admin only, and just hid the button from global mods
- global mods can view deleted magazines just like the original owner and admin can