### PR TITLE
Move menu's to dedicated twig templates + small refactoring

### DIFF
--- a/src/Service/MagazineManager.php
+++ b/src/Service/MagazineManager.php
@@ -191,11 +191,11 @@ class MagazineManager
 
     public function ban(Magazine $magazine, User $user, User $bannedBy, MagazineBanDto $dto): ?MagazineBan
     {
-        Assert::nullOrGreaterThan($dto->expiredAt, new \DateTime());
-
         if ($user->isAdmin() || $magazine->userIsModerator($user)) {
             throw new UserCannotBeBanned();
         }
+
+        Assert::nullOrGreaterThan($dto->expiredAt, new \DateTime());
 
         $ban = $magazine->addBan($user, $bannedBy, $dto->reason, $dto->expiredAt);
 

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -157,78 +157,7 @@
                                 subject: entry
                             }) }}
                         </li>
-                        <li class="dropdown">
-                            <button class="stretched-link" data-subject-target="more">{{ 'more'|trans }}</button>
-                            <ul class="dropdown__menu" data-controller="clipboard">
-                                <li>
-                                    <a href="{{ path('entry_report', {id: entry.id}) }}"
-                                       class="{{ html_classes({'active': is_route_name('entry_report')}) }}"
-                                       data-action="subject#getForm">
-                                        {{ 'report'|trans }}
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="{{ entry_voters_url(entry, 'up') }}"
-                                       class="{{ html_classes({'active': is_route_name('entry_fav') or is_route_name('entry_voters')}) }}">
-                                        {{ 'activity'|trans }}
-                                    </a>
-                                </li>
-
-                                {% if entry.domain %}
-                                    <li>
-                                        <a href="{{ path('domain_entries', {name: entry.domain.name}) }}">{{ 'more_from_domain'|trans }}</a>
-                                    </li>
-                                {% endif %}
-
-                                <li class="dropdown__separator"></li>
-                                <li>
-                                    <a target="_blank"
-                                       href="{{ entry.apId ?? path('ap_entry', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}">
-                                        {{ 'open_url_to_fediverse'|trans }}
-                                    </a>
-                                </li>
-                                <li>
-                                    <a data-action="clipboard#copy"
-                                       href="{{ entry.apId ?? path('ap_entry', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}">
-                                        {{ 'copy_url_to_fediverse'|trans }}
-                                    </a>
-                                </li>
-                                <li>
-                                    <a data-action="clipboard#copy"
-                                       href="{{ entry_url(entry) }}">{{ 'copy_url'|trans }}</a>
-                                </li>
-                                {% if is_granted('edit', entry) or (app.user and entry.isAuthor(app.user)) or is_granted('moderate', entry) %}
-                                    <li class="dropdown__separator"></li>
-                                {% endif %}
-                                {% if is_granted('edit', entry) %}
-                                    <li>
-                                        <a href="{{ entry_edit_url(entry) }}"
-                                           class="{{ html_classes({'active': is_route_name('entry_edit')}) }}">
-                                            {{ 'edit'|trans }}
-                                        </a>
-                                    </li>
-                                {% endif %}
-                                {% if app.user and entry.isAuthor(app.user) %}
-                                    <li>
-                                        <form method="post"
-                                              action="{{ entry_delete_url(entry) }}"
-                                              data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
-                                            <input type="hidden" name="token" value="{{ csrf_token('entry_delete') }}">
-                                            <button type="submit">{{ 'delete'|trans }}</button>
-                                        </form>
-                                    </li>
-                                {% endif %}
-                                {% if is_granted('moderate', entry) %}
-                                    <li>
-                                        <a href="{{ entry_moderate_url(entry) }}"
-                                           class="{{ html_classes({'active': is_route_name('entry_moderate')}) }}"
-                                           data-action="subject#showModPanel">
-                                            {{ 'moderate'|trans }}
-                                        </a>
-                                    </li>
-                                {% endif %}
-                            </ul>
-                        </li>
+                        {% include 'entry/_menu.html.twig' %}
                         <li data-subject-target="loader" style="display:none">
                             <div class="loader" role="status">
                                 <span class="visually-hidden">Loading...</span>

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -89,75 +89,7 @@
                         <li>
                             {{ component('boost', {subject: comment}) }}
                         </li>
