### PR TITLE
fixup style changes to effect change view option

### DIFF
--- a/assets/styles/pages/post_single.scss
+++ b/assets/styles/pages/post_single.scss
@@ -1,5 +1,5 @@
 .page-post-single {
-  .options__layout {
+  .options__view {
     grid-area: end;
   }
 

--- a/templates/entry/comment/_options.html.twig
+++ b/templates/entry/comment/_options.html.twig
@@ -36,11 +36,12 @@
     {% else %}
         <div class="options__title"><h2>{{ 'comments'|trans }} ({{ entry.commentCount }})</h2></div>
     {% endif %}
-    <menu class="options__layout">
+    <menu class="options__view">
         <li class="dropdown">
             <button aria-label="{{ 'change_view'|trans }}"
                     title="{{ 'change_view'|trans }}"><i
-                        class="fa-solid fa-layer-group"></i> {{ 'change_view'|trans }}</button>
+                        class="fa-solid fa-layer-group"></i>
+            </button>
             <ul class="dropdown__menu">
                 <li>
                     <a class="{{ html_classes({'active': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::ENTRY_COMMENTS_VIEW')) is same as constant('App\\Controller\\User\\ThemeSettingsController::CLASSIC')}) }}"

--- a/templates/magazine/_options.html.twig
+++ b/templates/magazine/_options.html.twig
@@ -27,11 +27,12 @@
         </li>
         {% endif %}
     </menu>
-    <menu class="options__layout">
+    <menu class="options__view">
         <li class="dropdown">
             <button aria-label="{{ 'change_view'|trans }}"
                     title="{{ 'change_view'|trans }}"><i
-                        class="fa-solid fa-layer-group"></i> {{ 'change_view'|trans }}</button>
+                        class="fa-solid fa-layer-group"></i>
+            </button>
             <ul class="dropdown__menu">
                 <li><a class="{{ html_classes({'active': route_has_param('view', 'table')}) }}"
                        href="{{ options_url('view', 'table') }}">{{ 'table_view'|trans }}</a></li>

--- a/templates/post/comment/_options.html.twig
+++ b/templates/post/comment/_options.html.twig
@@ -30,11 +30,12 @@
     {% else %}
         <div class="options__title"><h2>{{ 'comments'|trans }} ({{ post.commentCount }})</h2></div>
     {% endif %}
-    <menu class="options__layout">
+    <menu class="options__view">
         <li class="dropdown">
             <button aria-label="{{ 'change_view'|trans }}"
                     title="{{ 'change_view'|trans }}"><i
-                        class="fa-solid fa-layer-group"></i> {{ 'change_view'|trans }}</button>
+                        class="fa-solid fa-layer-group"></i>
+            </button>
             <ul class="dropdown__menu">
                 <li>
                     <a class="{{ html_classes({'active': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW')) is same as constant('App\\Controller\\User\\ThemeSettingsController::CLASSIC')}) }}"


### PR DESCRIPTION
minor change to fixup an unintended style change from #360 effecting the change view options on entry/post/magazine page

was
![image](https://github.com/MbinOrg/mbin/assets/146029455/c750553e-f86e-4c26-8e93-204e4800b18b)

accidentally
![image](https://github.com/MbinOrg/mbin/assets/146029455/83cbc323-388b-4ab6-b017-92b68e93ef6a)

now
![image](https://github.com/MbinOrg/mbin/assets/146029455/e4898cd9-90a8-4206-955a-feab8e801dc5)

this bar shows up on entry single, post single, and the overall `/magazine` pages. oh it's technically better now since the right edge is curved now and it wasn't originally, but not a big deal