### PR TITLE
change inline js `on*=` actions to stimulus controllers/actions

### DIFF
--- a/assets/controllers/confirmation_controller.js
+++ b/assets/controllers/confirmation_controller.js
@@ -1,0 +1,11 @@
+import {Controller} from '@hotwired/stimulus';
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    ask(event) {
+        if (!window.confirm(event.params.message)) {
+            event.preventDefault();
+            event.stopImmediatePropagation()
+        }
+    }
+}

--- a/assets/controllers/options_controller.js
+++ b/assets/controllers/options_controller.js
@@ -55,4 +55,9 @@ export default class extends Controller {
     closeMobileSidebar() {
         document.getElementById('sidebar').classList.remove('open');
     }
+
+    appearanceReloadRequired(event) {
+        event.target.classList.add('spin');
+        window.location.reload();
+    }
 }

--- a/assets/controllers/selection_controller.js
+++ b/assets/controllers/selection_controller.js
@@ -1,0 +1,8 @@
+import {Controller} from '@hotwired/stimulus';
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    changeLocation(event) {
+        window.location = event.currentTarget.value;
+    }
+}

--- a/templates/admin/magazine_ownership.html.twig
+++ b/templates/admin/magazine_ownership.html.twig
@@ -35,7 +35,7 @@
                             <aside class="magazine__subscribe">
                                 <form action="{{ path('admin_magazine_ownership_requests_accept', {name: request.magazine.name, username: request.user.username}) }}"
                                       name="ownership_requests_accept"
-                                      onsubmit="return confirm('{{ 'are_you_sure'|trans }}');"
+                                      data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}"
                                       method="post">
                                     <button type="submit"
                                             title="{{ 'accept'|trans }}"
@@ -46,7 +46,7 @@
                                 </form>
                                 <form action="{{ path('admin_magazine_ownership_requests_reject', {name: request.magazine.name, username: request.user.username}) }}"
                                       name="ownership_requests_reject"
-                                      onsubmit="return confirm('{{ 'are_you_sure'|trans }}');"
+                                      data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}"
                                       method="post">
                                     <button type="submit"
                                             class="btn btn__secondary"

--- a/templates/admin/moderators.html.twig
+++ b/templates/admin/moderators.html.twig
@@ -31,7 +31,7 @@
                         <div class="actions">
                             <form method="post"
                                   action="{{ path('admin_moderator_purge', {username: moderator.username}) }}"
-                                  onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                                  data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                                 <input type="hidden" name="token" value="{{ csrf_token('remove_moderator') }}">
                                 <button type="submit" class="btn btn__secondary">{{ 'delete'|trans }}</button>
                             </form>

--- a/templates/admin/users.html.twig
+++ b/templates/admin/users.html.twig
@@ -15,9 +15,9 @@
 {% block body %}
     {% include 'admin/_options.html.twig' %}
     <div class="section" id="content">
-        <div class="flex">
+        <div class="flex" data-controller="selection">
             <label class="select">
-                <select onchange="location = this.value;">
+                <select data-action="selection#changeLocation">"
                     <option value="{{ options_url('withFederated', false) }}">{{ 'local'|trans }}</option>
                     <option value="{{ options_url('withFederated', true) }}" {{ withFederated is same as true ? 'selected' : '' }}>{{ 'federated'|trans }}</option>
                 </select>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -79,7 +79,7 @@
         ? 'width--'~app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH'))
         : '') }}">
         <main id="main"
-              data-controller="lightbox timeago"
+              data-controller="lightbox timeago confirmation"
               class="{{ html_classes({'view-compact': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT')) is same as 'true'}) }}">
             {% block body %}{% endblock %}
         </main>

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -212,7 +212,7 @@
                                     <li>
                                         <form method="post"
                                               action="{{ entry_delete_url(entry) }}"
-                                              onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                                              data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                                             <input type="hidden" name="token" value="{{ csrf_token('entry_delete') }}">
                                             <button type="submit">{{ 'delete'|trans }}</button>
                                         </form>
@@ -240,7 +240,7 @@
                         <li>
                             <form method="post"
                                   action="{{ path('entry_restore', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}"
-                                  onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                                  data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                                 <input type="hidden" name="token" value="{{ csrf_token('entry_restore') }}">
                                 <button type="submit">{{ 'restore'|trans }}</button>
                             </form>

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -140,7 +140,7 @@
                                     <li>
                                         <form method="post"
                                               action="{{ entry_comment_delete_url(comment) }}"
