### PR TITLE
fix clearing ap cache of local magazines

### DIFF
--- a/src/EventSubscriber/ActivityPub/MagazineModeratorAddedRemovedSubscriber.php
+++ b/src/EventSubscriber/ActivityPub/MagazineModeratorAddedRemovedSubscriber.php
@@ -52,6 +52,10 @@ class MagazineModeratorAddedRemovedSubscriber implements EventSubscriberInterfac
 
     private function deleteCache(Magazine $magazine): void
     {
+        if (!$magazine->apId) {
+          return;
+        }
+
         try {
             $this->cache->delete('ap_'.hash('sha256', $magazine->apProfileId));
             $this->cache->delete('ap_'.hash('sha256', $magazine->apId));

--- a/src/EventSubscriber/ActivityPub/MagazineModeratorAddedRemovedSubscriber.php
+++ b/src/EventSubscriber/ActivityPub/MagazineModeratorAddedRemovedSubscriber.php
@@ -53,7 +53,7 @@ class MagazineModeratorAddedRemovedSubscriber implements EventSubscriberInterfac
     private function deleteCache(Magazine $magazine): void
     {
         if (!$magazine->apId) {
-          return;
+            return;
         }
 
         try {


### PR DESCRIPTION
right now accepting a moderator request or deleting a moderator for a local magazine results in a 500:

```
hash(): Argument #2 ($data) must be of type string, null given
in [src/EventSubscriber/ActivityPub/MagazineModeratorAddedRemovedSubscriber.php ](file:///var/www/mbin/src/EventSubscriber/ActivityPub/MagazineModeratorAddedRemovedSubscriber.php#L57)(line 57)
$this->cache->delete('ap_'.hash('sha256', $magazine->apId));
```