### PR TITLE
Repository refactoring and SQL optimization

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -54,9 +54,9 @@ parameters:
 
     html5_validation: true
 
-    front_sort_options: top|hot|active|newest|oldest|commented|ważne|gorące|aktywne|najnowsze|najstarsze|komentowane
-    front_time_options: 6h|12h|1d|1w|1m|1y|all|wszystko|∞
-    stats_type: general|content|views|votes|ogólne|treści|głosy|wyświetlenia
+    front_sort_options: top|hot|active|newest|oldest|commented
+    front_time_options: 6h|12h|1d|1w|1m|1y|all|∞
+    stats_type: general|content|views|votes
 
     number_regex: "[1-9][0-9]{0,17}"
     username_regex: '\w{2,25}|!deleted\d+'

--- a/src/Controller/Api/Domain/DomainRetrieveApi.php
+++ b/src/Controller/Api/Domain/DomainRetrieveApi.php
@@ -147,14 +147,12 @@ class DomainRetrieveApi extends DomainBaseApi
         $headers = $this->rateLimit($apiReadLimiter, $anonymousApiReadLimiter);
 
         $request = $this->request->getCurrentRequest();
-        $perPage = self::constrainPerPage($request->get('perPage', DomainRepository::PER_PAGE));
 
         if ($q = $request->get('q')) {
             $domains = $searchManager->findDomainsPaginated($q, $this->getPageNb($request), $perPage);
         } else {
             $domains = $repository->findAllPaginated(
-                $this->getPageNb($request),
-                $perPage
+                $this->getPageNb($request)
             );
         }
 

--- a/src/Entity/EntryComment.php
+++ b/src/Entity/EntryComment.php
@@ -235,6 +235,11 @@ class EntryComment implements VotableInterface, VisibilityInterface, ReportInter
         return array_values($this->tags ?? []);
     }
 
+    public function getRoot(): ?EntryComment
+    {
+        return $this->root;
+    }
+
     public function __sleep()
     {
         return [];

--- a/src/Repository/ApActivityRepository.php
+++ b/src/Repository/ApActivityRepository.php
@@ -68,16 +68,18 @@ class ApActivityRepository extends ServiceEntityRepository
         $postCommentClass = PostComment::class;
 
         $conn = $this->_em->getConnection();
-        $sql = '(
-            SELECT  COALESCE(entry.id, entry_comment.id, post.id, post_comment.id) AS id,
-                    COALESCE(:entryClass, :entryCommentClass, :postClass, :postCommentClass) AS type
-            FROM entry
-            LEFT JOIN entry_comment ON entry.ap_id = entry_comment.ap_id
-            LEFT JOIN post ON entry.ap_id = post.ap_id
-            LEFT JOIN post_comment ON entry.ap_id = post_comment.ap_id
-            WHERE entry.ap_id = :apId OR entry_comment.ap_id = :apId OR post.ap_id = :apId OR post_comment.ap_id = :apId
-        )';
-
+        $sql = '
+            (SELECT id, :entryClass AS type FROM entry
+            WHERE ap_id = :apId)
+            UNION ALL
+            (SELECT id, :entryCommentClass AS type FROM entry_comment
+            WHERE ap_id = :apId)
+            UNION ALL
+            (SELECT id, :postClass AS type FROM post
+            WHERE ap_id = :apId)
+            UNION ALL
+            (SELECT id, :postCommentClass AS type FROM post_comment
+            WHERE ap_id = :apId)';
         $stmt = $conn->prepare($sql);
         $stmt->bindValue('entryClass', $entryClass);
         $stmt->bindValue('entryCommentClass', $entryCommentClass);

--- a/src/Repository/ApActivityRepository.php
+++ b/src/Repository/ApActivityRepository.php
@@ -22,6 +22,11 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 class ApActivityRepository extends ServiceEntityRepository
 {
+    private const TYPE_MAP = [
+        'p' => [Post::class, PostComment::class],
+        't' => [Entry::class, EntryComment::class],
+    ];
+
     public function __construct(ManagerRegistry $registry, private SettingsManager $settingsManager)
     {
         parent::__construct($registry, ApActivity::class);
@@ -29,65 +34,41 @@ class ApActivityRepository extends ServiceEntityRepository
 
     public function findByObjectId(string $apId): ?array
     {
+        $exploded = [];
+
         $parsed = parse_url($apId);
-        if ($parsed['host'] === $this->settingsManager->get('KBIN_DOMAIN')) {
+        if ($parsed['host'] === $this->settingsManager->get('KBIN_DOMAIN') && isset(self::TYPE_MAP[$parsed['path'][3]])) {
             $exploded = array_filter(explode('/', $parsed['path']));
             $id = end($exploded);
-            if ('p' === $exploded[3]) {
-                if (4 === \count($exploded)) {
-                    return [
-                        'id' => $id,
-                        'type' => Post::class,
-                    ];
-                } else {
-                    return [
-                        'id' => $id,
-                        'type' => PostComment::class,
-                    ];
-                }
-            }
+            $type = self::TYPE_MAP[$exploded[3]][\count($exploded)];
 
-            if ('t' === $exploded[3]) {
-                if (4 === \count($exploded)) {
-                    return [
-                        'id' => $id,
-                        'type' => Entry::class,
-                    ];
-                } else {
-                    return [
-                        'id' => $id,
-                        'type' => EntryComment::class,
-                    ];
-                }
-            }
+            return ['id' => $id, 'type' => $type];
         }
-
-        $entryClass = Entry::class;
-        $entryCommentClass = EntryComment::class;
-        $postClass = Post::class;
-        $postCommentClass = PostComment::class;
 
         $conn = $this->_em->getConnection();
         $sql = '
-            (SELECT id, :entryClass AS type FROM entry
-            WHERE ap_id = :apId)
-            UNION
-            (SELECT id, :entryCommentClass AS type FROM entry_comment
-            WHERE ap_id = :apId)
-            UNION
-            (SELECT id, :postClass AS type FROM post
-            WHERE ap_id = :apId)
-            UNION
-            (SELECT id, :postCommentClass AS type FROM post_comment
-            WHERE ap_id = :apId)';
-        $stmt = $conn->prepare($sql);
-        $stmt->bindValue('entryClass', $entryClass);
-        $stmt->bindValue('entryCommentClass', $entryCommentClass);
-        $stmt->bindValue('postClass', $postClass);
-        $stmt->bindValue('postCommentClass', $postCommentClass);
-        $stmt->bindValue('apId', $apId);
-        $results = $stmt->executeQuery()->fetchAllAssociative();
+            SELECT id, :type AS type
+            FROM (
+                SELECT id, :entryClass AS type FROM entry
+                UNION
+                SELECT id, :entryCommentClass FROM entry_comment
+                UNION
+                SELECT id, :postClass FROM post
+                UNION
+                SELECT id, :postCommentClass FROM post_comment
+            ) AS combined
+            WHERE ap_id = :apId
+            LIMIT 1';
+        
+        $stmt = $conn->prepare($sql)->executeQuery([
+            'type' => self::TYPE_MAP[$parsed['path'][3]][\count($exploded)],
+            'entryClass' => Entry::class,
+            'entryCommentClass' => EntryComment::class,
+            'postClass' => Post::class,
+            'postCommentClass' => PostComment::class,
+            'apId' => $apId,
+        ]);
 
-        return \count($results) ? $results[0] : null;
+        return $stmt->fetchAllAssociative() ?: null;
     }
 }

--- a/src/Repository/ApActivityRepository.php
+++ b/src/Repository/ApActivityRepository.php
@@ -68,8 +68,8 @@ class ApActivityRepository extends ServiceEntityRepository
         $postCommentClass = PostComment::class;
 
         $conn = $this->_em->getConnection();
-        $sql = '
-        (SELECT
+        $sql = '(
+        SELECT
             id,
             CASE
                 WHEN table_name = \'entry\' THEN :entryClass
@@ -77,16 +77,15 @@ class ApActivityRepository extends ServiceEntityRepository
                 WHEN table_name = \'post\' THEN :postClass
                 WHEN table_name = \'post_comment\' THEN :postCommentClass
             END AS type
-        FROM
-            (
-                SELECT id, \'entry\' AS table_name FROM entry WHERE ap_id = :apId
-                UNION
-                SELECT id, \'entry_comment\' FROM entry_comment WHERE ap_id = :apId
-                UNION
-                SELECT id, \'post\' FROM post WHERE ap_id = :apId
-                UNION
-                SELECT id, \'post_comment\' FROM post_comment WHERE ap_id = :apId
-            ) AS combined_result)';
+        FROM (
+            SELECT id, \'entry\' AS table_name FROM entry WHERE ap_id = :apId
+            UNION ALL
+            SELECT id, \'entry_comment\' FROM entry_comment WHERE ap_id = :apId
+            UNION ALL
+            SELECT id, \'post\' FROM post WHERE ap_id = :apId
+            UNION ALL
+            SELECT id, \'post_comment\' FROM post_comment WHERE ap_id = :apId
+        ) AS combined_result)';
 
         $stmt = $conn->prepare($sql);
         $stmt->bindValue('entryClass', $entryClass);

--- a/src/Repository/ApActivityRepository.php
+++ b/src/Repository/ApActivityRepository.php
@@ -59,7 +59,7 @@ class ApActivityRepository extends ServiceEntityRepository
             ) AS combined
             WHERE ap_id = :apId
             LIMIT 1';
