### PR TITLE
recognize image url with extension case insensitively

### DIFF
--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -34,7 +34,7 @@ class ImageManager
 
     public static function isImageUrl(string $url): bool
     {
-        $urlExt = pathinfo($url, PATHINFO_EXTENSION);
+        $urlExt = mb_strtolower(pathinfo($url, PATHINFO_EXTENSION));
 
         $types = array_map(fn ($type) => str_replace('image/', '', $type), self::IMAGE_MIMETYPES);
 


### PR DESCRIPTION
because it's entirely possible to encounter valid image links that ends with uppercase extension, and current code doesn't recognize them at the moment