### PR TITLE
fix and adjust markdown rendering for images and links

### DIFF
--- a/src/Markdown/CommonMark/EmbedElement.php
+++ b/src/Markdown/CommonMark/EmbedElement.php
@@ -53,4 +53,16 @@ class EmbedElement
             ]
         );
     }
+
+    public static function buildDestructed(string $url, string $label = null): HtmlElement
+    {
+        return new HtmlElement(
+            'span',
+            [],
+            [
+                new HtmlElement('i', ['class' => 'fas fa-photo-video']),
+                $label ? sprintf(' %s (%s)', $label, $url) : ' '.$url,
+            ]
+        );
+    }
 }

--- a/src/Markdown/CommonMark/ExternalImagesRenderer.php
+++ b/src/Markdown/CommonMark/ExternalImagesRenderer.php
@@ -4,15 +4,31 @@ declare(strict_types=1);
 
 namespace App\Markdown\CommonMark;
 
+use App\Markdown\CommonMark\Node\UnresolvableLink;
+use App\Markdown\MarkdownConverter;
+use App\Markdown\RenderTarget;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Image;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
+use League\CommonMark\Node\Inline\Newline;
 use League\CommonMark\Node\Inline\Text;
 use League\CommonMark\Node\Node;
+use League\CommonMark\Node\NodeIterator;
+use League\CommonMark\Node\StringContainerInterface;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
 use League\CommonMark\Util\HtmlElement;
+use League\Config\ConfigurationAwareInterface;
+use League\Config\ConfigurationInterface;
 
-final class ExternalImagesRenderer implements NodeRendererInterface
+final class ExternalImagesRenderer implements NodeRendererInterface, ConfigurationAwareInterface
 {
+    private ConfigurationInterface $config;
+
+    public function setConfiguration(ConfigurationInterface $configuration): void
+    {
+        $this->config = $configuration;
+    }
+
     /**
      * @param Image $node
      */
@@ -22,12 +38,65 @@ final class ExternalImagesRenderer implements NodeRendererInterface
     ): HtmlElement {
         Image::assertInstanceOf($node);
 
-        $url = $title = $node->getUrl();
+        $renderTarget = $this->config->get('kbin')[MarkdownConverter::RENDER_TARGET];
 
-        if ($node->firstChild() instanceof Text) {
-            $title = $childRenderer->renderNodes([$node->firstChild()]);
+        $url = $node->getUrl();
+        $label = null;
+
+        if (RenderTarget::Page === $renderTarget) {
+            // skip rendering links inside the label (not allowed)
+            if ($node->hasChildren()) {
+                $cnodes = [];
+                foreach ($node->children() as $n) {
+                    if (
+                        ($n instanceof Link && $n instanceof StringContainerInterface)
+                        || $n instanceof UnresolvableLink
+                    ) {
+                        $cnodes[] = new Text($n->getLiteral());
+                    } else {
+                        $cnodes[] = $n;
+                    }
+                }
+                $label = $childRenderer->renderNodes($cnodes);
+            }
+
+            // self destructs rendering if parent is a link
+            // because while commonmark permits putting image inside link label,
+            // html does not allow nested interactive contents inside <a>
+            // see: https://spec.commonmark.org/0.30/#example-516
+            // and: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#technical_summary
+            if ($node->parent() && $node->parent() instanceof Link) {
+                return EmbedElement::buildDestructed($node->getUrl(), $this->getAltText($node));
+            }
+
+            return EmbedElement::buildEmbed($url, $label ?? $url);
         }
 
-        return EmbedElement::buildEmbed($url, $title);
+        return new HtmlElement(
+            'img',
+            [
+                'src' => $url,
+                'alt' => $node->hasChildren() ? $this->getAltText($node) : false,
+            ],
+            '',
+            true
+        );
+    }
+
+    // literally lifted from league/commonmark ImageRenderer
+    // see: https://github.com/thephpleague/commonmark/blob/7af3307679b2942d825562bfad202a52a03b4513/src/Extension/CommonMark/Renderer/Inline/ImageRenderer.php#L93
+    private function getAltText(Image $node): string
+    {
+        $altText = '';
+
+        foreach ((new NodeIterator($node)) as $n) {
+            if ($n instanceof StringContainerInterface) {
+                $altText .= $n->getLiteral();
+            } elseif ($n instanceof Newline) {
+                $altText .= ' ';
+            }
+        }
+
+        return $altText;
     }
 }