-                        <li class="dropdown">
-                            <button class="stretched-link" data-subject-target="more">{{ 'more'|trans }}</button>
-                            <ul class="dropdown__menu" data-controller="clipboard">
-                                <li>
-                                    <a href="{{ path('entry_comment_report', {id: comment.id}) }}"
-                                       class="{{ html_classes({'active': is_route_name('entry_comment_report')}) }}"
-                                       data-action="subject#getForm">
-                                        {{ 'report'|trans }}
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="{{ entry_comment_voters_url(comment, 'up') }}"
-                                       class="{{ html_classes({'active': is_route_name('entry_comment_favourites') or is_route_name('entry_comment_voters')}) }}">
-                                        {{ 'activity'|trans }}
-                                    </a>
-                                </li>
-                                <li class="dropdown__separator"></li>
-                                <li>
-                                    <a target="_blank"
-                                       href="{{ comment.apId ?? path('ap_entry_comment', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id}) }}">
-                                        {{ 'open_url_to_fediverse'|trans }}
-                                    </a>
-                                </li>
-                                <li>
-                                    <a data-action="clipboard#copy"
-                                       href="{{ comment.apId ?? path('ap_entry_comment', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id}) }}">
-                                        {{ 'copy_url_to_fediverse'|trans }}
-                                    </a>
-                                </li>
-                                <li>
-                                    <a data-action="clipboard#copy"
-                                       href="{{ entry_url(comment.entry) }}#{{ get_url_fragment(comment) }}">
-                                        {{ 'copy_url'|trans }}
-                                    </a>
-                                </li>
-                                {% if is_granted('edit', comment) or (app.user and comment.isAuthor(app.user)) or is_granted('moderate', comment) %}
-                                    <li class="dropdown__separator"></li>
-                                {% endif %}
-                                {% if is_granted('edit', comment) %}
-                                    <li>
-                                        <a href="{{ entry_comment_edit_url(comment) }}"
-                                           class="{{ html_classes({'active': is_route_name('entry_comment_edit')}) }}"
-                                           data-action="subject#getForm">
-                                            {{ 'edit'|trans }}
-                                        </a>
-                                    </li>
-                                {% endif %}
-                                {% if app.user and comment.isAuthor(app.user) %}
-                                    <li>
-                                        <form method="post"
-                                              action="{{ entry_comment_delete_url(comment) }}"
-                                              data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
-                                            <input type="hidden" name="token"
-                                                   value="{{ csrf_token('entry_comment_delete') }}">
-                                            <button type="submit">{{ 'delete'|trans }}</button>
-                                        </form>
-                                    </li>
-                                {% endif %}
-                                {% if is_granted('moderate', comment) %}
-                                    <li>
-                                        <a href="{{ entry_comment_moderate_url(comment) }}"
-                                           class="{{ html_classes({'active': is_route_name('entry_comment_moderate')}) }}"
-                                           data-action="subject#showModPanel">
-                                            {{ 'moderate'|trans }}
-                                        </a>
-                                    </li>
-                                {% endif %}
-                            </ul>
-                        </li>
+                        {% include 'entry/comment/_menu.html.twig' %}
                         <li data-subject-target="loader" style="display:none">
                             <div class="loader" role="status">
                                 <span class="visually-hidden">Loading...</span>

--- a/templates/components/entry_cross.html.twig
+++ b/templates/components/entry_cross.html.twig
@@ -54,78 +54,7 @@
                             subject: entry
                         }) }}
                     </li>