-        
+
         $stmt = $conn->prepare($sql)->executeQuery([
             'type' => self::TYPE_MAP[$parsed['path'][3]][\count($exploded)],
             'entryClass' => Entry::class,

--- a/src/Repository/ApActivityRepository.php
+++ b/src/Repository/ApActivityRepository.php
@@ -30,35 +30,19 @@ class ApActivityRepository extends ServiceEntityRepository
     public function findByObjectId(string $apId): ?array
     {
         $parsed = parse_url($apId);
+
         if ($parsed['host'] === $this->settingsManager->get('KBIN_DOMAIN')) {
             $exploded = array_filter(explode('/', $parsed['path']));
             $id = end($exploded);
-            if ('p' === $exploded[3]) {
-                if (4 === \count($exploded)) {
-                    return [
-                        'id' => $id,
-                        'type' => Post::class,
-                    ];
-                } else {
-                    return [
-                        'id' => $id,
-                        'type' => PostComment::class,
-                    ];
-                }
-            }
 
-            if ('t' === $exploded[3]) {
-                if (4 === \count($exploded)) {
-                    return [
-                        'id' => $id,
-                        'type' => Entry::class,
-                    ];
-                } else {
-                    return [
-                        'id' => $id,
-                        'type' => EntryComment::class,
-                    ];
-                }
+            $type = 'p' === $exploded[3] ? (4 === \count($exploded) ? Post::class : PostComment::class) :
+                    ('t' === $exploded[3] ? (4 === \count($exploded) ? Entry::class : EntryComment::class) : null);
+
+            if (null !== $type) {
+                return [
+                    'id' => $id,
+                    'type' => $type,
+                ];
             }
         }
 

--- a/src/Repository/ApActivityRepository.php
+++ b/src/Repository/ApActivityRepository.php
@@ -79,13 +79,13 @@ class ApActivityRepository extends ServiceEntityRepository
             END AS type
         FROM
             (
-                SELECT id, \'entry\' AS table_name FROM entry WHERE ap_id = :apId LIMIT 1
+                SELECT id, \'entry\' AS table_name FROM entry WHERE ap_id = :apId
                 UNION
-                SELECT id, \'entry_comment\' FROM entry_comment WHERE ap_id = :apId LIMIT 1
+                SELECT id, \'entry_comment\' FROM entry_comment WHERE ap_id = :apId
                 UNION
-                SELECT id, \'post\' FROM post WHERE ap_id = :apId LIMIT 1
+                SELECT id, \'post\' FROM post WHERE ap_id = :apId
                 UNION
-                SELECT id, \'post_comment\' FROM post_comment WHERE ap_id = :apId LIMIT 1
+                SELECT id, \'post_comment\' FROM post_comment WHERE ap_id = :apId
             ) AS combined_result)';
 
         $stmt = $conn->prepare($sql);

--- a/src/Repository/ApActivityRepository.php
+++ b/src/Repository/ApActivityRepository.php
@@ -79,13 +79,13 @@ class ApActivityRepository extends ServiceEntityRepository
             END AS type
         FROM
             (
-                SELECT id, \'entry\' AS table_name FROM entry WHERE ap_id = :apId ORDER BY id LIMIT 1
+                SELECT id, \'entry\' AS table_name FROM entry WHERE ap_id = :apId LIMIT 1
                 UNION
-                SELECT id, \'entry_comment\' FROM entry_comment WHERE ap_id = :apId ORDER BY id LIMIT 1
+                SELECT id, \'entry_comment\' FROM entry_comment WHERE ap_id = :apId LIMIT 1
                 UNION
-                SELECT id, \'post\' FROM post WHERE ap_id = :apId ORDER BY id LIMIT 1
+                SELECT id, \'post\' FROM post WHERE ap_id = :apId LIMIT 1
                 UNION
-                SELECT id, \'post_comment\' FROM post_comment WHERE ap_id = :apId ORDER BY id LIMIT 1
+                SELECT id, \'post_comment\' FROM post_comment WHERE ap_id = :apId LIMIT 1
             ) AS combined_result)';
 
         $stmt = $conn->prepare($sql);

--- a/src/Repository/ApActivityRepository.php
+++ b/src/Repository/ApActivityRepository.php
@@ -79,13 +79,13 @@ class ApActivityRepository extends ServiceEntityRepository
             END AS type
         FROM
             (
-                SELECT id, \'entry\' AS table_name FROM entry WHERE ap_id = :apId
+                SELECT id, \'entry\' AS table_name FROM entry WHERE ap_id = :apId ORDER BY id LIMIT 1
                 UNION
-                SELECT id, \'entry_comment\' FROM entry_comment WHERE ap_id = :apId
+                SELECT id, \'entry_comment\' FROM entry_comment WHERE ap_id = :apId ORDER BY id LIMIT 1
                 UNION
-                SELECT id, \'post\' FROM post WHERE ap_id = :apId
+                SELECT id, \'post\' FROM post WHERE ap_id = :apId ORDER BY id LIMIT 1
                 UNION
-                SELECT id, \'post_comment\' FROM post_comment WHERE ap_id = :apId
+                SELECT id, \'post_comment\' FROM post_comment WHERE ap_id = :apId ORDER BY id LIMIT 1
             ) AS combined_result)';
 
         $stmt = $conn->prepare($sql);

--- a/src/Repository/ApActivityRepository.php
+++ b/src/Repository/ApActivityRepository.php
@@ -75,7 +75,7 @@ class ApActivityRepository extends ServiceEntityRepository
             LEFT JOIN entry_comment ON entry.ap_id = entry_comment.ap_id
             LEFT JOIN post ON entry.ap_id = post.ap_id
             LEFT JOIN post_comment ON entry.ap_id = post_comment.ap_id
-            WHERE entry.ap_id = :apId OR entry_comment.ap_id = :apId OR post.ap_id = :apId OR post_comment.ap_id = :apId;
+            WHERE entry.ap_id = :apId OR entry_comment.ap_id = :apId OR post.ap_id = :apId OR post_comment.ap_id = :apId
         )';
 
         $stmt = $conn->prepare($sql);

