### PR TITLE
accept image attachment with appropiate mediaType set

### DIFF
--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -283,7 +283,7 @@ class ActivityPubManager
     {
         $images = array_filter(
             $attachment,
-            fn ($val) => \in_array($val['type'], ['Document', 'Image']) && ImageManager::isImageUrl($val['url'])
+            fn ($val) => $this->isImageAttachment($val)
         ); // @todo multiple images
 
         if (\count($images)) {
@@ -420,7 +420,7 @@ class ActivityPubManager
     {
         $images = array_filter(
             $attachment,
-            fn ($val) => \in_array($val['type'], ['Document', 'Image']) && ImageManager::isImageUrl($val['url'])
+            fn ($val) => $this->isImageAttachment($val)
         );
 
         array_shift($images);
@@ -471,5 +471,19 @@ class ActivityPubManager
         }
 
         return $this->updateMagazine($actorUrl);
+    }
+
+    private function isImageAttachment(array $object): bool
+    {
+        // attachment object has acceptable object type
+        if (!\in_array($object['type'], ['Document', 'Image'])) {
+            return false;
+        }
+
+        // attachment is either:
+        // - has `mediaType` field and is a recognized image types
+        // - image url looks like a link to image
+        return (!empty($object['mediaType']) && ImageManager::isImageType($object['mediaType']))
+            || ImageManager::isImageUrl($object['url']);
     }
 }

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -37,6 +37,11 @@ class ImageManager
         return \in_array($urlExt, $types);
     }
 
+    public static function isImageType(string $mediaType): bool
+    {
+        return \in_array($mediaType, self::IMAGE_MIMETYPES);
+    }
+
     public function store(string $source, string $filePath): bool
     {
         $fh = fopen($source, 'rb');


### PR DESCRIPTION
adjusted federated image handling to also accept image attachments with `mediaType` with known/recognized image formats

apparently it's possible to have image attachment where the image link points to hash/uuid shaped link without image extention, but also have `mediaType` field set to a (possibly recognized) image type, which would results in these posts to be dropped or missing their attached images

sample that I happened to encounter:
```jsonc
{
  "@context": [ /* snipped */ ],
  "type": "Note",
  "attachment": [
    {
      "mediaType": "image/jpeg",
      "name": "",
      "type": "Document",
      /* note that the image url doesn't have image extension but have `mediaType` set */
      "url": "https://media.instance.tld/13ee6d6408ab9730380d64e96e16b9c634fcc3c8be4c16e6bd1294876f66e2e1.44205B5D-D0B2-42AA-B742-6D399DD5915A"
    },
    {
      "mediaType": "image/jpeg",
      "name": "",
      "type": "Document",
      "url": "https://media.instance.tld/a3c604513b4c1ab82b26ef1bb85f2ca617b2f640e7b2767020ac8f1af8661567.B3B5D088-BA84-4456-BBD7-99BDCF858758"
    }
  ],
}
```