-                    <li class="dropdown">
-                        <button class="stretched-link" data-subject-target="more">{{ 'more'|trans }}</button>
-                        <ul class="dropdown__menu" data-controller="clipboard">
-                            <li>
-                                <a href="{{ path('entry_report', {id: entry.id}) }}"
-                                   class="{{ html_classes({'active': is_route_name('entry_report')}) }}"
-                                   data-action="subject#getForm">
-                                    {{ 'report'|trans }}
-                                </a>
-                            </li>
-                            <li>
-                                <a href="{{ entry_voters_url(entry, 'up') }}"
-                                   class="{{ html_classes({'active': is_route_name('entry_fav') or is_route_name('entry_voters')}) }}">
-                                    {{ 'activity'|trans }}
-                                </a>
-                            </li>
-
-                            {% if entry.domain %}
-                                <li>
-                                    <a href="{{ path('domain_entries', {name: entry.domain.name}) }}">{{ 'more_from_domain'|trans }}</a>
-                                </li>
-                            {% endif %}
-
-                            <li class="dropdown__separator"></li>
-                            <li>
-                                <a target="_blank"
-                                   href="{{ entry.apId ?? path('ap_entry', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}">
-                                    {{ 'open_url_to_fediverse'|trans }}
-                                </a>
-                            </li>
-                            <li>
-                                <a data-action="clipboard#copy"
-                                   href="{{ entry.apId ?? path('ap_entry', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}">
-                                    {{ 'copy_url_to_fediverse'|trans }}
-                                </a>
-                            </li>
-                            <li>
-                                <a data-action="clipboard#copy"
-                                   href="{{ entry_url(entry) }}">{{ 'copy_url'|trans }}</a>
-                            </li>
-                            {% if is_granted('edit', entry) or (app.user and entry.isAuthor(app.user)) or is_granted('moderate', entry) %}
-                                <li class="dropdown__separator"></li>
-                            {% endif %}
-                            {% if is_granted('edit', entry) %}
-                                <li>
-                                    <a href="{{ entry_edit_url(entry) }}"
-                                       class="{{ html_classes({'active': is_route_name('entry_edit')}) }}">
-                                        {{ 'edit'|trans }}
-                                    </a>
-                                </li>
-                            {% endif %}
-                            {% if app.user and entry.isAuthor(app.user) %}
-                                <li>
-                                    <form method="post"
-                                          action="{{ entry_delete_url(entry) }}"
-                                          data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
-                                        <input type="hidden" name="token" value="{{ csrf_token('entry_delete') }}">
-                                        <button type="submit">{{ 'delete'|trans }}</button>
-                                    </form>
-                                </li>
-                            {% endif %}
-                            {% if is_granted('moderate', entry) %}
-                                <li>
-                                    <a href="{{ entry_moderate_url(entry) }}"
-                                       class="{{ html_classes({'active': is_route_name('entry_moderate')}) }}"
-                                       data-action="subject#showModPanel">
-                                        {{ 'moderate'|trans }}
-                                    </a>
-                                </li>
-                            {% endif %}
-                        </ul>
-                    </li>
+                    {% include 'entry/_menu.html.twig' %}
                     <li data-subject-target="loader" style="display:none">
                         <div class="loader" role="status">
                             <span class="visually-hidden">Loading...</span>

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -93,73 +93,7 @@
                                 subject: post
                             }) }}
                         </li>
