### PR TITLE
Hide NSFW posts on user overview page when logged out or hide NSFW enabled

### DIFF
--- a/src/Command/Update/UserLastActiveUpdateCommand.php
+++ b/src/Command/Update/UserLastActiveUpdateCommand.php
@@ -25,9 +25,9 @@ class UserLastActiveUpdateCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $repo = $this->entityManager->getRepository(User::class);
+        $hideAdult = false;
 
         foreach ($repo->findAll() as $user) {
-            $hideAdult = false;
             $activity = $repo->findPublicActivity(1, $user, $hideAdult);
             if ($activity->count()) {
                 $user->lastActive = $activity->getCurrentPageResults()[0]->lastActive;

--- a/src/Command/Update/UserLastActiveUpdateCommand.php
+++ b/src/Command/Update/UserLastActiveUpdateCommand.php
@@ -27,7 +27,8 @@ class UserLastActiveUpdateCommand extends Command
         $repo = $this->entityManager->getRepository(User::class);
 
         foreach ($repo->findAll() as $user) {
-            $activity = $repo->findPublicActivity(1, $user);
+            $hideAdult = false;
+            $activity = $repo->findPublicActivity(1, $user, $hideAdult);
             if ($activity->count()) {
                 $user->lastActive = $activity->getCurrentPageResults()[0]->lastActive;
             }

--- a/src/Controller/ActivityPub/User/UserOutboxController.php
+++ b/src/Controller/ActivityPub/User/UserOutboxController.php
@@ -72,7 +72,8 @@ class UserOutboxController extends AbstractController
         User $user,
         int $page
     ): array {
-        $activity = $this->userRepository->findPublicActivity($page, $user);
+        $hideAdult = false;
+        $activity = $this->userRepository->findPublicActivity($page, $user, $hideAdult);
 
         $items = [];
         foreach ($activity as $item) {

--- a/src/Controller/ActivityPub/User/UserOutboxController.php
+++ b/src/Controller/ActivityPub/User/UserOutboxController.php
@@ -54,6 +54,7 @@ class UserOutboxController extends AbstractController
     private function getCollectionInfo(User $user): array
     {
         $hideAdult = false;
+
         return $this->collectionInfoWrapper->build(
             'ap_user_outbox',
             ['username' => $user->username],

--- a/src/Controller/ActivityPub/User/UserOutboxController.php
+++ b/src/Controller/ActivityPub/User/UserOutboxController.php
@@ -53,10 +53,11 @@ class UserOutboxController extends AbstractController
     ])]
     private function getCollectionInfo(User $user): array
     {
+        $hideAdult = false;
         return $this->collectionInfoWrapper->build(
             'ap_user_outbox',
             ['username' => $user->username],
-            $this->userRepository->countPublicActivity($user)
+            $this->userRepository->countPublicActivity($user, $hideAdult)
         );
     }
 

--- a/src/Controller/User/UserFrontController.php
+++ b/src/Controller/User/UserFrontController.php
@@ -37,7 +37,10 @@ class UserFrontController extends AbstractController
             $response->headers->set('X-Robots-Tag', 'noindex, nofollow');
         }
 
-        $activity = $repository->findPublicActivity($this->getPageNb($request), $user);
+        $requestedByUser = $this->getUser();
+        $hideAdult = (!$requestedByUser || $requestedByUser->hideAdult);
+
+        $activity = $repository->findPublicActivity($this->getPageNb($request), $user, $hideAdult);
 
         return $this->render(
             'user/overview.html.twig',

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -82,9 +82,9 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
 
     private function getPublicActivityQuery(User $user, bool $hideAdult): Result
     {
-        $adultFilter = "";
-        if($hideAdult) {
-            $adultFilter = " AND is_adult = :isAdult";
+        $adultFilter = '';
+        if ($hideAdult) {
+            $adultFilter = ' AND is_adult = :isAdult';
         }
 
         $conn = $this->_em->getConnection();

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -107,7 +107,7 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
         $stmt->bindValue('visibility', VisibilityInterface::VISIBILITY_VISIBLE);
 
         if ($hideAdult) {
-            $stmt->bindValue('isAdult', 'false');
+            $stmt->bindValue('isAdult', false, \PDO::PARAM_BOOL);
         }
 
         return $stmt->executeQuery();

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -82,33 +82,29 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
 
     private function getPublicActivityQuery(User $user, bool $hideAdult): Result
     {
-        $adultFilter = '';
-        if ($hideAdult) {
-            $adultFilter = 'AND is_adult = :isAdult';
-        }
-
         $conn = $this->_em->getConnection();
         $sql = "
         (SELECT id, created_at, 'entry' AS type FROM entry
-        WHERE user_id = :userId AND visibility = :visibility $adultFilter)
+        WHERE user_id = :userId AND visibility = :visibility
+        AND is_adult = CASE WHEN :hideAdult THEN false ELSE is_adult END)
         UNION
         (SELECT id, created_at, 'entry_comment' AS type FROM entry_comment
-        WHERE user_id = :userId AND visibility = :visibility $adultFilter)
+        WHERE user_id = :userId AND visibility = :visibility
+        AND is_adult = CASE WHEN :hideAdult THEN false ELSE is_adult END)
         UNION
         (SELECT id, created_at, 'post' AS type FROM post
-        WHERE user_id = :userId AND visibility = :visibility $adultFilter)
+        WHERE user_id = :userId AND visibility = :visibility
+        AND is_adult = CASE WHEN :hideAdult THEN false ELSE is_adult END)
         UNION
         (SELECT id, created_at, 'post_comment' AS type FROM post_comment
-        WHERE user_id = :userId AND visibility = :visibility $adultFilter)
+        WHERE user_id = :userId AND visibility = :visibility
+        AND is_adult = CASE WHEN :hideAdult THEN false ELSE is_adult END)
         ORDER BY created_at DESC";
 
         $stmt = $conn->prepare($sql);
         $stmt->bindValue('userId', $user->getId());
         $stmt->bindValue('visibility', VisibilityInterface::VISIBILITY_VISIBLE);
-
-        if ($hideAdult) {
-            $stmt->bindValue('isAdult', false, \PDO::PARAM_BOOL);
-        }
+        $stmt->bindValue('hideAdult', $hideAdult, \PDO::PARAM_BOOL);
 
         return $stmt->executeQuery();
     }

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -84,22 +84,22 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
     {
         $adultFilter = '';
         if ($hideAdult) {
-            $adultFilter = ' AND is_adult = :isAdult';
+            $adultFilter = 'AND is_adult = :isAdult';
         }
 
         $conn = $this->_em->getConnection();
         $sql = "
         (SELECT id, created_at, 'entry' AS type FROM entry
-        WHERE user_id = :userId AND visibility = :visibility".$adultFilter.")
+        WHERE user_id = :userId AND visibility = :visibility $adultFilter)
         UNION
         (SELECT id, created_at, 'entry_comment' AS type FROM entry_comment
-        WHERE user_id = :userId AND visibility = :visibility".$adultFilter.")
+        WHERE user_id = :userId AND visibility = :visibility $adultFilter)
         UNION
         (SELECT id, created_at, 'post' AS type FROM post
-        WHERE user_id = :userId AND visibility = :visibility".$adultFilter.")
+        WHERE user_id = :userId AND visibility = :visibility $adultFilter)
         UNION
         (SELECT id, created_at, 'post_comment' AS type FROM post_comment
-        WHERE user_id = :userId AND visibility = :visibility".$adultFilter.")
+        WHERE user_id = :userId AND visibility = :visibility $adultFilter)
         ORDER BY created_at DESC";
 
         $stmt = $conn->prepare($sql);

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -75,9 +75,9 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
             ->getOneOrNullResult();
     }
 
-    public function countPublicActivity(User $user): int
+    public function countPublicActivity(User $user, bool $hideAdult): int
     {
-        return $this->getPublicActivityQuery($user)->rowCount();
+        return $this->getPublicActivityQuery($user, $hideAdult)->rowCount();
     }
 
     private function getPublicActivityQuery(User $user, bool $hideAdult): Result


### PR DESCRIPTION
This filters out nsfw content where the user is the **author** of the entry, post, or comment. It does not filter out non-nsfw marked replies to nsfw content (wanted to keep this small for now to keep it simple)

Logged out:
![image](https://github.com/MbinOrg/mbin/assets/146029455/f482e148-b9a2-4753-a4db-f9098d57c24b)

Logged in with a user with hide nsfw checked:
![image](https://github.com/MbinOrg/mbin/assets/146029455/5fbe784c-af6b-4644-87ad-15ba8bd95eee)

Logged in with a user with hide nsfw unchecked:
![image](https://github.com/MbinOrg/mbin/assets/146029455/95548277-8458-4bf1-af16-7be507480a8a)
