### PR TITLE
hide more drop down menu after clicking moderate

### DIFF
--- a/assets/controllers/subject_controller.js
+++ b/assets/controllers/subject_controller.js
@@ -211,10 +211,25 @@ export default class extends Controller {
         }
     }
 
+    /**
+     * hideDropdownMenu is a helper to close drop down menus via a small
+     * hack of hiding it temporarily to cancel :hover states and bringing
+     * it back after. Hiding and showing too quickly results in the :hover
+     * state remaining in effect
+     */
+    async hideDropdownMenu(element) {
+      let dropdownMenu = this.element.querySelector('.dropdown .dropdown__menu');
+      dropdownMenu.classList.add('hidden');
+      await new Promise(r => setTimeout(r, 500));
+      dropdownMenu.classList.remove('hidden');
+    }
+
     async showModPanel(event) {
         event.preventDefault();
 
-        let container = this.element.querySelector('.moderate-inline')
+        this.hideDropdownMenu(this.element);
+
+        let container = this.element.querySelector('.moderate-inline');
         if (null !== container) {
             // moderate panel was already added to this post, toggle
             // hidden on it to show/hide it and exit


### PR DESCRIPTION
this is a small JS hack to make it so clicking moderate in the drop down hides the drop down, sleeps for 500ms, and then makes it non-hidden again (but it will be hidden because the mouse is no longer hovering over it)

@asdfzdfj if this is too crazy let me know and I can just close this, haha, I tried all sorts of things like `blur()` and `z-index` and everything. I don't want to _break_ the dropdown but since it's all CSS driven there isn't really a way to get CSS to stop CSSing, ya know, or rather if you're hovering over something with a hover state it just wants to stay that way. maybe I could make clicking the button takeover your mouse and throw it far away (this is a joke)

---

I want to do the same to report but looking at the report panel, it looks like I want to redo the UX for that as well to make it clearer: what you're reporting, who you're reporting to, why you're reporting it (predefined options). which may or may not be related to the issue we have to get remote reporting working