-                        <li class="dropdown">
-                            <button class="stretched-link" data-subject-target="more">{{ 'more'|trans }}</button>
-                            <ul class="dropdown__menu" data-controller="clipboard">
-                                <li>
-                                    <a href="{{ path('post_report', {id: post.id}) }}"
-                                       class="{{ html_classes({'active': is_route_name('post_report')}) }}"
-                                       data-action="subject#getForm">
-                                        {{ 'report'|trans }}
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="{{ post_voters_url(post, 'up') }}"
-                                       class="{{ html_classes({'active': is_route_name('post_favourites') or is_route_name('post_voters')}) }}">
-                                        {{ 'activity'|trans }}
-                                    </a>
-                                </li>
-                                <li class="dropdown__separator"></li>
-                                <li>
-                                    <a target="_blank"
-                                       href="{{ post.apId ?? path('ap_post', {magazine_name: post.magazine.name, post_id: post.id}) }}">
-                                        {{ 'open_url_to_fediverse'|trans }}
-                                    </a>
-                                </li>
-                                <li>
-                                    <a data-action="clipboard#copy"
-                                       href="{{ post.apId ?? path('ap_post', {magazine_name: post.magazine.name, post_id: post.id}) }}">
-                                        {{ 'copy_url_to_fediverse'|trans }}
-                                    </a>
-                                </li>
-                                <li>
-                                    <a data-action="clipboard#copy" href="{{ post_url(post) }}">
-                                        {{ 'copy_url'|trans }}
-                                    </a>
-                                </li>
-                                {% if is_granted('edit', post) or (app.user and post.isAuthor(app.user)) or is_granted('moderate', post) %}
-                                    <li class="dropdown__separator"></li>
-                                {% endif %}
-                                {% if is_granted('edit', post) %}
-                                    <li>
-                                        <a href="{{ post_edit_url(post) }}"
-                                           class="{{ html_classes({'active': is_route_name('post_edit')}) }}"
-                                           data-action="subject#getForm">
-                                            {{ 'edit'|trans }}
-                                        </a>
-                                    </li>
-                                {% endif %}
-                                {% if app.user and post.isAuthor(app.user) %}
-                                    <li>
-                                        <form method="post"
-                                              action="{{ post_delete_url(post) }}"
-                                              data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
-                                            <input type="hidden" name="token" value="{{ csrf_token('post_delete') }}">
-                                            <button type="submit">{{ 'delete'|trans }}</button>
-                                        </form>
-                                    </li>
-                                {% endif %}
-                                {% if is_granted('moderate', post) %}
-                                    <li>
-                                        <a href="{{ post_moderate_url(post) }}"
-                                           class="{{ html_classes({'active': is_route_name('post_moderate')}) }}"
-                                           data-action="subject#showModPanel">
-                                            {{ 'moderate'|trans }}
-                                        </a>
-                                    </li>
-                                {% endif %}
-                            </ul>
-                        </li>
+                        {% include 'post/_menu.html.twig' %}
                         <li data-subject-target="loader" style="display:none">
                             <div class="loader" role="status">
                                 <span class="visually-hidden">Loading...</span>

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -93,75 +93,7 @@
                                 subject: comment
                             }) }}
                         </li>
