### PR TITLE
version bump from 1.1.0 to 1.2.0

### DIFF
--- a/src/Factory/ActivityPub/NodeInfoFactory.php
+++ b/src/Factory/ActivityPub/NodeInfoFactory.php
@@ -11,7 +11,7 @@ class NodeInfoFactory
 {
     private const NODE_PROTOCOL = 'activitypub';
     private const MBIN_REPOSITORY_URL = 'https://github.com/MbinOrg/mbin';
-    private const MBIN_VERSION = '1.1.0'; // TODO: Should come from git tags?
+    private const MBIN_VERSION = '1.2.0'; // TODO: Should come from git tags?
 
     public function __construct(
         private readonly StatsContentRepository $repository,


### PR DESCRIPTION
Was planning to add this to release notes. Let me know thoughts on if this is a bad idea (like should go in a changelog) or if I missed anything, there were obviously a lot of changes but I find it hard to put some of them into words, like improving markdown parsing, fixing thumbnails, fixing previews, and such. Perhaps we should use milestones if you can link PRs to them, because it'd be nice if I could just link to all enhancements after the 1.1.0 tag

---

| DB migrations | New ENV vars | Will log users out |
| :-----------: | :-----------: | :-----------: |
| :ballot_box_with_check:   | :ballot_box_with_check: | :ballot_box_with_check: |

Major Features

- exiftool image cleaning
  - By default, if exiftool is found, sanitize local uploads of GPS data
  - Can be configured via env vars to turn off / scrub more details / work on external images
- Subscriber counts now populated from source magazines
- Implementation of [FEP-1b12](https://codeberg.org/fediverse/fep/src/branch/main/fep/1b12/fep-1b12.md)
  - Moderators will now appear from AP software that implement linked FEP
  - Likewise, Mbin moderators will now appear for other software that implement it
- New indexes for reducing DB CPU usage