### PR TITLE
Add current sort and time options to navbar links

### DIFF
--- a/src/Twig/Runtime/NavbarExtensionRuntime.php
+++ b/src/Twig/Runtime/NavbarExtensionRuntime.php
@@ -20,11 +20,17 @@ class NavbarExtensionRuntime implements RuntimeExtensionInterface
     public function navbarThreadsUrl(?Magazine $magazine): string
     {
         if ($magazine instanceof Magazine) {
-            return $this->urlGenerator->generate('front_magazine', ['name' => $magazine->name]);
+            return $this->urlGenerator->generate('front_magazine', [
+                'name' => $magazine->name,
+                ...$this->getActiveOptions()
+            ]);
         }
 
         if ($domain = $this->requestStack->getCurrentRequest()->get('domain')) {
-            return $this->urlGenerator->generate('domain_entries', ['name' => $domain->name]);
+            return $this->urlGenerator->generate('domain_entries', [
+                'name' => $domain->name,
+                ...$this->getActiveOptions()
+            ]);
         }
 
         if (str_starts_with($this->getCurrentRouteName(), 'tag')) {
@@ -35,24 +41,27 @@ class NavbarExtensionRuntime implements RuntimeExtensionInterface
         }
 
         if (str_ends_with($this->getCurrentRouteName(), '_subscribed')) {
-            return $this->urlGenerator->generate('front_subscribed');
+            return $this->urlGenerator->generate('front_subscribed', $this->getActiveOptions());
         }
 
         if (str_ends_with($this->getCurrentRouteName(), '_favourite')) {
-            return $this->urlGenerator->generate('front_favourite');
+            return $this->urlGenerator->generate('front_favourite', $this->getActiveOptions());
         }
 
         if (str_ends_with($this->getCurrentRouteName(), '_moderated')) {
-            return $this->urlGenerator->generate('front_moderated');
+            return $this->urlGenerator->generate('front_moderated', $this->getActiveOptions());
         }
 
-        return $this->urlGenerator->generate('front');
+        return $this->urlGenerator->generate('front', $this->getActiveOptions());
     }
 
     public function navbarPostsUrl(?Magazine $magazine): string
     {
         if ($magazine instanceof Magazine) {
-            return $this->urlGenerator->generate('magazine_posts', ['name' => $magazine->name]);
+            return $this->urlGenerator->generate('magazine_posts', [
+                'name' => $magazine->name,
+                ...$this->getActiveOptions()
+            ]);
         }
 
         if (str_starts_with($this->getCurrentRouteName(), 'tag')) {
@@ -63,18 +72,18 @@ class NavbarExtensionRuntime implements RuntimeExtensionInterface
         }
 
         if (str_ends_with($this->getCurrentRouteName(), '_subscribed')) {
-            return $this->urlGenerator->generate('posts_subscribed');
+            return $this->urlGenerator->generate('posts_subscribed', $this->getActiveOptions());
         }
 
         if (str_ends_with($this->getCurrentRouteName(), '_favourite')) {
-            return $this->urlGenerator->generate('posts_favourite');
+            return $this->urlGenerator->generate('posts_favourite', $this->getActiveOptions());
         }
 
         if (str_ends_with($this->getCurrentRouteName(), '_moderated')) {
-            return $this->urlGenerator->generate('posts_moderated');
+            return $this->urlGenerator->generate('posts_moderated', $this->getActiveOptions());
         }
 
-        return $this->urlGenerator->generate('posts_front');
+        return $this->urlGenerator->generate('posts_front', $this->getActiveOptions());
     }
 
     public function navbarPeopleUrl(?Magazine $magazine): string
@@ -96,5 +105,32 @@ class NavbarExtensionRuntime implements RuntimeExtensionInterface
     private function getCurrentRouteName(): string
     {
         return $this->requestStack->getCurrentRequest()->get('_route') ?? 'front';
+    }
+
+    private function getActiveOptions(): array
+    {
+        $sortOption = $this->getActiveSortOption();
+        $timeOption = $this->getActiveTimeOption();
+        $options = [];
+
+        // don't add the current options if they are the defaults
+        if ($sortOption !== 'hot') {
+            $options['sortBy'] = $sortOption;
+        }
+        if ($timeOption !== '∞') {
+            $options['time'] = $timeOption;
+        }
+
+        return $options;
+    }
+
+    private function getActiveSortOption(): string
+    {
+        return $this->requestStack->getCurrentRequest()->get('sortBy') ?? 'hot';
+    }
+
+    private function getActiveTimeOption(): string
+    {
+        return $this->requestStack->getCurrentRequest()->get('time') ?? '∞';
     }
 }

--- a/src/Twig/Runtime/NavbarExtensionRuntime.php
+++ b/src/Twig/Runtime/NavbarExtensionRuntime.php
@@ -22,14 +22,14 @@ class NavbarExtensionRuntime implements RuntimeExtensionInterface
         if ($magazine instanceof Magazine) {
             return $this->urlGenerator->generate('front_magazine', [
                 'name' => $magazine->name,
-                ...$this->getActiveOptions()
+                ...$this->getActiveOptions(),
             ]);
         }
 
         if ($domain = $this->requestStack->getCurrentRequest()->get('domain')) {
             return $this->urlGenerator->generate('domain_entries', [
                 'name' => $domain->name,
-                ...$this->getActiveOptions()
+                ...$this->getActiveOptions(),
             ]);
         }
 
@@ -60,7 +60,7 @@ class NavbarExtensionRuntime implements RuntimeExtensionInterface
         if ($magazine instanceof Magazine) {
             return $this->urlGenerator->generate('magazine_posts', [
                 'name' => $magazine->name,
-                ...$this->getActiveOptions()
+                ...$this->getActiveOptions(),
             ]);
         }
 
@@ -114,10 +114,10 @@ class NavbarExtensionRuntime implements RuntimeExtensionInterface
         $options = [];
 
         // don't add the current options if they are the defaults
-        if ($sortOption !== 'hot') {
+        if ('hot' !== $sortOption) {
             $options['sortBy'] = $sortOption;
         }
-        if ($timeOption !== '∞') {
+        if ('∞' !== $timeOption) {
             $options['time'] = $timeOption;
         }
 


### PR DESCRIPTION
This changes the Threads and Microblog navbar link to preserve the currently active `sortBy` and `time` settings

| On | Current thread link | Current microblog link | New thread link | New microblog link |
|--------|--------|--------|--------|--------|
| `/` or `/microblog` | `/all` | `/microblog` | `/all` | `/microblog` |
| `/newest` or `/microblog/newest` | `/all` | `/microblog` | `/all/newest` | `/microblog/newest` |
| `/newest/1m` or `/microblog/newest/1m` | `/all` | `/microblog` | `/all/newest/1m` | `/microblog/newest/1m` |
| `/sub` or `/sub/microblog` | `/sub` | `/sub/microblog` | `/sub` | `/sub/microblog` |
| `/sub/newest` or `/sub/microblog/newest` | `/sub` | `/sub/microblog` | `/sub/newest` | `/sub/microblog/newest` |
| `/sub/newest/1m` or `/sub/microblog/newest/1m` | `/sub` | `/sub/microblog` | `/sub/newest/1m` | `/sub/microblog/newest/1m` |

Etc for `/mod` and `/fav`. At the moment it's not preserving `type` option as that is specific to threads and not shared by microblogs, but if desired I could add it. I'm a bit skeptical of the usefulness of filtering by "type" (which are: links, thread, photos, videos)