### PR TITLE
inline moderate panel ux updates

### DIFF
--- a/assets/controllers/subject_controller.js
+++ b/assets/controllers/subject_controller.js
@@ -214,16 +214,17 @@ export default class extends Controller {
     async showModPanel(event) {
         event.preventDefault();
 
-        let container = this.element.nextElementSibling && this.element.nextElementSibling.classList.contains('js-container') ? this.element.nextElementSibling : null;
-        if (null === container) {
-            container = document.createElement('div');
-            container.classList.add('js-container');
-            this.element.insertAdjacentHTML('afterend', container.outerHTML);
-        } else {
-            if (container.querySelector('.moderate-panel')) {
-                return;
-            }
+        let container = this.element.querySelector('.moderate-inline')
+        if (null !== container) {
+            // moderate panel was already added to this post, toggle
+            // hidden on it to show/hide it and exit
+            container.classList.toggle('hidden');
+            return;
         }
+
+        container = document.createElement('div');
+        container.classList.add('moderate-inline');
+        this.element.insertAdjacentHTML('beforeend', container.outerHTML);
 
         try {
             this.loadingValue = true;
@@ -233,7 +234,7 @@ export default class extends Controller {
             response = await ok(response);
             response = await response.json();
 
-            this.element.nextElementSibling.insertAdjacentHTML('afterbegin', response.html);
+            this.element.querySelector('.moderate-inline').insertAdjacentHTML('afterbegin', response.html);
         } catch (e) {
             window.location.href = event.target.href;
         } finally {

--- a/assets/styles/components/_comment.scss
+++ b/assets/styles/components/_comment.scss
@@ -182,7 +182,7 @@ $comment-margin-sm: .3rem;
 
   &:hover,
   &:focus-within {
-    header, menu, footer menu, footer .boosts {
+    header, footer menu, footer .boosts {
       @include fade-in(.5s, .75);
     }
   }

--- a/assets/styles/components/_comment.scss
+++ b/assets/styles/components/_comment.scss
@@ -29,7 +29,8 @@ $comment-margin-sm: .3rem;
   grid-gap: .5rem;
   grid-template-areas: "avatar header vote"
                          "avatar body body"
-                         "avatar footer footer";
+                         "avatar footer footer"
+                         "moderate moderate moderate";
   grid-template-columns: min-content auto min-content;
   margin: .5rem 0;
   padding: 0.5rem 0.75rem;
@@ -39,7 +40,8 @@ $comment-margin-sm: .3rem;
   @include media-breakpoint-down(sm) {
     grid-template-areas: "avatar header vote"
                          "body body body"
-                         "footer footer footer";
+                         "footer footer footer"
+                         "moderate moderate moderate";
   }
 
   &:hover,
@@ -110,33 +112,6 @@ $comment-margin-sm: .3rem;
   }
 
 
-  menu {
-    column-gap: 1rem;
-    display: grid;
-    grid-area: meta;
-    grid-auto-columns: max-content;
-    grid-auto-flow: column;
-    list-style: none;
-    opacity: .75;
-    position: relative;
-    z-index: 4;
-
-    & > a.active,
-    & > li button.active, {
-      text-decoration: underline;
-    }
-
-    button,
-    a {
-      font-size: .8rem;
-      @include kbin-btn-link;
-    }
-
-    li:first-child a {
-      padding-left: 0;
-    }
-  }
-
   .vote {
     display: flex;
     gap: .5rem;
@@ -153,6 +128,33 @@ $comment-margin-sm: .3rem;
     font-size: .75rem;
     font-weight: 300;
     grid-area: footer;
+
+    menu {
+      column-gap: 1rem;
+      display: grid;
+      grid-area: meta;
+      grid-auto-columns: max-content;
+      grid-auto-flow: column;
+      list-style: none;
+      opacity: .75;
+      position: relative;
+      z-index: 4;
+
+      & > a.active,
+      & > li button.active, {
+        text-decoration: underline;
+      }
+
+      button,
+      a {
+        font-size: .8rem;
+        @include kbin-btn-link;
+      }
+
+      li:first-child a {
+        padding-left: 0;
+      }
+    }
 
     menu, .boosts {
       opacity: .75;

--- a/assets/styles/components/_entry.scss
+++ b/assets/styles/components/_entry.scss
@@ -334,7 +334,7 @@
 
   &:hover,
   &:focus-within {
-    menu,
+    footer menu,
     .entry__meta {
       @include fade-in(.5s, .75);
     }

--- a/assets/styles/components/_entry.scss
+++ b/assets/styles/components/_entry.scss
@@ -8,6 +8,7 @@
                        "vote image shortDesc"
                        "vote image meta"
                        "vote image footer"
+                       "moderate moderate moderate"
                        "preview preview preview"
                        "body body body";
   grid-template-columns: min-content min-content 1fr;
@@ -21,6 +22,7 @@
                        "vote shortDesc"
                        "vote meta"
                        "vote footer"
+                       "moderate moderate"
                        "body body";
     grid-template-columns: min-content 1fr;
   }
@@ -41,6 +43,7 @@
                          "shortDesc shortDesc"
                          "meta meta"
                          "footer footer"
+                         "moderate moderate"
                          "preview preview"
                          "body body";
     grid-template-columns: min-content 1fr;
@@ -58,6 +61,7 @@
                            "shortDesc shortDesc"
                            "meta meta"
                            "footer footer"
+                           "moderate moderate"
                            "body body";
       grid-template-columns: min-content 1fr;
     }
@@ -66,6 +70,7 @@
       grid-template-areas: "title title vote"
                        "meta meta image"
                        "footer footer image"
+                       "moderate moderate moderate"
                        "preview preview preview"
                        "body body body";
       grid-template-columns: 1fr min-content min-content;
@@ -86,6 +91,7 @@
                        "shortDesc shortDesc"
                        "meta meta"
                        "footer footer"
+                       "moderate moderate"
                        "body body";
       grid-template-columns: 1fr min-content;
     }
@@ -96,6 +102,7 @@
       grid-template-areas: "vote title image"
                        "vote meta image"
                        "vote footer image"
+                       "moderate moderate moderate"
                        "preview preview preview"
                        "body body body";
       grid-template-columns: min-content 1fr min-content;
@@ -411,7 +418,8 @@
 }
 
 .entry-cross {
-  grid-template-areas: "vote meta" !important;
+  grid-template-areas: "vote meta"
+                       "moderate moderate" !important;
   grid-template-columns: min-content 1fr !important;
   margin-top: -.5rem;
 

--- a/assets/styles/components/_post.scss
+++ b/assets/styles/components/_post.scss
@@ -28,7 +28,8 @@
   grid-template-areas: "avatar header vote"
                          "avatar body body"
                          "avatar meta meta"
-                         "avatar footer footer";
+                         "avatar footer footer"
+                         "moderate moderate moderate";
   grid-template-columns: min-content auto min-content;
   margin: 0 0 .5rem;
   padding: 0.75rem;
@@ -39,7 +40,8 @@
     grid-template-areas: "avatar header vote"
                          "body body body"
                          "meta meta meta"
-                         "footer footer footer";
+                         "footer footer footer"
+                         "moderate moderate moderate";
   }
 
   &:hover,
@@ -92,37 +94,6 @@
     }
   }
 
-  menu {
-    column-gap: 1rem;
-    display: grid;
-    grid-area: meta;
-    grid-auto-columns: max-content;
-    grid-auto-flow: column;
-    list-style: none;
-    opacity: .75;
-    position: relative;
-    z-index: 4;
-
-    & > li {
-      line-height: 1rem;
-    }
-
-    & > a.active,
-    & > li button.active {
-      text-decoration: underline;
-    }
-
-    button,
-    a {
-      font-size: .8rem;
-      @include kbin-btn-link;
-    }
-
-    li:first-child a {
-      padding-left: 0;
-    }
-  }
-
   .vote {
     display: flex;
     gap: .5rem;
@@ -142,6 +113,37 @@
     menu, .boosts {
       font-size: .75rem;
       opacity: .75;
+    }
+
+    menu {
+      column-gap: 1rem;
+      display: grid;
+      grid-area: meta;
+      grid-auto-columns: max-content;
+      grid-auto-flow: column;
+      list-style: none;
+      opacity: .75;
+      position: relative;
+      z-index: 4;
+
+      & > li {
+        line-height: 1rem;
+      }
+
+      & > a.active,
+      & > li button.active {
+        text-decoration: underline;
+      }
+
+      button,
+      a {
+        font-size: .8rem;
+        @include kbin-btn-link;
+      }
+
+      li:first-child a {
+        padding-left: 0;
+      }
     }
 
     a {

--- a/assets/styles/components/_post.scss
+++ b/assets/styles/components/_post.scss
@@ -177,7 +177,7 @@
 
   &:hover,
   &:focus-within {
-    header, menu, footer menu, footer .boosts {
+    header, footer menu, footer .boosts {
       @include fade-in(.5s, .75);
     }
   }

--- a/assets/styles/components/_subject.scss
+++ b/assets/styles/components/_subject.scss
@@ -89,8 +89,6 @@
     input,
     select,
     input[type=checkbox] {
-      // border: var(--kbin-meta-border);
-      // border-radius: 0 !important;
       margin-right: .25rem;
     }
 
@@ -99,9 +97,6 @@
       text-decoration: underline;
     }
 
-    // button, input[type='submit'], a {
-    //   @include kbin-btn-link;
-    // }
   }
 }
 

--- a/assets/styles/components/_subject.scss
+++ b/assets/styles/components/_subject.scss
@@ -66,7 +66,6 @@ div.moderate-inline {
 }
 
 .moderate-panel {
-  margin: .5rem 0 !important;
   position: relative;
   z-index: 2;
 

--- a/assets/styles/components/_subject.scss
+++ b/assets/styles/components/_subject.scss
@@ -78,6 +78,10 @@
       padding: .25rem;
     }
 
+    input {
+      width: 10rem;
+    }
+
     .actions form {
       display: flex;
     }
@@ -85,8 +89,8 @@
     input,
     select,
     input[type=checkbox] {
-      border: var(--kbin-meta-border);
-      border-radius: 0 !important;
+      // border: var(--kbin-meta-border);
+      // border-radius: 0 !important;
       margin-right: .25rem;
     }
 
@@ -95,9 +99,9 @@
       text-decoration: underline;
     }
 
-    button, input[type='submit'], a {
-      @include kbin-btn-link;
-    }
+    // button, input[type='submit'], a {
+    //   @include kbin-btn-link;
+    // }
   }
 }
 

