### PR TITLE
enable image preview for image under instance domain

### DIFF
--- a/src/Utils/Embed.php
+++ b/src/Utils/Embed.php
@@ -37,6 +37,10 @@ class Embed
     public function fetch($url): self
     {
         if ($this->settings->isLocalUrl($url)) {
+            if (ImageManager::isImageUrl($url)) {
+                return $this->createLocalImage($url);
+            }
+
             return $this;
         }
 
@@ -99,6 +103,15 @@ class Embed
         }
 
         return $html;
+    }
+
+    private function createLocalImage(string $url): self
+    {
+        $c = clone $this;
+        $c->url = $url;
+        $c->html = sprintf('<img src="%s">', $url);
+
+        return $c;
     }
 
     public function getType(): string


### PR DESCRIPTION
for instances with media path is under instance's domain, the media preview would not function (returns empty preview) due to a certain guard in embed fetcher, which is quite evident in simple setups because the default media path is at `/media/` under the instance domain.

this restores the media preview for such images