### PR TITLE
Unable to ban admin

### DIFF
--- a/src/Exception/UserCannotBeBanned.php
+++ b/src/Exception/UserCannotBeBanned.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+final class UserCannotBeBanned extends \Exception
+{
+}

--- a/src/Service/MagazineManager.php
+++ b/src/Service/MagazineManager.php
@@ -19,6 +19,7 @@ use App\Event\Magazine\MagazineBlockedEvent;
 use App\Event\Magazine\MagazineModeratorAddedEvent;
 use App\Event\Magazine\MagazineModeratorRemovedEvent;
 use App\Event\Magazine\MagazineSubscribedEvent;
+use App\Exception\UserCannotBeBanned;
 use App\Factory\MagazineFactory;
 use App\Message\DeleteImageMessage;
 use App\Message\MagazinePurgeMessage;
@@ -191,6 +192,10 @@ class MagazineManager
     public function ban(Magazine $magazine, User $user, User $bannedBy, MagazineBanDto $dto): ?MagazineBan
     {
         Assert::nullOrGreaterThan($dto->expiredAt, new \DateTime());
+
+        if ($user->isAdmin() || $magazine->userIsModerator($user)) {
+            throw new UserCannotBeBanned();
+        }
 
         $ban = $magazine->addBan($user, $bannedBy, $dto->reason, $dto->expiredAt);
 

--- a/src/Service/UserManager.php
+++ b/src/Service/UserManager.php
@@ -10,12 +10,14 @@ use App\Entity\User;
 use App\Entity\UserFollowRequest;
 use App\Event\User\UserBlockEvent;
 use App\Event\User\UserFollowEvent;
+use App\Exception\UserCannotBeBanned;
 use App\Factory\UserFactory;
 use App\Message\DeleteImageMessage;
 use App\Message\DeleteUserMessage;
 use App\Message\UserCreatedMessage;
 use App\Message\UserUpdatedMessage;
 use App\Repository\ImageRepository;
+use App\Repository\ReputationRepository;
 use App\Repository\UserFollowRepository;
 use App\Repository\UserFollowRequestRepository;
 use App\Security\EmailVerifier;
@@ -30,23 +32,27 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 
-class UserManager
+readonly class UserManager
 {
     public function __construct(
-        private readonly UserFactory $factory,
-        private readonly UserPasswordHasherInterface $passwordHasher,
-        private readonly TokenStorageInterface $tokenStorage,
-        private readonly RequestStack $requestStack,
-        private readonly EventDispatcherInterface $dispatcher,
-        private readonly MessageBusInterface $bus,
-        private readonly EmailVerifier $verifier,
-        private readonly EntityManagerInterface $entityManager,
-        private readonly RateLimiterFactory $userRegisterLimiter,
-        private readonly UserFollowRequestRepository $requestRepository,
-        private readonly UserFollowRepository $userFollowRepository,
-        private readonly ImageRepository $imageRepository,
-        private readonly Security $security,
+        private UserFactory $factory,
+        private UserPasswordHasherInterface $passwordHasher,
+        private TokenStorageInterface $tokenStorage,
+        private RequestStack $requestStack,
+        private EventDispatcherInterface $dispatcher,
+        private MessageBusInterface $bus,
+        private EmailVerifier $verifier,
+        private EntityManagerInterface $entityManager,
+        private RateLimiterFactory $userRegisterLimiter,
+        private UserFollowRequestRepository $requestRepository,
+        private UserFollowRepository $userFollowRepository,
+        private ImageRepository $imageRepository,
+        private Security $security,
+        private CacheInterface $cache,
+        private ReputationRepository $reputationRepository
     ) {
     }
 
@@ -254,6 +260,10 @@ class UserManager
     {
         $user->isBanned = true;
 
+        if ($user->isAdmin() || $user->isModerator()) {
+            throw new UserCannotBeBanned();
+        }
+
         $this->entityManager->persist($user);
         $this->entityManager->flush();
     }
@@ -341,5 +351,20 @@ class UserManager
         foreach ($user->follows as $follow) {
             $this->unfollow($user, $follow->following);
         }
+    }
+
+    /**
+     * Get user reputation total add it behind a cache.
+     */
+    public function getReputationTotal(User $user): int
+    {
+        return $this->cache->get(
+            "user_reputation_{$user->getId()}",
+            function (ItemInterface $item) use ($user) {
+                $item->expiresAfter(60);
+
+                return $this->reputationRepository->getUserReputationTotal($user);
+            }
+        );
     }
 }

--- a/src/Service/UserManager.php
+++ b/src/Service/UserManager.php
@@ -258,11 +258,11 @@ readonly class UserManager
 
     public function ban(User $user): void
     {
-        $user->isBanned = true;
-
         if ($user->isAdmin() || $user->isModerator()) {
             throw new UserCannotBeBanned();
         }
+
+        $user->isBanned = true;
 
         $this->entityManager->persist($user);
         $this->entityManager->flush();

--- a/src/Twig/Runtime/UserExtensionRuntime.php
+++ b/src/Twig/Runtime/UserExtensionRuntime.php
@@ -8,14 +8,12 @@ use App\Entity\User;
 use App\Service\MentionManager;
 use App\Service\UserManager;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Contracts\Cache\CacheInterface;
 use Twig\Extension\RuntimeExtensionInterface;
 
 class UserExtensionRuntime implements RuntimeExtensionInterface
 {
     public function __construct(
         private readonly Security $security,
-        private readonly CacheInterface $cache,
         private readonly MentionManager $mentionManager,
         private readonly UserManager $userManager
     ) {

--- a/src/Twig/Runtime/UserExtensionRuntime.php
+++ b/src/Twig/Runtime/UserExtensionRuntime.php
@@ -5,20 +5,19 @@ declare(strict_types=1);
 namespace App\Twig\Runtime;
 
 use App\Entity\User;
-use App\Repository\ReputationRepository;
 use App\Service\MentionManager;
+use App\Service\UserManager;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Contracts\Cache\CacheInterface;
-use Symfony\Contracts\Cache\ItemInterface;
 use Twig\Extension\RuntimeExtensionInterface;
 
 class UserExtensionRuntime implements RuntimeExtensionInterface
 {
     public function __construct(
         private readonly Security $security,
-        private readonly ReputationRepository $reputationRepository,
         private readonly CacheInterface $cache,
-        private readonly MentionManager $mentionManager
+        private readonly MentionManager $mentionManager,
+        private readonly UserManager $userManager
     ) {
     }
 
@@ -47,13 +46,6 @@ class UserExtensionRuntime implements RuntimeExtensionInterface
 
     public function getReputationTotal(User $user): int
     {
-        return $this->cache->get(
-            "user_reputation_{$user->getId()}",
-            function (ItemInterface $item) use ($user) {
-                $item->expiresAfter(60);
-
-                return $this->reputationRepository->getUserReputationTotal($user);
-            }
-        );
+        return $this->userManager->getReputationTotal($user);
     }
 }


### PR DESCRIPTION
Cherry-pick changes from [Kbin RTR#9](https://codeberg.org/Kbin/kbin-core/commit/65bed2880347731561ead891e9cd0ba567b8524e)

- Unable to ban admins (yes we might hide the button.. but in theory you can still trigger the actual call)
- Small refactoring of reputationTotal call (moving the function/impl.)
- Move whole `UserManager` class to readonly.