--- a/assets/styles/components/_subject.scss
+++ b/assets/styles/components/_subject.scss
@@ -59,6 +59,12 @@
   }
 }
 
+div.moderate-inline {
+  grid-area: moderate;
+  // this is to appear below the more menu
+  z-index: -1;
+}
+
 .moderate-panel {
   margin: .5rem 0 !important;
   position: relative;

--- a/src/Controller/Entry/Comment/EntryCommentChangeAdultController.php
+++ b/src/Controller/Entry/Comment/EntryCommentChangeAdultController.php
@@ -37,6 +37,11 @@ class EntryCommentChangeAdultController extends AbstractController
 
         $this->entityManager->flush();
 
+        $this->addFlash(
+            'success',
+            $comment->isAdult ? 'flash_mark_as_adult_success' : 'flash_unmark_as_adult_success'
+        );
+
         return $this->redirectToRefererOrHome($request);
     }
 }

--- a/src/Controller/Entry/EntryChangeAdultController.php
+++ b/src/Controller/Entry/EntryChangeAdultController.php
@@ -36,7 +36,7 @@ class EntryChangeAdultController extends AbstractController
 
         $this->addFlash(
             'success',
-            $entry->isAdult ? 'flash_thread_mark_as_adult_success' : 'flash_thread_unmark_as_adult_success'
+            $entry->isAdult ? 'flash_mark_as_adult_success' : 'flash_unmark_as_adult_success'
         );
 
         return $this->redirectToRefererOrHome($request);

