### PR TITLE
Add captcha to contact form

### DIFF
--- a/src/Form/ContactType.php
+++ b/src/Form/ContactType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\DTO\ContactDto;
+use App\Form\EventListener\CaptchaListener;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -14,6 +15,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ContactType extends AbstractType
 {
+    public function __construct(
+        private readonly CaptchaListener $captchaListener,
+    ) {
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -22,6 +28,8 @@ class ContactType extends AbstractType
             ->add('email', EmailType::class)
             ->add('message', TextareaType::class)
             ->add('submit', SubmitType::class);
+
+        $builder->addEventSubscriber($this->captchaListener);
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/templates/page/contact.html.twig
+++ b/templates/page/contact.html.twig
@@ -21,6 +21,11 @@
             {{ form_row(form.email, {label: 'email'}) }}
             {{ form_row(form.message, {label: 'message'}) }}
             {{ form_row(form.surname, {label: false, attr: {style: 'display:none !important'}}) }}
+            {% if kbin_captcha_enabled() %}
+                    {{ form_row(form.captcha, {
+                        label: false
+                    }) }}
+                {% endif %}
             <div class="actions">
                 {{ form_row(form.submit, {label: 'send', attr: {class: 'btn btn__primary'}}) }}
             </div>


### PR DESCRIPTION
The public facing (and unauthenticated) `/contact` page currently does not have any spam protection in place, this PR adds the same code that's used in the user registration form to the contact form if the instance admin has Captcha enabled.