-                                              onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                                              data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                                             <input type="hidden" name="token"
                                                    value="{{ csrf_token('entry_comment_delete') }}">
                                             <button type="submit">{{ 'delete'|trans }}</button>
@@ -169,7 +169,7 @@
                         <li>
                             <form method="post"
                                   action="{{ path('entry_comment_restore', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id}) }}"
-                                  onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                                  data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                                 <input type="hidden" name="token" value="{{ csrf_token('entry_comment_restore') }}">
                                 <button type="submit">{{ 'restore'|trans }}</button>
                             </form>

--- a/templates/components/entry_cross.html.twig
+++ b/templates/components/entry_cross.html.twig
@@ -109,7 +109,7 @@
                                 <li>
                                     <form method="post"
                                           action="{{ entry_delete_url(entry) }}"
-                                          onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                                          data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                                         <input type="hidden" name="token" value="{{ csrf_token('entry_delete') }}">
                                         <button type="submit">{{ 'delete'|trans }}</button>
                                     </form>
@@ -137,7 +137,7 @@
                     <li>
                         <form method="post"
                               action="{{ path('entry_restore', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}"
-                              onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                              data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                             <input type="hidden" name="token" value="{{ csrf_token('entry_restore') }}">
                             <button type="submit">{{ 'restore'|trans|lower }}</button>
                         </form>

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -143,7 +143,7 @@
                                     <li>
                                         <form method="post"
                                               action="{{ post_delete_url(post) }}"
-                                              onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                                              data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                                             <input type="hidden" name="token" value="{{ csrf_token('post_delete') }}">
                                             <button type="submit">{{ 'delete'|trans }}</button>
                                         </form>
@@ -176,7 +176,7 @@
                         <li>
                             <form method="post"
                                   action="{{ path('post_restore', {magazine_name: post.magazine.name, post_id: post.id}) }}"
-                                  onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                                  data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                                 <input type="hidden" name="token" value="{{ csrf_token('post_restore') }}">
                                 <button type="submit">{{ 'restore'|trans }}</button>
                             </form>

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -144,7 +144,7 @@
                                     <li>
                                         <form method="post"
                                               action="{{ post_comment_delete_url(comment) }}"
-                                              onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                                              data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                                             <input type="hidden" name="token"
                                                    value="{{ csrf_token('post_comment_delete') }}">
                                             <button type="submit">{{ 'delete'|trans }}</button>
@@ -173,7 +173,7 @@
                         <li>
                             <form method="post"
                                   action="{{ path('post_comment_restore', {magazine_name: comment.magazine.name, post_id: comment.post.id, comment_id: comment.id}) }}"
-                                  onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                                  data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                                 <input type="hidden" name="token" value="{{ csrf_token('post_comment_restore') }}">
                                 <button type="submit">{{ 'restore'|trans }}</button>
                             </form>

--- a/templates/components/report_list.html.twig
+++ b/templates/components/report_list.html.twig
@@ -53,7 +53,7 @@
                 {% if report.status is not same as REPORT_REJECTED %}
                     <form method="post"
                           action="{{ path('magazine_panel_report_reject', {'magazine_name': report.subject.magazine.name, 'report_id': report.id}) }}"
-                          onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                          data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                         <input type="hidden" name="token" value="{{ csrf_token('report_decline') }}">
                         <button type="submit" class="btn btn__secondary">{{ 'reject'|trans }}</button>
                     </form>
@@ -61,7 +61,7 @@
                 {% if report.status is not same as REPORT_APPROVED %}
                     <form method="post"
                           action="{{ path('magazine_panel_report_approve', {'magazine_name': report.subject.magazine.name, 'report_id': report.id} ) }}"
-                          onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                          data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                         <input type="hidden" name="token" value="{{ csrf_token('report_approve') }}">
                         <button type="submit" class="btn btn__secondary">{{ 'approve'|trans }}</button>
                     </form>

--- a/templates/entry/_form_article.html.twig
+++ b/templates/entry/_form_article.html.twig
@@ -38,7 +38,7 @@
                  alt="{{ entry.image.altText }}">
             <button formaction="{{ path('entry_image_delete', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}"
                     class="btn-link"
-                    onclick="return confirm('{{ 'are_you_sure'|trans }}');">
+                    data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                 <i class="fa-solid fa-xmark"></i>
             </button>
         {% endif %}

