### PR TITLE
increase image store exception logging to error

### DIFF
--- a/src/Repository/ImageRepository.php
+++ b/src/Repository/ImageRepository.php
@@ -95,7 +95,7 @@ class ImageRepository extends ServiceEntityRepository
         try {
             $this->imageManager->store($source, $filePath);
         } catch (\Exception $e) {
-            $this->logger->warning(
+            $this->logger->error(
                 'findOrCreateFromSource: failed to store image file: '.$e->getMessage(),
                 ['origin' => $origin],
             );


### PR DESCRIPTION
should make it easier to debug when the image upload gone wrong as failed upload have a visible detrimental results and logging with warning level isn't enough to get it logged on prod