### PR TITLE
fix duplicate sensitive image state id collision

### DIFF
--- a/templates/components/_figure_entry.html.twig
+++ b/templates/components/_figure_entry.html.twig
@@ -1,8 +1,8 @@
 {# this fragment is only meant to be used in entry component #}
 {% with {
-    sensitiveId: 'sensitive-check-'~entry.image.id,
-    isSingle: is_route_name('entry_single'),
-    route: isSingle ? singleRoute : entry_url(entry)
+    sensitive_id: 'sensitive-check-%s-%s'|format(entry.id, entry.image.id),
+    is_single: is_route_name('entry_single'),
+    route: is_single ? single_route : entry_url(entry)
 } %}
 <figure>
     <div class="image-filler" aria-hidden="true">
@@ -11,13 +11,13 @@
         {% endif %}
     </div>
     {% if entry.isAdult %}
-        <input id="{{ sensitiveId }}"
+        <input id="{{ sensitive_id }}"
                type="checkbox"
                class="sensitive-state"
                aria-label="{{ 'sensitive_toggle'|trans }}">
     {% endif %}
     <a href="{{ route }}"
-       class="{{ html_classes('sensitive-checked--show', {'thumb': isSingle and lightbox|default(false)}) }}"
+       class="{{ html_classes('sensitive-checked--show', {'thumb': is_single and lightbox|default(false)}) }}"
        rel="{{ setRel ? get_rel(route) : '' }}"
     >
         <img class="thumb-subject"
@@ -25,7 +25,7 @@
              alt="{{ entry.image.altText }}">
     </a>
     {% if entry.isAdult %}
-        <label for="{{ sensitiveId }}"
+        <label for="{{ sensitive_id }}"
                class="sensitive-button sensitive-button-show sensitive-checked--hide"
                title="{{ 'sensitive_show'|trans }}"
                aria-label="{{ 'sensitive_show'|trans }}">
@@ -33,7 +33,7 @@
                 <i class="fa-solid fa-eye"></i>
             </div>
         </label>
-        <label for="{{ sensitiveId }}"
+        <label for="{{ sensitive_id }}"
                class="sensitive-button sensitive-button-hide sensitive-checked--show"
                title="{{ 'sensitive_hide'|trans }}"
                aria-label="{{ 'sensitive_hide'|trans }}">

--- a/templates/components/_figure_entry.html.twig
+++ b/templates/components/_figure_entry.html.twig
@@ -2,8 +2,15 @@
 {% with {
     sensitive_id: 'sensitive-check-%s-%s'|format(entry.id, entry.image.id),
     is_single: is_route_name('entry_single'),
-    route: is_single ? single_route : entry_url(entry)
 } %}
+{% if type is same as 'image' %}
+    {% set single_route = uploaded_asset(entry.image.filePath) %}
+    {% set lightbox = true %}
+{% elseif type is same as 'link' %}
+    {% set single_route = entry.url %}
+    {% set set_rel = true %}
+{% endif %}
+{% set route = is_single ? single_route : entry_url(entry) %}
 <figure>
     <div class="image-filler" aria-hidden="true">
         {% if entry.image.blurhash %}
@@ -17,8 +24,10 @@
                aria-label="{{ 'sensitive_toggle'|trans }}">
     {% endif %}
     <a href="{{ route }}"
-       class="{{ html_classes('sensitive-checked--show', {'thumb': is_single and lightbox|default(false)}) }}"
-       rel="{{ setRel ? get_rel(route) : '' }}"
+       class="{{ html_classes('sensitive-checked--show', {
+            'thumb': is_single and lightbox|default(false)
+       }) }}"
+       rel="{{ set_rel ? get_rel(route) : '' }}"
     >
         <img class="thumb-subject"
              src="{{ asset(entry.image.filePath)|imagine_filter('entry_thumb') }}"

--- a/templates/components/_figure_entry.html.twig
+++ b/templates/components/_figure_entry.html.twig
@@ -4,13 +4,10 @@
     is_single: is_route_name('entry_single'),
 } %}
 {% if type is same as 'image' %}
-    {% set single_route = uploaded_asset(entry.image.filePath) %}
-    {% set lightbox = true %}
+    {% set route = is_single ? uploaded_asset(entry.image.filePath) : entry_url(entry) %}
 {% elseif type is same as 'link' %}
-    {% set single_route = entry.url %}
-    {% set set_rel = true %}
+    {% set route = is_single ? entry.url : entry_url(entry) %}
 {% endif %}
-{% set route = is_single ? single_route : entry_url(entry) %}
 <figure>
     <div class="image-filler" aria-hidden="true">
         {% if entry.image.blurhash %}
@@ -25,9 +22,9 @@
     {% endif %}
     <a href="{{ route }}"
        class="{{ html_classes('sensitive-checked--show', {
-            'thumb': is_single and lightbox|default(false)
+            'thumb': is_single and (type is same as 'image')
        }) }}"
-       rel="{{ set_rel ? get_rel(route) : '' }}"
+       rel="{{ (type is same as 'link') ? get_rel(route) : '' }}"
     >
         <img class="thumb-subject"
              src="{{ asset(entry.image.filePath)|imagine_filter('entry_thumb') }}"

