### PR TITLE
remove owner listing from magazine box

### DIFF
--- a/templates/components/magazine_box.html.twig
+++ b/templates/components/magazine_box.html.twig
@@ -38,9 +38,7 @@
             <li>{{ 'created_at'|trans }}:
                 {{ component('date', {date: computed.magazine.createdAt}) }}
             </li>
-            <li>{{ 'owner'|trans }}: <span>{{ component('user_inline', {user: computed.magazine.owner}) }}</span></li>
             <li>{{ 'subscribers'|trans }}: <span>{{ computed.magazine.subscriptionsCount }}</span></li>
-            <li>{{ 'online'|trans }}: <span>-</span></li>
         </ul>
     {% endif %}
     {% if showMeta %}


### PR DESCRIPTION
information is redundant as they appear in moderators unless they are the admin and it's a remote mag, which is already implied they have total control of the instance

this is also the component used when searching up a magazine. I thought it'd be used in more places but this is the only instance of `'owner'|trans` and `magazine.owner` in the project

owner continues to not have a delete button on the magazine moderators list page

remove placeholder online in magazine, not sure if online makes sense as a status for a magazine

<details>
<summary>remote mag before/after</summary>

before:
![image](https://github.com/MbinOrg/mbin/assets/146029455/7c9b57b4-56fa-499f-832f-dc92a2260ed4)

after:
![image](https://github.com/MbinOrg/mbin/assets/146029455/0bb0cd2e-aed9-40bd-9163-64f70a6a8f04)

</details>


<details>
<summary>local mag before/after</summary>

before:
![image](https://github.com/MbinOrg/mbin/assets/146029455/efc8c3e1-de43-48f6-96be-3790203aa385)

after:
![image](https://github.com/MbinOrg/mbin/assets/146029455/c12a393d-f491-48d0-a284-28ae69ba5504)

</details>

follow up to #235 