### PR TITLE
add some missing contexts for AP/json-ld output

### DIFF
--- a/src/Controller/ActivityPub/User/UserOutboxController.php
+++ b/src/Controller/ActivityPub/User/UserOutboxController.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Controller\ActivityPub\User;
 
 use App\Controller\AbstractController;
+use App\Entity\Contracts\ActivityPubActivityInterface;
 use App\Entity\User;
-use App\Factory\ActivityPub\PostNoteFactory;
 use App\Repository\UserRepository;
 use App\Service\ActivityPub\Wrapper\CollectionInfoWrapper;
 use App\Service\ActivityPub\Wrapper\CollectionItemsWrapper;
@@ -85,7 +85,7 @@ class UserOutboxController extends AbstractController
             $activity,
             $items,
             $page,
-            PostNoteFactory::ADDITIONAL_CONTEXTS
+            ActivityPubActivityInterface::ADDITIONAL_CONTEXTS
         );
     }
 }

--- a/src/Controller/ActivityPub/User/UserOutboxController.php
+++ b/src/Controller/ActivityPub/User/UserOutboxController.php
@@ -61,13 +61,13 @@ class UserOutboxController extends AbstractController
     }
 
     #[ArrayShape([
-     '@context' => 'string',
-     'type' => 'string',
-     'partOf' => 'string',
-     'id' => 'string',
-     'totalItems' => 'int',
-     'orderedItems' => 'array',
- ])]
+        '@context' => 'string',
+        'type' => 'string',
+        'partOf' => 'string',
+        'id' => 'string',
+        'totalItems' => 'int',
+        'orderedItems' => 'array',
+    ])]
     private function getCollectionItems(
         User $user,
         int $page
@@ -85,7 +85,7 @@ class UserOutboxController extends AbstractController
             $activity,
             $items,
             $page,
-            PostNoteFactory::getContext()
+            PostNoteFactory::ADDITIONAL_CONTEXTS
         );
     }
 }

--- a/src/Entity/Contracts/ActivityPubActivityInterface.php
+++ b/src/Entity/Contracts/ActivityPubActivityInterface.php
@@ -14,4 +14,18 @@ interface ActivityPubActivityInterface
     public const CONTEXT_URL = 'https://www.w3.org/ns/activitystreams';
     public const SECURITY_URL = 'https://w3id.org/security/v1';
     public const PUBLIC_URL = 'https://www.w3.org/ns/activitystreams#Public';
+
+    public const ADDITIONAL_CONTEXTS = [
+        'ostatus' => 'http://ostatus.org#',
+        'toot' => 'http://joinmastodon.org/ns#',
+        'pt' => 'https://joinpeertube.org/ns#',
+        'lemmy' => 'https://join-lemmy.org/ns#',
+        'Hashtag' => 'as:Hashtag',
+        'sensitive' => 'as:sensitive',
+        'blurhash' => 'toot:blurhash',
+        'focalPoint' => 'toot:focalPoint',
+        'votersCount' => 'toot:votersCount',
+        'commentsEnabled' => 'pt:commentsEnabled',
+        'stickied' => 'lemmy:stickied',
+    ];
 }

--- a/src/Factory/ActivityPub/EntryCommentNoteFactory.php
+++ b/src/Factory/ActivityPub/EntryCommentNoteFactory.php
@@ -38,7 +38,7 @@ class EntryCommentNoteFactory
             $note['@context'] = [
                 ActivityPubActivityInterface::CONTEXT_URL,
                 ActivityPubActivityInterface::SECURITY_URL,
-                PostNoteFactory::getContext(),
+                PostNoteFactory::ADDITIONAL_CONTEXTS,
             ];
         }
 

--- a/src/Factory/ActivityPub/EntryCommentNoteFactory.php
+++ b/src/Factory/ActivityPub/EntryCommentNoteFactory.php
@@ -38,7 +38,7 @@ class EntryCommentNoteFactory
             $note['@context'] = [
                 ActivityPubActivityInterface::CONTEXT_URL,
                 ActivityPubActivityInterface::SECURITY_URL,
-                PostNoteFactory::ADDITIONAL_CONTEXTS,
+                ActivityPubActivityInterface::ADDITIONAL_CONTEXTS,
             ];
         }
 

--- a/src/Factory/ActivityPub/EntryPageFactory.php
+++ b/src/Factory/ActivityPub/EntryPageFactory.php
@@ -22,10 +22,13 @@ class EntryPageFactory
         'lemmy' => 'https://join-lemmy.org/ns#',
         'ostatus' => 'http://ostatus.org#',
         'peertube' => 'https://joinpeertube.org/ns#',
