### PR TITLE
remove admin submenu when viewing reports as global mod

### DIFF
--- a/templates/admin/pages.html.twig
+++ b/templates/admin/pages.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 
 {%- block title -%}
-    {{- 'settings'|trans }} - {{ parent() -}}
+    {{- 'pages'|trans }} - {{ parent() -}}
 {%- endblock -%}
 
 {% block mainClass %}page-admin-settings page-settings{% endblock %}

--- a/templates/admin/reports.html.twig
+++ b/templates/admin/reports.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 
 {%- block title -%}
-    {{- 'federation'|trans }} - {{ parent() -}}
+    {{- 'reports'|trans }} - {{ parent() -}}
 {%- endblock -%}
 
 {% block mainClass %}page-admin-federation{% endblock %}
@@ -13,6 +13,9 @@
 {% endblock %}
 
 {% block body %}
-    {% include 'admin/_options.html.twig' %}
-        {{ component('report_list', {reports: reports}) }}
+    {# global mods can see this page, but not navigate to any other menu option, so hiding it for now #}
+    {% if is_granted('ROLE_ADMIN') %}
+        {% include 'admin/_options.html.twig' %}
+    {% endif %}
+    {{ component('report_list', {reports: reports}) }}
 {% endblock %}


### PR DESCRIPTION
at the moment, global mods see all the admin submenu options but clicking on any of them just redirects them to the landing page. this removes the sub menu for now until there is a use case of another mod page. it's also possible we'd want to make `/mod` routes for global mods instead but that can happen later if there are more as well

as admin (and how it looked before as global mod)
![image](https://github.com/MbinOrg/mbin/assets/146029455/2c95901b-1ce1-4bcc-8161-11e6daf638df)

as global mod
![image](https://github.com/MbinOrg/mbin/assets/146029455/50b0f4df-2c6c-4ae0-8eb9-bfed37174106)