--- a/templates/entry/_form_image.html.twig
+++ b/templates/entry/_form_image.html.twig
@@ -28,7 +28,7 @@
                  alt="{{ entry.image.altText }}">
             <button formaction="{{ path('entry_image_delete', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}"
                     class="btn-link"
-                    onclick="return confirm('{{ 'are_you_sure'|trans }}');">
+                    data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                 <i class="fa-solid fa-xmark"></i>
             </button>
         {% endif %}

--- a/templates/entry/_form_link.html.twig
+++ b/templates/entry/_form_link.html.twig
@@ -48,7 +48,7 @@
                  alt="{{ entry.image.altText }}">
             <button formaction="{{ path('entry_image_delete', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}"
                     class="btn-link"
-                    onclick="return confirm('{{ 'are_you_sure'|trans }}');">
+                    data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                 <i class="fa-solid fa-xmark"></i>
             </button>
         {% endif %}

--- a/templates/entry/_moderate_panel.html.twig
+++ b/templates/entry/_moderate_panel.html.twig
@@ -31,7 +31,7 @@
         <li>
             <form action="{{ entry_delete_url(entry) }}"
                   method="post"
-                  onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                  data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                 <input type="hidden" name="token" value="{{ csrf_token('entry_delete') }}">
                 <button type="submit" class="btn btn__secondary">
                     <i class="fa fa-dumpster"></i> <span>{{ 'delete'|trans }}</span>
@@ -42,7 +42,7 @@
             <li>
                 <form action="{{ path('entry_purge', {magazine_name: entry.magazine.name,entry_id: entry.id,}) }}"
                       method="post"
-                      onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                      data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                     <input type="hidden" name="token" value="{{ csrf_token('entry_purge') }}">
                     <button type="submit" class="btn btn__danger">
                         <i class="fa fa-dumpster"></i> <span>{{ 'purge'|trans }}</span>
@@ -55,7 +55,7 @@
                 <form name="change_magazine"
                       action="{{ path('entry_change_magazine', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}"
                       method="post"
-                      onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                      data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                     <input type="hidden" name="token" value="{{ csrf_token('change_magazine') }}">
                     <input id="change_magazine_new_magazine" required="required" placeholder="{{ entry.magazine.name }}" name="change_magazine[new_magazine]">
                     <button type="submit" class="btn btn__secondary">

--- a/templates/entry/comment/_form_comment.html.twig
+++ b/templates/entry/comment/_form_comment.html.twig
@@ -31,8 +31,8 @@
                  alt="{{ comment.image.altText }}">
             <button formaction="{{ path('entry_comment_image_delete', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id}) }}"
                     class="btn-link"
-                    data-action="subject#removeImage"
-                    onclick="return confirm('{{ 'are_you_sure'|trans }}');">
+                    data-action="confirmation#ask subject#removeImage"
+                    data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                 <i class="fa-solid fa-xmark"></i>
             </button>
         {% endif %}

--- a/templates/entry/comment/_moderate_panel.html.twig
+++ b/templates/entry/comment/_moderate_panel.html.twig
@@ -22,7 +22,7 @@
         <li>
             <form action="{{ entry_comment_delete_url(comment) }}"
                   method="post"
-                  onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                  data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                 <input type="hidden" name="token" value="{{ csrf_token('entry_comment_delete') }}">
                 <button type="submit" class="btn btn__secondary">
                     <i class="fa fa-dumpster"></i> <span>{{ 'delete'|trans }}</span>
@@ -33,7 +33,7 @@
             <li>
                 <form action="{{ path('entry_comment_purge', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id}) }}"
                       method="post"
-                      onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                      data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                     <input type="hidden" name="token" value="{{ csrf_token('entry_comment_purge') }}">
                     <button type="submit" class="btn btn__danger">
                         <i class="fa fa-dumpster"></i> <span>{{ 'purge'|trans }}</span>

--- a/templates/layout/_options_appearance.html.twig
+++ b/templates/layout/_options_appearance.html.twig
@@ -1,6 +1,6 @@
 <div class="settings-list">
     <div class="reload-required-section">
-        <button onclick="window.location.reload(); this.classList.add('spin');" class="btn btn-link">
+        <button data-action="options#appearanceReloadRequired:prevent" class="btn btn-link">
             <i class="fa fa-refresh"></i>{{ 'reload_to_apply'|trans }}
         </button>
     </div>

