### PR TITLE
change AP as:Hashtag text property key to 'name'

### DIFF
--- a/src/Service/ActivityPub/Wrapper/TagsWrapper.php
+++ b/src/Service/ActivityPub/Wrapper/TagsWrapper.php
@@ -21,7 +21,7 @@ class TagsWrapper
                 ['name' => $tag],
                 UrlGeneratorInterface::ABSOLUTE_URL
             ),
-            'tag' => '#'.$tag,
+            'name' => '#'.$tag,
         ], $tags);
     }
 }


### PR DESCRIPTION
changed the property of `as:Hashtag` object that contains tag's label from `tag` to `name` to be more consistent with other software

compared to how other software (specifically, mastodon and akkoma) does tags in AP representation, they use `name` property to put the tag's label in but mbin/kbin was using `tag` property for some reason, and from what I could see from git blame, it switched between `name` and `tag` a few times