### PR TITLE
2fa - handle form errors with visible error and log

### DIFF
--- a/src/Controller/User/Profile/User2FAController.php
+++ b/src/Controller/User/Profile/User2FAController.php
@@ -188,7 +188,10 @@ class User2FAController extends AbstractController
         }
 
         if (!$form->isValid()) {
-            $this->logger->warning('2fa an error occurred submitting the form "{errors}"', ['errors' => $form->getErrors()]);
+            $this->logger->warning('2fa error occurred user "{username}" submitting the form "{errors}"', [
+                'username' => $dto->username,
+                'errors' => $form->getErrors(),
+            ]);
             $form->get('totpCode')->addError(new FormError($this->translator->trans('2fa.setup_error')));
 
             return $form;

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -673,6 +673,7 @@ two_factor_backup: Two-factor authentication backup codes
 2fa.authentication_code.label: Authentication Code
 2fa.verify: Verify
 2fa.code_invalid: The authentication code is not valid
+2fa.setup_error: Error enabling 2FA for account
 2fa.enable: Setup two-factor authentication
 2fa.disable: Disable two-factor authentication
 2fa.backup: Your two-factor backup codes


### PR DESCRIPTION
this handles the situation when the form is considered invalid for any reason by showing an error message to the user and logging to the log file.

![image](https://github.com/MbinOrg/mbin/assets/146029455/9f868b2b-5b04-4519-a39d-b999560ed12d)

log example:

```
[2023-11-29T03:44:18.462966+00:00] app.WARNING: 2fa error occurred user "admin" submitting the form "ERROR: This value is not a valid email address.
" {"username":"admin","errors":{"Symfony\\Component\\Form\\FormErrorIterator":"ERROR: This value is not a valid email address.
"}} []
```

fixes #305

"fixes" as in now displays an error message and logs the output. I think there's still the open question as to _why_ users hit this. I couldn't quite figure this out myself, as the error above shows it says email is not valid, which is true, but I have no idea what that has to do with 2fa. The form interface being submitted, `UserTwoFactorType`, does not appear to contain email address. Might need to bring in someone with more php / experience with the DTO relationships here