### PR TITLE
recognize `image/webp` and some more media type as image

### DIFF
--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -15,8 +15,12 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class ImageManager
 {
-    public const IMAGE_MIMETYPES = ['image/jpeg', 'image/jpg', 'image/gif', 'image/png'];
-    public const IMAGE_MIMETYPE_STR = 'image/jpeg, image/jpg, image/gif, image/png';
+    public const IMAGE_MIMETYPES = [
+        'image/jpeg', 'image/jpg', 'image/gif', 'image/png',
+        'image/jxl', 'image/heic', 'image/heif',
+        'image/webp', 'image/avif',
+    ];
+    public const IMAGE_MIMETYPE_STR = 'image/jpeg, image/jpg, image/gif, image/png, image/jxl, image/heic, image/heif, image/webp, image/avif';
     public const MAX_IMAGE_BYTES = 6000000;
 
     public function __construct(
@@ -101,7 +105,7 @@ class ImageManager
                     'timeout' => 5,
                     'max_duration' => 5,
                     'headers' => [
-                        'Accept' => implode(', ', self::IMAGE_MIMETYPES),
+                        'Accept' => implode(', ', array_diff(self::IMAGE_MIMETYPES, ['image/webp', 'image/avif'])),
                     ],
                     'on_progress' => function (int $downloaded, int $downloadSize) {
                         if (
@@ -122,7 +126,7 @@ class ImageManager
 
             $this->validate($tempFile);
         } catch (\Exception $e) {
-            if ($fh) {
+            if ($fh && \is_resource($fh)) {
                 fclose($fh);
             }
             unlink($tempFile);


### PR DESCRIPTION
recognize the following image format as an image type in addition to existing types:
- `image/webp`
- `image/avif`
- `image/jxl`
- `image/heic`
- `image/heif`

`image/webp` and `image/avif` are not used in `Accept` header when downloading source images to prevent all sorts of automatic conversion for non webp/avif image delivery to take place, downloading webp/avif link would still results in webp/avif images anyway.

(ahh, webp, what a cursed format: everyone wants to serve them but rarely anyone wants to receive them, and this is currently no exception)