-                        <li class="dropdown">
-                            <button class="stretched-link" data-subject-target="more">{{ 'more'|trans }}</button>
-                            <ul class="dropdown__menu" data-controller="clipboard">
-                                <li>
-                                    <a href="{{ path('post_comment_report', {id: comment.id}) }}"
-                                       class="{{ html_classes({'active': is_route_name('post_comment_report')}) }}"
-                                       data-action="subject#getForm">
-                                        {{ 'report'|trans }}
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="{{ post_comment_voters_url(comment) }}"
-                                       class="{{ html_classes({'active': is_route_name('post_comment_favourites') or is_route_name('post_comment_voters')}) }}">
-                                        {{ 'activity'|trans }}
-                                    </a>
-                                </li>
-                                <li class="dropdown__separator"></li>
-                                <li>
-                                    <a target="_blank"
-                                       href="{{ comment.apId ?? path('ap_post_comment', {magazine_name: comment.magazine.name, post_id: comment.post.id, comment_id: comment.id}) }}">
-                                        {{ 'open_url_to_fediverse'|trans }}
-                                    </a>
-                                </li>
-                                <li>
-                                    <a data-action="clipboard#copy"
-                                       href="{{ comment.apId ?? path('ap_post_comment', {magazine_name: comment.magazine.name, post_id: comment.post.id, comment_id: comment.id}) }}">
-                                        {{ 'copy_url_to_fediverse'|trans }}
-                                    </a>
-                                </li>
-                                <li>
-                                    <a data-action="clipboard#copy"
-                                       href="{{ post_url(comment.post) }}#{{ get_url_fragment(comment) }}">
-                                        {{ 'copy_url'|trans }}
-                                    </a>
-                                </li>
-                                {% if is_granted('edit', comment) or (app.user and comment.isAuthor(app.user)) or is_granted('moderate', comment) %}
-                                    <li class="dropdown__separator"></li>
-                                {% endif %}
-                                {% if is_granted('edit', comment) %}
-                                    <li>
-                                        <a href="{{ post_comment_edit_url(comment) }}"
-                                           class="{{ html_classes({'active': is_route_name('post_comment_edit')}) }}"
-                                           data-action="subject#getForm">
-                                            {{ 'edit'|trans }}
-                                        </a>
-                                    </li>
-                                {% endif %}
-                                {% if app.user and comment.isAuthor(app.user) %}
-                                    <li>
-                                        <form method="post"
-                                              action="{{ post_comment_delete_url(comment) }}"
-                                              data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
-                                            <input type="hidden" name="token"
-                                                   value="{{ csrf_token('post_comment_delete') }}">
-                                            <button type="submit">{{ 'delete'|trans }}</button>
-                                        </form>
-                                    </li>
-                                {% endif %}
-                                {% if is_granted('moderate', comment) %}
-                                    <li>
-                                        <a href="{{ post_comment_moderate_url(comment) }}"
-                                           class="{{ html_classes({'active': is_route_name('post_comment_moderate')}) }}"
-                                           data-action="subject#showModPanel">
-                                            {{ 'moderate'|trans }}
-                                        </a>
-                                    </li>
-                                {% endif %}
-                            </ul>
-                        </li>
+                        {% include 'post/comment/_menu.html.twig' %}
                         <li data-subject-target="loader" style="display:none">
                             <div class="loader" role="status">
                                 <span class="visually-hidden">Loading...</span>

--- a/templates/entry/_menu.html.twig
+++ b/templates/entry/_menu.html.twig
@@ -1,0 +1,67 @@
+<li class="dropdown">
+  <button class="stretched-link" data-subject-target="more">{{ 'more'|trans }}</button>
+  <ul class="dropdown__menu" data-controller="clipboard">
+    <li>
+      <a href="{{ path('entry_report', {id: entry.id}) }}"
+        class="{{ html_classes({'active': is_route_name('entry_report')}) }}" data-action="subject#getForm">
+        {{ 'report'|trans }}
+      </a>
+    </li>
+    <li>
+      <a href="{{ entry_voters_url(entry, 'up') }}"
+        class="{{ html_classes({'active': is_route_name('entry_fav') or is_route_name('entry_voters')}) }}">
+        {{ 'activity'|trans }}
+      </a>
+    </li>
+
+    {% if entry.domain %}
+    <li>
+      <a href="{{ path('domain_entries', {name: entry.domain.name}) }}">{{ 'more_from_domain'|trans }}</a>
+    </li>
+    {% endif %}
+
+    <li class="dropdown__separator"></li>
+    <li>
+      <a target="_blank"
+        href="{{ entry.apId ?? path('ap_entry', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}">
+        {{ 'open_url_to_fediverse'|trans }}
+      </a>
+    </li>
+    <li>
+      <a data-action="clipboard#copy"
+        href="{{ entry.apId ?? path('ap_entry', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}">
+        {{ 'copy_url_to_fediverse'|trans }}
+      </a>
+    </li>
+    <li>
+      <a data-action="clipboard#copy" href="{{ entry_url(entry) }}">{{ 'copy_url'|trans }}</a>
+    </li>
+    {% if is_granted('edit', entry) or (app.user and entry.isAuthor(app.user)) or is_granted('moderate', entry) %}
+    <li class="dropdown__separator"></li>
+    {% endif %}
+    {% if is_granted('edit', entry) %}
+    <li>
+      <a href="{{ entry_edit_url(entry) }}" class="{{ html_classes({'active': is_route_name('entry_edit')}) }}">
+        {{ 'edit'|trans }}
+      </a>
+    </li>
+    {% endif %}
+    {% if app.user and entry.isAuthor(app.user) %}
+    <li>
+      <form method="post" action="{{ entry_delete_url(entry) }}" data-action="confirmation#ask"
+        data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
+        <input type="hidden" name="token" value="{{ csrf_token('entry_delete') }}">
+        <button type="submit">{{ 'delete'|trans }}</button>
+      </form>
+    </li>
+    {% endif %}
+    {% if is_granted('moderate', entry) %}
+    <li>
+      <a href="{{ entry_moderate_url(entry) }}" class="{{ html_classes({'active': is_route_name('entry_moderate')}) }}"
+        data-action="subject#showModPanel">
+        {{ 'moderate'|trans }}
+      </a>
+    </li>
+    {% endif %}
+  </ul>
+</li>

