### PR TITLE
2fa - add active style to 2fa pages in user settings

### DIFF
--- a/templates/user/settings/_options.html.twig
+++ b/templates/user/settings/_options.html.twig
@@ -21,7 +21,7 @@
         </li>
         <li>
             <a href="{{ path('user_settings_password') }}"
-               class="{{ html_classes({'active': is_route_name('user_settings_password')}) }}">
+               class="{{ html_classes({'active': is_route_name('user_settings_password') or is_route_name_starts_with('user_settings_2fa')}) }}">
                 {{ 'password_and_2fa'|trans }}
             </a>
         </li>


### PR DESCRIPTION
adds the active style to `Password & 2fa` when on the 2fa routes, mainly the setup and get new backup code pages, the other 2 routes are showing the qr code or disabling it

![image](https://github.com/MbinOrg/mbin/assets/146029455/593f5e0b-248d-4267-9520-2cab557d10fc)
![image](https://github.com/MbinOrg/mbin/assets/146029455/b2864cf1-38e3-416d-bf6b-fd65f291319c)
