### PR TITLE
remove online placeholders

### DIFF
--- a/templates/entry/_info.html.twig
+++ b/templates/entry/_info.html.twig
@@ -17,7 +17,6 @@
     <ul class="info">
         <li>{{ 'added'|trans }}: {{ component('date', {date: entry.createdAt}) }}</li>
         <li>{{ 'views'|trans }}: <span>{{ entry.views }}</span></li>
-        <li>{{ 'online'|trans }}: <span>-</span></li>
         <li>{{ 'ratio'|trans }}:
             <span>{{ entry.countUpvotes }} {% if entry.countUpvotes %}({{ (entry.countUpvotes / entry.countVotes)|format_percent_number }}){% endif %}</span>
         </li>

--- a/templates/post/_info.html.twig
+++ b/templates/post/_info.html.twig
@@ -16,7 +16,6 @@
     {{ component('user_actions', {user: post.user}) }}
     <ul class="info">
         <li>{{ 'added'|trans }}: {{ component('date', {date: post.createdAt}) }}</li>
-        <li>{{ 'online'|trans }}: <span>-</span></li>
         <li>{{ 'up_votes'|trans }}:
             <span>{{ post.countUpvotes }}</span>
         </li>


### PR DESCRIPTION
this removes the `Online: -` that appears in user boxes in a thread or specific microblog post page, the one for magazines was removed in #307 

this isn't to say there can be no plans to ever implement online status if someone wants to pick that up / work on it / discuss it, this is only to clean the frontend up from currently unimplemented features

after screenshots

![image](https://github.com/MbinOrg/mbin/assets/146029455/913e9c25-b663-4e48-9bb4-24e1d443e7d4)
![image](https://github.com/MbinOrg/mbin/assets/146029455/f36ecce9-0848-4f02-bac2-4d73ec7f06dc)
