### PR TITLE
Changes to report links and magazine report fix

### DIFF
--- a/src/Repository/MagazineRepository.php
+++ b/src/Repository/MagazineRepository.php
@@ -260,7 +260,7 @@ class MagazineRepository extends ServiceEntityRepository
         $dql = 'SELECT r FROM '.Report::class.' r WHERE r.magazine = :magazine';
 
         if (Report::STATUS_ANY !== $status) {
-            $dql .= ' AND WHERE r.status = :status';
+            $dql .= ' AND r.status = :status';
         }
 
         $dql .= " ORDER BY CASE WHEN r.status = 'pending' THEN 1 ELSE 2 END, r.weight DESC, r.createdAt DESC";

--- a/templates/admin/_options.html.twig
+++ b/templates/admin/_options.html.twig
@@ -2,6 +2,7 @@
 {%- set TYPE_CONTENT = constant('App\\Repository\\StatsRepository::TYPE_CONTENT') -%}
 {%- set TYPE_VIEWS = constant('App\\Repository\\StatsRepository::TYPE_VIEWS') -%}
 {%- set TYPE_VOTES = constant('App\\Repository\\StatsRepository::TYPE_VOTES') -%}
+{%- set STATUS_PENDING = constant('App\\Entity\\Report::STATUS_PENDING') -%}
 <aside class="options options--top" id="options">
     <div></div>
     <menu class="options__main">
@@ -24,7 +25,7 @@
             </a>
         </li>
         <li>
-            <a href="{{ path('admin_reports') }}"
+            <a href="{{ path('admin_reports', {status: STATUS_PENDING}) }}"
                class="{{ html_classes({'active': is_route_name('admin_reports')}) }}">
                 {{ 'reports'|trans }}
             </a>

--- a/templates/components/report_list.html.twig
+++ b/templates/components/report_list.html.twig
@@ -7,12 +7,6 @@
 <div class="pills">
     <menu>
         <li>
-            <a href="{{ path(routeName, {name: magazineName}) }}"
-               class="{{ html_classes({'active': route_has_param('status', REPORT_ANY)}) }}">
-                {{ 'all'|trans }}
-            </a>
-        </li>
-        <li>
             <a href="{{ path(routeName, {status: REPORT_PENDING, name: magazineName}) }}"
                class="{{ html_classes({'active': route_has_param('status', REPORT_PENDING)}) }}">
                 {{ 'pending'|trans }}
@@ -28,6 +22,12 @@
             <a href="{{ path(routeName, {status: REPORT_REJECTED, name: magazineName}) }}"
                class="{{ html_classes({'active': route_has_param('status', REPORT_REJECTED)}) }}">
                 {{ 'rejected'|trans }}
+            </a>
+        </li>
+        <li>
+            <a href="{{ path(routeName, {name: magazineName}) }}"
+               class="{{ html_classes({'active': route_has_param('status', REPORT_ANY)}) }}">
+                {{ 'all'|trans }}
             </a>
         </li>
     </menu>

--- a/templates/layout/_header.html.twig
+++ b/templates/layout/_header.html.twig
@@ -1,3 +1,4 @@
+{%- set STATUS_PENDING = constant('App\\Entity\\Report::STATUS_PENDING') -%}
 <header id="header" class="header">
     <div class="kbin-container
           {{ html_classes(app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH'))
@@ -188,7 +189,7 @@
                         {% endif %}
                         {% if is_granted('ROLE_MODERATOR') %}
                             <li>
-                                <a href="{{ path('admin_reports') }}"
+                                <a href="{{ path('admin_reports', {status: STATUS_PENDING}) }}"
                                    class="{{ html_classes({'active': is_route_name_starts_with('admin')}) }}">
                                     {{ 'reports'|trans }}
                                 </a>

--- a/templates/magazine/panel/_options.html.twig
+++ b/templates/magazine/panel/_options.html.twig
@@ -1,3 +1,4 @@
+{%- set STATUS_PENDING = constant('App\\Entity\\Report::STATUS_PENDING') -%}
 <aside class="options options--top options-activity" id="options">
     <div class="options__title">
         <h2>{{ 'magazine_panel'|trans }}</h2>
@@ -10,7 +11,7 @@
             </a>
         </li>
         <li>
-            <a href="{{ path('magazine_panel_reports', {name: magazine.name}) }}"
+            <a href="{{ path('magazine_panel_reports', {name: magazine.name, status: STATUS_PENDING}) }}"
                class="{{ html_classes({'active': is_route_name('magazine_panel_reports')}) }}">
                 {{ 'reports'|trans }}
             </a>
@@ -64,33 +65,4 @@
             </a>
         </li>
     </menu>
-    {% if is_route_name('magazine_panel_reports') %}
-        <menu class="options__filters">
-            <li class="dropdown">
-                <button aria-label="{{ 'filter_by_time'|trans }}"
-                        title="{{ 'filter_by_time'|trans }}"><i
-                            class="fa-solid fa-filter"></i> {{ 'filters'|trans }}</button>
-                <ul class="dropdown__menu">
-                    <li>
-                        <a href=""
-                           class="active">
-                            {{ 'all'|trans }}
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#"
-                           class="">
-                            {{ 'approved'|trans }}
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#"
-                           class="">
-                            {{ 'rejected'|trans }}
-                        </a>
-                    </li>
-                </ul>
-            </li>
-        </menu>
-    {% endif %}
 </aside>


### PR DESCRIPTION
- change report links to go to pending route
- move pending to far left and all to far right
- remove non-functional filter
- fix duplicate where clause

I found the default page landing on all reports to be fairly useless, generally I think you're going to care about pending reports rather than all reports ever made. Instead of changing the default in routing (which I think would change say `/reports` to be pending and `/reports/all` to exist which might break history), I changed the links that go to reports to go to `/pending` instead. I also rearranged the menu items to be: Pending, Accepted, Rejected, All

This also fixes a 500 error when viewing magazine reports for accepted/pending/rejected that I noticed while making this change

![image](https://github.com/MbinOrg/mbin/assets/146029455/620b66bf-a651-4dd4-9c5e-95bd99f99a1b)