--- a/templates/entry/comment/_menu.html.twig
+++ b/templates/entry/comment/_menu.html.twig
@@ -1,0 +1,69 @@
+<li class="dropdown">
+    <button class="stretched-link" data-subject-target="more">{{ 'more'|trans }}</button>
+    <ul class="dropdown__menu" data-controller="clipboard">
+        <li>
+            <a href="{{ path('entry_comment_report', {id: comment.id}) }}"
+                class="{{ html_classes({'active': is_route_name('entry_comment_report')}) }}"
+                data-action="subject#getForm">
+                {{ 'report'|trans }}
+            </a>
+        </li>
+        <li>
+            <a href="{{ entry_comment_voters_url(comment, 'up') }}"
+                class="{{ html_classes({'active': is_route_name('entry_comment_favourites') or is_route_name('entry_comment_voters')}) }}">
+                {{ 'activity'|trans }}
+            </a>
+        </li>
+        <li class="dropdown__separator"></li>
+        <li>
+            <a target="_blank"
+                href="{{ comment.apId ?? path('ap_entry_comment', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id}) }}">
+                {{ 'open_url_to_fediverse'|trans }}
+            </a>
+        </li>
+        <li>
+            <a data-action="clipboard#copy"
+                href="{{ comment.apId ?? path('ap_entry_comment', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id}) }}">
+                {{ 'copy_url_to_fediverse'|trans }}
+            </a>
+        </li>
+        <li>
+            <a data-action="clipboard#copy"
+                href="{{ entry_url(comment.entry) }}#{{ get_url_fragment(comment) }}">
+                {{ 'copy_url'|trans }}
+            </a>
+        </li>
+        {% if is_granted('edit', comment) or (app.user and comment.isAuthor(app.user)) or is_granted('moderate', comment) %}
+            <li class="dropdown__separator"></li>
+        {% endif %}
+        {% if is_granted('edit', comment) %}
+            <li>
+                <a href="{{ entry_comment_edit_url(comment) }}"
+                    class="{{ html_classes({'active': is_route_name('entry_comment_edit')}) }}"
+                    data-action="subject#getForm">
+                    {{ 'edit'|trans }}
+                </a>
+            </li>
+        {% endif %}
+        {% if app.user and comment.isAuthor(app.user) %}
+            <li>
+                <form method="post"
+                        action="{{ entry_comment_delete_url(comment) }}"
+                        data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
+                    <input type="hidden" name="token"
+                            value="{{ csrf_token('entry_comment_delete') }}">
+                    <button type="submit">{{ 'delete'|trans }}</button>
+                </form>
+            </li>
+        {% endif %}
+        {% if is_granted('moderate', comment) %}
+            <li>
+                <a href="{{ entry_comment_moderate_url(comment) }}"
+                    class="{{ html_classes({'active': is_route_name('entry_comment_moderate')}) }}"
+                    data-action="subject#showModPanel">
+                    {{ 'moderate'|trans }}
+                </a>
+            </li>
+        {% endif %}
+    </ul>
+</li>