--- a/templates/magazine/_moderators_list.html.twig
+++ b/templates/magazine/_moderators_list.html.twig
@@ -15,7 +15,7 @@
                     <div class="actions">
                         <form method="post"
                               action="{{ path('magazine_panel_moderator_purge', {magazine_name: magazine.name, moderator_id: moderator.id}) }}"
-                              onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                              data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                             <input type="hidden" name="token" value="{{ csrf_token('remove_moderator') }}">
                             <button type="submit" class="btn btn__secondary">{{ 'delete'|trans }}</button>
                         </form>

--- a/templates/magazine/moderators.html.twig
+++ b/templates/magazine/moderators.html.twig
@@ -20,7 +20,7 @@
             <form action="{{ path('magazine_moderator_request', {name: magazine.name}) }}"
                   method="POST"
                   class="float-end mb-2"
-                  onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                  data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                 <input type="hidden" name="token" value="{{ csrf_token('moderator_request') }}">
                 <button type="submit" class="btn btn__secondary">
                     <i class="fa-solid fa-hand-point-up"></i>

--- a/templates/magazine/panel/badges.html.twig
+++ b/templates/magazine/panel/badges.html.twig
@@ -29,7 +29,7 @@
                             <div class="actions">
                                 <form method="post"
                                       action="{{ path('magazine_panel_badge_remove', {'magazine_name': badge.magazine.name, 'badge_id': badge.id} ) }}"
-                                      onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                                      data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                                     <input type="hidden" name="token" value="{{ csrf_token('badge_remove') }}">
                                     <button type="submit" class="btn btn__secondary">{{ 'delete'|trans }}</button>
                                 </form>

--- a/templates/magazine/panel/bans.html.twig
+++ b/templates/magazine/panel/bans.html.twig
@@ -45,7 +45,7 @@
                         <td>
                             <form method="post"
                                   action="{{ path('magazine_panel_unban', {name: ban.magazine.name, username: ban.user.username}) }}"
-                                  onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                                  data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                                 <input type="hidden" name="token" value="{{ csrf_token('magazine_unban') }}">
                                 <button class="btn btn__secondary">{{ 'delete'|trans }}</button>
                             </form>

--- a/templates/magazine/panel/general.html.twig
+++ b/templates/magazine/panel/general.html.twig
@@ -1,5 +1,4 @@
 {% extends 'base.html.twig' %}
-
 {%- block title -%}
     {{- 'general'|trans }} - {{ 'magazine_panel'|trans }} - {{ parent() -}}
 {%- endblock -%}
@@ -54,7 +53,7 @@
                 <div class="mb-2">
                     {% if magazine.visibility is same as 'visible' %}
                         <form action="{{ path('magazine_delete', {name: magazine.name}) }}" method="POST"
-                              onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                              data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                             <input type="hidden" name="token" value="{{ csrf_token('magazine_delete') }}">
                             <button type="submit" class="btn btn__primary">
                                 <i class="fa-solid fa-dumpster"></i> <span>{{ 'delete_magazine'|trans }}</span>
@@ -62,7 +61,7 @@
                         </form>
                     {% else %}
                         <form action="{{ path('magazine_restore', {name: magazine.name}) }}" method="POST"
-                              onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                              data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                             <input type="hidden" name="token" value="{{ csrf_token('magazine_restore') }}">
                             <button type="submit" class="btn btn__primary">
                                 <i class="fa-solid fa-dumpster"></i> <span>{{ 'restore_magazine'|trans }}</span>
@@ -73,7 +72,7 @@
                 {% if is_granted('ROLE_ADMIN') %}
                 <div class="mb-2">
                     <form action="{{ path('magazine_remove_subscriptions', {name: magazine.name}) }}" method="POST"
-                          onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                          data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                         <input type="hidden" name="token" value="{{ csrf_token('magazine_remove_subscriptions') }}">
                         <button type="submit" class="btn btn__danger">
                             <i class="fa-solid fa-users-slash"></i> <span>{{ 'remove_subscriptions'|trans }}</span>
@@ -84,7 +83,7 @@
                 {% if is_granted('purge', magazine) %}
                     <div class="mb-2">
                         <form action="{{ path('magazine_purge_content', {name: magazine.name}) }}" method="POST"