--- a/src/Repository/ApActivityRepository.php
+++ b/src/Repository/ApActivityRepository.php
@@ -69,22 +69,13 @@ class ApActivityRepository extends ServiceEntityRepository
 
         $conn = $this->_em->getConnection();
         $sql = '(
-            SELECT 
-                id,
-                CASE
-                    WHEN entry.ap_id IS NOT NULL THEN :entryClass
-                    WHEN entry_comment.ap_id IS NOT NULL THEN :entryCommentClass
-                    WHEN post.ap_id IS NOT NULL THEN :postClass
-                    WHEN post_comment.ap_id IS NOT NULL THEN :postCommentClass
-                END AS type
+            SELECT  COALESCE(entry.id, entry_comment.id, post.id, post_comment.id) AS id,
+                    COALESCE(:entryClass, :entryCommentClass, :postClass, :postCommentClass) AS type
             FROM entry
-            LEFT JOIN entry_comment ON entry.id = entry_comment.entry_id
-            LEFT JOIN post ON entry.id = post.entry_id
-            LEFT JOIN post_comment ON post.id = post_comment.post_id
-            WHERE entry.ap_id = :apId
-                OR entry_comment.ap_id = :apId
-                OR post.ap_id = :apId
-                OR post_comment.ap_id = :apId;
+            LEFT JOIN entry_comment ON entry.ap_id = entry_comment.ap_id
+            LEFT JOIN post ON entry.ap_id = post.ap_id
+            LEFT JOIN post_comment ON entry.ap_id = post_comment.ap_id
+            WHERE entry.ap_id = :apId OR entry_comment.ap_id = :apId OR post.ap_id = :apId OR post_comment.ap_id = :apId;
         )';
 
         $stmt = $conn->prepare($sql);

--- a/src/Repository/Criteria.php
+++ b/src/Repository/Criteria.php
@@ -86,6 +86,7 @@ abstract class Criteria
 
     public int $page = 1;
     public ?Magazine $magazine = null;
+    public ?Entry $entry = null;
     public ?User $user = null;
     public ?int $perPage = null;
     public bool $moderated = false;

--- a/src/Repository/Criteria.php
+++ b/src/Repository/Criteria.php
@@ -7,6 +7,7 @@ namespace App\Repository;
 use App\Entity\Contracts\VisibilityInterface;
 use App\Entity\Entry;
 use App\Entity\Magazine;
+use App\Entity\Post;
 use App\Entity\User;
 
 abstract class Criteria
@@ -87,6 +88,7 @@ abstract class Criteria
     public int $page = 1;
     public ?Magazine $magazine = null;
     public ?Entry $entry = null;
+    public ?Post $post = null;
     public ?User $user = null;
     public ?int $perPage = null;
     public bool $moderated = false;

--- a/src/Repository/Criteria.php
+++ b/src/Repository/Criteria.php
@@ -91,6 +91,7 @@ abstract class Criteria
     public ?int $perPage = null;
     public bool $moderated = false;
     public bool $favourite = false;
+    public bool $onlyParents = false;
     public ?string $type = null;
     public string $sortOption = EntryRepository::SORT_DEFAULT;
     public string $time = EntryRepository::TIME_DEFAULT;

--- a/src/Repository/Criteria.php
+++ b/src/Repository/Criteria.php
@@ -136,9 +136,7 @@ abstract class Criteria
 
     public function setType(?string $type): self
     {
-        if ($type) {
-            $this->type = $type;
-        }
+        $this->type = $type ?: $this->type;
 
         return $this;
     }
@@ -159,19 +157,14 @@ abstract class Criteria
 
     public function addLanguage(string $lang): self
     {
-        if (null === $this->languages) {
-            $this->languages = [];
-        }
-        array_push($this->languages, $lang);
+        $this->languages[] = $lang;
 
         return $this;
     }
 
     public function showSortOption(?string $sortOption): self
     {
-        if ($sortOption) {
-            $this->sortOption = $sortOption;
-        }
+        $this->sortOption = $sortOption ?: $this->sortOption;
 
         return $this;
     }
@@ -186,13 +179,6 @@ abstract class Criteria
             'newest' => Criteria::SORT_NEW,
             'oldest' => Criteria::SORT_OLD,
             'commented' => Criteria::SORT_COMMENTED,
-
-            'ważne' => Criteria::SORT_TOP,
-            'gorące' => Criteria::SORT_HOT,
-            'aktywne' => Criteria::SORT_ACTIVE,
-            'najnowsze' => Criteria::SORT_NEW,
-            'najstarsze' => Criteria::SORT_OLD,
-            'komentowane' => Criteria::SORT_COMMENTED,
         ];
     }
 
@@ -216,12 +202,6 @@ abstract class Criteria
             '1y' => Criteria::TIME_YEAR,
             '∞' => Criteria::TIME_ALL,
             'all' => Criteria::TIME_ALL,
-            'wszystko' => Criteria::TIME_ALL,
-            '3g' => Criteria::TIME_3_HOURS,
-            '6g' => Criteria::TIME_6_HOURS,
-            '12g' => Criteria::TIME_12_HOURS,
-            '1t' => Criteria::TIME_WEEK,
-            '1r' => Criteria::TIME_YEAR,
         ];
 
         return $routes[$value] ?? null;
@@ -241,12 +221,6 @@ abstract class Criteria
             'photos' => Entry::ENTRY_TYPE_IMAGE,
             'image' => Entry::ENTRY_TYPE_IMAGE,
             'images' => Entry::ENTRY_TYPE_IMAGE,
-
-            'artykuł' => Entry::ENTRY_TYPE_ARTICLE,
-            'artykuły' => Entry::ENTRY_TYPE_ARTICLE,
-            'linki' => Entry::ENTRY_TYPE_LINK,
-            'obraz' => Entry::ENTRY_TYPE_IMAGE,
-            'obrazy' => Entry::ENTRY_TYPE_IMAGE,
         ];
 
         return $routes[$value] ?? null;
