### PR TITLE
Fix doctrine migration diff for remember me table

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -42,6 +42,8 @@ security:
                 secret: '%kernel.secret%'
                 lifetime: 604800
                 path: /
+                token_provider:
+                    doctrine: true
             two_factor:
                 auth_form_path: 2fa_login
                 check_path: 2fa_login_check


### PR DESCRIPTION
Fix DB Migration diff command regarding remember me table. 

Before the `php bin/console doctrine:migrations:diff` command generated a new migration file with `$this->addSql('DROP TABLE rememberme_token');` etc. Since there was already a correct migration file in place, we do not need to change anything else, except setting this boolean.

More info: https://symfony.com/doc/current/security/remember_me.html#storing-remember-me-tokens-in-the-database