### PR TITLE
Announce posts and comments

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -11,6 +11,7 @@ use App\Entity\Traits\ActivityPubActorTrait;
 use App\Entity\Traits\CreatedAtTrait;
 use App\Entity\Traits\VisibilityTrait;
 use App\Repository\UserRepository;
+use App\Service\ActivityPub\ApHttpClient;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
@@ -29,6 +30,7 @@ use Scheb\TwoFactorBundle\Model\BackupCodeInterface;
 use Scheb\TwoFactorBundle\Model\Totp\TotpConfiguration;
 use Scheb\TwoFactorBundle\Model\Totp\TotpConfigurationInterface;
 use Scheb\TwoFactorBundle\Model\Totp\TwoFactorInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -865,5 +867,23 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Visibil
             ->where(Criteria::expr()->eq('magazine', $magazine));
 
         return $this->magazineOwnershipRequests->matching($criteria)->count() > 0;
+    }
+
+    public function getFollowerUrl(ApHttpClient $client, UrlGeneratorInterface $urlGenerator, bool $isRemote): ?string
+    {
+        if ($isRemote) {
+            $actorObject = $client->getActorObject($this->apProfileId);
+            if ($actorObject and isset($actorObject['followers']) and \is_string($actorObject['followers'])) {
+                return $actorObject['followers'];
+            }
+
+            return null;
+        } else {
+            return $urlGenerator->generate(
+                'ap_user_followers',
+                ['username' => $this->username],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            );
+        }
     }
 }

--- a/src/EventSubscriber/VoteHandleSubscriber.php
+++ b/src/EventSubscriber/VoteHandleSubscriber.php
@@ -56,6 +56,7 @@ class VoteHandleSubscriber implements EventSubscriberInterface
             $this->bus->dispatch(
                 new AnnounceMessage(
                     $event->vote->user->getId(),
+                    null,
                     $event->votable->getId(),
                     \get_class($event->votable),
                 ),

--- a/src/Factory/ActivityPub/EntryCommentNoteFactory.php
+++ b/src/Factory/ActivityPub/EntryCommentNoteFactory.php
@@ -45,6 +45,11 @@ class EntryCommentNoteFactory
             $tags[] = $comment->magazine->name;
         }
 