--- a/templates/post/_menu.html.twig
+++ b/templates/post/_menu.html.twig
@@ -1,0 +1,67 @@
+<li class="dropdown">
+    <button class="stretched-link" data-subject-target="more">{{ 'more'|trans }}</button>
+    <ul class="dropdown__menu" data-controller="clipboard">
+        <li>
+            <a href="{{ path('post_report', {id: post.id}) }}"
+                class="{{ html_classes({'active': is_route_name('post_report')}) }}"
+                data-action="subject#getForm">
+                {{ 'report'|trans }}
+            </a>
+        </li>
+        <li>
+            <a href="{{ post_voters_url(post, 'up') }}"
+                class="{{ html_classes({'active': is_route_name('post_favourites') or is_route_name('post_voters')}) }}">
+                {{ 'activity'|trans }}
+            </a>
+        </li>
+        <li class="dropdown__separator"></li>
+        <li>
+            <a target="_blank"
+                href="{{ post.apId ?? path('ap_post', {magazine_name: post.magazine.name, post_id: post.id}) }}">
+                {{ 'open_url_to_fediverse'|trans }}
+            </a>
+        </li>
+        <li>
+            <a data-action="clipboard#copy"
+                href="{{ post.apId ?? path('ap_post', {magazine_name: post.magazine.name, post_id: post.id}) }}">
+                {{ 'copy_url_to_fediverse'|trans }}
+            </a>
+        </li>
+        <li>
+            <a data-action="clipboard#copy" href="{{ post_url(post) }}">
+                {{ 'copy_url'|trans }}
+            </a>
+        </li>
+        {% if is_granted('edit', post) or (app.user and post.isAuthor(app.user)) or is_granted('moderate', post) %}
+            <li class="dropdown__separator"></li>
+        {% endif %}
+        {% if is_granted('edit', post) %}
+            <li>
+                <a href="{{ post_edit_url(post) }}"
+                    class="{{ html_classes({'active': is_route_name('post_edit')}) }}"
+                    data-action="subject#getForm">
+                    {{ 'edit'|trans }}
+                </a>
+            </li>
+        {% endif %}
+        {% if app.user and post.isAuthor(app.user) %}
+            <li>
+                <form method="post"
+                        action="{{ post_delete_url(post) }}"
+                        data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
+                    <input type="hidden" name="token" value="{{ csrf_token('post_delete') }}">
+                    <button type="submit">{{ 'delete'|trans }}</button>
+                </form>
+            </li>
+        {% endif %}
+        {% if is_granted('moderate', post) %}
+            <li>
+                <a href="{{ post_moderate_url(post) }}"
+                    class="{{ html_classes({'active': is_route_name('post_moderate')}) }}"
+                    data-action="subject#showModPanel">
+                    {{ 'moderate'|trans }}
+                </a>
+            </li>
+        {% endif %}
+    </ul>
+</li>

