### PR TITLE
fetch previews only once per page load

### DIFF
--- a/assets/controllers/preview_controller.js
+++ b/assets/controllers/preview_controller.js
@@ -47,9 +47,8 @@ export default class extends Controller {
         event.preventDefault();
 
         if (this.containerTarget.hasChildNodes()) {
-            this.containerTarget.replaceChildren();
-            this.containerTarget.classList.add('hidden');
-            return
+            this.containerTarget.classList.toggle('hidden');
+            return;
         }
 
         try {

--- a/assets/controllers/preview_controller.js
+++ b/assets/controllers/preview_controller.js
@@ -75,7 +75,7 @@ export default class extends Controller {
                         data-action="preview#retry"
                         data-preview-url-param="${event.params.url}"
                         data-preview-ratio-param="${event.params.ratio}">
-                            Failed to load. Click to retry.
+                            Failed to load. Click here to retry.
                     </a>
                 </div>`
             this.containerTarget.innerHTML = failedHtml;


### PR DESCRIPTION
this is a simple change where, after clicking the preview button once, further clicking will only hide and show the content, with no further AJAX calls to fetch the content again. If it fails, it will act as it did before showing a click to retry prompt (clicking preview will hide and show this prompt, but clicking on the prompt itself works to refetch the content)

@asdfzdfj since you touched the preview stuff recently, want to check with you that this makes sense

edit: tested this with asdfzdfj's example post of linked youtube with 2 image inlines and it appears to work, fetched each preview only once and correctly hid/made visible the previews after that