### PR TITLE
adjust logging for docker setups

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -14,6 +14,11 @@ when@dev:
                 include_stacktraces: true
                 max_files: 10
                 channels: ['!event']
+            stderr:
+                type: stream
+                path: 'php://stderr'
+                level: info
+                channels: ['!event']
             # uncomment to get logging in your browser
             # you may have to allow bigger header sizes in your Web server configuration
             #firephp:
@@ -57,9 +62,17 @@ when@prod:
                 excluded_http_codes: [404, 405]
                 buffer_size: 50 # How many messages should be saved? Prevent memory leaks
             nested:
+                type: group
+                members: [nested_file, nested_stderr]
+            nested_file:
                 type: rotating_file
                 max_files: 7
                 path: '%kernel.logs_dir%/%kernel.environment%.log'
+                level: debug
+                formatter: monolog.formatter.json
+            nested_stderr:
+                type: stream
+                path: 'php://stderr'
                 level: debug
                 formatter: monolog.formatter.json
             console:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -103,9 +103,9 @@ COPY --from=builder-nodejs --chown=$USER:$GROUP $MBIN_HOME/public $MBIN_HOME/pub
 COPY --link docker/caddy/Caddyfile /etc/caddy/Caddyfile
 COPY --chmod=755 --link docker/docker-entrypoint ./
 
-RUN mkdir -p public/media /data /config && \
-    chown -R $USER:$GROUP public/media /data /config .env && \
-    chmod 777 public/media
+RUN mkdir -p public/media var/log /data /config && \
+    chown -R $USER:$GROUP public/media var /data /config .env && \
+    chmod 777 public/media var
 
 # Switch user
 USER $USER:$GROUP

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -53,6 +53,7 @@ services:
         ]
     volumes:
       - ./storage/media:/var/www/mbin/public/media
+      - ./storage/logs:/var/www/mbin/var/log
     # If you want to change configs locally, without rebuilding the image use:
     #  - ../config:/var/www/mbin/config
     env_file:
@@ -80,6 +81,7 @@ services:
       test: ["CMD-SHELL", "ps aux | grep 'messenger[:]consume' || exit 1"]
     volumes:
       - ./storage/media:/var/www/mbin/public/media
+      - ./storage/logs:/var/www/mbin/var/log
     # If you want to change configs locally, without rebuilding the image use:
     #  - ../config:/var/www/mbin/config
     env_file:
@@ -107,6 +109,7 @@ services:
       test: ["CMD-SHELL", "ps aux | grep 'messenger[:]consume' || exit 1"]
     volumes:
       - ./storage/media:/var/www/mbin/public/media
+      - ./storage/logs:/var/www/mbin/var/log
     # If you want to change configs locally, without rebuilding the image use:
     #  - ../config:/var/www/mbin/config
     env_file:

--- a/docs/docker_deployment_guide.md
+++ b/docs/docker_deployment_guide.md
@@ -93,8 +93,8 @@ image: "ghcr.io/mbinorg/mbin:latest"
 ```bash
 cp ../.env.example_docker .env
 cp compose.prod.yml compose.override.yml
-mkdir -p storage/media storage/caddy_config storage/caddy_data
-sudo chown $USER:$USER storage/media storage/caddy_config storage/caddy_data
+mkdir -p storage/media storage/caddy_config storage/caddy_data storage/logs
+sudo chown $USER:$USER storage/media storage/caddy_config storage/caddy_data storage/logs
 ```
 
 ### Configure `.env` and `compose.override.yml`
@@ -172,8 +172,11 @@ Next, log in and create a magazine named "random" to which unclassified content 
 
 ### Debugging / Logging
 
-1. See the running container IDs: `docker ps`
-2. You can see the logs via (use `-f` to follow the output): `docker logs -f <container_id>`
+1. List the running service containers with `docker compose ps`
+2. You can see the logs with `docker compose logs -f <service>` (use `-f` to follow the output)
+3. for `php`, `messenger` and `messenger_ap` services, the application log is also available at
+   `storage/logs` directory on the host, named after the running environment and date
+   (e.g. `storage/logs/prod-2023-12-01.log`)
 
 ### Add auxiliary containers to `compose.yml`
 


### PR DESCRIPTION
I thought someone already hooked the app log to docker logs but apparently not so here goes:

- mount the log directory within `php`, `messenger` and `messenger_ap` services to host `storage/logs` directory for easier access and more persistent log storage, so it doesn't get washed away when recreating containers while trying to debug something
- adjust logging to also send logs to stderr, which will be output to docker logs, and can be viewed using `docker logs`, `docker compose logs` and the like  
  for bare metal setups, this stderr log should already be discarded by php-fpm (see php-fpm option `catch_workers_output`)
- add extra instructions and mentions in the docker guide about logging, as introduced by this change