### PR TITLE
Fix 2 errors when announcing anything

### DIFF
--- a/src/MessageHandler/ActivityPub/Outbox/DeliverHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/DeliverHandler.php
@@ -27,9 +27,13 @@ class DeliverHandler
             return;
         }
 
-        $actor = $this->manager->findActorOrCreate(
-            $message->payload['object']['attributedTo'] ?? $message->payload['actor']
-        );
+        if ('Announce' !== $message->payload['type']) {
+            $actor = $this->manager->findActorOrCreate(
+                $message->payload['object']['attributedTo'] ?? $message->payload['actor']
+            );
+        } else {
+            $actor = $this->manager->findActorOrCreate($message->payload['actor']);
+        }
 
         if (!$actor) {
             return;

--- a/src/Service/ActivityPub/Wrapper/AnnounceWrapper.php
+++ b/src/Service/ActivityPub/Wrapper/AnnounceWrapper.php
@@ -25,7 +25,7 @@ class AnnounceWrapper
             'id' => $this->urlGenerator->generate('ap_object', ['id' => $id], UrlGeneratorInterface::ABSOLUTE_URL),
             'type' => 'Announce',
             'actor' => $user,
-            'object' => $object['id'],
+            'object' => $object,
             'to' => [ActivityPubActivityInterface::PUBLIC_URL, $object['attributedTo']],
             'cc' => $object['cc'] ?? [],
             'published' => (new \DateTime())->format(DATE_ATOM),


### PR DESCRIPTION
- lemmy is not able to handle announce posts where the object is a url reference -> just put the whole object there
- we got errors when announcing posts that are from another instance, because we tried to sign them with the private key of the actor which is only available for local users