+        $cc = [$this->groupFactory->getActivityPubId($comment->magazine)];
+        if ($followersUrl = $comment->user->getFollowerUrl($this->client, $this->urlGenerator, null !== $comment->apId)) {
+            $cc[] = $followersUrl;
+        }
+
         $note = array_merge($note ?? [], [
             'type' => 'Note',
             'id' => $this->getActivityPubId($comment),
@@ -53,16 +58,7 @@ class EntryCommentNoteFactory
             'to' => [
                 ActivityPubActivityInterface::PUBLIC_URL,
             ],
-            'cc' => [
-                $this->groupFactory->getActivityPubId($comment->magazine),
-                $comment->apId
-                    ? ($this->client->getActorObject($comment->user->apProfileId)['followers']) ?? []
-                    : $this->urlGenerator->generate(
-                        'ap_user_followers',
-                        ['username' => $comment->user->username],
-                        UrlGeneratorInterface::ABSOLUTE_URL
-                    ),
-            ],
+            'cc' => $cc,
             'content' => $this->markdownConverter->convertToHtml($comment->body, [MarkdownConverter::RENDER_TARGET => RenderTarget::ActivityPub]),
             'mediaType' => 'text/html',
             'source' => $comment->body ? [

--- a/src/Factory/ActivityPub/EntryCommentNoteFactory.php
+++ b/src/Factory/ActivityPub/EntryCommentNoteFactory.php
@@ -123,13 +123,7 @@ class EntryCommentNoteFactory
 
     private function getReplyTo(EntryComment $comment): string
     {
-        if ($comment->apId) {
-            return $comment->apId;
-        }
-
-        return $comment->parent ? $this->getActivityPubId($comment->parent) : $this->pageFactory->getActivityPubId(
-            $comment->entry
-        );
+        return $comment->parent ? $this->getActivityPubId($comment->parent) : $this->pageFactory->getActivityPubId($comment->entry);
     }
 
     private function getReplyToAuthor(EntryComment $comment): string

--- a/src/Factory/ActivityPub/EntryPageFactory.php
+++ b/src/Factory/ActivityPub/EntryPageFactory.php
@@ -44,6 +44,20 @@ class EntryPageFactory
             $tags[] = $entry->magazine->name;
         }
 
+        $cc = [];
+        if ($entry->apId) {
+            $actorObject = $this->client->getActorObject($entry->user->apProfileId);
+            if (isset($actorObject['followers'])) {
+                $cc = [$actorObject['followers']];
+            }
+        } else {
+            $cc = [$this->urlGenerator->generate(
+                'ap_user_followers',
+                ['username' => $entry->user->username],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )];
+        }
+
         $page = array_merge($page ?? [], [
             'id' => $this->getActivityPubId($entry),
             'type' => 'Page',
@@ -53,15 +67,7 @@ class EntryPageFactory
                 $this->groupFactory->getActivityPubId($entry->magazine),
                 ActivityPubActivityInterface::PUBLIC_URL,
             ],
-            'cc' => [
-                $entry->apId
-                    ? ($this->client->getActorObject($entry->user->apProfileId)['followers']) ?? []
-                    : $this->urlGenerator->generate(
-                        'ap_user_followers',
-                        ['username' => $entry->user->username],
-                        UrlGeneratorInterface::ABSOLUTE_URL
-                    ),
-            ],
+            'cc' => $cc,
             'name' => $entry->title,
             'content' => $entry->body ? $this->markdownConverter->convertToHtml(
                 $entry->body,

--- a/src/Factory/ActivityPub/EntryPageFactory.php
+++ b/src/Factory/ActivityPub/EntryPageFactory.php
@@ -45,17 +45,8 @@ class EntryPageFactory
         }
 
         $cc = [];
-        if ($entry->apId) {
-            $actorObject = $this->client->getActorObject($entry->user->apProfileId);
-            if (isset($actorObject['followers'])) {
-                $cc = [$actorObject['followers']];
-            }
-        } else {
-            $cc = [$this->urlGenerator->generate(
-                'ap_user_followers',
-                ['username' => $entry->user->username],
-                UrlGeneratorInterface::ABSOLUTE_URL
-            )];
+        if ($followersUrl = $entry->user->getFollowerUrl($this->client, $this->urlGenerator, null !== $entry->apId)) {
+            $cc[] = $followersUrl;
         }
 
         $page = array_merge($page ?? [], [

--- a/src/Factory/ActivityPub/PostCommentNoteFactory.php
+++ b/src/Factory/ActivityPub/PostCommentNoteFactory.php
@@ -127,13 +127,7 @@ class PostCommentNoteFactory
 
     private function getReplyTo(PostComment $comment): string
     {
-        if ($comment->apId) {
-            return $comment->apId;
-        }
-
-        return $comment->parent ? $this->getActivityPubId($comment->parent) : $this->postNoteFactory->getActivityPubId(
-            $comment->post
-        );
+        return $comment->parent ? $this->getActivityPubId($comment->parent) : $this->postNoteFactory->getActivityPubId($comment->post);
     }
 
     private function getReplyToAuthor(PostComment $comment): string

--- a/src/Factory/ActivityPub/PostNoteFactory.php
+++ b/src/Factory/ActivityPub/PostNoteFactory.php
@@ -51,6 +51,11 @@ class PostNoteFactory
             $tags
         );
 
+        $cc = [];
+        if ($followersUrl = $post->user->getFollowerUrl($this->client, $this->urlGenerator, null !== $post->apId)) {
+            $cc[] = $followersUrl;
+        }
+
         $note = array_merge($note ?? [], [
             'id' => $this->getActivityPubId($post),
             'type' => 'Note',
@@ -60,15 +65,7 @@ class PostNoteFactory
                 $this->groupFactory->getActivityPubId($post->magazine),
                 ActivityPubActivityInterface::PUBLIC_URL,
             ],
-            'cc' => [
-                $post->apId
-                    ? ($this->client->getActorObject($post->user->apProfileId)['followers']) ?? []
-                    : $this->urlGenerator->generate(
-                        'ap_user_followers',
-                        ['username' => $post->user->username],
-                        UrlGeneratorInterface::ABSOLUTE_URL
-                    ),
-            ],
+            'cc' => $cc,
             'sensitive' => $post->isAdult(),
             'stickied' => $post->sticky,
             'content' => $this->markdownConverter->convertToHtml(

--- a/src/Message/ActivityPub/Outbox/AnnounceMessage.php
+++ b/src/Message/ActivityPub/Outbox/AnnounceMessage.php
@@ -9,7 +9,8 @@ use App\Message\Contracts\AsyncApMessageInterface;
 class AnnounceMessage implements AsyncApMessageInterface
 {
     public function __construct(
-        public int $userId,
+        public ?int $userId,
+        public ?int $magazineId,
         public int $objectId,
         public string $objectType,
         public bool $removeAnnounce = false

--- a/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\MessageHandler\ActivityPub\Inbox;
 
+use App\Entity\EntryComment;
+use App\Entity\Post;
+use App\Entity\PostComment;
 use App\Message\ActivityPub\Inbox\AnnounceMessage;
 use App\Message\ActivityPub\Inbox\ChainActivityMessage;
 use App\Message\ActivityPub\Inbox\LikeMessage;
@@ -88,12 +91,18 @@ class ChainActivityHandler
         $object = end($chain);
 
         if (!empty($object)) {
-            match ($this->getType($object)) {
-                'Question' => $this->note->create($object),
-                'Note' => $this->note->create($object),
+            $createdObject = match ($this->getType($object)) {
+                'Question', 'Note' => $this->note->create($object),
                 'Page' => $this->page->create($object),
                 default => null
             };
+
+            if ($createdObject and ($createdObject instanceof EntryComment or $createdObject instanceof Post or $createdObject instanceof PostComment)) {
+                if (null !== $createdObject->apId and null === $createdObject->magazine->apId) {
+                    // local magazine, but remote post
+                    $this->bus->dispatch(new \App\Message\ActivityPub\Outbox\AnnounceMessage(null, $createdObject->magazine->getId(), $createdObject->getId(), \get_class($createdObject)));
+                }
+            }
 
             array_pop($chain);
 

--- a/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
@@ -10,6 +10,7 @@ use App\Entity\PostComment;
 use App\Message\ActivityPub\Inbox\AnnounceMessage;
 use App\Message\ActivityPub\Inbox\ChainActivityMessage;
 use App\Message\ActivityPub\Inbox\LikeMessage;
+use App\Message\ActivityPub\Outbox\AnnounceMessage as OutboxAnnounceMessage;
 use App\Repository\ApActivityRepository;
 use App\Service\ActivityPub\ApHttpClient;
 use App\Service\ActivityPub\Note;
@@ -100,7 +101,7 @@ class ChainActivityHandler
             if ($createdObject and ($createdObject instanceof EntryComment or $createdObject instanceof Post or $createdObject instanceof PostComment)) {
                 if (null !== $createdObject->apId and null === $createdObject->magazine->apId) {
                     // local magazine, but remote post
-                    $this->bus->dispatch(new \App\Message\ActivityPub\Outbox\AnnounceMessage(null, $createdObject->magazine->getId(), $createdObject->getId(), \get_class($createdObject)));
+                    $this->bus->dispatch(new OutboxAnnounceMessage(null, $createdObject->magazine->getId(), $createdObject->getId(), \get_class($createdObject)));
                 }
             }
 

--- a/src/MessageHandler/ActivityPub/Inbox/FollowHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/FollowHandler.php
@@ -13,6 +13,7 @@ use App\Service\ActivityPubManager;
 use App\Service\MagazineManager;
 use App\Service\UserManager;
 use JetBrains\PhpStorm\ArrayShape;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
@@ -23,12 +24,14 @@ class FollowHandler
         private readonly UserManager $userManager,
         private readonly MagazineManager $magazineManager,
         private readonly ApHttpClient $client,
+        private readonly LoggerInterface $logger,
         private readonly AcceptWrapper $acceptWrapper
     ) {
     }
 
-    public function __invoke(FollowMessage $message)
+    public function __invoke(FollowMessage $message): void
     {
+        $this->logger->debug('got a FollowMessage: {message}', [$message]);
         $actor = $this->activityPubManager->findActorOrCreate($message->payload['actor']);
         // Check if actor is not empty
         if (!empty($actor)) {

--- a/src/MessageHandler/ActivityPub/Outbox/AnnounceHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/AnnounceHandler.php
@@ -4,18 +4,25 @@ declare(strict_types=1);
 
 namespace App\MessageHandler\ActivityPub\Outbox;
 
+use App\Entity\Entry;
+use App\Entity\EntryComment;
+use App\Entity\Magazine;
+use App\Entity\Post;
+use App\Entity\PostComment;
+use App\Entity\User;
 use App\Factory\ActivityPub\ActivityFactory;
 use App\Message\ActivityPub\Outbox\AnnounceMessage;
 use App\Message\ActivityPub\Outbox\DeliverMessage;
 use App\Repository\MagazineRepository;
 use App\Repository\UserRepository;
 use App\Service\ActivityPub\Wrapper\AnnounceWrapper;
+use App\Service\ActivityPub\Wrapper\CreateWrapper;
 use App\Service\ActivityPub\Wrapper\UndoWrapper;
 use App\Service\ActivityPubManager;
 use App\Service\SettingsManager;
 use Doctrine\ORM\EntityManagerInterface;
-use JetBrains\PhpStorm\ArrayShape;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsMessageHandler]
@@ -27,6 +34,7 @@ class AnnounceHandler
         private readonly EntityManagerInterface $entityManager,
         private readonly AnnounceWrapper $announceWrapper,
         private readonly UndoWrapper $undoWrapper,
+        private readonly CreateWrapper $createWrapper,
         private readonly ActivityPubManager $activityPubManager,
         private readonly ActivityFactory $activityFactory,
         private readonly MessageBusInterface $bus,
@@ -34,35 +42,46 @@ class AnnounceHandler
     ) {
     }
 
-    #[ArrayShape([
-        '@context' => 'string',
-        'id' => 'string',
-        'actor' => 'string',
-        'object' => 'string',
-    ])]
-    public function __invoke(
-        AnnounceMessage $message
-    ): void {
+    public function __invoke(AnnounceMessage $message): void
+    {
         if (!$this->settingsManager->get('KBIN_FEDERATION_ENABLED')) {
             return;
         }
 
-        $user = $this->userRepository->find($message->userId);
+        if (null !== $message->userId) {
+            $actor = $this->userRepository->find($message->userId);
+        } elseif (null !== $message->magazineId) {
+            $actor = $this->magazineRepository->find($message->magazineId);
+        } else {
+            throw new UnrecoverableMessageHandlingException('no actor was specified');
+        }
+
         $object = $this->entityManager->getRepository($message->objectType)->find($message->objectId);
 
         $activity = $this->announceWrapper->build(
-            $this->activityPubManager->getActorProfileId($user),
+            $this->activityPubManager->getActorProfileId($actor),
             $this->activityFactory->create($object),
         );
+
+        if ($object instanceof Entry or $object instanceof Post or $object instanceof EntryComment or $object instanceof PostComment) {
+            $wrapperObject = $this->createWrapper->build($object);
+            unset($wrapperObject['@context']);
+            $activity['object'] = $wrapperObject;
+        }
 
         if ($message->removeAnnounce) {
             $activity = $this->undoWrapper->build($activity);
         }
 
-        $this->deliver(array_filter($this->userRepository->findAudience($user)), $activity);
-        $this->deliver(array_filter($this->activityPubManager->createInboxesFromCC($activity, $user)), $activity);
-        $this->deliver(array_filter($this->magazineRepository->findAudience($object->magazine)), $activity);
-        $this->deliver([$object->user->apInboxUrl], $activity);
+        if ($actor instanceof User) {
+            $this->deliver(array_filter($this->userRepository->findAudience($actor)), $activity);
+            $this->deliver(array_filter($this->activityPubManager->createInboxesFromCC($activity, $actor)), $activity);
+            $this->deliver(array_filter($this->magazineRepository->findAudience($object->magazine)), $activity);
+            $this->deliver([$object->user->apInboxUrl], $activity);
+        } elseif ($actor instanceof Magazine) {
+            $createHost = parse_url($object->apId, PHP_URL_HOST);
+            $this->deliver(array_filter($this->magazineRepository->findAudience($actor), fn ($item) => null !== $item and $createHost !== parse_url($item, PHP_URL_HOST)), $activity);
+        }
     }
 
     private function deliver(array $followers, array $activity): void

--- a/src/Service/ActivityPub/Page.php
+++ b/src/Service/ActivityPub/Page.php
@@ -17,6 +17,7 @@ use App\Service\ActivityPubManager;
 use App\Service\EntryManager;
 use App\Service\SettingsManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 
 class Page
 {
@@ -29,6 +30,7 @@ class Page
         private readonly SettingsManager $settingsManager,
         private readonly ImageFactory $imageFactory,
         private readonly ApObjectExtractor $objectExtractor,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -42,6 +44,8 @@ class Page
 
             $current = $this->repository->findByObjectId($object['id']);
             if ($current) {
+                $this->logger->debug('Page already exists, not creating it');
+
                 return $this->entityManager->getRepository($current['type'])->find((int) $current['id']);
             }
 
@@ -85,6 +89,8 @@ class Page
             } else {
                 $dto->lang = $this->settingsManager->get('KBIN_DEFAULT_LANG');
             }
+
+            $this->logger->debug('creating page');
 
             return $this->entryManager->create(
                 $dto,

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -59,11 +59,10 @@ class ActivityPubManager
 
     public function getActorProfileId(ActivityPubActorInterface $actor): string
     {
-        /**
-         * @var $actor User
-         */
-        if (!$actor->apId) {
-            return $this->personFactory->getActivityPubId($actor);
+        if ($actor instanceof User) {
+            if (!$actor->apId) {
+                return $this->personFactory->getActivityPubId($actor);
+            }
         }
 
         // @todo blid webfinger


### PR DESCRIPTION
Right now magazines hosted on mBin never announce posts or comments.

### Why is that a problem

We have instances A, B, and C and Users X (on A), Y (on B) and Z (on C). We have a magazine F on instance A. When Y posts something to F then only the instances A and B know of that post. Z will never know this post exists unless another activity referencing this post is sent to C (that would be likes or comments, but **only** from users on A, because other activities will not be forwarded to C).

This is always a problem, but especially for small communities.

### Why is announcing the solution

sending an `Announce` activity solves the problem, because it is basically forwarding. So every post created on a magazine, from local or remote users are just forwarded to every server with at least one subsciber