### PR TITLE
add early out of sidebar selector when not a sidebar option

### DIFF
--- a/assets/controllers/options_controller.js
+++ b/assets/controllers/options_controller.js
@@ -10,11 +10,16 @@ export default class extends Controller {
     connect() {
         const activeTabFragment = window.location.hash;
 
-        if (activeTabFragment) {
-            this.actionsTarget.querySelector(`a[href="${activeTabFragment}"]`).classList.add('active');
-
-            this.activeTabValue = activeTabFragment.substring(1);
+        if (!activeTabFragment) {
+          return;
         }
+
+        if (activeTabFragment !== '#federation' && activeTabFragment !== '#settings') {
+          return;
+        }
+
+        this.actionsTarget.querySelector(`a[href="${activeTabFragment}"]`).classList.add('active');
+        this.activeTabValue = activeTabFragment.substring(1);
     }
 
     /** @param {ActionEvent} e */


### PR DESCRIPTION
Right now browsing to a URL with `#comments` (or any hash after the URL), produces the following JavaScript error:

```
Error connecting controller
 TypeError: this.actionsTarget.querySelector(...) is null
```

this is because the sidebar options controller activates whenever there is a hash and attempts to add classes to the target of the hash. This change makes it early out if the hash is not specifically `#federation` or `#settings`, the two sidebar options. Perhaps a little brittle if it ever changes but if it does this file needs a fairly big overhaul anyways

(There are two more sidebar options on mobile, close and home, but both are links rather than things that open and get active styling)