-        'commentsEnabled' => 'peeertube:commentsEnabled',
+        'toot' => 'http://joinmastodon.org/ns#',
         'sensitive' => 'as:sensitive',
-        'stickied' => 'lemmy:stickied',
+        'blurhash' => 'toot:blurhash',
+        'focalPoint' => 'toot:focalPoint',
         'votersCount' => 'toot:votersCount',
+        'commentsEnabled' => 'peertube:commentsEnabled',
+        'stickied' => 'lemmy:stickied',
     ];
 
     public function __construct(

--- a/src/Factory/ActivityPub/EntryPageFactory.php
+++ b/src/Factory/ActivityPub/EntryPageFactory.php
@@ -18,19 +18,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class EntryPageFactory
 {
-    public const ADDITIONAL_CONTEXTS = [
-        'lemmy' => 'https://join-lemmy.org/ns#',
-        'ostatus' => 'http://ostatus.org#',
-        'peertube' => 'https://joinpeertube.org/ns#',
-        'toot' => 'http://joinmastodon.org/ns#',
-        'sensitive' => 'as:sensitive',
-        'blurhash' => 'toot:blurhash',
-        'focalPoint' => 'toot:focalPoint',
-        'votersCount' => 'toot:votersCount',
-        'commentsEnabled' => 'peertube:commentsEnabled',
-        'stickied' => 'lemmy:stickied',
-    ];
-
     public function __construct(
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly GroupFactory $groupFactory,
@@ -50,7 +37,7 @@ class EntryPageFactory
             $page['@context'] = [
                 ActivityPubActivityInterface::CONTEXT_URL,
                 ActivityPubActivityInterface::SECURITY_URL,
-                self::ADDITIONAL_CONTEXTS,
+                ActivityPubActivityInterface::ADDITIONAL_CONTEXTS,
             ];
         }
 

--- a/src/Factory/ActivityPub/EntryPageFactory.php
+++ b/src/Factory/ActivityPub/EntryPageFactory.php
@@ -18,6 +18,16 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class EntryPageFactory
 {
+    public const ADDITIONAL_CONTEXTS = [
+        'lemmy' => 'https://join-lemmy.org/ns#',
+        'ostatus' => 'http://ostatus.org#',
+        'peertube' => 'https://joinpeertube.org/ns#',
+        'commentsEnabled' => 'peeertube:commentsEnabled',
+        'sensitive' => 'as:sensitive',
+        'stickied' => 'lemmy:stickied',
+        'votersCount' => 'toot:votersCount',
+    ];
+
     public function __construct(
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly GroupFactory $groupFactory,
@@ -37,7 +47,7 @@ class EntryPageFactory
             $page['@context'] = [
                 ActivityPubActivityInterface::CONTEXT_URL,
                 ActivityPubActivityInterface::SECURITY_URL,
-                PostNoteFactory::getContext(),
+                self::ADDITIONAL_CONTEXTS,
             ];
         }
 

--- a/src/Factory/ActivityPub/GroupFactory.php
+++ b/src/Factory/ActivityPub/GroupFactory.php
@@ -13,8 +13,8 @@ class GroupFactory
 {
     public const ADDITIONAL_CONTEXTS = [
         'lemmy' => 'https://join-lemmy.org/ns#',
-        'postingRestrictedToMods' => 'lemmy:postingRestrictedToMods',
         'sensitive' => 'as:sensitive',
+        'postingRestrictedToMods' => 'lemmy:postingRestrictedToMods',
     ];
 
     public function __construct(

--- a/src/Factory/ActivityPub/GroupFactory.php
+++ b/src/Factory/ActivityPub/GroupFactory.php
@@ -11,6 +11,12 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class GroupFactory
 {
+    public const ADDITIONAL_CONTEXTS = [
+        'lemmy' => 'https://join-lemmy.org/ns#',
+        'postingRestrictedToMods' => 'lemmy:postingRestrictedToMods',
+        'sensitive' => 'as:sensitive',
+    ];
+
     public function __construct(
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly ImageManager $imageManager
@@ -21,7 +27,11 @@ class GroupFactory
     {
         $group = [
             'type' => 'Group',
-            '@context' => [ActivityPubActivityInterface::CONTEXT_URL, ActivityPubActivityInterface::SECURITY_URL],
+            '@context' => [
+                ActivityPubActivityInterface::CONTEXT_URL,
+                ActivityPubActivityInterface::SECURITY_URL,
+                self::ADDITIONAL_CONTEXTS,
+            ],
             'id' => $this->getActivityPubId($magazine),
             'name' => $magazine->title, // lemmy
             'preferredUsername' => $magazine->name,

--- a/src/Factory/ActivityPub/InstanceFactory.php
+++ b/src/Factory/ActivityPub/InstanceFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Factory\ActivityPub;
 
+use App\Entity\Contracts\ActivityPubActivityInterface;
 use App\Service\ActivityPub\ApHttpClient;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -21,7 +22,13 @@ class InstanceFactory
         $actor = 'https://'.$this->kbinDomain.'/i/actor';
 
         return [
-            '@context' => 'https://www.w3.org/ns/activitystreams',
+            '@context' => [
+                ActivityPubActivityInterface::CONTEXT_URL,
+                ActivityPubActivityInterface::SECURITY_URL,
+                [
+                    'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers',
+                ],
+            ],
             'id' => $actor,
             'type' => 'Application',
             'name' => 'Mbin',

--- a/src/Factory/ActivityPub/PersonFactory.php
+++ b/src/Factory/ActivityPub/PersonFactory.php
@@ -9,11 +9,17 @@ use App\Entity\User;
 use App\Markdown\MarkdownConverter;
 use App\Markdown\RenderTarget;
 use App\Service\ImageManager;
-use JetBrains\PhpStorm\ArrayShape;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class PersonFactory
 {
+    public const ADDITIONAL_CONTEXTS = [
+        'schema' => 'http://schema.org#',
+        'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers',
+        'PropertyValue' => 'schema:PropertyValue',
+        'value' => 'schema:value',
+    ];
+
     public function __construct(
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly ImageManager $imageManager,
@@ -27,7 +33,7 @@ class PersonFactory
             $person['@context'] = [
                 ActivityPubActivityInterface::CONTEXT_URL,
                 ActivityPubActivityInterface::SECURITY_URL,
-                $this->getContext(),
+                self::ADDITIONAL_CONTEXTS,
             ];
         }
 
@@ -99,22 +105,6 @@ class PersonFactory
         }
 
         return $person;
-    }
-
-    #[ArrayShape([
-        'manuallyApprovesFollowers' => 'string',
-        'schema' => 'string',
-        'PropertyValue' => 'string',
-        'value' => 'string',
-    ])]
-    public function getContext(): array
-    {
-        return [
-            'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers',
-            'schema' => 'http://schema.org#',
-            'PropertyValue' => 'schema:PropertyValue',
-            'value' => 'schema:value',
-        ];
     }
 
     public function getActivityPubId(User $user): string

--- a/src/Factory/ActivityPub/PostCommentNoteFactory.php
+++ b/src/Factory/ActivityPub/PostCommentNoteFactory.php
@@ -38,7 +38,7 @@ class PostCommentNoteFactory
             $note['@context'] = [
                 ActivityPubActivityInterface::CONTEXT_URL,
                 ActivityPubActivityInterface::SECURITY_URL,
-                PostNoteFactory::ADDITIONAL_CONTEXTS,
+                ActivityPubActivityInterface::ADDITIONAL_CONTEXTS,
             ];
         }
 

--- a/src/Factory/ActivityPub/PostCommentNoteFactory.php
+++ b/src/Factory/ActivityPub/PostCommentNoteFactory.php
@@ -38,7 +38,7 @@ class PostCommentNoteFactory
             $note['@context'] = [
                 ActivityPubActivityInterface::CONTEXT_URL,
                 ActivityPubActivityInterface::SECURITY_URL,
-                PostNoteFactory::getContext(),
+                PostNoteFactory::ADDITIONAL_CONTEXTS,
             ];
         }
 

--- a/src/Factory/ActivityPub/PostNoteFactory.php
+++ b/src/Factory/ActivityPub/PostNoteFactory.php
@@ -19,19 +19,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class PostNoteFactory
 {
-    public const ADDITIONAL_CONTEXTS = [
-        'lemmy' => 'https://join-lemmy.org/ns#',
-        'ostatus' => 'http://ostatus.org#',
-        'peertube' => 'https://joinpeertube.org/ns#',
-        'toot' => 'http://joinmastodon.org/ns#',
-        'sensitive' => 'as:sensitive',
-        'blurhash' => 'toot:blurhash',
-        'focalPoint' => 'toot:focalPoint',
-        'votersCount' => 'toot:votersCount',
-        'commentsEnabled' => 'peertube:commentsEnabled',
-        'stickied' => 'lemmy:stickied',
-    ];
-
     public function __construct(
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly GroupFactory $groupFactory,
@@ -52,7 +39,7 @@ class PostNoteFactory
             $note['@context'] = [
                 ActivityPubActivityInterface::CONTEXT_URL,
                 ActivityPubActivityInterface::SECURITY_URL,
-                self::ADDITIONAL_CONTEXTS,
+                ActivityPubActivityInterface::ADDITIONAL_CONTEXTS,
             ];
         }
 

--- a/src/Factory/ActivityPub/PostNoteFactory.php
+++ b/src/Factory/ActivityPub/PostNoteFactory.php
@@ -15,11 +15,20 @@ use App\Service\ActivityPub\Wrapper\TagsWrapper;
 use App\Service\ActivityPubManager;
 use App\Service\MentionManager;
 use App\Service\TagManager;
-use JetBrains\PhpStorm\ArrayShape;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class PostNoteFactory
 {
+    public const ADDITIONAL_CONTEXTS = [
+        'lemmy' => 'https://join-lemmy.org/ns#',
+        'ostatus' => 'http://ostatus.org#',
+        'peertube' => 'https://joinpeertube.org/ns#',
+        'commentsEnabled' => 'peertube:commentsEnabled',
+        'sensitive' => 'as:sensitive',
+        'stickied' => 'lemmy:stickied',
+        'votersCount' => 'toot:votersCount',
+    ];
+
     public function __construct(
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly GroupFactory $groupFactory,
@@ -40,7 +49,7 @@ class PostNoteFactory
             $note['@context'] = [
                 ActivityPubActivityInterface::CONTEXT_URL,
                 ActivityPubActivityInterface::SECURITY_URL,
-                self::getContext(),
+                self::ADDITIONAL_CONTEXTS,
             ];
         }
 
@@ -103,20 +112,6 @@ class PostNoteFactory
         $note['to'] = array_unique(array_merge($note['to'], $this->activityPubManager->createCcFromBody($post->body)));
 
         return $note;
-    }
-
-    #[ArrayShape([
-        'ostatus' => 'string',
-        'sensitive' => 'string',
-        'votersCount' => 'string',
-    ])]
-    public static function getContext(): array
-    {
-        return [
-            'ostatus' => 'http://ostatus.org#',
-            'sensitive' => 'as:sensitive',
-            'votersCount' => 'toot:votersCount',
-        ];
     }
 
     public function getActivityPubId(Post $post): string

--- a/src/Factory/ActivityPub/PostNoteFactory.php
+++ b/src/Factory/ActivityPub/PostNoteFactory.php
@@ -23,10 +23,13 @@ class PostNoteFactory
         'lemmy' => 'https://join-lemmy.org/ns#',
         'ostatus' => 'http://ostatus.org#',
         'peertube' => 'https://joinpeertube.org/ns#',
-        'commentsEnabled' => 'peertube:commentsEnabled',
+        'toot' => 'http://joinmastodon.org/ns#',
         'sensitive' => 'as:sensitive',
-        'stickied' => 'lemmy:stickied',
+        'blurhash' => 'toot:blurhash',
+        'focalPoint' => 'toot:focalPoint',
         'votersCount' => 'toot:votersCount',
+        'commentsEnabled' => 'peertube:commentsEnabled',
+        'stickied' => 'lemmy:stickied',
     ];
 
     public function __construct(

--- a/src/Service/ActivityPub/Wrapper/CollectionItemsWrapper.php
+++ b/src/Service/ActivityPub/Wrapper/CollectionItemsWrapper.php
@@ -33,7 +33,8 @@ class CollectionItemsWrapper
         array $context = null
     ): array {
         $result = [
-            '@context' => $context ? array_merge([ActivityPubActivityInterface::CONTEXT_URL], [$context])
+            '@context' => $context
+                ? array_merge([ActivityPubActivityInterface::CONTEXT_URL], [$context])
                 : ActivityPubActivityInterface::CONTEXT_URL,
             'type' => 'OrderedCollectionPage',
             'partOf' => $this->urlGenerator->generate($routeName, $routeParams, UrlGeneratorInterface::ABSOLUTE_URL),


### PR DESCRIPTION
add some missing contexts for properties found in returned AP responses, the responses should now properly resolves as a json-ld object

just for the off-chance that something is actually parsing AP responses as a json-ld objects and not just a weirdly shaped json