-                              onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                              data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                             <input type="hidden" name="token" value="{{ csrf_token('magazine_purge_content') }}">
                             <button type="submit" class="btn btn__danger">
                                 <i class="fa-solid fa-dumpster"></i> <span>{{ 'purge_content'|trans }}</span>
@@ -93,7 +92,7 @@
                     </div>
                     <div>
                         <form action="{{ path('magazine_purge', {name: magazine.name}) }}" method="POST"
-                              onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                              data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                             <input type="hidden" name="token" value="{{ csrf_token('magazine_purge') }}">
                             <button type="submit" class="btn btn__danger">
                                 <i class="fa-solid fa-dumpster-fire"></i> <span>{{ 'purge_magazine'|trans }}</span>

--- a/templates/magazine/panel/moderator_requests.html.twig
+++ b/templates/magazine/panel/moderator_requests.html.twig
@@ -38,7 +38,7 @@
                             <aside class="magazine__subscribe">
                                 <form action="{{ path('magazine_panel_moderator_request_accept', {name: request.magazine.name, username: request.user.username}) }}"
                                       name="ownership_requests_accept"
-                                      onsubmit="return confirm('{{ 'are_you_sure'|trans }}');"
+                                      data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}"
                                       method="post">
                                     <button type="submit"
                                             title="{{ 'accept'|trans }}"
@@ -49,7 +49,7 @@
                                 </form>
                                 <form action="{{ path('magazine_panel_moderator_request_reject', {name: request.magazine.name, username: request.user.username}) }}"
                                       name="ownership_requests_reject"
-                                      onsubmit="return confirm('{{ 'are_you_sure'|trans }}');"
+                                      data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}"
                                       method="post">
                                     <button type="submit"
                                             class="btn btn__secondary"

--- a/templates/notifications/front.html.twig
+++ b/templates/notifications/front.html.twig
@@ -25,7 +25,7 @@
                 </button>
             </form>
             <form method="post" action="{{ path('notifications_clear') }}"
-                  onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                  data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                 <input type="hidden" name="token" value="{{ csrf_token('clear_notifications') }}">
                 <button class="btn btn__secondary" type="submit">
                     <i class="fa-solid fa-dumpster"></i> <span>{{ 'purge'|trans }}</span>

--- a/templates/post/_form_post.html.twig
+++ b/templates/post/_form_post.html.twig
@@ -42,8 +42,8 @@
                  alt="{{ post.image.altText }}">
             <button formaction="{{ path('post_image_delete', {magazine_name: post.magazine.name, post_id: post.id}) }}"
                     class="btn-link"
-                    data-action="subject#removeImage"
-                    onclick="return confirm('{{ 'are_you_sure'|trans }}');">
+                    data-action="confirmation#ask subject#removeImage"
+                    data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                 <i class="fa-solid fa-xmark"></i>
             </button>
         {% endif %}

--- a/templates/post/_moderate_panel.html.twig
+++ b/templates/post/_moderate_panel.html.twig
@@ -31,7 +31,7 @@
         <li>
             <form action="{{ post_delete_url(post) }}"
                   method="post"
-                  onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                  data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                 <input type="hidden" name="token" value="{{ csrf_token('post_delete') }}">
                 <button type="submit" class="btn btn__secondary">
                     <i class="fa fa-dumpster"></i> <span>{{ 'delete'|trans }}</span>
@@ -42,7 +42,7 @@
             <li>
                 <form action="{{ path('post_purge', {magazine_name: post.magazine.name, post_id: post.id,}) }}"
                       method="post"
-                      onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                      data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                     <input type="hidden" name="token" value="{{ csrf_token('post_purge') }}">
                     <button type="submit" class="btn btn__danger">
                         <i class="fa fa-dumpster"></i> <span>{{ 'purge'|trans }}</span>
@@ -55,7 +55,7 @@
                 <form name="change_magazine"
                       action="{{ path('post_change_magazine', {magazine_name: post.magazine.name, post_id: post.id}) }}"
                       method="post"
-                      onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                      data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                     <input type="hidden" name="token" value="{{ csrf_token('change_magazine') }}">
                     <input id="change_magazine_new_magazine" required="required" placeholder="{{ post.magazine.name }}" name="change_magazine[new_magazine]">
                     <button type="submit" class="btn btn__secondary">