--- a/src/Controller/Entry/EntryChangeAdultController.php
+++ b/src/Controller/Entry/EntryChangeAdultController.php
@@ -34,6 +34,11 @@ class EntryChangeAdultController extends AbstractController
 
         $this->entityManager->flush();
 
+        $this->addFlash(
+            'success',
+            $entry->isAdult ? 'flash_thread_mark_as_adult_success' : 'flash_thread_unmark_as_adult_success'
+        );
+
         return $this->redirectToRefererOrHome($request);
     }
 }

--- a/src/Controller/Post/Comment/PostCommentChangeAdultController.php
+++ b/src/Controller/Post/Comment/PostCommentChangeAdultController.php
@@ -37,6 +37,11 @@ class PostCommentChangeAdultController extends AbstractController
 
         $this->entityManager->flush();
 
+        $this->addFlash(
+            'success',
+            $comment->isAdult ? 'flash_mark_as_adult_success' : 'flash_unmark_as_adult_success'
+        );
+
         return $this->redirectToRefererOrHome($request);
     }
 }

--- a/src/Controller/Post/PostChangeAdultController.php
+++ b/src/Controller/Post/PostChangeAdultController.php
@@ -33,6 +33,11 @@ class PostChangeAdultController extends AbstractController
 
         $this->entityManager->flush();
 
+        $this->addFlash(
+            'success',
+            $post->isAdult ? 'flash_mark_as_adult_success' : 'flash_unmark_as_adult_success'
+        );
+
         return $this->redirectToRefererOrHome($request);
     }
 }

--- a/templates/entry/_moderate_panel.html.twig
+++ b/templates/entry/_moderate_panel.html.twig
@@ -1,4 +1,4 @@
-<div class="section section--small moderate-panel">
+<div class="moderate-panel">
     <menu>
         <li>
             <form action="{{ path('entry_pin', {'magazine_name': entry.magazine.name, 'entry_id': entry.id}) }}"

--- a/templates/entry/_moderate_panel.html.twig
+++ b/templates/entry/_moderate_panel.html.twig
@@ -1,15 +1,31 @@
 <div class="section section--small moderate-panel">
     <menu>
         <li>
-            <a class="stretched-link"
-               href="{{ path('magazine_panel_ban', {'name': entry.magazine.name, 'username': entry.user.username}) }}">{{ 'ban'|trans|lower }}</a>
-        </li>
-        <li>
             <form action="{{ path('entry_pin', {'magazine_name': entry.magazine.name, 'entry_id': entry.id}) }}"
                   method="post">
                 <input type="hidden" name="token" value="{{ csrf_token('entry_pin') }}">
