### PR TITLE
provide markdown body `source` property in AP entries/posts

### DIFF
--- a/src/Factory/ActivityPub/EntryCommentNoteFactory.php
+++ b/src/Factory/ActivityPub/EntryCommentNoteFactory.php
@@ -68,6 +68,10 @@ class EntryCommentNoteFactory
             ],
             'content' => $this->markdownConverter->convertToHtml($comment->body, [MarkdownConverter::RENDER_TARGET => RenderTarget::ActivityPub]),
             'mediaType' => 'text/html',
+            'source' => $comment->body ? [
+                'content' => $comment->body,
+                'mediaType' => 'text/markdown',
+            ] : null,
             'url' => $this->getActivityPubId($comment),
             'tag' => array_merge(
                 $this->tagsWrapper->build($tags),

--- a/src/Factory/ActivityPub/EntryPageFactory.php
+++ b/src/Factory/ActivityPub/EntryPageFactory.php
@@ -74,6 +74,10 @@ class EntryPageFactory
                 array_map(fn ($val) => '#'.$val, $tags)
             ),
             'mediaType' => 'text/html',
+            'source' => $entry->body ? [
+                'content' => $entry->body,
+                'mediaType' => 'text/markdown',
+            ] : null,
             'url' => $this->getUrl($entry),
             'tag' => array_merge(
                 $this->tagsWrapper->build($tags),

--- a/src/Factory/ActivityPub/PostCommentNoteFactory.php
+++ b/src/Factory/ActivityPub/PostCommentNoteFactory.php
@@ -71,6 +71,10 @@ class PostCommentNoteFactory
                 [MarkdownConverter::RENDER_TARGET => RenderTarget::ActivityPub],
             ),
             'mediaType' => 'text/html',
+            'source' => $comment->body ? [
+                'content' => $comment->body,
+                'mediaType' => 'text/markdown',
+            ] : null,
             'url' => $this->getActivityPubId($comment),
             'tag' => array_merge(
                 $this->tagsWrapper->build($tags),

--- a/src/Factory/ActivityPub/PostNoteFactory.php
+++ b/src/Factory/ActivityPub/PostNoteFactory.php
@@ -49,6 +49,11 @@ class PostNoteFactory
             $tags[] = $post->magazine->name;
         }
 
+        $body = $this->tagManager->joinTagsToBody(
+            $post->body,
+            $tags
+        );
+
         $note = array_merge($note ?? [], [
             'id' => $this->getActivityPubId($post),
             'type' => 'Note',
@@ -70,13 +75,14 @@ class PostNoteFactory
             'sensitive' => $post->isAdult(),
             'stickied' => $post->sticky,
             'content' => $this->markdownConverter->convertToHtml(
-                $this->tagManager->joinTagsToBody(
-                    $post->body,
-                    $tags
-                ),
+                $body,
                 [MarkdownConverter::RENDER_TARGET => RenderTarget::ActivityPub],
             ),
             'mediaType' => 'text/html',
+            'source' => $post->body ? [
+                'content' => $body,
+                'mediaType' => 'text/markdown',
+            ] : null,
             'url' => $this->getActivityPubId($post),
             'tag' => array_merge(
                 $this->tagsWrapper->build($tags),


### PR DESCRIPTION
add `source` property to AP entries/posts objects when the entries/posts body exist, with `content` being the object's markdown body and `mediaType` being `text/markdown`

I was planning to combine this changes with ingesting incoming objects' `source` property but there were some complications on that part so I decided to get this change out first as it seems more simpler