### PR DESCRIPTION
- fix link label rendering missing parts that isn't plain text

  basically, it turns out that commonmark _does_ permit the link label to contain inline markups, but if *any* part of link label isn't a plain text then the label gets chopped off as the label now consists of more than one nodes, and the current code only renders first child.

  example: for a link label that looks like `example.com/@somehandle`, the `@somehandle` part might get parsed as an `UnresolvableLink` node in the label, and not be rendered because it's not the first child, thus leaving the final link label to look like `example.com/`.
  
  ![image](https://github.com/MbinOrg/mbin/assets/20770492/658108a1-bdf0-45a2-9704-e4da73037a70)
  ![image](https://github.com/MbinOrg/mbin/assets/20770492/f360542e-63e3-4456-adc1-b7baa5116725)
  <details><summary>AP representation</summary>
  <p>

  ```html
  <p><a href="https://spec.commonmark.org/0.30/#example-515" class="kbin-media-link">a </a> because why not</p>
  <p><span class="preview" data-controller="preview"><button class="show-preview" data-action="preview#show" data-preview-url-param="https://akkoma.asdfzdfj.xyz/media/b2c3161c-6869-4705-93b8-035c1528a560/weyowang-F77MS2TXYAABDda.jpg" data-preview-ratio-param="0" aria-label="Show preview"><i class="fas fa-photo-video"></i></button><a href="https://akkoma.asdfzdfj.xyz/media/b2c3161c-6869-4705-93b8-035c1528a560/weyowang-F77MS2TXYAABDda.jpg" rel="nofollow noopener noreferrer" target="_blank">also </a><span class="preview-target hidden" data-preview-target="container"></span></span><br/>
  this one doesn't have label: <span class="preview" data-controller="preview"><button class="show-preview" data-action="preview#show" data-preview-url-param="https://akkoma.asdfzdfj.xyz/media/b2c3161c-6869-4705-93b8-035c1528a560/weyowang-F77MS2TXYAABDda.jpg" data-preview-ratio-param="0" aria-label="Show preview"><i class="fas fa-photo-video"></i></button><a href="https://akkoma.asdfzdfj.xyz/media/b2c3161c-6869-4705-93b8-035c1528a560/weyowang-F77MS2TXYAABDda.jpg" rel="nofollow noopener noreferrer" target="_blank">https://akkoma.asdfzdfj.xyz/media/b2c3161c-6869-4705-93b8-035c1528a560/weyowang-F77MS2TXYAABDda.jpg</a><span class="preview-target hidden" data-preview-target="container"></span></span></p>
  <p>time for an extra degenerate cases: <a href="https://spec.commonmark.org/0.30/#example-516" class="kbin-media-link">https://spec.commonmark.org/0.30/#example-516</a>,<br/>
  case 2 <a href="https://spec.commonmark.org/0.30/#example-516" class="kbin-media-link">no label: </a></p>
  ```

  </p>
  </details> 


- adjust markdown rendering to work differently in AP

  - remove extra html elements when rendering links with embed (they're for embed preview controller)
  - remove extra html classes when rendering links (the code's there but it doesn't seems to work for some reason?)
  - render inline image as a simple `<img>` tag the label, if any, is inserted as alt text
  - *intentionally* rendering image inside link label for web view in a broken/regressed way: while commonmark permits putting image inside link label, the frontend renders both link _and_ image as links, and html doesn't allow nested interactive contents inside `<a>` tag, which includes link with destination (`<a href="...">`), and button (the part you click to open preview)

    for AP representation, it renders into `<a><img/></a>` as usual.

combined changes now looks like this:

![image](https://github.com/MbinOrg/mbin/assets/20770492/a5c84278-5bfd-438b-8fdc-38fd13619e60)
![image](https://github.com/MbinOrg/mbin/assets/20770492/a691ad76-88dc-4fbf-b120-429abc43eb25)
<details><summary>AP epresentation</summary>
<p>

  ```html
  <p><a href="https://spec.commonmark.org/0.30/#example-515">a <em>link</em> with <del>inline</del> <code>styling</code>, and youtube.com/@corningmuseumofglass too</a> because why not</p>
  <p><img src="https://akkoma.asdfzdfj.xyz/media/b2c3161c-6869-4705-93b8-035c1528a560/weyowang-F77MS2TXYAABDda.jpg" alt="also one for inline image" /><br/>
  this one doesn't have label: <img src="https://akkoma.asdfzdfj.xyz/media/b2c3161c-6869-4705-93b8-035c1528a560/weyowang-F77MS2TXYAABDda.jpg" /></p>
  <p>time for an extra degenerate cases: <a href="https://spec.commonmark.org/0.30/#example-516"><img src="https://akkoma.asdfzdfj.xyz/media/4154637d-651a-4d34-b347-1eeea1bf78d7/K1mch_i-F6ah1OSacAAvQEv.jpg" alt="case 1" /></a>,<br/>
  case 2 <a href="https://spec.commonmark.org/0.30/#example-516">no label: <img src="https://akkoma.asdfzdfj.xyz/media/4154637d-651a-4d34-b347-1eeea1bf78d7/K1mch_i-F6ah1OSacAAvQEv.jpg" /></a></p>
  ```

</p>
</details> 

this should restore the missing label parts in link rendering, and should help external applications to ingest `content` property in AP representation easier and more accurately

ps: currently testing some git and workflow related stuff, please don't merge `main` updates in for me, I'll update it myself.