### PR TITLE
fix malformed external media link label that contain newline

### DIFF
--- a/src/Service/ActivityPub/ApObjectExtractor.php
+++ b/src/Service/ActivityPub/ApObjectExtractor.php
@@ -50,14 +50,28 @@ class ApObjectExtractor
             if ($images = $this->activityPubManager->handleExternalImages($attachments)) {
                 $body .= "\n\n".implode(
                     "  \n",
-                    array_map(fn ($image) => "![{$image->name}]({$image->url})", $images)
+                    array_map(
+                        fn ($image) => sprintf(
+                            '![%s](%s)',
+                            preg_replace('/\r\n|\r|\n/', ' ', $image->name),
+                            $image->url
+                        ),
+                        $images
+                    )
                 );
             }
 
             if ($videos = $this->activityPubManager->handleExternalVideos($attachments)) {
                 $body .= "\n\n".implode(
                     "  \n",
-                    array_map(fn ($video) => "![{$video->name}]({$video->url})", $videos)
+                    array_map(
+                        fn ($video) => sprintf(
+                            '![%s](%s)',
+                            preg_replace('/\r\n|\r|\n/', ' ', $video->name),
+                            $video->url
+                        ),
+                        $videos
+                    )
                 );
             }
         }


### PR DESCRIPTION
if the external media in federated content contains newline in its `name` property, typically the image alt text, then the created link will be malformed

this change just replaced all the newlines in them with a space

it'll be something like this
```markdown
- broken, the link is not rendered
![mark
with
a
gun](https://whatever.domain/the/image/is.png)
```

```markdown
- this patch, the link renders properly
![mark with a gun](https://whatever.domain/the/image/is.png)

```