### PR TITLE
Update time filter display

### DIFF
--- a/assets/styles/layout/_options.scss
+++ b/assets/styles/layout/_options.scss
@@ -28,15 +28,6 @@
     }
   }
 
- &__layout{
-    li{
-      button{
-        border-bottom-left-radius: 0px!important;
-        border-bottom-right-radius: 0px!important;
-      }
-    }
-  }
-
   .scroll {
     position: static;
     align-self: center;
@@ -48,7 +39,7 @@
     .scroll-left,
     .scroll-right{
       padding: 0.5rem;
-      cursor: pointer;   
+      cursor: pointer;
       color: var(--kbin-button-secondary-text-color);
 
       &:hover,
@@ -58,9 +49,9 @@
     }
   }
 
-  &__filters{
+  &__view{
 
-    li:first-of-type{
+    li:not(:last-of-type){
       button{
         border-bottom-left-radius: 0px!important;
         border-bottom-right-radius: 0px!important;
@@ -69,9 +60,9 @@
     li:last-of-type{
       button{
         border-bottom-left-radius: 0px!important;
-      }  
+      }
     }
-    
+
   }
 
   &--top {
@@ -132,12 +123,20 @@
     text-transform: uppercase;
   }
 
-  &__layout button,
-  &__filters button {
+  &__view button {
     font-size: 0;
 
-    i, span {
+    i {
       font-size: .85rem;
+    }
+
+    span {
+      font-size: .85rem;
+      margin-left: 0.5rem;
+
+      @include media-breakpoint-down(lg) {
+          display: none;
+      }
     }
   }
 }

--- a/src/Twig/Extension/ContextExtension.php
+++ b/src/Twig/Extension/ContextExtension.php
@@ -22,6 +22,7 @@ final class ContextExtension extends AbstractExtension
             new TwigFunction('get_active_sort_option', [ContextExtensionRuntime::class, 'getActiveSortOption']),
             new TwigFunction('is_route_params_contains', [ContextExtensionRuntime::class, 'isRouteParamsContains']),
             new TwigFunction('get_route_param', [ContextExtensionRuntime::class, 'getRouteParam']),
+            new TwigFunction('get_time_param_translated', [ContextExtensionRuntime::class, 'getTimeParamTranslated']),
         ];
     }
 }

--- a/src/Twig/Runtime/ContextExtensionRuntime.php
+++ b/src/Twig/Runtime/ContextExtensionRuntime.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace App\Twig\Runtime;
 
+use App\Repository\Criteria;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Extension\RuntimeExtensionInterface;
 
 class ContextExtensionRuntime implements RuntimeExtensionInterface
 {
-    public function __construct(private readonly RequestStack $requestStack)
-    {
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        private readonly TranslatorInterface $translator,
+    ) {
     }
 
     public function isRouteNameContains(string $needle): bool
@@ -61,5 +65,18 @@ class ContextExtensionRuntime implements RuntimeExtensionInterface
     public function getRouteParam(string $name): ?string
     {
         return $this->requestStack->getCurrentRequest()->get($name);
+    }
+
+    public function getTimeParamTranslated(): string
+    {
+        $paramValue = $this->getRouteParam('time');
+        if (!\in_array($paramValue, Criteria::TIME_ROUTES_EN)
+            || '∞' === $paramValue
+            || 'all' === $paramValue
+        ) {
+            return $this->translator->trans('all_time');
+        }
+
+        return $this->translator->trans($paramValue);
     }
 }

--- a/templates/entry/_options.html.twig
+++ b/templates/entry/_options.html.twig
@@ -32,37 +32,17 @@
             </a>
         </li>
     </menu>
-    <menu class="options__layout">
-        <li class="dropdown">
-            <button aria-label="{{ 'change_view'|trans }}"
-                    title="{{ 'change_view'|trans }}"><i
-                        class="fa-solid fa-table-list"></i> {{ 'change_view'|trans }}</button>
-            <ul class="dropdown__menu">
-                <li>
-                    <a class="{{ html_classes({'active': not app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT')) or app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT')) is same as 'false'}) }}"
-                       href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT'), value: 'false'}) }}">
-                        {{ 'classic_view'|trans }}
-                    </a>
-                </li>
-                <li>
-                    <a class="{{ html_classes({'active': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT')) is same as 'true'}) }}"
-                       href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT'), value: 'true'}) }}">
-                        {{ 'compact_view'|trans }}
-                    </a>
-                </li>
-            </ul>
-        </li>
-    </menu>
-    <menu class="options__filters">
+    <menu class="options__view">
         <li class="dropdown">
             <button aria-label="{{ 'filter_by_time'|trans }}"
                     title="{{ 'filter_by_time'|trans }}"><i
-                        class="fa-solid fa-arrow-up-wide-short"></i> {{ 'filter_by_time'|trans }}</button>
+                        class="fa-solid fa-clock"></i> <span>{{ get_time_param_translated() }}</span>
+            </button>
             <ul class="dropdown__menu">
                 <li>
                     <a href="{{ options_url('time', '∞') }}"
                        class="{{ html_classes({'active': route_has_param('time', '∞') or not get_route_param('time')}) }}">
-                        {{ '∞' }}
+                        {{ 'all_time'|trans }}
                     </a>
                 </li>
                 <li>
@@ -112,7 +92,8 @@
             <button
                     aria-label="{{ 'filter_by_type'|trans }}"
                     title="{{ 'filter_by_type'|trans }}"><i
-                        class="fa-solid fa-filter"></i> {{ 'filter_by_type'|trans }}</button>
+                        class="fa-solid fa-filter"></i>
+            </button>
             <ul class="dropdown__menu">
                 <li>
                     <a href="{{ options_url('type', 'all') }}"
@@ -142,6 +123,26 @@
                     <a href="{{ options_url('type', 'videos') }}"
                        class="{{ html_classes({'active': route_has_param('type', 'videos')}) }}">
                         {{ 'videos'|trans }}
+                    </a>
+                </li>
+            </ul>
+        </li>
+        <li class="dropdown">
+            <button aria-label="{{ 'change_view'|trans }}"
+                    title="{{ 'change_view'|trans }}"><i
+                        class="fa-solid fa-table-list"></i>
+            </button>
+            <ul class="dropdown__menu">
+                <li>
+                    <a class="{{ html_classes({'active': not app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT')) or app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT')) is same as 'false'}) }}"
+                       href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT'), value: 'false'}) }}">
+                        {{ 'classic_view'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a class="{{ html_classes({'active': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT')) is same as 'true'}) }}"
+                       href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT'), value: 'true'}) }}">
+                        {{ 'compact_view'|trans }}
                     </a>
                 </li>
             </ul>

--- a/templates/post/_options.html.twig
+++ b/templates/post/_options.html.twig
@@ -32,16 +32,17 @@
             </a>
         </li>
     </menu>
-    <menu class="options__filters">
+    <menu class="options__view">
         <li class="dropdown">
             <button aria-label="{{ 'filter_by_time'|trans }}"
                     title="{{ 'filter_by_time'|trans }}"><i
-                        class="fa-solid fa-arrow-up-wide-short"></i> {{ 'filter_by_time'|trans }}</button>
+                        class="fa-solid fa-clock"></i> <span>{{ get_time_param_translated() }}</span>
+            </button>
             <ul class="dropdown__menu">
                 <li>
                     <a href="{{ options_url('time', '∞') }}"
                        class="{{ html_classes({'active': route_has_param('time', '∞') or not get_route_param('time')}) }}">
-                        {{ '∞' }}
+                        {{ 'all_time'|trans }}
                     </a>
                 </li>
                 <li>

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -784,3 +784,4 @@ sensitive_warning: Sensitive content
 sensitive_toggle: Toggle visibility of sensitive content
 sensitive_show: Click to show
 sensitive_hide: Click to hide
+all_time: All time


### PR DESCRIPTION
- change time filter to show currently selected option when on larger display than mobile
- change icon from asc,desc icon to clock
- move time filter first

not sure about other people but I found the time filter very hidden and confusing
![image](https://github.com/MbinOrg/mbin/assets/146029455/0a6c7f5f-2e73-42f1-8ee2-bda4e60132bd)

the middle option here is time, but it uses an ascending / descending icon and doesn't really indicate what it's for or doing

this changes the bar to look like this:
![image](https://github.com/MbinOrg/mbin/assets/146029455/e981307c-8324-41c5-a4cf-4c799f861b4f)

showing the currently selected option, moved it to be the first as it seemed more important than filtering entry types

another look:
![image](https://github.com/MbinOrg/mbin/assets/146029455/aae38caa-458f-49d8-b203-45bd60021761)

showing dropdown:
![image](https://github.com/MbinOrg/mbin/assets/146029455/884a6ceb-d551-427a-b902-fe3f5f3f2185)

microblog:
![image](https://github.com/MbinOrg/mbin/assets/146029455/9d8de200-8a26-4617-8309-7c3ff120f925)

on mobile it will not show the label to save room:
![image](https://github.com/MbinOrg/mbin/assets/146029455/0d8088b8-4f1c-4d31-8a65-2aff172d994f)