-                <button type="submit">
-                    <span>{{ entry.sticky ? 'unpin'|trans|lower : 'pin'|trans|lower }}</span>
+                <button type="submit" class="btn btn__secondary">
+                    <i class="fa fa-thumbtack"></i> <span>{{ entry.sticky ? 'unpin'|trans : 'pin'|trans }}</span>
+                </button>
+            </form>
+        </li>
+        <li>
+            <form action="{{ path('entry_change_adult', {magazine_name: magazine.name, entry_id: entry.id}) }}"
+                  method="post">
+                <input type="hidden" name="token" value="{{ csrf_token('change_adult') }}">
+                <input name="adult"
+                       type="hidden" value="{{ entry.isAdult ? 'off' : 'on' }}">
+                <button type="submit" class="btn btn__secondary">
+                    <i class="fa fa-{{ entry.isAdult ? 'eye' : 'eye-slash' }}"></i> <span>{{ entry.isAdult ? 'unmark_as_adult'|trans : 'mark_as_adult'|trans }}</span>
+                </button>
+            </form>
+        </li>
+        <li>
+            <form action="{{ path('magazine_panel_ban', {'name': entry.magazine.name, 'username': entry.user.username}) }}"
+                  method="get">
+                <input type="hidden" name="token" value="{{ csrf_token('entry_user_ban') }}">
+                <button type="submit" class="btn btn__secondary">
+                    <i class="fa fa-ban"></i> <span>{{ 'ban'|trans }}</span>
                 </button>
             </form>
         </li>
@@ -18,8 +34,8 @@
                   method="post"
                   onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                 <input type="hidden" name="token" value="{{ csrf_token('entry_delete') }}">
-                <button type="submit">
-                    <span>{{ 'delete'|trans|lower }}</span>
+                <button type="submit" class="btn btn__secondary">
+                    <i class="fa fa-dumpster"></i> <span>{{ 'delete'|trans }}</span>
                 </button>
             </form>
         </li>
@@ -29,8 +45,8 @@
                       method="post"
                       onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                     <input type="hidden" name="token" value="{{ csrf_token('entry_purge') }}">
-                    <button type="submit">
-                        <span>{{ 'purge'|trans|lower }}</span>
+                    <button type="submit" class="btn btn__danger">
+                        <i class="fa fa-dumpster"></i> <span>{{ 'purge'|trans }}</span>
                     </button>
                 </form>
             </li>
@@ -42,9 +58,9 @@
                       method="post"
                       onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                     <input type="hidden" name="token" value="{{ csrf_token('change_magazine') }}">
-                    <input id="change_magazine_new_magazine" name="change_magazine[new_magazine]">
+                    <input id="change_magazine_new_magazine" required="required" name="change_magazine[new_magazine]">
                     <button type="submit" class="btn btn__secondary">
-                        {{ 'change_magazine'|trans|lower }}
+                        {{ 'change_magazine'|trans }}
                     </button>
                 </form>
             </li>
@@ -52,20 +68,8 @@
         <li class="actions">
             {{ form_start(form, {action: path('entry_change_lang', {magazine_name: magazine.name, entry_id: entry.id})}) }}
             {{ form_row(form.lang, {label: false, row_attr: {class: 'checkbox'}}) }}
-            {{ form_row(form.submit, {label: 'change_language'|trans|lower, attr: {class: 'btn btn__secondary'}}) }}
+            {{ form_row(form.submit, {label: 'change_language'|trans, attr: {class: 'btn btn__secondary'}}) }}
             {{ form_end(form) }}
-        </li>
-        <li class="actions">
-            <div class="checkbox">
-                <form action="{{ path('entry_change_adult', {magazine_name: magazine.name, entry_id: entry.id}) }}"
-                      method="post"
-                      onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
-                    <input type="hidden" name="token" value="{{ csrf_token('change_adult') }}">
-                    <input name="adult"
-                           type="checkbox" {{ entry.isAdult ? 'checked' : '' }}>
-                    <button type="submit">{{ 'is_adult'|trans|lower }}</button>
-                </form>
-            </div>
         </li>
     </menu>
 </div>

--- a/templates/entry/_moderate_panel.html.twig
+++ b/templates/entry/_moderate_panel.html.twig
@@ -23,7 +23,6 @@
         <li>
             <form action="{{ path('magazine_panel_ban', {'name': entry.magazine.name, 'username': entry.user.username}) }}"
                   method="get">
-                <input type="hidden" name="token" value="{{ csrf_token('entry_user_ban') }}">
                 <button type="submit" class="btn btn__secondary">
                     <i class="fa fa-ban"></i> <span>{{ 'ban'|trans }}</span>
                 </button>

--- a/templates/entry/_moderate_panel.html.twig
+++ b/templates/entry/_moderate_panel.html.twig
@@ -57,7 +57,7 @@
                       method="post"
                       onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                     <input type="hidden" name="token" value="{{ csrf_token('change_magazine') }}">
-                    <input id="change_magazine_new_magazine" required="required" name="change_magazine[new_magazine]">
+                    <input id="change_magazine_new_magazine" required="required" placeholder="{{ entry.magazine.name }}" name="change_magazine[new_magazine]">
                     <button type="submit" class="btn btn__secondary">
                         {{ 'change_magazine'|trans }}
                     </button>

--- a/templates/entry/comment/_moderate_panel.html.twig
+++ b/templates/entry/comment/_moderate_panel.html.twig
@@ -1,16 +1,31 @@
 <div class="section section--small moderate-panel">
     <menu>
         <li>
