### PR TITLE
add form error to 2fa form

### DIFF
--- a/src/Controller/User/Profile/User2FAController.php
+++ b/src/Controller/User/Profile/User2FAController.php
@@ -188,11 +188,8 @@ class User2FAController extends AbstractController
         }
 
         if (!$form->isValid()) {
-            $this->logger->warning('2fa error occurred user "{username}" submitting the form "{errors}"', [
-                'username' => $dto->username,
-                'errors' => $form->getErrors(),
-            ]);
             $form->get('totpCode')->addError(new FormError($this->translator->trans('2fa.setup_error')));
+            $form->get('totpCode')->addError(new FormError((string) $form->getErrors()));
 
             return $form;
         }


### PR DESCRIPTION
this removes the error log and instead just puts it on the form

at first I was hesitant because:
- I'm not sure all of what error values this will display, though I doubt symfony would JS inject an error on us, no idea if they'll make any sense. like the one in the image makes no sense given only the context of the form
- it's not translated, but that's true of a lot of our symfony form errors. for instance if you try to submit a thread with no body it will say body is required but only in english
- not sure this is the best way to add form errors, there seems to be about a couple dozen that have changed over 7 years. tried all sorts of `foreach` and `->getMessage()`. Most failed except this

![image](https://github.com/MbinOrg/mbin/assets/146029455/c2050568-b83f-44b1-b02f-7d01e1e4de13)

related #305