--- a/templates/post/comment/_form_comment.html.twig
+++ b/templates/post/comment/_form_comment.html.twig
@@ -34,8 +34,8 @@
                  alt="{{ comment.image.altText }}">
             <button formaction="{{ path('post_comment_image_delete', {magazine_name: comment.magazine.name, post_id: comment.post.id, comment_id: comment.id}) }}"
                     class="btn-link"
-                    data-action="subject#removeImage"
-                    onclick="return confirm('{{ 'are_you_sure'|trans }}');">
+                    data-action="confirmation#ask subject#removeImage"
+                    data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                 <i class="fa-solid fa-xmark"></i>
             </button>
         {% endif %}

--- a/templates/post/comment/_moderate_panel.html.twig
+++ b/templates/post/comment/_moderate_panel.html.twig
@@ -22,7 +22,7 @@
         <li>
             <form action="{{ post_comment_delete_url(comment) }}"
                   method="post"
-                  onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                  data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                 <input type="hidden" name="token" value="{{ csrf_token('post_comment_delete') }}">
                 <button type="submit" class="btn btn__secondary">
                     <i class="fa fa-dumpster"></i> <span>{{ 'delete'|trans }}</span>
@@ -33,7 +33,7 @@
             <li>
                 <form action="{{ path('post_comment_purge', {magazine_name: comment.magazine.name, post_id: post.id, comment_id: comment.id}) }}"
                       method="post"
-                      onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                      data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                     <input type="hidden" name="token" value="{{ csrf_token('post_comment_purge') }}">
                     <button type="submit" class="btn btn__danger">
                         <i class="fa fa-dumpster"></i> <span>{{ 'purge'|trans }}</span>

--- a/templates/stats/_filters.html.twig
+++ b/templates/stats/_filters.html.twig
@@ -1,6 +1,6 @@
-<div class="flex">
+<div class="flex" data-controller="selection">
     <label class="select">
-        <select onchange="location = this.value;">
+        <select data-action="selection#changeLocation">
             <option value="{{ options_url('statsPeriod', -1) }}">{{ 'all'|trans }}</option>
             <option value="{{ options_url('statsPeriod', 7) }}" {{ period is same as 7 ? 'selected' : '' }}>{{ 'week'|trans }}</option>
             <option value="{{ options_url('statsPeriod', 14) }}" {{ period is same as 14 ? 'selected' : '' }}>
@@ -12,7 +12,7 @@
         </select>
     </label>
     <label class="select">
-        <select onchange="location = this.value;">
+        <select data-action="selection#changeLocation">
             <option value="{{ options_url('withFederated', false) }}">{{ 'local'|trans }}</option>
             <option value="{{ options_url('withFederated', true) }}" {{ withFederated is same as true ? 'selected' : '' }}>{{ 'federated'|trans }}</option>
         </select>

--- a/templates/user/overview.html.twig
+++ b/templates/user/overview.html.twig
@@ -18,7 +18,7 @@
                 {% if user.isTotpAuthenticationEnabled and is_granted('ROLE_ADMIN') %}
                     <form action="{{ path('user_2fa_remove', {username: user.username}) }}"
                           method="POST"
-                          onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                          data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                         <input type="hidden" name="token" value="{{ csrf_token('user_2fa_remove') }}">
                         <button type="submit" class="btn btn__secondary">
                             <i class="fa fa-mobile"></i> <span>{{ '2fa.remove'|trans }}</span>
@@ -27,8 +27,8 @@
                     <hr>
                 {% endif %}
                 <form action="{{ path(user.isBanned ? 'user_unban' : 'user_ban', {username: user.username}) }}"
-                      method="POST"
-                      onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                    method="POST"
+                    data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                     <input type="hidden" name="token" value="{{ csrf_token('user_ban') }}">
                     <button type="submit" class="btn btn__secondary">
                         <i class="fa fa-ban"></i> <span>{{ user.isBanned ? 'unban_account'|trans : 'ban_account'|trans }}</span>
@@ -37,7 +37,7 @@
                 <hr>
                 <form action="{{ path(user.visibility is same as 'trashed' ? 'user_unsuspend' : 'user_suspend', {username: user.username}) }}"
                     method="POST"
-                    onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                    data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                     <input type="hidden" name="token" value="{{ csrf_token('user_suspend') }}">
                     <button type="submit" class="btn btn__secondary" title="{{ 'user_suspend_desc'|trans }}">
                         <i class="fa-solid fa-pause"></i> {{ user.visibility is same as 'trashed' ? 'unsuspend_account'|trans : 'suspend_account'|trans }}