-            <a class="stretched-link"
-               href="{{ path('magazine_panel_ban', {'name': comment.magazine.name, 'username': comment.user.username}) }}">{{ 'ban'|trans }}</a>
+            <form action="{{ path('entry_comment_change_adult', {magazine_name: magazine.name, entry_id: entry.id, comment_id: comment.id}) }}"
+                  method="post">
+                <input type="hidden" name="token" value="{{ csrf_token('change_adult') }}">
+                <input name="adult"
+                       type="hidden" value="{{ comment.isAdult ? 'off' : 'on' }}">
+                <button type="submit" class="btn btn__secondary">
+                    <i class="fa fa-{{ comment.isAdult ? 'eye' : 'eye-slash' }}"></i> <span>{{ comment.isAdult ? 'unmark_as_adult'|trans : 'mark_as_adult'|trans }}</span>
+                </button>
+            </form>
+        </li>
+        <li>
+            <form action="{{ path('magazine_panel_ban', {'name': comment.magazine.name, 'username': comment.user.username}) }}"
+                  method="get">
+                <button type="submit" class="btn btn__secondary">
+                    <i class="fa fa-ban"></i> <span>{{ 'ban'|trans }}</span>
+                </button>
+            </form>
         </li>
         <li>
             <form action="{{ entry_comment_delete_url(comment) }}"
                   method="post"
                   onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                 <input type="hidden" name="token" value="{{ csrf_token('entry_comment_delete') }}">
-                <button type="submit">
-                    <span>{{ 'delete'|trans }}</span>
+                <button type="submit" class="btn btn__secondary">
+                    <i class="fa fa-dumpster"></i> <span>{{ 'delete'|trans }}</span>
                 </button>
             </form>
         </li>
@@ -20,8 +35,8 @@
                       method="post"
                       onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                     <input type="hidden" name="token" value="{{ csrf_token('entry_comment_purge') }}">
-                    <button type="submit">
-                        <span>{{ 'purge'|trans }}</span>
+                    <button type="submit" class="btn btn__danger">
+                        <i class="fa fa-dumpster"></i> <span>{{ 'purge'|trans }}</span>
                     </button>
                 </form>
             </li>
@@ -29,20 +44,8 @@
         <li class="actions">
             {{ form_start(form, {action: path('entry_comment_change_lang', {magazine_name: magazine.name, entry_id: entry.id, comment_id: comment.id})}) }}
             {{ form_row(form.lang, {label: false, row_attr: {class: 'checkbox'}}) }}
-            {{ form_row(form.submit, {label: 'change_language'|trans|lower, attr: {class: 'btn btn__secondary'}}) }}
+            {{ form_row(form.submit, {label: 'change_language'|trans, attr: {class: 'btn btn__secondary'}}) }}
             {{ form_end(form) }}
-        </li>
-        <li class="actions">
-            <div class="checkbox">
-                <form action="{{ path('entry_comment_change_adult', {magazine_name: magazine.name, entry_id: entry.id, comment_id: comment.id}) }}"
-                      method="post"
-                      onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
-                    <input type="hidden" name="token" value="{{ csrf_token('change_adult') }}">
-                    <input name="adult"
-                           type="checkbox" {{ comment.isAdult ? 'checked' : '' }}>
-                    <button type="submit">{{ 'is_adult'|trans }}</button>
-                </form>
-            </div>
         </li>
     </menu>
 </div>

--- a/templates/entry/comment/_moderate_panel.html.twig
+++ b/templates/entry/comment/_moderate_panel.html.twig
@@ -1,4 +1,4 @@
-<div class="section section--small moderate-panel">
+<div class="moderate-panel">
     <menu>
         <li>
             <form action="{{ path('entry_comment_change_adult', {magazine_name: magazine.name, entry_id: entry.id, comment_id: comment.id}) }}"

--- a/templates/entry/comment/moderate.html.twig
+++ b/templates/entry/comment/moderate.html.twig
@@ -18,6 +18,8 @@
             comment: comment,
         }) }}
         {% include 'layout/_flash.html.twig' %}
-        {% include 'entry/comment/_moderate_panel.html.twig' %}
+        <div class="section section--small">
+          {% include 'entry/comment/_moderate_panel.html.twig' %}
+        </div>
     </div>
 {% endblock %}

--- a/templates/entry/moderate.html.twig
+++ b/templates/entry/moderate.html.twig
@@ -23,6 +23,8 @@
             class: 'section--top'
         }) }}
         {% include 'layout/_flash.html.twig' %}
-        {% include 'entry/_moderate_panel.html.twig' %}
+        <div class="section section--small">
+          {% include 'entry/_moderate_panel.html.twig' %}
+        </div>
     </div>
 {% endblock %}

--- a/templates/post/_moderate_panel.html.twig
+++ b/templates/post/_moderate_panel.html.twig
@@ -57,7 +57,7 @@
                       method="post"
                       onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                     <input type="hidden" name="token" value="{{ csrf_token('change_magazine') }}">
-                    <input id="change_magazine_new_magazine" required="required" name="change_magazine[new_magazine]">
+                    <input id="change_magazine_new_magazine" required="required" placeholder="{{ post.magazine.name }}" name="change_magazine[new_magazine]">
                     <button type="submit" class="btn btn__secondary">
                         {{ 'change_magazine'|trans }}
                     </button>