@@ -261,11 +235,7 @@ abstract class Criteria
 
     public function setTime(?string $time): self
     {
-        if ($time) {
-            $this->time = $time;
-        } else {
-            $this->time = EntryRepository::TIME_DEFAULT;
-        }
+        $this->time = $time ?? EntryRepository::TIME_DEFAULT;
 
         return $this;
     }

--- a/src/Repository/DomainRepository.php
+++ b/src/Repository/DomainRepository.php
@@ -34,15 +34,11 @@ class DomainRepository extends ServiceEntityRepository
     public function findAllPaginated(?int $page): PagerfantaInterface
     {
         $qb = $this->createQueryBuilder('d');
-
-        $pagerfanta = new Pagerfanta(
-            new QueryAdapter(
-                $qb
-            )
-        );
+        $adapter = new QueryAdapter($qb);
+        $pagerfanta = new Pagerfanta($adapter);
 
         try {
-            $pagerfanta->setMaxPerPage($criteria->perPage ?? self::PER_PAGE);
+            $pagerfanta->setMaxPerPage(self::PER_PAGE);
             $pagerfanta->setCurrentPage($page);
         } catch (NotValidCurrentPageException $e) {
             throw new NotFoundHttpException();
@@ -53,11 +49,8 @@ class DomainRepository extends ServiceEntityRepository
 
     public function findSubscribedDomains(int $page, User $user): PagerfantaInterface
     {
-        $pagerfanta = new Pagerfanta(
-            new CollectionAdapter(
-                $user->subscribedDomains
-            )
-        );
+        $adapter = new CollectionAdapter($user->subscribedDomains);
+        $pagerfanta = new Pagerfanta($adapter);
 
         try {
             $pagerfanta->setMaxPerPage(self::PER_PAGE);
@@ -71,11 +64,8 @@ class DomainRepository extends ServiceEntityRepository
 
     public function findBlockedDomains(int $page, User $user): PagerfantaInterface
     {
-        $pagerfanta = new Pagerfanta(
-            new CollectionAdapter(
-                $user->blockedDomains
-            )
-        );
+        $adapter = new CollectionAdapter($user->blockedDomains);
+        $pagerfanta = new Pagerfanta($adapter);
 
         try {
             $pagerfanta->setMaxPerPage(self::PER_PAGE);

--- a/src/Repository/DomainRepository.php
+++ b/src/Repository/DomainRepository.php
@@ -38,8 +38,9 @@ class DomainRepository extends ServiceEntityRepository
         $pagerfanta = new Pagerfanta($adapter);
 
         try {
-            $pagerfanta->setMaxPerPage(self::PER_PAGE);
-            $pagerfanta->setCurrentPage($page);
+            $pagerfanta
+                ->setMaxPerPage(self::PER_PAGE)
+                ->setCurrentPage($page);
         } catch (NotValidCurrentPageException $e) {
             throw new NotFoundHttpException();
         }
@@ -53,8 +54,9 @@ class DomainRepository extends ServiceEntityRepository
         $pagerfanta = new Pagerfanta($adapter);
 
         try {
-            $pagerfanta->setMaxPerPage(self::PER_PAGE);
-            $pagerfanta->setCurrentPage($page);
+            $pagerfanta
+                ->setMaxPerPage(self::PER_PAGE)
+                ->setCurrentPage($page);
         } catch (NotValidCurrentPageException $e) {
             throw new NotFoundHttpException();
         }
@@ -68,8 +70,9 @@ class DomainRepository extends ServiceEntityRepository
         $pagerfanta = new Pagerfanta($adapter);
 
         try {
-            $pagerfanta->setMaxPerPage(self::PER_PAGE);
-            $pagerfanta->setCurrentPage($page);
+            $pagerfanta
+                ->setMaxPerPage(self::PER_PAGE)
+                ->setCurrentPage($page);
         } catch (NotValidCurrentPageException $e) {
             throw new NotFoundHttpException();
         }

--- a/src/Repository/EmbedRepository.php
+++ b/src/Repository/EmbedRepository.php
@@ -24,8 +24,6 @@ class EmbedRepository extends ServiceEntityRepository
 
     public function add(Embed $entity, bool $flush = true): void
     {
-        // Check if embed url does not exists yet (null),
-        // before we try to insert a new DB record
         if (null === $this->findOneByUrl($entity->url)) {
             $this->_em->persist($entity);
             if ($flush) {

--- a/src/Repository/MagazineOwnershipRequestRepository.php
+++ b/src/Repository/MagazineOwnershipRequestRepository.php
@@ -41,7 +41,7 @@ class MagazineOwnershipRequestRepository extends ServiceEntityRepository
         );
 
         try {
-            $pagerfanta->setMaxPerPage($criteria->perPage ?? self::PER_PAGE);
+            $pagerfanta->setMaxPerPage(self::PER_PAGE);
             $pagerfanta->setCurrentPage($page);
         } catch (NotValidCurrentPageException $e) {
             throw new NotFoundHttpException();

--- a/src/Repository/ModeratorRequestRepository.php
+++ b/src/Repository/ModeratorRequestRepository.php
@@ -44,7 +44,7 @@ class ModeratorRequestRepository extends ServiceEntityRepository
         );
 
         try {
-            $pagerfanta->setMaxPerPage($criteria->perPage ?? self::PER_PAGE);
+            $pagerfanta->setMaxPerPage(self::PER_PAGE);
             $pagerfanta->setCurrentPage($page);
         } catch (NotValidCurrentPageException $e) {
             throw new NotFoundHttpException();

--- a/src/Repository/PostCommentRepository.php
+++ b/src/Repository/PostCommentRepository.php
@@ -48,11 +48,6 @@ class PostCommentRepository extends ServiceEntityRepository implements TagReposi
 
     public function findByCriteria(PostCommentPageView $criteria)
     {
-        //        return $this->createQueryBuilder('pc')
-        //            ->orderBy('pc.createdAt', 'DESC')
-        //            ->setMaxResults(10)
-        //            ->getQuery()
-        //            ->getResult();
         $pagerfanta = new Pagerfanta(
             new QueryAdapter(
                 $this->getCommentQueryBuilder($criteria),

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -18,14 +18,12 @@ use App\Entity\PostFavourite;
 use App\Entity\User;
 use App\Entity\UserBlock;
 use App\Entity\UserFollow;
-use App\PageView\EntryPageView;
 use App\PageView\PostPageView;
 use App\Pagination\AdapterFactory;
 use App\Repository\Contract\TagRepositoryInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Pagerfanta\Exception\NotValidCurrentPageException;
@@ -34,7 +32,6 @@ use Pagerfanta\PagerfantaInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Contracts\Cache\CacheInterface;
-use Symfony\Contracts\Cache\ItemInterface;
 
 /**
  * @method Post|null find($id, $lockMode = null, $lockVersion = null)
@@ -407,35 +404,5 @@ class PostRepository extends ServiceEntityRepository implements TagRepositoryInt
             ->where('p.tags IS NOT NULL')
             ->getQuery()
             ->getResult();
-    }
-
-    private function countAll(EntryPageView|Criteria $criteria): int
-    {
-        return $this->cache->get(
-            'posts_count_'.$criteria->magazine?->name,
-            function (ItemInterface $item) use ($criteria): int {
-                $item->expiresAfter(60);
-
-                if (!$criteria->magazine) {
-                    $query = $this->_em->createQuery(
-                        'SELECT COUNT(p.id) FROM App\Entity\Post p WHERE p.visibility = :visibility'
-                    )
-                        ->setParameter('visibility', VisibilityInterface::VISIBILITY_VISIBLE);
-                } else {
-                    $query = $this->_em->createQuery(
-                        'SELECT COUNT(p.id) FROM App\Entity\Post p WHERE p.visibility = :visibility AND p.magazine = :magazine'
-                    )
-                        ->setParameters(
-                            ['visibility' => VisibilityInterface::VISIBILITY_VISIBLE, 'magazine' => $criteria->magazine]
-                        );
-                }
-
-                try {
-                    return $query->getSingleScalarResult();
-                } catch (NoResultException $e) {
-                    return 0;
-                }
-            }
-        );
     }
 }

--- a/src/Repository/SearchRepository.php
+++ b/src/Repository/SearchRepository.php
@@ -5,12 +5,8 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\Contracts\VisibilityInterface;
-use App\Entity\Entry;
-use App\Entity\EntryComment;
 use App\Entity\Magazine;
 use App\Entity\Moderator;
-use App\Entity\Post;
-use App\Entity\PostComment;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Pagerfanta\Adapter\ArrayAdapter;
@@ -94,7 +90,7 @@ class SearchRepository
             throw new NotFoundHttpException();
         }
 
-        $result = $pagerfanta->getCurrentPageResults();
+        $result = (array) $pagerfanta->getCurrentPageResults();
 
         return $this->buildResult($result, $page, $countAll);
     }
@@ -132,7 +128,7 @@ class SearchRepository
             throw new NotFoundHttpException();
         }
 
-        $result = $pagerfanta->getCurrentPageResults();
+        $result = (array) $pagerfanta->getCurrentPageResults();
 
         return $this->buildResult($result, $page, $countAll);
     }
@@ -145,9 +141,9 @@ class SearchRepository
         (SELECT id, created_at, 'entry' AS type FROM entry WHERE ap_id ILIKE :url) 
         UNION ALL
         (SELECT id, created_at, 'entry_comment' AS type FROM entry_comment WHERE ap_id ILIKE :url)
-        UNION ALL
+        UNION  ALL
         (SELECT id, created_at, 'post' AS type FROM post WHERE ap_id ILIKE :url)
-        UNION ALL
+        UNION  ALL
         (SELECT id, created_at, 'post_comment' AS type FROM post_comment WHERE ap_id ILIKE :url)
         ORDER BY created_at DESC
         ";
@@ -171,25 +167,17 @@ class SearchRepository
         $result = $pagerfanta->getCurrentPageResults();
 
         $objects = [];
-        if ($this->getOverviewIds((array) $result, 'entry')) {
-            $objects = $this->entityManager->getRepository(Entry::class)->findBy(
-                ['id' => $this->getOverviewIds((array) $result, 'entry')]
-            );
-        }
-        if ($this->getOverviewIds((array) $result, 'entry_comment')) {
-            $objects = $this->entityManager->getRepository(EntryComment::class)->findBy(
-                ['id' => $this->getOverviewIds((array) $result, 'entry_comment')]
-            );
-        }
-        if ($this->getOverviewIds((array) $result, 'post')) {
-            $objects = $this->entityManager->getRepository(Post::class)->findBy(
-                ['id' => $this->getOverviewIds((array) $result, 'post')]
-            );
-        }
-        if ($this->getOverviewIds((array) $result, 'post_comment')) {
-            $objects = $this->entityManager->getRepository(Post::class)->findBy(
-                ['id' => $this->getOverviewIds((array) $result, 'post_comment')]
-            );
+
+        $types = ['entry', 'entry_comment', 'post', 'post_comment'];
+
+        foreach ($types as $type) {
+            $overviewIds = $this->getOverviewIds((array) $result, $type);
+
+            if ($overviewIds) {
+                $entityClass = "App\\Entity\\$type";
+                $repository = $this->entityManager->getRepository($entityClass);
+                $objects = array_merge($objects, $repository->findBy(['id' => $overviewIds]));
+            }
         }
 
         return $objects ?? [];
@@ -204,32 +192,32 @@ class SearchRepository
 
     private function buildResult(array $result, $page, $countAll)
     {
-        $entries = $this->entityManager->getRepository(Entry::class)->findBy(
-            ['id' => $this->getOverviewIds((array) $result, 'entry')]
-        );
-        $entryComments = $this->entityManager->getRepository(EntryComment::class)->findBy(
-            ['id' => $this->getOverviewIds((array) $result, 'entry_comment')]
-        );
-        $post = $this->entityManager->getRepository(Post::class)->findBy(
-            ['id' => $this->getOverviewIds((array) $result, 'post')]
-        );
-        $postComment = $this->entityManager->getRepository(PostComment::class)->findBy(
-            ['id' => $this->getOverviewIds((array) $result, 'post_comment')]
-        );
+        $overviewIds = [
+            'entry' => $this->getOverviewIds($result, 'entry'),
+            'entry_comment' => $this->getOverviewIds($result, 'entry_comment'),
+            'post' => $this->getOverviewIds($result, 'post'),
+            'post_comment' => $this->getOverviewIds($result, 'post_comment'),
+        ];
 
-        $result = array_merge($entries, $entryComments, $post, $postComment);
-        uasort($result, fn ($a, $b) => $a->getCreatedAt() > $b->getCreatedAt() ? -1 : 1);
+        $objects = [];
+        foreach ($overviewIds as $type => $ids) {
+            if ($ids) {
+                $entityClass = "App\\Entity\\$type";
+                $repository = $this->entityManager->getRepository($entityClass);
+                $objects = array_merge($objects, $repository->findBy(['id' => $ids]));
+            }
+        }
 
-        $pagerfanta = new Pagerfanta(
-            new ArrayAdapter(
-                $result
-            )
-        );
+        // Sort the objects by createdAt property
+        usort($objects, fn ($a, $b) => $a->getCreatedAt() > $b->getCreatedAt() ? -1 : 1);
+
+        // Create a Pagerfanta instance with the sorted array
+        $pagerfanta = new Pagerfanta(new ArrayAdapter($objects));
 
         try {
             $pagerfanta->setMaxPerPage(self::PER_PAGE);
             $pagerfanta->setCurrentPage($page);
-            $pagerfanta->setMaxNbPages($countAll > 0 ? ((int) ceil($countAll / self::PER_PAGE)) : 1);
+            $pagerfanta->setMaxNbPages($countAll > 0 ? (int) ceil($countAll / self::PER_PAGE) : 1);
         } catch (NotValidCurrentPageException $e) {
             throw new NotFoundHttpException();
         }

--- a/src/Repository/StatsVotesRepository.php
+++ b/src/Repository/StatsVotesRepository.php
@@ -269,53 +269,75 @@ class StatsVotesRepository extends StatsRepository
 
         foreach (['entry', 'entry_comment', 'post', 'post_comment'] as $table) {
             $relation = false === strstr($table, '_comment') ? $table.'_id' : 'comment_id';
-            $sql = 'SELECT date_trunc(?, e.created_at) as datetime, COUNT(case e.choice when 1 then 1 else null end) as boost, COUNT(case e.choice when -1 then 1 else null end) as down FROM '.$table.'_vote e 
-                        INNER JOIN '.$table.' AS parent ON '.$relation.' = parent.id';
+
+            // Common SQL for both queries
+            $commonSql = 'SELECT date_trunc(:interval, e.created_at) as datetime ';
+
+            // First Query
+            $sql1 = $commonSql.', COUNT(case e.choice when 1 then 1 else null end) as boost, COUNT(case e.choice when -1 then 1 else null end) as down 
+                FROM '.$table.'_vote e 
+                INNER JOIN '.$table.' AS parent ON '.$relation.' = parent.id
+                WHERE e.created_at BETWEEN :start AND :end';
+
+            // Add magazine condition
             if ($magazine) {
-                $sql .= ' AND parent.magazine_id = ?';
+                $sql1 .= ' AND parent.magazine_id = :magazineId';
             }
-            $sql .= ' WHERE e.created_at BETWEEN ? AND ?';
+
+            // Add local condition
             if ($this->onlyLocal) {
-                $sql = $sql.' AND EXISTS (SELECT * FROM public.user WHERE public.user.id=e.user_id AND public.user.ap_id IS NULL)';
+                $sql1 .= ' AND EXISTS (SELECT * FROM public.user WHERE public.user.id=e.user_id AND public.user.ap_id IS NULL)';
             }
-            $sql = $sql.' GROUP BY 1 ORDER BY 1';
 
-            $stmt = $conn->prepare($sql);
-            $index = 1;
-            $stmt->bindValue($index++, $interval);
+            $sql1 .= ' GROUP BY 1 ORDER BY 1';
+
+            // Execute the first query
+            $stmt1 = $conn->prepare($sql1);
+            $stmt1->bindValue(':interval', $interval);
+            $stmt1->bindValue(':start', $this->start, 'datetime');
+            $stmt1->bindValue(':end', $end, 'datetime');
             if ($magazine) {
-                $stmt->bindValue($index++, $magazine->getId(), ParameterType::INTEGER);
+                $stmt1->bindValue(':magazineId', $magazine->getId(), ParameterType::INTEGER);
             }
-            $stmt->bindValue($index++, $this->start, 'datetime');
-            $stmt->bindValue($index++, $end, 'datetime');
 
-            $results[$table] = $stmt->executeQuery()->fetchAllAssociative();
+            $results[$table] = $stmt1->executeQuery()->fetchAllAssociative();
+
+            // Second Query
+            $sql2 = $commonSql.', COUNT(e.id) as up 
+                FROM favourite e 
+                WHERE e.created_at BETWEEN :start AND :end';
+
+            // Add magazine condition
+            if ($magazine) {
+                $sql2 .= ' AND e.magazine_id = :magazineId';
+            }
+
+            // Add local condition
+            if ($this->onlyLocal) {
+                $sql2 .= ' AND EXISTS (SELECT * FROM public.user WHERE public.user.id=e.user_id AND public.user.ap_id IS NULL)';
+            }
+
+            $sql2 .= ' AND e.'.$table.'_id IS NOT NULL GROUP BY 1 ORDER BY 1';
+
+            // Execute the second query
+            $stmt2 = $conn->prepare($sql2);
+            $stmt2->bindValue(':interval', $interval);
+            $stmt2->bindValue(':start', $this->start, 'datetime');
+            $stmt2->bindValue(':end', $end, 'datetime');
+            if ($magazine) {
+                $stmt2->bindValue(':magazineId', $magazine->getId(), ParameterType::INTEGER);
+            }
+
+            $favourites = $stmt2->executeQuery()->fetchAllAssociative();
+
+            // Process the results without the helper function
             $datemap = [];
-            for ($i = 0; $i < \count($results[$table]); ++$i) {
-                $datemap[$results[$table][$i]['datetime']] = $i;
+
+            foreach ($results[$table] as $i => $result) {
+                $datemap[$result['datetime']] = $i;
                 $results[$table][$i]['up'] = 0;
             }
 
-            $sql = 'SELECT date_trunc(?, e.created_at) as datetime, COUNT(e.id) as up FROM favourite e 
-                        WHERE e.created_at BETWEEN ? AND ?';
-            if ($magazine) {
-                $sql .= ' AND e.magazine_id = ?';
-            }
-            $sql .= ' AND e.'.$table.'_id IS NOT NULL';
-            if ($this->onlyLocal) {
-                $sql = $sql.' AND EXISTS (SELECT * FROM public.user WHERE public.user.id=e.user_id AND public.user.ap_id IS NULL)';
-            }
-            $sql = $sql.' GROUP BY 1 ORDER BY 1';
-
-            $stmt = $conn->prepare($sql);
-            $stmt->bindValue(1, $interval);
-            $stmt->bindValue(2, $this->start, 'datetime');
-            $stmt->bindValue(3, $end, 'datetime');
-            if ($magazine) {
-                $stmt->bindValue(4, $magazine->getId(), ParameterType::INTEGER);
-            }
-
-            $favourites = $stmt->executeQuery()->fetchAllAssociative();
             foreach ($favourites as $favourite) {
                 if (\array_key_exists($favourite['datetime'], $datemap)) {
                     $results[$table][$datemap[$favourite['datetime']]]['up'] = $favourite['up'];
@@ -329,7 +351,8 @@ class StatsVotesRepository extends StatsRepository
                 }
             }
 
-            usort($results[$table], fn ($a, $b): int => $a['datetime'] <=> $b['datetime']);
+            // Sort the results
+            usort($results[$table], fn ($a, $b) => $a['datetime'] <=> $b['datetime']);
         }
 
         return $results;
@@ -343,41 +366,53 @@ class StatsVotesRepository extends StatsRepository
 
         foreach (['entry', 'entry_comment', 'post', 'post_comment'] as $table) {
             $relation = false === strstr($table, '_comment') ? $table.'_id' : 'comment_id';
-            $sql = 'SELECT COUNT(case e.choice when 1 then 1 else null end) as boost, COUNT(case e.choice when -1 then 1 else null end) as down FROM '.$table.'_vote e 
-            INNER JOIN '.$table.' AS parent ON '.$relation.' = parent.id';
+
+            // First Query
+            $sql1 = 'SELECT COUNT(case e.choice when 1 then 1 else null end) as boost, COUNT(case e.choice when -1 then 1 else null end) as down 
+                FROM '.$table.'_vote e 
+                INNER JOIN '.$table.' AS parent ON '.$relation.' = parent.id';
+
+            // Add magazine condition
             if ($magazine) {
-                $sql .= ' AND parent.magazine_id = ?';
+                $sql1 .= ' AND parent.magazine_id = ?';
             }
+
+            // Add local condition
             if ($this->onlyLocal) {
-                $sql .= ' AND EXISTS (SELECT * FROM public.user WHERE public.user.id=e.user_id AND public.user.ap_id IS NULL)';
+                $sql1 .= ' AND EXISTS (SELECT * FROM public.user WHERE public.user.id=e.user_id AND public.user.ap_id IS NULL)';
             }
 
-            $stmt = $conn->prepare($sql);
+            $stmt1 = $conn->prepare($sql1);
             if ($magazine) {
-                $stmt->bindValue(1, $magazine->getId(), ParameterType::INTEGER);
+                $stmt1->bindValue(1, $magazine->getId(), ParameterType::INTEGER);
             }
 
-            $results[$table] = $stmt->executeQuery()->fetchAllAssociative();
+            $results[$table] = $stmt1->executeQuery()->fetchAllAssociative();
 
-            $sql = 'SELECT COUNT(e.id) as up FROM favourite e 
-                        WHERE e.'.$table.'_id IS NOT NULL';
+            // Second Query
+            $sql2 = 'SELECT COUNT(e.id) as up FROM favourite e 
+                WHERE e.'.$table.'_id IS NOT NULL';
+
+            // Add magazine condition
             if ($magazine) {
-                $sql .= ' AND e.magazine_id = ?';
+                $sql2 .= ' AND e.magazine_id = ?';
             }
+
+            // Add local condition
             if ($this->onlyLocal) {
-                $sql = $sql.' AND EXISTS (SELECT * FROM public.user WHERE public.user.id=e.user_id AND public.user.ap_id IS NULL)';
+                $sql2 .= ' AND EXISTS (SELECT * FROM public.user WHERE public.user.id=e.user_id AND public.user.ap_id IS NULL)';
             }
 
-            $stmt = $conn->prepare($sql);
+            $stmt2 = $conn->prepare($sql2);
             if ($magazine) {
-                $stmt->bindValue(1, $magazine->getId(), ParameterType::INTEGER);
+                $stmt2->bindValue(1, $magazine->getId(), ParameterType::INTEGER);
             }
 
-            $favourites = $stmt->executeQuery()->fetchAllAssociative();
+            $favourites = $stmt2->executeQuery()->fetchAllAssociative();
 
-            if (0 < \count($results[$table]) && 0 < \count($favourites)) {
+            if (\count($results[$table]) > 0 && \count($favourites) > 0) {
                 $results[$table][0]['up'] = $favourites[0]['up'];
-            } elseif (0 < \count($favourites)) {
+            } elseif (\count($favourites) > 0) {
                 $results[$table][] = [
                     'boost' => 0,
                     'down' => 0,
@@ -391,7 +426,7 @@ class StatsVotesRepository extends StatsRepository
                 ];
             }
 
-            usort($results[$table], fn ($a, $b): int => $a['datetime'] <=> $b['datetime']);
+            usort($results[$table], fn ($a, $b) => $a['datetime'] <=> $b['datetime']);
         }
 
         return $results;

--- a/src/Repository/TagRepository.php
+++ b/src/Repository/TagRepository.php
@@ -30,11 +30,11 @@ class TagRepository
         $conn = $this->entityManager->getConnection();
         $sql = "
         (SELECT id, created_at, 'entry' AS type FROM entry WHERE tags @> :tag = true AND visibility = :visibility)
-        UNION ALL
+        UNION
         (SELECT id, created_at, 'entry_comment' AS type FROM entry_comment WHERE tags @> :tag = true AND visibility = :visibility)
-        UNION ALL
+        UNION
         (SELECT id, created_at, 'post' AS type FROM post WHERE tags @> :tag = true AND visibility = :visibility)
-        UNION ALL
+        UNION
         (SELECT id, created_at, 'post_comment' AS type FROM post_comment WHERE tags @> :tag = true AND visibility = :visibility)
         ORDER BY created_at DESC";
         $stmt = $conn->prepare($sql);

--- a/src/Repository/TagRepository.php
+++ b/src/Repository/TagRepository.php
@@ -30,11 +30,11 @@ class TagRepository
         $conn = $this->entityManager->getConnection();
         $sql = "
         (SELECT id, created_at, 'entry' AS type FROM entry WHERE tags @> :tag = true AND visibility = :visibility)
-        UNION
+        UNION ALL
         (SELECT id, created_at, 'entry_comment' AS type FROM entry_comment WHERE tags @> :tag = true AND visibility = :visibility)
-        UNION
+        UNION ALL
         (SELECT id, created_at, 'post' AS type FROM post WHERE tags @> :tag = true AND visibility = :visibility)
-        UNION
+        UNION ALL
         (SELECT id, created_at, 'post_comment' AS type FROM post_comment WHERE tags @> :tag = true AND visibility = :visibility)
         ORDER BY created_at DESC";
         $stmt = $conn->prepare($sql);

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -86,13 +86,13 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
         $sql = "
         (SELECT id, created_at, 'entry' AS type FROM entry
         WHERE user_id = :userId AND visibility = :visibility)
-        UNION
+        UNION ALL
         (SELECT id, created_at, 'entry_comment' AS type FROM entry_comment
         WHERE user_id = :userId AND visibility = :visibility)
-        UNION
+        UNION ALL
         (SELECT id, created_at, 'post' AS type FROM post
         WHERE user_id = :userId AND visibility = :visibility)
-        UNION
+        UNION ALL
         (SELECT id, created_at, 'post_comment' AS type FROM post_comment
         WHERE user_id = :userId AND visibility = :visibility)
         ORDER BY created_at DESC";
@@ -473,11 +473,11 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
         $conn = $this->_em->getConnection();
         $sql = '
         (SELECT count(id), user_id FROM entry WHERE magazine_id = :magazineId GROUP BY user_id ORDER BY count DESC LIMIT 50)
-        UNION
+        UNION ALL
         (SELECT count(id), user_id FROM entry_comment WHERE magazine_id = :magazineId GROUP BY user_id ORDER BY count DESC LIMIT 50)
-        UNION
+        UNION ALL
         (SELECT count(id), user_id FROM post WHERE magazine_id = :magazineId GROUP BY user_id ORDER BY count DESC LIMIT 50)
-        UNION
+        UNION ALL
         (SELECT count(id), user_id FROM post_comment WHERE magazine_id = :magazineId GROUP BY user_id ORDER BY count DESC LIMIT 50)
         ORDER BY count DESC';
 
@@ -489,11 +489,9 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
         foreach ($counter as $item) {
             $user_id = $item['user_id'];
             $count = $item['count'];
-            if (isset($output[$user_id])) {
-                $output[$user_id]['count'] += $count;
-            } else {
-                $output[$user_id] = ['count' => $count, 'user_id' => $user_id];
-            }
+
+            $output[$user_id]['count'] = ($output[$user_id]['count'] ?? 0) + $count;
+            $output[$user_id]['user_id'] = $user_id;
         }
 
         $user = array_map(fn ($item) => $item['user_id'], $output);

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -86,13 +86,13 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
         $sql = "
         (SELECT id, created_at, 'entry' AS type FROM entry
         WHERE user_id = :userId AND visibility = :visibility)
-        UNION ALL
+        UNION
         (SELECT id, created_at, 'entry_comment' AS type FROM entry_comment
         WHERE user_id = :userId AND visibility = :visibility)
-        UNION ALL
+        UNION
         (SELECT id, created_at, 'post' AS type FROM post
         WHERE user_id = :userId AND visibility = :visibility)
-        UNION ALL
+        UNION
         (SELECT id, created_at, 'post_comment' AS type FROM post_comment
         WHERE user_id = :userId AND visibility = :visibility)
         ORDER BY created_at DESC";
@@ -473,11 +473,11 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
         $conn = $this->_em->getConnection();
         $sql = '
         (SELECT count(id), user_id FROM entry WHERE magazine_id = :magazineId GROUP BY user_id ORDER BY count DESC LIMIT 50)
-        UNION ALL
+        UNION
         (SELECT count(id), user_id FROM entry_comment WHERE magazine_id = :magazineId GROUP BY user_id ORDER BY count DESC LIMIT 50)
-        UNION ALL
+        UNION
         (SELECT count(id), user_id FROM post WHERE magazine_id = :magazineId GROUP BY user_id ORDER BY count DESC LIMIT 50)
-        UNION ALL
+        UNION
         (SELECT count(id), user_id FROM post_comment WHERE magazine_id = :magazineId GROUP BY user_id ORDER BY count DESC LIMIT 50)
         ORDER BY count DESC';
 
@@ -489,9 +489,11 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
         foreach ($counter as $item) {
             $user_id = $item['user_id'];
             $count = $item['count'];
-
-            $output[$user_id]['count'] = ($output[$user_id]['count'] ?? 0) + $count;
-            $output[$user_id]['user_id'] = $user_id;
+            if (isset($output[$user_id])) {
+                $output[$user_id]['count'] += $count;
+            } else {
+                $output[$user_id] = ['count' => $count, 'user_id' => $user_id];
+            }
         }
 
         $user = array_map(fn ($item) => $item['user_id'], $output);

--- a/src/Repository/VoteRepository.php
+++ b/src/Repository/VoteRepository.php
@@ -17,11 +17,11 @@ class VoteRepository
         $conn = $this->entityManager->getConnection();
         $sql = "
         (SELECT id, 'entry' AS type FROM entry_vote {$this->where($date, $withFederated)}) 
-        UNION ALL
+        UNION 
         (SELECT id, 'entry_comment' AS type FROM entry_comment_vote {$this->where($date, $withFederated)})
-        UNION ALL
+        UNION 
         (SELECT id, 'post' AS type FROM post_vote {$this->where($date, $withFederated)})
-        UNION ALL
+        UNION 
         (SELECT id, 'post_comment' AS type FROM post_comment_vote {$this->where($date, $withFederated)})
         ";
 
@@ -34,8 +34,15 @@ class VoteRepository
     private function where(\DateTimeImmutable $date = null, bool $withFederated = null): string
     {
         $dateWhere = $date ? "created_at > '{$date->format('Y-m-d H:i:s')}'" : '';
-        $federationWhere = !$withFederated ? ' AND EXISTS (SELECT * FROM public.user WHERE public.user.ap_id IS NULL and public.user.id=user_id)' : '';
-
-        return $dateWhere ? "WHERE $dateWhere$federationWhere" : '';
+        $withoutFederationWhere = 'EXISTS (SELECT * FROM public.user WHERE public.user.ap_id IS NULL and public.user.id=user_id)';
+        if ($date and !$withFederated) {
+            return "WHERE $dateWhere AND $withoutFederationWhere";
+        } elseif ($date and true === $withFederated) {
+            return "WHERE $dateWhere";
+        } elseif (!$date and !$withFederated) {
+            return "WHERE $withoutFederationWhere";
+        } else {
+            return '';
+        }
     }
 }

--- a/src/Repository/VoteRepository.php
+++ b/src/Repository/VoteRepository.php
@@ -17,11 +17,11 @@ class VoteRepository
         $conn = $this->entityManager->getConnection();
         $sql = "
         (SELECT id, 'entry' AS type FROM entry_vote {$this->where($date, $withFederated)}) 
-        UNION 
+        UNION ALL
         (SELECT id, 'entry_comment' AS type FROM entry_comment_vote {$this->where($date, $withFederated)})
-        UNION 
+        UNION ALL
         (SELECT id, 'post' AS type FROM post_vote {$this->where($date, $withFederated)})
-        UNION 
+        UNION ALL
         (SELECT id, 'post_comment' AS type FROM post_comment_vote {$this->where($date, $withFederated)})
         ";
 
@@ -34,15 +34,8 @@ class VoteRepository
     private function where(\DateTimeImmutable $date = null, bool $withFederated = null): string
     {
         $dateWhere = $date ? "created_at > '{$date->format('Y-m-d H:i:s')}'" : '';
-        $withoutFederationWhere = 'EXISTS (SELECT * FROM public.user WHERE public.user.ap_id IS NULL and public.user.id=user_id)';
-        if ($date and !$withFederated) {
-            return "WHERE $dateWhere AND $withoutFederationWhere";
-        } elseif ($date and true === $withFederated) {
-            return "WHERE $dateWhere";
-        } elseif (!$date and !$withFederated) {
-            return "WHERE $withoutFederationWhere";
-        } else {
-            return '';
-        }
+        $federationWhere = !$withFederated ? ' AND EXISTS (SELECT * FROM public.user WHERE public.user.ap_id IS NULL and public.user.id=user_id)' : '';
+
+        return $dateWhere ? "WHERE $dateWhere$federationWhere" : '';
     }
 }


### PR DESCRIPTION
This is a living PR to introduce our own refactoring efforts and SQL optimizations to the `Repository` code.

**`src\Repository\ApActivityRepository.php`:**
- [x] Each `ap_id` _should_ be unique, switching to `UNION ALL` shows slight performance improvement by not checking for duplicates. `ap_id` index exists on each relevant table in this query after https://github.com/MbinOrg/mbin/pull/282, which  seems to be ultimately making **all** the difference in performance.
- [x] **Refactoring**: cleaned up local instance checks in `findByObjectId`

**`src\Repository\Criteria.php`:**
- [x] **Refactoring/cleanup**: `setType`, `addLanguage`, `showSortOption`, `routes`, `resolveTime`, `resolveType`, `setTime`
- [x] Removed hardcoded Polish translations

**`src/Repository/DomainRepository.php`:**
- [x]  Cleanup and improve readability of `findAllPaginated`, `findSubscribedDomains`, `findBlockedDomains`
- [x] "Bug" fix in `src/Controller/Api/Domain/DomainRetrieveApi.php`, argument being thrownout in call to `findAllPaginated`

**`src/Repository/EntryRepository.php`:**
- [x] Remove unused `countAll` function

Test subject to evaluate performance impacts **after** `dev` environment testing and verification: [kbin.run](https://kbin.run/)