--- a/templates/components/_figure_image.html.twig
+++ b/templates/components/_figure_image.html.twig
@@ -2,17 +2,17 @@
     <div class="figure-container">
         <div class="figure-thumb">
             <a href="{{ uploaded_asset(image.filePath) }}" class="thumb">
-                <img src="{{ asset(image.filePath)|imagine_filter(thumbFilter) }}"
+                <img src="{{ asset(image.filePath)|imagine_filter(thumb_filter) }}"
                      alt="{{ image.altText }}">
             </a>
         </div>
-        {% if isAdult %}
-            {% with {sensitiveId: 'sensitive-check-'~image.id} %}
-            <input id="{{ sensitiveId }}"
+        {% if is_adult %}
+            {% with {sensitive_id: 'sensitive-check-%s-%s'|format(parent_id, image.id) } %}
+            <input id="{{ sensitive_id }}"
                    type="checkbox"
                    class="sensitive-state"
                    aria-label="{{ 'sensitive_toggle'|trans }}">
-            <label for="{{ sensitiveId }}"
+            <label for="{{ sensitive_id }}"
                    class="sensitive-button sensitive-button-show sensitive-checked--hide"
                    title="{{ 'sensitive_show'|trans }}">
                 <div class="figure-blur" aria-hidden="true">
@@ -23,7 +23,7 @@
                     {{ 'sensitive_show'|trans }}
                 </div>
             </label>
-            <label for="{{ sensitiveId }}"
+            <label for="{{ sensitive_id }}"
                    class="sensitive-button sensitive-button-hide sensitive-checked--show"
                    title="{{ 'sensitive_hide'|trans }}"
                    aria-label="{{ 'sensitive_hide'|trans }}">

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -90,13 +90,13 @@
                     {% if entry.type is same as 'link' or entry.type is same as 'video' %}
                         {{ include('components/_figure_entry.html.twig', {
                             entry: entry,
-                            singleRoute: entry.url,
-                            setRel: true
+                            single_route: entry.url,
+                            set_rel: true
                         }) }}
                     {% elseif entry.type is same as 'image' or entry.type is same as 'article' %}
                         {{ include('components/_figure_entry.html.twig', {
                             entry: entry,
-                            singleRoute: uploaded_asset(entry.image.filePath),
+                            single_route: uploaded_asset(entry.image.filePath),
                             lightbox: true
                         }) }}
                     {% endif %}

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -88,17 +88,9 @@
             {% if SHOW_THUMBNAILS is same as V_TRUE %}
                 {% if entry.image %}
                     {% if entry.type is same as 'link' or entry.type is same as 'video' %}
-                        {{ include('components/_figure_entry.html.twig', {
-                            entry: entry,
-                            single_route: entry.url,
-                            set_rel: true
-                        }) }}
+                        {{ include('components/_figure_entry.html.twig', {entry: entry, type: 'link'}) }}
                     {% elseif entry.type is same as 'image' or entry.type is same as 'article' %}
-                        {{ include('components/_figure_entry.html.twig', {
-                            entry: entry,
-                            single_route: uploaded_asset(entry.image.filePath),
-                            lightbox: true
-                        }) }}
+                        {{ include('components/_figure_entry.html.twig', {entry: entry, type: 'image'}) }}
                     {% endif %}
                 {% else %}
                     <div class="no-image-placeholder">

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -79,8 +79,9 @@
                 {% if (comment.visibility in ['visible', 'private'] or comment.visibility is same as 'trashed' and this.canSeeTrashed) and comment.image %}
                     {{ include('components/_figure_image.html.twig', {
                         image: comment.image,
-                        isAdult: comment.isAdult,
-                        thumbFilter: 'post_thumb'
+                        parent_id: comment.id,
+                        is_adult: comment.isAdult,
+                        thumb_filter: 'post_thumb'
                     }) }}
                 {% endif %}
                 {% if comment.visibility in ['visible', 'private'] %}

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -58,8 +58,9 @@
                 {% if post.image %}
                     {{ include('components/_figure_image.html.twig', {
                         image: post.image,
-                        isAdult: post.isAdult,
-                        thumbFilter: 'post_thumb'
+                        parent_id: post.id,
+                        is_adult: post.isAdult,
+                        thumb_filter: 'post_thumb'
                     }) }}
                 {% endif %}
                 {% if post.visibility in ['visible', 'private'] %}

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -80,8 +80,9 @@
                 {% if (comment.visibility in ['visible', 'private'] or comment.visibility is same as 'trashed' and this.canSeeTrashed) and comment.image %}
                     {{ include('components/_figure_image.html.twig', {
                         image: comment.image,
-                        isAdult: comment.isAdult,
-                        thumbFilter: 'post_thumb'
+                        parent_id: comment.id,
+                        is_adult: comment.isAdult,
+                        thumb_filter: 'post_thumb'
                     }) }}
                 {% endif %}
                 {% if comment.visibility in ['visible', 'private'] %}


### PR DESCRIPTION
@e-five256 pointed out that when >1 sensitive posts are right next to each other that shares the same image, clicking show on either would only affect the first one.

this is most likely due to the checkbox that stores sensitive state has an id named after the image id, which would results in html id collision in such cases where multiple parents shares the same image and this its id, and the behavior for duplicated html id is effectively undefined.

this adds the the entry/post/comment id that associates with the image to the part of sensitive state id generation in addition to exising image id, which should make it harder to collide.

(also rename a bunch of variables to change cases but that shouldn't affect functionality)