--- a/templates/post/_moderate_panel.html.twig
+++ b/templates/post/_moderate_panel.html.twig
@@ -1,4 +1,4 @@
-<div class="section section--small moderate-panel">
+<div class="moderate-panel">
     <menu>
         <li>
             <form action="{{ path('post_pin', {'magazine_name': post.magazine.name, 'post_id': post.id}) }}"

--- a/templates/post/_moderate_panel.html.twig
+++ b/templates/post/_moderate_panel.html.twig
@@ -1,15 +1,30 @@
 <div class="section section--small moderate-panel">
     <menu>
         <li>
-            <a class="stretched-link"
-               href="{{ path('magazine_panel_ban', {'name': post.magazine.name, 'username': post.user.username}) }}">{{ 'ban'|trans }}</a>
-        </li>
-        <li>
             <form action="{{ path('post_pin', {'magazine_name': post.magazine.name, 'post_id': post.id}) }}"
                   method="post">
                 <input type="hidden" name="token" value="{{ csrf_token('post_pin') }}">
-                <button type="submit">
-                    <span>{{ post.sticky ? 'unpin'|trans : 'pin'|trans }}</span>
+                <button type="submit" class="btn btn__secondary">
+                    <i class="fa fa-thumbtack"></i> <span>{{ post.sticky ? 'unpin'|trans : 'pin'|trans }}</span>
+                </button>
+            </form>
+        </li>
+        <li>
+            <form action="{{ path('post_change_adult', {magazine_name: magazine.name, post_id: post.id}) }}"
+                  method="post">
+                <input type="hidden" name="token" value="{{ csrf_token('change_adult') }}">
+                <input name="adult"
+                       type="hidden" value="{{ post.isAdult ? 'off' : 'on' }}">
+                <button type="submit" class="btn btn__secondary">
+                    <i class="fa fa-{{ post.isAdult ? 'eye' : 'eye-slash' }}"></i> <span>{{ post.isAdult ? 'unmark_as_adult'|trans : 'mark_as_adult'|trans }}</span>
+                </button>
+            </form>
+        </li>
+        <li>
+            <form action="{{ path('magazine_panel_ban', {'name': post.magazine.name, 'username': post.user.username}) }}"
+                  method="get">
+                <button type="submit" class="btn btn__secondary">
+                    <i class="fa fa-ban"></i> <span>{{ 'ban'|trans }}</span>
                 </button>
             </form>
         </li>
@@ -18,8 +33,8 @@
                   method="post"
                   onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                 <input type="hidden" name="token" value="{{ csrf_token('post_delete') }}">
-                <button type="submit">
-                    <span>{{ 'delete'|trans }}</span>
+                <button type="submit" class="btn btn__secondary">
+                    <i class="fa fa-dumpster"></i> <span>{{ 'delete'|trans }}</span>
                 </button>
             </form>
         </li>
@@ -29,8 +44,8 @@
                       method="post"
                       onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                     <input type="hidden" name="token" value="{{ csrf_token('post_purge') }}">
-                    <button type="submit">
-                        <span>{{ 'purge'|trans }}</span>
+                    <button type="submit" class="btn btn__danger">
+                        <i class="fa fa-dumpster"></i> <span>{{ 'purge'|trans }}</span>
                     </button>
                 </form>
             </li>
@@ -42,7 +57,7 @@
                       method="post"
                       onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                     <input type="hidden" name="token" value="{{ csrf_token('change_magazine') }}">
-                    <input id="change_magazine_new_magazine" name="change_magazine[new_magazine]">
+                    <input id="change_magazine_new_magazine" required="required" name="change_magazine[new_magazine]">
                     <button type="submit" class="btn btn__secondary">
                         {{ 'change_magazine'|trans }}
                     </button>
@@ -52,20 +67,8 @@
         <li class="actions">
             {{ form_start(form, {action: path('post_change_lang', {magazine_name: magazine.name, post_id: post.id})}) }}
             {{ form_row(form.lang, {label: false, row_attr: {class: 'checkbox'}}) }}
-            {{ form_row(form.submit, {label: 'change_language'|trans|lower, attr: {class: 'btn btn__secondary'}}) }}
+            {{ form_row(form.submit, {label: 'change_language'|trans, attr: {class: 'btn btn__secondary'}}) }}
             {{ form_end(form) }}
-        </li>
-        <li class="actions">
-            <div class="checkbox">
-                <form action="{{ path('post_change_adult', {magazine_name: magazine.name, post_id: post.id}) }}"
-                      method="post"
-                      onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
-                    <input type="hidden" name="token" value="{{ csrf_token('change_adult') }}">
-                    <input name="adult"
-                           type="checkbox" {{ post.isAdult ? 'checked' : '' }}>
-                    <button type="submit">{{ 'is_adult'|trans }}</button>
-                </form>
-            </div>
         </li>
     </menu>
 </div>

--- a/templates/post/comment/_moderate_panel.html.twig
+++ b/templates/post/comment/_moderate_panel.html.twig
@@ -1,16 +1,31 @@
 <div class="section section--small moderate-panel">
     <menu>
         <li>
