### PR TITLE
Add an edit my profile button to your own user profile pages

### DIFF
--- a/templates/components/user_actions.html.twig
+++ b/templates/components/user_actions.html.twig
@@ -34,5 +34,9 @@
             </button>
             <input type="hidden" name="token" value="{{ csrf_token('block') }}">
         </form>
+    {% elseif app.user is same as user and is_route_name_starts_with('user') and not is_route_name_contains('settings') %}
+        <a href="{{ path('user_settings_profile') }}" title="{{ 'edit_my_profile'|trans }}" aria-label="{{ 'edit_my_profile'|trans }}">
+            <button class="btn btn__secondary">{{ 'edit_my_profile'|trans }}</button>
+        </a>
     {% endif %}
 </aside>

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -740,6 +740,7 @@ page_width_fixed: Fixed
 open_url_to_fediverse: Open original URL
 change_my_avatar: Change my avatar
 change_my_cover: Change my cover
+edit_my_profile: Edit my profile
 account_settings_changed: Your account settings have been successfully changed. You
   will need to login again.
 magazine_deletion: Magazine deletion


### PR DESCRIPTION
This adds a button "Edit my profile" to the user actions when viewing your own profile on the user profile pages. Does not appear in actions for yourself when viewed on settings or people pages (matching the edit my avatar/edit my cover quick links that were added in the past)

![image](https://github.com/MbinOrg/mbin/assets/146029455/463c69b3-1db6-46c4-963b-6b0907f08d89)

fixes #69

felt like this satisfies the conditions to make it easier to get to the profile settings section of the site, this is similar to github now where viewing your own profile allows you to click your avatar to go to where to change it and there's an edit profile button below it for the same