@@ -47,7 +47,7 @@
                 {% if is_granted('ROLE_ADMIN') %}
                     <form action="{{ path('user_remove_following', {username: user.username}) }}"
                           method="POST"
-                          onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                          data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                         <input type="hidden" name="token" value="{{ csrf_token('user_remove_following') }}">
                         <button type="submit" class="btn btn__secondary">
                             <i class="fa fa-solid fa-users-slash"></i> <span>{{ 'remove_following'|trans }}</span>
@@ -55,14 +55,14 @@
                     </form>
                     <hr>
                     <form action="{{ path('user_delete_content', {username: user.username}) }}" method="POST"
-                          onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                          data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                         <input type="hidden" name="token" value="{{ csrf_token('user_delete_content') }}">
                         <button type="submit" class="btn btn__secondary" title="{{ 'delete_content_desc'|trans }}">
                             <i class="fa fa-dumpster"></i> <span>{{ 'delete_content'|trans }}</span>
                         </button>
                     </form>
                     <form action="{{ path('user_purge_content', {username: user.username}) }}" method="POST"
-                          onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                          data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                         <input type="hidden" name="token" value="{{ csrf_token('user_purge_content') }}">
                         <button type="submit" class="btn btn__danger" title="{{ 'purge_content_desc'|trans }}">
                             <i class="fa-solid fa-dumpster-fire"></i> <span>{{ 'purge_content'|trans }}</span>
@@ -70,14 +70,14 @@
                     </form>
                     <hr>
                     <form action="{{ path('user_delete_account', {username: user.username}) }}" method="POST"
-                          onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                          data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                         <input type="hidden" name="token" value="{{ csrf_token('user_delete_account') }}">
                         <button type="submit" class="btn btn__secondary" title="{{ 'delete_account_desc'|trans }}">
                             <i class="fa fa-dumpster"></i> <span>{{ 'delete_account'|trans }}</span>
                         </button>
                     </form>
                     <form action="{{ path('user_purge_account', {username: user.username}) }}" method="POST"
-                          onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                          data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                         <input type="hidden" name="token" value="{{ csrf_token('user_purge_account') }}">
                         <button type="submit" class="btn btn__danger" title="{{ 'purge_account_desc'|trans }}">
                             <i class="fa-solid fa-dumpster-fire"></i> <span>{{ 'purge_account'|trans }}</span>

--- a/templates/user/settings/general.html.twig
+++ b/templates/user/settings/general.html.twig
@@ -53,7 +53,7 @@
             <p>{{ 'request_account_deletion_description'|trans }}</p>
             {% if app.user.visibility is same as 'soft_deleted' %}
                 <form action="{{ path('user_delete_request_revoke', {username: app.user.username}) }}" method="POST"
-                      onsubmit="return confirm('{{ 'are_you_sure'|trans }}');"
+                      data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}"
                       class="mb-2">
                     <input type="hidden" name="token" value="{{ csrf_token('user_delete') }}">
                     <button type="submit" class="btn btn__danger">
@@ -62,7 +62,7 @@
                 </form>
             {% else %}
                 <form action="{{ path('user_delete_request', {username: app.user.username}) }}" method="POST"
-                      onsubmit="return confirm('{{ 'are_you_sure'|trans }}');"
+                      data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}"
                       class="mb-2">
                     <input type="hidden" name="token" value="{{ csrf_token('user_delete') }}">
                     <button type="submit" class="btn btn__danger">

--- a/templates/user/settings/password.html.twig
+++ b/templates/user/settings/password.html.twig
@@ -34,11 +34,10 @@
     <div class="section">
         <div class="container">
             <h2>{{ 'two_factor_authentication'|trans }}</h2>
-            
                 {% if has2fa %}
                     <form action="{{ path('user_settings_2fa_disable') }}"
                         method="POST"
-                        onsubmit="return confirm('{{ 'are_you_sure'|trans }}');">
+                        data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
                         <input type="hidden" name="token" value="{{ csrf_token('user_2fa_remove') }}">
                         <div class="row">
                             <button type="submit" class="btn btn__primary">


### PR DESCRIPTION
moved inline js into stimulus controllers and actions

- replaced `<select>` location change
- replaced "are you sure?" confirm action
- replaced "reload to apply" button in appearance setting

please try to make use of stimulus for js needs rather than adding inline js afther this