-            <a class="stretched-link"
-               href="{{ path('magazine_panel_ban', {'name': comment.magazine.name, 'username': comment.user.username}) }}">{{ 'ban'|trans }}</a>
+            <form action="{{ path('post_comment_change_adult', {magazine_name: magazine.name, post_id: post.id, comment_id: comment.id}) }}"
+                  method="post">
+                <input type="hidden" name="token" value="{{ csrf_token('change_adult') }}">
+                <input name="adult"
+                       type="hidden" value="{{ comment.isAdult ? 'off' : 'on' }}">
+                <button type="submit" class="btn btn__secondary">
+                    <i class="fa fa-{{ comment.isAdult ? 'eye' : 'eye-slash' }}"></i> <span>{{ comment.isAdult ? 'unmark_as_adult'|trans : 'mark_as_adult'|trans }}</span>
+                </button>
+            </form>
+        </li>
+        <li>
+            <form action="{{ path('magazine_panel_ban', {'name': comment.magazine.name, 'username': comment.user.username}) }}"
+                  method="get">
+                <button type="submit" class="btn btn__secondary">
+                    <i class="fa fa-ban"></i> <span>{{ 'ban'|trans }}</span>
+                </button>
+            </form>
         </li>
         <li>
             <form action="{{ post_comment_delete_url(comment) }}"
                   method="post"
                   onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                 <input type="hidden" name="token" value="{{ csrf_token('post_comment_delete') }}">
-                <button type="submit">
-                    <span>{{ 'delete'|trans }}</span>
+                <button type="submit" class="btn btn__secondary">
+                    <i class="fa fa-dumpster"></i> <span>{{ 'delete'|trans }}</span>
                 </button>
             </form>
         </li>
@@ -20,8 +35,8 @@
                       method="post"
                       onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
                     <input type="hidden" name="token" value="{{ csrf_token('post_comment_purge') }}">
-                    <button type="submit">
-                        <span>{{ 'purge'|trans }}</span>
+                    <button type="submit" class="btn btn__danger">
+                        <i class="fa fa-dumpster"></i> <span>{{ 'purge'|trans }}</span>
                     </button>
                 </form>
             </li>
@@ -29,20 +44,8 @@
         <li class="actions">
             {{ form_start(form, {action: path('post_comment_change_lang', {magazine_name: magazine.name, post_id: post.id, comment_id: comment.id})}) }}
             {{ form_row(form.lang, {label: false, row_attr: {class: 'checkbox'}}) }}
-            {{ form_row(form.submit, {label: 'change_language'|trans|lower, attr: {class: 'btn btn__secondary'}}) }}
+            {{ form_row(form.submit, {label: 'change_language'|trans, attr: {class: 'btn btn__secondary'}}) }}
             {{ form_end(form) }}
-        </li>
-        <li class="actions">
-            <div class="checkbox">
-                <form action="{{ path('post_comment_change_adult', {magazine_name: magazine.name, post_id: post.id, comment_id: comment.id}) }}"
-                      method="post"
-                      onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
-                    <input type="hidden" name="token" value="{{ csrf_token('change_adult') }}">
-                    <input name="adult"
-                           type="checkbox" {{ comment.isAdult ? 'checked' : '' }}>
-                    <button type="submit">{{ 'is_adult'|trans }}</button>
-                </form>
-            </div>
         </li>
     </menu>
 </div>

--- a/templates/post/comment/_moderate_panel.html.twig
+++ b/templates/post/comment/_moderate_panel.html.twig
@@ -1,4 +1,4 @@
-<div class="section section--small moderate-panel">
+<div class="moderate-panel">
     <menu>
         <li>
             <form action="{{ path('post_comment_change_adult', {magazine_name: magazine.name, post_id: post.id, comment_id: comment.id}) }}"

--- a/templates/post/comment/moderate.html.twig
+++ b/templates/post/comment/moderate.html.twig
@@ -20,6 +20,8 @@
             dateAsUrl: false,
         }) }}
         {% include 'layout/_flash.html.twig' %}
-        {% include 'post/comment/_moderate_panel.html.twig' %}
+        <div class="section section--small">
+          {% include 'post/comment/_moderate_panel.html.twig' %}
+        </div>
     </div>
 {% endblock %}

--- a/templates/post/moderate.html.twig
+++ b/templates/post/moderate.html.twig
@@ -21,6 +21,8 @@
             class: 'section--top',
         }) }}
         {% include 'layout/_flash.html.twig' %}
-        {% include 'post/_moderate_panel.html.twig' %}
+        <div class="section section--small">
+          {% include 'post/_moderate_panel.html.twig' %}
+        </div>
     </div>
 {% endblock %}

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -252,6 +252,8 @@ flash_thread_unpin_success: The thread has been successfully unpinned.
 flash_magazine_new_success: The magazine has been created successfully. You can now
   add new content or explore the magazine's administration panel.
 flash_magazine_edit_success: The magazine has been successfully edited.
+flash_thread_mark_as_adult_success: The thread has been successfully marked as NSFW.
+flash_thread_unmark_as_adult_success: The thread has been successfully unmarked as NSFW.
 too_many_requests: Limit exceeded, please try again later.
 set_magazines_bar: Magazines bar
 set_magazines_bar_desc: add the magazine names after the comma
@@ -317,6 +319,8 @@ pin: Pin
 unpin: Unpin
 change_magazine: Change magazine
 change_language: Change language
