### PR TITLE
fix media preview for crossposted entry component

### DIFF
--- a/assets/styles/components/_entry.scss
+++ b/assets/styles/components/_entry.scss
@@ -419,6 +419,7 @@
 
 .entry-cross {
   grid-template-areas: "vote meta"
+                       "preview preview"
                        "moderate moderate" !important;
   grid-template-columns: min-content 1fr !important;
   margin-top: -.5rem;
@@ -441,6 +442,12 @@
     margin-right: 0 !important;
   }
 
+  @include media-breakpoint-down(sm) {
+    .vote {
+      margin-left: var(--kbin-entry-element-spacing) !important;
+    }
+  }
+
   footer {
     margin-bottom: 0;
   }
@@ -453,6 +460,10 @@
     align-self: center;
     margin-left: 0;
     margin-bottom: 0 !important;
+  }
+
+  .entry__preview {
+    opacity: 1.0;
   }
 }
 

--- a/templates/components/entry_cross.html.twig
+++ b/templates/components/entry_cross.html.twig
@@ -161,6 +161,7 @@
             </div>
         </footer>
     </aside>
+    <aside class="meta entry__preview hidden" data-preview-target="container"></aside>
     {% if not app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_THUMBNAILS')) or app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_THUMBNAILS')) is same as 'true' %}
     {% endif %}
     {% if entry.visibility in ['visible', 'private'] %}


### PR DESCRIPTION
fix media preview in crossposted entry not working by adding a missing preview container target in crossposted panel that mbin preview controller uses.