### PR TITLE
Add a small margin between top level entry comments

### DIFF
--- a/assets/styles/components/_comment.scss
+++ b/assets/styles/components/_comment.scss
@@ -194,6 +194,13 @@ $comment-margin-sm: .3rem;
   }
 }
 
+.comments-view-style--tree,
+.comments-view-style--classic {
+    .comment-level--1:not(:first-child) {
+        margin-top: 0.5rem;
+    }
+}
+
 .comments-tree {
   position: relative;
 

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -1,7 +1,10 @@
-{%- set SHOW_PREVIEW = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_PREVIEW'), 'false') -%}
-{%- set SHOW_THUMBNAILS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_THUMBNAILS'), 'true') -%}
-{%- set SHOW_USER_AVATARS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_USERS_AVATARS'), 'true') -%}
-{%- set SHOW_MAGAZINE_ICONS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_MAGAZINES_ICONS'), 'true') -%}
+{%- set V_TRUE = constant('App\\Controller\\User\\ThemeSettingsController::TRUE') -%}
+{%- set V_FALSE = constant('App\\Controller\\User\\ThemeSettingsController::FALSE') -%}
+
+{%- set SHOW_PREVIEW = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_PREVIEW'), V_FALSE) -%}
+{%- set SHOW_THUMBNAILS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_THUMBNAILS'), V_TRUE) -%}
+{%- set SHOW_USER_AVATARS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_USERS_AVATARS'), V_TRUE) -%}
+{%- set SHOW_MAGAZINE_ICONS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_MAGAZINES_ICONS'), V_TRUE) -%}
 
 {% if not app.user or (app.user and not app.user.isBlocked(entry.user)) %}
     {% if entry.visibility is same as 'private' and (not app.user or not app.user.isFollower(entry.user)) %}
@@ -14,9 +17,9 @@
     {% else %}
         <article{{ attributes.defaults({
             class: html_classes('entry section subject', {
-                'no-image': SHOW_THUMBNAILS is same as 'false',
+                'no-image': SHOW_THUMBNAILS is same as V_FALSE,
                 'own': app.user and entry.isAuthor(app.user),
-                'show-preview': SHOW_PREVIEW is same as 'true' and not entry.isAdult
+                'show-preview': SHOW_PREVIEW is same as V_TRUE and not entry.isAdult
             })}).without('id') }}
                 id="entry-{{ entry.id }}"
                 data-controller="subject preview mentions"
@@ -74,15 +77,15 @@
                 {% endif %}
             {% endif %}
             <aside class="meta entry__meta">
-                <span>{{ component('user_inline', {user: entry.user, showAvatar: SHOW_USER_AVATARS is same as 'true'}) -}}</span>
+                <span>{{ component('user_inline', {user: entry.user, showAvatar: SHOW_USER_AVATARS is same as V_TRUE}) -}}</span>
                 <span>,</span>
                 <span>{{ component('date', {date: entry.createdAt}) }}</span>
                 <span>{{ component('date_edited', {createdAt: entry.createdAt, editedAt: entry.editedAt}) }}</span>
                 {% if showMagazineName %}
-                    <span>{{ 'to'|trans }} {{ component('magazine_inline', {magazine: entry.magazine, showAvatar: SHOW_MAGAZINE_ICONS is same as 'true'}) }}</span>
+                    <span>{{ 'to'|trans }} {{ component('magazine_inline', {magazine: entry.magazine, showAvatar: SHOW_MAGAZINE_ICONS is same as V_TRUE}) }}</span>
                 {% endif %}
             </aside>
-            {% if SHOW_THUMBNAILS is same as 'true' %}
+            {% if SHOW_THUMBNAILS is same as V_TRUE %}
                 {% if entry.image %}
                     {% if entry.type is same as 'link' or entry.type is same as 'video' %}
                         <figure>

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -1,6 +1,10 @@
-{%- set SHOW_PREVIEW = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_PREVIEW'), 'false') -%}
-{%- set DYNAMIC_LISTS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_DYNAMIC_LISTS'), 'false') -%}
-{%- set VIEW_STYLE = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::ENTRY_COMMENTS_VIEW'), 'tree') -%}
+{%- set V_TRUE = constant('App\\Controller\\User\\ThemeSettingsController::TRUE') -%}
+{%- set V_FALSE = constant('App\\Controller\\User\\ThemeSettingsController::FALSE') -%}
+{%- set V_TREE = constant('App\\Controller\\User\\ThemeSettingsController::TREE') -%}
+
+{%- set SHOW_PREVIEW = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_PREVIEW'), V_FALSE) -%}
+{%- set DYNAMIC_LISTS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_DYNAMIC_LISTS'), V_FALSE) -%}
+{%- set VIEW_STYLE = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::ENTRY_COMMENTS_VIEW'), V_TREE) -%}
 
 {% if not app.user or (app.user and not app.user.isBlocked(comment.user)) %}
     {% if comment.visibility is same as 'private' and (not app.user or not app.user.isFollower(comment.user)) %}
@@ -13,12 +17,12 @@
             class: html_classes('section comment entry-comment subject ' ~ 'comment-level--' ~ this.getLevel(),{
                 'own': app.user and comment.isAuthor(app.user),
                 'author': comment.isAuthor(comment.entry.user),
-                'show-preview': SHOW_PREVIEW is same as 'true' and not comment.isAdult
+                'show-preview': SHOW_PREVIEW is same as V_TRUE and not comment.isAdult
             })}).without('id') }}
                 id="entry-comment-{{ comment.id }}"
                 data-controller="comment subject mentions"
                 data-subject-parent-value="{{ comment.parent ? comment.parent.id : '' }}"
-                data-action="{{- DYNAMIC_LISTS is same as 'true' ? 'notifications:Notification@window->subject#notification' : '' -}}">
+                data-action="{{- DYNAMIC_LISTS is same as V_TRUE ? 'notifications:Notification@window->subject#notification' : '' -}}">
             <header>
                 {% if comment.isAdult %}<span class="badge danger">18+</span>{% endif %}
                 {{ component('user_inline', {user: comment.user, showAvatar: false}) }}

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -1,4 +1,7 @@
-{%- set SHOW_PREVIEW = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_PREVIEW'), 'false') -%}
+{%- set V_TRUE = constant('App\\Controller\\User\\ThemeSettingsController::TRUE') -%}
+{%- set V_FALSE = constant('App\\Controller\\User\\ThemeSettingsController::FALSE') -%}
+
+{%- set SHOW_PREVIEW = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_PREVIEW'), V_FALSE) -%}
 
 {% if not app.user or (app.user and not app.user.isBlocked(post.user)) %}
     {% if post.visibility is same as 'private' and (not app.user or not app.user.isFollower(post.user)) %}
@@ -10,7 +13,7 @@
         <blockquote{{ attributes.defaults({
             class: html_classes('section post subject ', {
                 'own': app.user and post.isAuthor(app.user),
-                'show-preview': SHOW_PREVIEW is same as 'true' and not post.isAdult
+                'show-preview': SHOW_PREVIEW is same as V_TRUE and not post.isAdult
             })}).without('id') }}
                 id="post-{{ post.id }}"
                 data-controller="post subject mentions"

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -1,5 +1,9 @@
-{%- set SHOW_PREVIEW = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_PREVIEW'), 'false') -%}
-{%- set VIEW_STYLE = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW'), 'tree') -%}
+{%- set V_TRUE = constant('App\\Controller\\User\\ThemeSettingsController::TRUE') -%}
+{%- set V_FALSE = constant('App\\Controller\\User\\ThemeSettingsController::FALSE') -%}
+{%- set V_TREE = constant('App\\Controller\\User\\ThemeSettingsController::TREE') -%}
+
+{%- set SHOW_PREVIEW = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_PREVIEW'), V_FALSE) -%}
+{%- set VIEW_STYLE = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW'), V_TREE) -%}
 
 {% if withPost %}
     {{ component('post', {post: comment.post}) }}
@@ -15,7 +19,7 @@
             class: html_classes('section comment post-comment subject ' ~ 'comment-level--' ~ this.getLevel(),{
                 'own': app.user and comment.isAuthor(app.user),
                 'author': comment.isAuthor(comment.post.user),
-                'show-preview': SHOW_PREVIEW is same as 'true' and not comment.isAdult
+                'show-preview': SHOW_PREVIEW is same as V_TRUE and not comment.isAdult
             })}).without('id') }}
                 id="post-comment-{{ comment.id }}"
                 data-controller="comment subject mentions"

--- a/templates/entry/_list.html.twig
+++ b/templates/entry/_list.html.twig
@@ -1,5 +1,11 @@
+{%- set V_TRUE = constant('App\\Controller\\User\\ThemeSettingsController::TRUE') -%}
+{%- set V_FALSE = constant('App\\Controller\\User\\ThemeSettingsController::FALSE') -%}
+
+{%- set DYNAMIC_LISTS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_DYNAMIC_LISTS'), V_FALSE) -%}
+{%- set INFINITE_SCROLL = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_INFINITE_SCROLL'), V_FALSE) -%}
+
 <div data-controller="subject-list"
-     data-action="{{- app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_DYNAMIC_LISTS')) is same as 'true' ? 'notifications:EntryCreatedNotification@window->subject-list#addMainSubject' : 'notifications:EntryCreatedNotification@window->subject-list#increaseCounter' -}}">
+     data-action="{{- DYNAMIC_LISTS is same as V_TRUE ? 'notifications:EntryCreatedNotification@window->subject-list#addMainSubject' : 'notifications:EntryCreatedNotification@window->subject-list#increaseCounter' -}}">
     {% for entry in entries %}
         {{ component('entry', {
             entry: entry,
@@ -7,7 +13,7 @@
         }) }}
     {% endfor %}
     {% if(entries.haveToPaginate is defined and entries.haveToPaginate) %}
-        {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_INFINITE_SCROLL')) is same as 'true' %}
+        {% if INFINITE_SCROLL is same as V_TRUE %}
             <div data-controller="infinite-scroll" class="infinite-scroll">
                 {{ component('loader', {'data-infinite-scroll-target': 'loader'}) }}
                 <div data-infinite-scroll-target="pagination" class="visually-hidden">

--- a/templates/entry/comment/_list.html.twig
+++ b/templates/entry/comment/_list.html.twig
@@ -8,38 +8,44 @@
 {%- set VIEW_STYLE = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::ENTRY_COMMENTS_VIEW'), V_TREE) -%}
 
 {% if showNested is not defined %}
-	{% if VIEW_STYLE is same as V_CHAT %}
-		{% set showNested = false %}
-	{% else %}
-		{% set showNested = true %}
-	{% endif %}
+    {% if VIEW_STYLE is same as V_CHAT %}
+        {% set showNested = false %}
+    {% else %}
+        {% set showNested = true %}
+    {% endif %}
 {% endif %}
-
-<section class="{{ html_classes('comments entry-comments comments-tree', { 'show-comment-avatar' : SHOW_COMMENT_USER_AVATARS is same as V_TRUE}, 'comments-view-style--'~VIEW_STYLE) }}" data-controller="subject-list" data-action="{{- DYNAMIC_LISTS is same as V_TRUE ? 'notifications:EntryCommentCreatedNotification@window->subject-list#addComment' : 'notifications:EntryCommentCreatedNotification@window->subject-list#increaseCounter' -}}">
-	{% for comment in comments %}
-		{{ component('entry_comment', {
+{% set autoAction = 'notifications:EntryCommentCreatedNotification@window->subject-list#addComment' %}
+{% set manualAction = 'notifications:EntryCommentCreatedNotification@window->subject-list#increaseCounter' %}
+<div class="{{ html_classes('comments entry-comments comments-tree', {
+        'show-comment-avatar' : SHOW_COMMENT_USER_AVATARS is same as V_TRUE },
+        'comments-view-style--'~VIEW_STYLE
+    ) }}"
+    data-controller="subject-list"
+    data-action="{{- DYNAMIC_LISTS is same as V_TRUE ? autoAction : manualAction -}}">
+    {% for comment in comments %}
+    {{ component('entry_comment', {
             comment: comment,
             showNested: showNested,
             dateAsUrl: dateAsUrl is defined ? dateAsUrl : false,
             showMagazineName: magazine is not defined or not magazine,
             showEntryTitle: entry is not defined or not entry
         }) }}
-	{% endfor %}
-	{% if(comments.haveToPaginate is defined and comments.haveToPaginate) %}
-		{{ pagerfanta(comments, null, {'pageParameter':'[p]'}) }}
-	{% endif %}
-	{% if not comments|length %}
-		<aside class="section section--muted">
-			<p>{{ 'no_comments'|trans }}</p>
-		</aside>
-	{% elseif VIEW_STYLE is same as V_TREE %}
-		<div class="comment-line--2"></div>
-		<div class="comment-line--3"></div>
-		<div class="comment-line--4"></div>
-		<div class="comment-line--5"></div>
-		<div class="comment-line--6"></div>
-		<div class="comment-line--7"></div>
-		<div class="comment-line--8"></div>
-		<div class="comment-line--9"></div>
-	{% endif %}
-</section>
+    {% endfor %}
+    {% if(comments.haveToPaginate is defined and comments.haveToPaginate) %}
+        {{ pagerfanta(comments, null, {'pageParameter':'[p]'}) }}
+    {% endif %}
+    {% if not comments|length %}
+        <aside class="section section--muted">
+            <p>{{ 'no_comments'|trans }}</p>
+        </aside>
+    {% elseif VIEW_STYLE is same as V_TREE %}
+        <div class="comment-line--2"></div>
+        <div class="comment-line--3"></div>
+        <div class="comment-line--4"></div>
+        <div class="comment-line--5"></div>
+        <div class="comment-line--6"></div>
+        <div class="comment-line--7"></div>
+        <div class="comment-line--8"></div>
+        <div class="comment-line--9"></div>
+    {% endif %}
+</div>

--- a/templates/entry/comment/_list.html.twig
+++ b/templates/entry/comment/_list.html.twig
@@ -1,12 +1,21 @@
+{%- set V_TRUE = constant('App\\Controller\\User\\ThemeSettingsController::TRUE') -%}
+{%- set V_FALSE = constant('App\\Controller\\User\\ThemeSettingsController::FALSE') -%}
+{%- set V_CHAT = constant('App\\Controller\\User\\ThemeSettingsController::CHAT') -%}
+{%- set V_TREE = constant('App\\Controller\\User\\ThemeSettingsController::TREE') -%}
+
+{%- set DYNAMIC_LISTS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_DYNAMIC_LISTS'), V_FALSE) -%}
+{%- set SHOW_COMMENT_USER_AVATARS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_COMMENTS_SHOW_USER_AVATAR'), V_TRUE) -%}
+{%- set VIEW_STYLE = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::ENTRY_COMMENTS_VIEW'), V_TREE) -%}
+
 {% if showNested is not defined %}
-	{% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::ENTRY_COMMENTS_VIEW')) is same as constant('App\\Controller\\User\\ThemeSettingsController::CHAT') %}
+	{% if VIEW_STYLE is same as V_CHAT %}
 		{% set showNested = false %}
 	{% else %}
 		{% set showNested = true %}
 	{% endif %}
 {% endif %}
 
-<section class="{{ html_classes('comments entry-comments comments-tree', { 'show-comment-avatar' : app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_COMMENTS_SHOW_USER_AVATAR')) is same as 'true' or not app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_COMMENTS_SHOW_USER_AVATAR'))}) }}" data-controller="subject-list" data-action="{{- app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_DYNAMIC_LISTS')) is same as 'true' ? 'notifications:EntryCommentCreatedNotification@window->subject-list#addComment' : 'notifications:EntryCommentCreatedNotification@window->subject-list#increaseCounter' -}}">
+<section class="{{ html_classes('comments entry-comments comments-tree', { 'show-comment-avatar' : SHOW_COMMENT_USER_AVATARS is same as V_TRUE}, 'comments-view-style--'~VIEW_STYLE) }}" data-controller="subject-list" data-action="{{- DYNAMIC_LISTS is same as V_TRUE ? 'notifications:EntryCommentCreatedNotification@window->subject-list#addComment' : 'notifications:EntryCommentCreatedNotification@window->subject-list#increaseCounter' -}}">
 	{% for comment in comments %}
 		{{ component('entry_comment', {
             comment: comment,
@@ -23,7 +32,7 @@
 		<aside class="section section--muted">
 			<p>{{ 'no_comments'|trans }}</p>
 		</aside>
-	{% elseif app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::ENTRY_COMMENTS_VIEW')) is null or app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::ENTRY_COMMENTS_VIEW')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TREE') %}
+	{% elseif VIEW_STYLE is same as V_TREE %}
 		<div class="comment-line--2"></div>
 		<div class="comment-line--3"></div>
 		<div class="comment-line--4"></div>

--- a/templates/entry/single.html.twig
+++ b/templates/entry/single.html.twig
@@ -38,23 +38,23 @@
         {% include 'layout/_flash.html.twig' %}
         {% include 'entry/comment/_options.html.twig' %}
         {% include('user/_visibility_info.html.twig') %}
-        
+
         {% if user is defined and user and user.visibility is same as 'visible' and (user_settings.comment_reply_position == constant('App\\Controller\\User\\ThemeSettingsController::TOP')) %}
             <div id="comment-add" class="section">
                 {% include 'entry/comment/_form_comment.html.twig' %}
             </div>
         {% endif %}
-        
+
         <div id="comments">
             {% include 'entry/comment/_list.html.twig' %}
         </div>
 
-         {% if user is defined and user and user.visibility is same as 'visible' and (user_settings.comment_reply_position == constant('App\\Controller\\User\\ThemeSettingsController::BOTTOM'))  %}
+        {% if user is defined and user and user.visibility is same as 'visible' and (user_settings.comment_reply_position == constant('App\\Controller\\User\\ThemeSettingsController::BOTTOM'))  %}
             <div id="comment-add" class="section">
                 {% include 'entry/comment/_form_comment.html.twig' %}
             </div>
         {% endif %}
-        
+
         {% include 'entry/_options_activity.html.twig' %}
     </div>
 {% endblock %}

--- a/templates/post/_list.html.twig
+++ b/templates/post/_list.html.twig
@@ -1,9 +1,17 @@
+{%- set V_TRUE = constant('App\\Controller\\User\\ThemeSettingsController::TRUE') -%}
+{%- set V_FALSE = constant('App\\Controller\\User\\ThemeSettingsController::FALSE') -%}
+
+{%- set SHOW_COMMENT_USER_AVATARS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_COMMENTS_SHOW_USER_AVATAR'), V_TRUE) -%}
+{%- set SHOW_POST_USER_AVATARS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_USERS_AVATARS'), V_TRUE) -%}
+{%- set DYNAMIC_LISTS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_DYNAMIC_LISTS'), V_FALSE) -%}
+{%- set INFINITE_SCROLL = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_INFINITE_SCROLL'), V_FALSE) -%}
+
 <div data-controller="subject-list"
      class="{{ html_classes({
-         'show-comment-avatar': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_COMMENTS_SHOW_USER_AVATAR')) is same as 'true' or not app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_COMMENTS_SHOW_USER_AVATAR')),
-         'show-post-avatar': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_USERS_AVATARS')) is same as 'true' or not app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_USERS_AVATARS'))
+         'show-comment-avatar': SHOW_COMMENT_USER_AVATARS is same as V_TRUE,
+         'show-post-avatar': SHOW_POST_USER_AVATARS is same as V_TRUE
      }) }}"
-     data-action="{{- app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_DYNAMIC_LISTS')) is same as 'true' ? 'notifications:PostCreatedNotification@window->subject-list#addMainSubject notifications:PostCommentCreatedNotification@window->subject-list#addCommentOverview' : 'notifications:PostCreatedNotification@window->subject-list#increaseCounter' -}}">
+     data-action="{{- DYNAMIC_LISTS is same as V_TRUE ? 'notifications:PostCreatedNotification@window->subject-list#addMainSubject notifications:PostCommentCreatedNotification@window->subject-list#addCommentOverview' : 'notifications:PostCreatedNotification@window->subject-list#increaseCounter' -}}">
     {% for post in posts %}
         {{ component('post', {
             post: post,
@@ -12,7 +20,7 @@
         }) }}
     {% endfor %}
     {% if(posts.haveToPaginate is defined and posts.haveToPaginate) %}
-        {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_INFINITE_SCROLL')) is same as 'true' %}
+        {% if INFINITE_SCROLL is same as V_TRUE %}
             <div data-controller="infinite-scroll" class="infinite-scroll">
                 {{ component('loader', {'data-infinite-scroll-target': 'loader'}) }}
                 <div data-infinite-scroll-target="pagination" class="visually-hidden">

--- a/templates/post/comment/_list.html.twig
+++ b/templates/post/comment/_list.html.twig
@@ -1,5 +1,15 @@
+{%- set V_TRUE = constant('App\\Controller\\User\\ThemeSettingsController::TRUE') -%}
+{%- set V_FALSE = constant('App\\Controller\\User\\ThemeSettingsController::FALSE') -%}
+{%- set V_CHAT = constant('App\\Controller\\User\\ThemeSettingsController::CHAT') -%}
+{%- set V_TREE = constant('App\\Controller\\User\\ThemeSettingsController::TREE') -%}
+
+{%- set SHOW_COMMENT_USER_AVATARS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_COMMENTS_SHOW_USER_AVATAR'), V_TRUE) -%}
+{%- set SHOW_POST_USER_AVATARS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_USERS_AVATARS'), V_TRUE) -%}
+{%- set DYNAMIC_LISTS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_DYNAMIC_LISTS'), V_FALSE) -%}
+{%- set VIEW_STYLE = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW'), V_TREE) -%}
+
 {% if showNested is not defined %}
-    {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW')) is same as constant('App\\Controller\\User\\ThemeSettingsController::CHAT') %}
+    {% if VIEW_STYLE is same as V_CHAT %}
         {% set showNested = false %}
     {% else %}
         {% set showNested = true %}
@@ -10,13 +20,13 @@
 {% endif %}
 {% set autoAction = is_route_name('post_single') ? 'notifications:PostCommentCreatedNotification@window->subject-list#addComment' : 'notifications:PostCommentCreatedNotification@window->subject-list#addCommentOverview' %}
 {% set manualAction = is_route_name('post_single') ? 'notifications:PostCommentCreatedNotification@scroll-top#increaseCounter' : 'notifications:PostCommentCreatedNotification@window->scroll_top#increaseCounter' %}
-<div class="comments post-comments comments-tree"
-     class="{{ html_classes({
-         'show-comment-avatar': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_COMMENTS_SHOW_USER_AVATAR')) is same as 'true' or not app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_COMMENTS_SHOW_USER_AVATAR')),
-         'show-post-avatar': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_USERS_AVATARS')) is same as 'true' or not app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_USERS_AVATARS'))
-     }) }}"
+<div class="{{ html_classes('comments post-comments comments-tree', {
+         'show-comment-avatar': SHOW_COMMENT_USER_AVATARS is same as V_TRUE,
+         'show-post-avatar': SHOW_POST_USER_AVATARS is same as V_TRUE },
+         'comments-view-style--'~VIEW_STYLE
+     ) }}"
      data-controller="subject-list"
-     data-action="{{- app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_DYNAMIC_LISTS')) is same as 'true' ? autoAction : manualAction -}}">
+     data-action="{{- DYNAMIC_LISTS is same as V_TRUE ? autoAction : manualAction -}}">
     {% for comment in comments %}
         {{ component('post_comment', {
             comment: comment,
@@ -32,7 +42,7 @@
         <aside class="section section--muted">
             <p>{{ 'no_comments'|trans }}</p>
         </aside>
-    {% elseif app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW')) is null or app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TREE') %}
+    {% elseif VIEW_STYLE is same as V_TREE %}
         <div class="comment-line--2"></div>
         <div class="comment-line--3"></div>
         <div class="comment-line--4"></div>

--- a/templates/post/single.html.twig
+++ b/templates/post/single.html.twig
@@ -39,19 +39,19 @@
         {% include 'layout/_flash.html.twig' %}
 
         {% if user is defined and user and user.visibility is same as 'visible' and (user_settings.comment_reply_position == constant('App\\Controller\\User\\ThemeSettingsController::TOP')) %}
-        <section id="comment-add" class="section">
-            {% include 'post/comment/_form_comment.html.twig' %}
-        </section>
+            <div id="comment-add" class="section">
+                {% include 'post/comment/_form_comment.html.twig' %}
+            </div>
         {% endif %}
 
-        <section id="comments">
+        <div id="comments">
             {% include 'post/comment/_list.html.twig' %}
-        </section>
+        </div>
 
         {% if user is defined and user and user.visibility is same as 'visible' and (user_settings.comment_reply_position == constant('App\\Controller\\User\\ThemeSettingsController::BOTTOM')) %}
-        <section id="comment-add" class="section">
-            {% include 'post/comment/_form_comment.html.twig' %}
-        </section>
+            <div id="comment-add" class="section">
+                {% include 'post/comment/_form_comment.html.twig' %}
+            </div>
         {% endif %}
 
         {% include 'post/_options_activity.html.twig' %}


### PR DESCRIPTION
Adds a very small margin above top level entry comments after the first one (as the first one already has spacing from the reply box / sort order. It also adds the current view style class to the `<section>` tag as doing this in chat view makes no sense (top parents are together at the top with their replies all at the bottom completely unlinked)

this was first suggested here https://codeberg.org/Kbin/kbin-core/issues/1165

I've been running with this in tampermonkey ever since, and I think it helps improve readability / flow and is a small enough change that hopefully wouldn't upset too many people

when comparing the screenshots, look at the spacing right above top parent 2 & 3

also does a bunch of cleanup of constants, using the correct values of the cookies to compare against just in case anyone changes the constant for true in the controller to something else, matching what @asdfzdfj did for the sidebar settings originally

before tree
![image](https://github.com/MbinOrg/mbin/assets/146029455/2e540618-f101-48a1-ab73-6c417d657174)

after tree
![image](https://github.com/MbinOrg/mbin/assets/146029455/dbe3e5b6-33dc-4f75-8e69-cb840308667f)

<details>
<summary>classic</summary>

before classic
![image](https://github.com/MbinOrg/mbin/assets/146029455/e4472229-c491-4715-acab-3c676e6782b1)

after classic
![image](https://github.com/MbinOrg/mbin/assets/146029455/24125621-4c62-4a32-9e4e-6bcd901a110c)

</details>