+mark_as_adult: Mark NSFW
+unmark_as_adult: Unmark NSFW
 change: Change
 pinned: Pinned
 preview: Preview

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -252,8 +252,8 @@ flash_thread_unpin_success: The thread has been successfully unpinned.
 flash_magazine_new_success: The magazine has been created successfully. You can now
   add new content or explore the magazine's administration panel.
 flash_magazine_edit_success: The magazine has been successfully edited.
-flash_thread_mark_as_adult_success: The thread has been successfully marked as NSFW.
-flash_thread_unmark_as_adult_success: The thread has been successfully unmarked as NSFW.
+flash_mark_as_adult_success: The post has been successfully marked as NSFW.
+flash_unmark_as_adult_success: The post has been successfully unmarked as NSFW.
 too_many_requests: Limit exceeded, please try again later.
 set_magazines_bar: Magazines bar
 set_magazines_bar_desc: add the magazine names after the comma


### PR DESCRIPTION
This changes the UX of the moderate panel shown for entry/post/entry comment/post comment. The initial design seemed a bit confusing; for example needing to check or uncheck the "18+ / NSFW" checkbox and then knowing that you had to click the label of the text to save the setting. There was also the fact that everything was a button, but styled so that you couldn't tell they were buttons.

Main changes:
- everything is now styled as buttons / input that the rest of the site has
  - things are definitely spaced out a bit more now, smaller views might flow over to new lines. I'm hesitant to put _too_ much effort in keeping things a single line, on mobile it will obviously be multiple. There might be ways to take elements out, I was especially thinking of pulling out some elements and showing/hiding with javascript like change magazine but don't want the moderate panel to require javascript
- reordered the elements, placing safer actions to the left. don't mind discussion on this. I tend to believe the easiest elements to click are on edges (left/right), so generally put more dangerous ones in the middle, but obviously screen size and such can change the order itself so trying for a specific order can be a headache
- change magazine text box has a placeholder of the magazine it is currently in just as a helpful reminder
- can no longer submit change magazine with a "" value, which caused a 500
- is_adult checkbox is now just a button that swaps between the two values (the checkbox is hidden and given the state of the reverse value of what it is)
  - removed the confirm prompt, it seems reversible enough that checking seemed overkill
- a popup that lets you know success on updating a thread as nsfw, maybe we want to use this flash message for all of the changes, but since I _think_ your settings might allow hiding nsfw, felt a popup just in case it disappeared from view would be helpful

How it looks now (as a global mod, it looks the same but the purge button is omitted, as a regular mod believe both purge and change magazine options are omitted):

- entry
![image](https://github.com/MbinOrg/mbin/assets/146029455/dba1c881-5ff6-451a-a86f-dfe1f932820b)
- post
![image](https://github.com/MbinOrg/mbin/assets/146029455/bf8d5db1-4020-4e8b-ae02-94fccbacd408)
- entry comment
![image](https://github.com/MbinOrg/mbin/assets/146029455/fadd7205-ba5a-487f-886a-33486a5789bb)
- post comment
![image](https://github.com/MbinOrg/mbin/assets/146029455/beb3b68f-15da-4b7f-918e-2495fee39044)
- mobile entry
![image](https://github.com/MbinOrg/mbin/assets/146029455/9fafa476-0c39-40df-ba1c-db49b4a74aa8)

<details>
<summary>iteration 1 (old):</summary>

- entry
![image](https://github.com/MbinOrg/mbin/assets/146029455/0f90f697-b197-4553-8824-920534d6e834)
- post
![image](https://github.com/MbinOrg/mbin/assets/146029455/4f3aef37-8b0c-4263-a5bb-c8d53accd2dd)
- entry comment
![image](https://github.com/MbinOrg/mbin/assets/146029455/7db8c5d1-575b-4e3e-8e97-c3b83de785b6)
- post comment
![image](https://github.com/MbinOrg/mbin/assets/146029455/005f55f4-e840-41af-bb40-6a90b5e888a4)

- updating nsfw flash message
![image](https://github.com/MbinOrg/mbin/assets/146029455/2de83b7d-fd09-4373-97c3-d1264d79f18b)
- mobile entry
![image](https://github.com/MbinOrg/mbin/assets/146029455/469cd353-fbf6-4980-a15e-78d6dfc8f195)
</details>

<details>
<summary>How it looked previously:</summary>

- entry
![image](https://github.com/MbinOrg/mbin/assets/146029455/c536d7c6-84db-4839-a385-aab8080b54bf)
- post
![image](https://github.com/MbinOrg/mbin/assets/146029455/60a4e8c4-be4c-4034-9999-add4a7f84f60)
- entry comment
![image](https://github.com/MbinOrg/mbin/assets/146029455/3212faa3-dd97-4049-8a92-5b3e16a11bc5)
- post comment
![image](https://github.com/MbinOrg/mbin/assets/146029455/7f1ce05f-f07c-43c0-b7dd-6304842caa1b)

- mobile entry
![image](https://github.com/MbinOrg/mbin/assets/146029455/cf887946-a169-46e4-817e-caf0a564f183)

</details>
