### PR TITLE
markdown details/spoilers block extension

### DIFF
--- a/assets/styles/_variables.scss
+++ b/assets/styles/_variables.scss
@@ -175,4 +175,13 @@ $aspect-ratios: (
   --kbin-footer-link-color: #fff;
   --kbin-footer-link-hover-color: var(--kbin-header-link-hover-color);
 
+  // details
+  --mbin-details-border: var(--kbin-section-border);
+  --mbin-details-separator-border: var(--kbin-meta-border);
+
+  --mbin-details-detail-color: var(--kbin-link-hover-color);
+  --mbin-details-spoiler-color: var(--kbin-danger-color);
+
+  --mbin-details-detail-label: "Details";
+  --mbin-details-spoiler-label: "Spoiler";
 }

--- a/assets/styles/layout/_layout.scss
+++ b/assets/styles/layout/_layout.scss
@@ -201,6 +201,7 @@ figure {
   textarea,
   select,
   button,
+  details,
   .preview img,
   .preview iframe,
   .dropdown__menu,
@@ -385,6 +386,50 @@ p > code {
   background: var(--kbin-bg);
   padding: 0.2rem .4rem;
   font-size: .85rem;
+}
+
+details {
+  border: var(--mbin-details-border);
+  border-left: 2px solid var(--mbin-details-detail-color);
+  padding: .5rem;
+  margin: .5rem 0;
+
+  summary {
+    padding-left: .5rem;
+    cursor: pointer;
+
+    > * {
+      display: inline;
+    }
+
+    &:empty::after {
+      content: var(--mbin-details-detail-label);
+    }
+  }
+
+  .content {
+    margin-top: .5rem;
+    padding-top: .5rem;
+    padding-left: .5rem;
+  }
+
+  &.spoiler {
+    border-left: 2px solid var(--mbin-details-spoiler-color);
+
+    summary:empty::after {
+      content: var(--mbin-details-spoiler-label);
+    }
+  }
+
+  &[open] .content {
+    border-top: var(--mbin-details-separator-border);
+  }
+
+  @include media-breakpoint-down(sm) {
+    summary, .content {
+      padding-left: .25rem;
+    }
+  }
 }
 
 .markdown {

--- a/assets/styles/layout/_layout.scss
+++ b/assets/styles/layout/_layout.scss
@@ -407,7 +407,7 @@ details {
     }
   }
 
-  .content {
+  > .content {
     margin-top: .5rem;
     padding-top: .5rem;
     padding-left: .5rem;
@@ -421,12 +421,20 @@ details {
     }
   }
 
-  &[open] .content {
+  &[open] > .content {
     border-top: var(--mbin-details-separator-border);
   }
 
   @include media-breakpoint-down(sm) {
-    summary, .content {
+    summary,
+    > .content {
+      padding-left: .25rem;
+    }
+  }
+
+  #sidebar & {
+    summary,
+    > .content {
       padding-left: .25rem;
     }
   }

--- a/assets/styles/mixins/theme-dark.scss
+++ b/assets/styles/mixins/theme-dark.scss
@@ -127,4 +127,11 @@
   --kbin-footer-text-color: #fff;
   --kbin-footer-link-color: #fff;
   --kbin-footer-link-hover-color: var(--kbin-header-link-hover-color);
+
+  // details
+  --mbin-details-border: var(--kbin-section-border);
+  --mbin-details-separator-border: var(--kbin-meta-border);
+
+  --mbin-details-detail-color: var(--kbin-link-hover-color);
+  --mbin-details-spoiler-color: var(--kbin-danger-color);
 }

--- a/assets/styles/mixins/theme-light.scss
+++ b/assets/styles/mixins/theme-light.scss
@@ -127,4 +127,11 @@
   --kbin-footer-text-color: #fff;
   --kbin-footer-link-color: #fff;
   --kbin-footer-link-hover-color: var(--kbin-header-link-hover-color);
+
+  // details
+  --mbin-details-border: var(--kbin-section-border);
+  --mbin-details-separator-border: var(--kbin-meta-border);
+
+  --mbin-details-detail-color: var(--kbin-link-hover-color);
+  --mbin-details-spoiler-color: var(--kbin-danger-color);
 }

--- a/assets/styles/mixins/theme-solarized-dark.scss
+++ b/assets/styles/mixins/theme-solarized-dark.scss
@@ -146,6 +146,13 @@ $green: #859900;
   --kbin-footer-link-color: var(--kbin-link-color);
   --kbin-footer-link-hover-color: var(--kbin-link-hover-color);
 
+  // details
+  --mbin-details-border: var(--kbin-section-border);
+  --mbin-details-separator-border: var(--kbin-meta-border);
+
+  --mbin-details-detail-color: #{$blue};
+  --mbin-details-spoiler-color: var(--kbin-danger-color);
+
   .options--top,
   .section--top {
     border-top: var(--kbin-options-border) !important;

--- a/assets/styles/mixins/theme-solarized-light.scss
+++ b/assets/styles/mixins/theme-solarized-light.scss
@@ -146,6 +146,13 @@ $green: #859900;
   --kbin-footer-link-color: var(--kbin-link-color);
   --kbin-footer-link-hover-color: var(--kbin-link-hover-color);
 
+  // details
+  --mbin-details-border: var(--kbin-section-border);
+  --mbin-details-separator-border: var(--kbin-meta-border);
+
+  --mbin-details-detail-color: #{$blue};
+  --mbin-details-spoiler-color: var(--kbin-danger-color);
+
   .options--top,
   .section--top {
     border-top: var(--kbin-options-border) !important;

--- a/assets/styles/themes/_kbin.scss
+++ b/assets/styles/themes/_kbin.scss
@@ -126,6 +126,13 @@
   --kbin-footer-link-color: #fff;
   --kbin-footer-link-hover-color: var(--kbin-header-link-hover-color);
 
+  // details
+  --mbin-details-border: var(--kbin-section-border);
+  --mbin-details-separator-border: var(--kbin-meta-border);
+
+  --mbin-details-detail-color: var(--kbin-link-hover-color);
+  --mbin-details-spoiler-color: var(--kbin-danger-color);
+
   .section--top,
   .options--top {
     border-top: var(--kbin-options-border) !important;

--- a/assets/styles/themes/_tokyo-night.scss
+++ b/assets/styles/themes/_tokyo-night.scss
@@ -126,6 +126,13 @@
   --kbin-footer-link-color: #e8e8ee;
   --kbin-footer-link-hover-color: var(--kbin-header-link-hover-color);
 
+  // details
+  --mbin-details-border: var(--kbin-section-border);
+  --mbin-details-separator-border: var(--kbin-meta-border);
+
+  --mbin-details-detail-color: var(--kbin-link-hover-color);
+  --mbin-details-spoiler-color: var(--kbin-danger-color);
+
   .options--top,
   .section--top {
     border-top: var(--kbin-options-border) !important;

--- a/src/Markdown/CommonMark/DetailsBlockParser.php
+++ b/src/Markdown/CommonMark/DetailsBlockParser.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Markdown\CommonMark;
+
+use App\Markdown\CommonMark\Node\DetailsBlock;
+use League\CommonMark\Node\Block\AbstractBlock;
+use League\CommonMark\Node\Block\Paragraph;
+use League\CommonMark\Parser\Block\AbstractBlockContinueParser;
+use League\CommonMark\Parser\Block\BlockContinue;
+use League\CommonMark\Parser\Block\BlockContinueParserInterface;
+use League\CommonMark\Parser\Block\BlockContinueParserWithInlinesInterface;
+use League\CommonMark\Parser\Cursor;
+use League\CommonMark\Parser\InlineParserEngineInterface;
+use League\CommonMark\Util\RegexHelper;
+
+final class DetailsBlockParser extends AbstractBlockContinueParser implements BlockContinueParserWithInlinesInterface
+{
+    public const FENCE_END_PATTERN = '/^(?:\:{3,})(?= *$)/';
+
+    private DetailsBlock $block;
+
+    public function __construct(string $title, int $fenceLength, int $fenceOffset)
+    {
+        $this->block = new DetailsBlock($title, $fenceLength, $fenceOffset);
+    }
+
+    public function tryContinue(Cursor $cursor, BlockContinueParserInterface $activeBlockParser): ?BlockContinue
+    {
+        // Check for closing fence
+        if (!$cursor->isIndented()
+            && DetailsBlock::FENCE_CHAR === $cursor->getNextNonSpaceCharacter()) {
+            $match = RegexHelper::matchFirst(
+                self::FENCE_END_PATTERN,
+                $cursor->getLine(),
+                $cursor->getNextNonSpacePosition()
+            );
+
+            if (null !== $match && \strlen($match[0]) >= $this->block->getLength()) {
+                // closing fence found - finalize block
+                return BlockContinue::finished();
+            }
+        }
+
+        // Skip optional spaces of fence offset
+        // Optimization: don't attempt to match if we're at a non-space position
+        if ($cursor->getNextNonSpacePosition() > $cursor->getPosition()) {
+            $cursor->match('/^ {0,'.$this->block->getOffset().'}/');
+        }
+
+        return BlockContinue::at($cursor);
+    }
+
+    public function closeBlock(): void
+    {
+        $title = $this->block->getTitle();
+
+        if ($title && preg_match('/^spoiler\b/', $title)) {
+            $this->block->setSpoiler(true);
+
+            $title = preg_replace('/^spoiler\s*/', '', $title);
+            $this->block->setTitle($title);
+        }
+    }
+
+    public function parseInlines(InlineParserEngineInterface $inlineParser): void
+    {
+        $titleBlock = new Paragraph();
+        $inlineParser->parse($this->block->getTitle(), $titleBlock);
+        if ($titleBlock->hasChildren()) {
+            $titleBlock->data->set('section', 'summary');
+            $this->block->prependChild($titleBlock);
+        }
+    }
+
+    public function getBlock(): DetailsBlock
+    {
+        return $this->block;
+    }
+
+    public function isContainer(): bool
+    {
+        return true;
+    }
+
+    public function canContain(AbstractBlock $childBlock): bool
+    {
+        if ($childBlock instanceof DetailsBlock) {
+            return $this->block->getLength() > $childBlock->getLength();
+        }
+
+        return true;
+    }
+}

--- a/src/Markdown/CommonMark/DetailsBlockRenderer.php
+++ b/src/Markdown/CommonMark/DetailsBlockRenderer.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Markdown\CommonMark;
+
+use App\Markdown\CommonMark\Node\DetailsBlock;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
+use League\CommonMark\Util\HtmlElement;
+
+final class DetailsBlockRenderer implements NodeRendererInterface
+{
+    /** @param DetailsBlock $node */
+    public function render(
+        Node $node,
+        ChildNodeRendererInterface $childRenderer
+    ): HtmlElement {
+        DetailsBlock::assertInstanceOf($node);
+
+        $attrs = $node->data->get('attributes');
+
+        $summary = $node->getSummary();
+        $contents = $node->getContents();
+
+        return new HtmlElement(
+            'details',
+            $attrs,
+            [
+                new HtmlElement(
+                    'summary',
+                    [],
+                    $summary ? $childRenderer->renderNodes($summary->children()) : '',
+                ),
+                new HtmlElement(
+                    'div',
+                    [
+                        'class' => 'content',
+                    ],
+                    $childRenderer->renderNodes($contents),
+                ),
+            ]
+        );
+    }
+}

--- a/src/Markdown/CommonMark/DetailsBlockStartParser.php
+++ b/src/Markdown/CommonMark/DetailsBlockStartParser.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Markdown\CommonMark;
+
+use App\Markdown\CommonMark\Node\DetailsBlock;
+use League\CommonMark\Parser\Block\BlockStart;
+use League\CommonMark\Parser\Block\BlockStartParserInterface;
+use League\CommonMark\Parser\Cursor;
+use League\CommonMark\Parser\MarkdownParserStateInterface;
+
+final class DetailsBlockStartParser implements BlockStartParserInterface
+{
+    public const FENCE_START_PATTERN = '/^[ \t]*(?:\:{3,})(?!.*\:\:\:)/';
+
+    public function tryStart(Cursor $cursor, MarkdownParserStateInterface $parserState): ?BlockStart
+    {
+        if ($cursor->isIndented() || DetailsBlock::FENCE_CHAR !== $cursor->getNextNonSpaceCharacter()) {
+            return BlockStart::none();
+        }
+
+        $indent = $cursor->getIndent();
+        $fence = $cursor->match(self::FENCE_START_PATTERN);
+        if (null === $fence) {
+            return BlockStart::none();
+        }
+
+        // todo: maybe move title parsing into DetailsBlockParser
+        $title = ltrim($cursor->getRemainder());
+        $cursor->advanceToEnd();
+
+        $fence = ltrim($fence, " \t");
+
+        return BlockStart::of(new DetailsBlockParser($title, \strlen($fence), $indent))->at($cursor);
+    }
+}

--- a/src/Markdown/CommonMark/Node/DetailsBlock.php
+++ b/src/Markdown/CommonMark/Node/DetailsBlock.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Markdown\CommonMark\Node;
+
+use League\CommonMark\Node\Block\AbstractBlock;
+use League\CommonMark\Node\Node;
+
+class DetailsBlock extends AbstractBlock
+{
+    public const FENCE_CHAR = ':';
+
+    private bool $spoiler = false;
+
+    public function __construct(
+        private string $title,
+        private int $length,
+        private int $offset,
+    ) {
+        parent::__construct();
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title)
+    {
+        $this->title = $title;
+    }
+
+    private function isSummaryBlock(Node $node): bool
+    {
+        return 'summary' === $node->data->get('section', '');
+    }
+
+    public function getSummary(): ?Node
+    {
+        foreach ($this->children() as $cnode) {
+            if ($this->isSummaryBlock($cnode)) {
+                return $cnode;
+            }
+        }
+
+        return null;
+    }
+
+    /** @return iterable<Node> */
+    public function getContents(): iterable
+    {
+        $children = [];
+        foreach ($this->children() as $cnode) {
+            if (!$this->isSummaryBlock($cnode)) {
+                $children[] = $cnode;
+            }
+        }
+
+        return $children;
+    }
+
+    public function isSpoiler(): bool
+    {
+        return $this->spoiler;
+    }
+
+    public function setSpoiler(bool $spoiler): void
+    {
+        $this->spoiler = $spoiler;
+        if ($spoiler) {
+            $this->data->append('attributes/class', 'spoiler');
+        } else {
+            $classes = $this->data->get('attributes/class', '');
+            $this->data->set('attributes/class', array_diff(explode(' ', $classes), ['spoiler']));
+        }
+    }
+
+    public function getLength(): int
+    {
+        return $this->length;
+    }
+
+    public function setLength(int $length): void
+    {
+        $this->length = $length;
+    }
+
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
+
+    public function setOffset(int $offset): void
+    {
+        $this->offset = $offset;
+    }
+}

--- a/src/Markdown/MarkdownExtension.php
+++ b/src/Markdown/MarkdownExtension.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace App\Markdown;
 
 use App\Markdown\CommonMark\CommunityLinkParser;
+use App\Markdown\CommonMark\DetailsBlockRenderer;
+use App\Markdown\CommonMark\DetailsBlockStartParser;
 use App\Markdown\CommonMark\ExternalImagesRenderer;
 use App\Markdown\CommonMark\ExternalLinkRenderer;
 use App\Markdown\CommonMark\MentionLinkParser;
+use App\Markdown\CommonMark\Node\DetailsBlock;
 use App\Markdown\CommonMark\Node\UnresolvableLink;
 use App\Markdown\CommonMark\TagLinkParser;
 use App\Markdown\CommonMark\UnresolvableLinkRenderer;
@@ -27,6 +30,8 @@ final class MarkdownExtension implements ConfigurableExtensionInterface
         private readonly ExternalLinkRenderer $linkRenderer,
         private readonly ExternalImagesRenderer $imagesRenderer,
         private readonly UnresolvableLinkRenderer $unresolvableLinkRenderer,
+        private readonly DetailsBlockStartParser $detailsBlockStartParser,
+        private readonly DetailsBlockRenderer $detailsBlockRenderer,
     ) {
     }
 
@@ -39,6 +44,8 @@ final class MarkdownExtension implements ConfigurableExtensionInterface
 
     public function register(EnvironmentBuilderInterface $environment): void
     {
+        $environment->addBlockStartParser($this->detailsBlockStartParser);
+
         $environment->addInlineParser($this->communityLinkParser);
         $environment->addInlineParser($this->mentionLinkParser);
         $environment->addInlineParser($this->tagLinkParser);
@@ -46,5 +53,6 @@ final class MarkdownExtension implements ConfigurableExtensionInterface
         $environment->addRenderer(Link::class, $this->linkRenderer, 1);
         $environment->addRenderer(Image::class, $this->imagesRenderer, 1);
         $environment->addRenderer(UnresolvableLink::class, $this->unresolvableLinkRenderer, 1);
+        $environment->addRenderer(DetailsBlock::class, $this->detailsBlockRenderer, 1);
     }
 }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -24,6 +24,9 @@
 
     {% block stylesheets %}
         {{ encore_entry_link_tags('app') }}
+        <style>
+            {% include 'components/_details_label.css.twig' %}
+        </style>
     {% endblock %}
 
     {% block javascripts %}

--- a/templates/components/_details_label.css.twig
+++ b/templates/components/_details_label.css.twig
@@ -1,0 +1,4 @@
+:root {
+    --mbin-details-detail-label: "{{ 'details'|trans|e('css') }}";
+    --mbin-details-spoiler-label: "{{ 'spoiler'|trans|e('css') }}";
+}

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -784,4 +784,6 @@ sensitive_warning: Sensitive content
 sensitive_toggle: Toggle visibility of sensitive content
 sensitive_show: Click to show
 sensitive_hide: Click to hide
+details: Details
+spoiler: Spoiler
 all_time: All time


### PR DESCRIPTION
markdown syntax:

```
:::[spoiler] [title]
body content, markup *allowed*
:::
```

renders into html `<details>` element, with the text specified behind the opening fence used for title/details block `<summary>`

if the title starts with the word `spoiler` then the block will have a slightly different color style indicating that this block is meant to be a spoiler, also the word `spoiler` itself will be stripped from the final title

looks something like this:

![image](https://github.com/MbinOrg/mbin/assets/20770492/abecec5f-5f34-4ebc-90e1-980df59821cc)