--- a/templates/post/comment/_menu.html.twig
+++ b/templates/post/comment/_menu.html.twig
@@ -1,0 +1,69 @@
+<li class="dropdown">
+    <button class="stretched-link" data-subject-target="more">{{ 'more'|trans }}</button>
+    <ul class="dropdown__menu" data-controller="clipboard">
+        <li>
+            <a href="{{ path('post_comment_report', {id: comment.id}) }}"
+                class="{{ html_classes({'active': is_route_name('post_comment_report')}) }}"
+                data-action="subject#getForm">
+                {{ 'report'|trans }}
+            </a>
+        </li>
+        <li>
+            <a href="{{ post_comment_voters_url(comment) }}"
+                class="{{ html_classes({'active': is_route_name('post_comment_favourites') or is_route_name('post_comment_voters')}) }}">
+                {{ 'activity'|trans }}
+            </a>
+        </li>
+        <li class="dropdown__separator"></li>
+        <li>
+            <a target="_blank"
+                href="{{ comment.apId ?? path('ap_post_comment', {magazine_name: comment.magazine.name, post_id: comment.post.id, comment_id: comment.id}) }}">
+                {{ 'open_url_to_fediverse'|trans }}
+            </a>
+        </li>
+        <li>
+            <a data-action="clipboard#copy"
+                href="{{ comment.apId ?? path('ap_post_comment', {magazine_name: comment.magazine.name, post_id: comment.post.id, comment_id: comment.id}) }}">
+                {{ 'copy_url_to_fediverse'|trans }}
+            </a>
+        </li>
+        <li>
+            <a data-action="clipboard#copy"
+                href="{{ post_url(comment.post) }}#{{ get_url_fragment(comment) }}">
+                {{ 'copy_url'|trans }}
+            </a>
+        </li>
+        {% if is_granted('edit', comment) or (app.user and comment.isAuthor(app.user)) or is_granted('moderate', comment) %}
+            <li class="dropdown__separator"></li>
+        {% endif %}
+        {% if is_granted('edit', comment) %}
+            <li>
+                <a href="{{ post_comment_edit_url(comment) }}"
+                    class="{{ html_classes({'active': is_route_name('post_comment_edit')}) }}"
+                    data-action="subject#getForm">
+                    {{ 'edit'|trans }}
+                </a>
+            </li>
+        {% endif %}
+        {% if app.user and comment.isAuthor(app.user) %}
+            <li>
+                <form method="post"
+                      action="{{ post_comment_delete_url(comment) }}"
+                      data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
+                    <input type="hidden" name="token"
+                            value="{{ csrf_token('post_comment_delete') }}">
+                    <button type="submit">{{ 'delete'|trans }}</button>
+                </form>
+            </li>
+        {% endif %}
+        {% if is_granted('moderate', comment) %}
+            <li>
+                <a href="{{ post_comment_moderate_url(comment) }}"
+                    class="{{ html_classes({'active': is_route_name('post_comment_moderate')}) }}"
+                    data-action="subject#showModPanel">
+                    {{ 'moderate'|trans }}
+                </a>
+            </li>
+        {% endif %}
+    </ul>
+</li>

--- a/tests/Unit/Service/TagManagerTest.php
+++ b/tests/Unit/Service/TagManagerTest.php
@@ -5,19 +5,16 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Service;
 
 use App\Service\TagManager;
-use App\Tests\WebTestCase;
+use PHPUnit\Framework\TestCase;
 
-class TagManagerTest extends WebTestCase
+class TagManagerTest extends TestCase
 {
     /**
      * @dataProvider provider
      */
     public function testExtract(string $input, ?array $output): void
     {
-        $this->createClient();
-
-        $manager = $this->getService(TagManager::class);
-        $this->assertEquals($output, $manager->extract($input, 'kbin'));
+        $this->assertEquals($output, (new TagManager())->extract($input, 'kbin'));
     }
 
     public static function provider(): array

--- a/tests/Unit/Utils/SluggerTest.php
+++ b/tests/Unit/Utils/SluggerTest.php
@@ -4,19 +4,17 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Utils;
 
-use App\Tests\WebTestCase;
 use App\Utils\Slugger;
+use PHPUnit\Framework\TestCase;
 
-class SluggerTest extends WebTestCase
+class SluggerTest extends TestCase
 {
     /**
      * @dataProvider provider
      */
     public function testCamelCase(string $input, string $output): void
     {
-        $this->createClient();
-        $slugger = $this->getService(Slugger::class);
-        $this->assertEquals($output, $slugger->camelCase($input));
+        $this->assertEquals($output, Slugger::camelCase($input));
     }
 
     public static function provider(): array


### PR DESCRIPTION
Cherry-picking again only changes I would like from [RTR#9v2](https://codeberg.org/Kbin/kbin-core/commit/1df30ff42b0570558c6871090644dc4bfc937c26#diff-6e42284c7979a95ac01ba1c2db60297737eb4619). I do not sync the spam protection, in fact in future commits this feature is removed again from kbin. It just doesn't make sense. I also will not sync the removal of this view counter (we keep using this feature).

- Move menu's to it's own dedicated twig templates for easier reuse (bonus: also makes it easier to sync other future changes)
- Small refactor admin ban to top of method
- Small refactoring with unit-tests
