### PR TITLE
hide moderator delete button in remote situations

### DIFF
--- a/src/EventSubscriber/ActivityPub/MagazineModeratorAddedRemovedSubscriber.php
+++ b/src/EventSubscriber/ActivityPub/MagazineModeratorAddedRemovedSubscriber.php
@@ -52,6 +52,10 @@ class MagazineModeratorAddedRemovedSubscriber implements EventSubscriberInterfac
 
     private function deleteCache(Magazine $magazine): void
     {
+        if (!$magazine->apId) {
+          return;
+        }
+
         try {
             $this->cache->delete('ap_'.hash('sha256', $magazine->apProfileId));
             $this->cache->delete('ap_'.hash('sha256', $magazine->apId));

--- a/src/EventSubscriber/ActivityPub/MagazineModeratorAddedRemovedSubscriber.php
+++ b/src/EventSubscriber/ActivityPub/MagazineModeratorAddedRemovedSubscriber.php
@@ -53,11 +53,7 @@ class MagazineModeratorAddedRemovedSubscriber implements EventSubscriberInterfac
     private function deleteCache(Magazine $magazine): void
     {
         if (!$magazine->apId) {
-<<<<<<< HEAD
-          return;
-=======
             return;
->>>>>>> origin
         }
 
         try {

--- a/templates/magazine/_moderators_list.html.twig
+++ b/templates/magazine/_moderators_list.html.twig
@@ -11,7 +11,7 @@
                     </a>
                     <small>{{ component('date', {date: moderator.createdAt}) }}</small>
                 </div>
-                {% if is_granted('edit', magazine) and not moderator.isOwner %}
+                {% if is_granted('edit', magazine) and not moderator.isOwner and (magazine.apId is same as null or moderator.user.apId is same as null) %}
                     <div class="actions">
                         <form method="post"
                               action="{{ path('magazine_panel_moderator_purge', {magazine_name: magazine.name, moderator_id: moderator.id}) }}"


### PR DESCRIPTION
only show the delete moderator button for local magazines or local users

deleting local moderators from remote magazines may not work completely as the AP events might need more ironing out, but worst cast it might readd the local moderator if the source doesn't accept the request

followup to #235