### PR TITLE
Add user verify command to activate/deactivate user via php bin/console

### DIFF
--- a/src/Command/VerifyCommand.php
+++ b/src/Command/VerifyCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'mbin:user:verify',
-    description: 'This command allows you to activate or deactivate a user.',
+    description: 'This command allows you to manually activate or deactivate a user, bypassing email verification.',
 )]
 class VerifyCommand extends Command
 {
@@ -32,8 +32,8 @@ class VerifyCommand extends Command
     protected function configure(): void
     {
         $this->addArgument('username', InputArgument::REQUIRED)
-            ->addOption('activate', 'a', InputOption::VALUE_NONE, 'Activate user')
-            ->addOption('deactivate', 'd', InputOption::VALUE_NONE, 'Deactivate user');
+            ->addOption('activate', 'a', InputOption::VALUE_NONE, 'Activate user, bypass email verification')
+            ->addOption('deactivate', 'd', InputOption::VALUE_NONE, 'Deactivate user, require email verification');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -50,11 +50,9 @@ class VerifyCommand extends Command
         }
 
         if (!$activate && !$deactivate) {
-
             if ($user->isVerified) {
                 $io->success('The provided user is verified.');
-            }
-            else {
+            } else {
                 $io->success('The provided user is unverified.');
             }
 

--- a/src/Command/VerifyCommand.php
+++ b/src/Command/VerifyCommand.php
@@ -51,9 +51,9 @@ class VerifyCommand extends Command
 
         if (!$activate && !$deactivate) {
             if ($user->isVerified) {
-                $io->success('The provided user is verified and can login.');
+                $io->success('The user is verified and can login.');
             } else {
-                $io->success('The provided user is unverified and cannot login.');
+                $io->success('The user is unverified and cannot login.');
             }
 
             return Command::SUCCESS;

--- a/src/Command/VerifyCommand.php
+++ b/src/Command/VerifyCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Repository\UserRepository;
+use App\Service\UserManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'mbin:user:verify',
+    description: 'This command allows you to activate or deactivate a user.',
+)]
+class VerifyCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly UserRepository $repository,
+        private readonly UserManager $manager
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('username', InputArgument::REQUIRED)
+            ->addOption('activate', 'a', InputOption::VALUE_NONE, 'Activate user')
+            ->addOption('deactivate', 'd', InputOption::VALUE_NONE, 'Deactivate user');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $activate = $input->getOption('activate');
+        $deactivate = $input->getOption('deactivate');
+        $user = $this->repository->findOneByUsername($input->getArgument('username'));
+
+        if (!$user) {
+            $io->error('User does not exist.');
+
+            return Command::FAILURE;
+        }
+
+        if (!$activate && !$deactivate) {
+
+            if ($user->isVerified) {
+                $io->success('The provided user is verified.');
+            }
+            else {
+                $io->success('The provided user is unverified.');
+            }
+
+            return Command::SUCCESS;
+        }
+
+        if ($activate) {
+            $user->isVerified = true;
+            $this->entityManager->flush();
+
+            $io->success('The user has been activated.');
+        } elseif ($deactivate) {
+            $user->isVerified = false;
+            $this->entityManager->flush();
+
+            $io->success('The user has been deactivated.');
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/VerifyCommand.php
+++ b/src/Command/VerifyCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'mbin:user:verify',
-    description: 'This command allows you to manually activate or deactivate a user, bypassing email verification.',
+    description: 'This command allows you to manually activate or deactivate a user, bypassing email verification requirement.',
 )]
 class VerifyCommand extends Command
 {
@@ -32,8 +32,8 @@ class VerifyCommand extends Command
     protected function configure(): void
     {
         $this->addArgument('username', InputArgument::REQUIRED)
-            ->addOption('activate', 'a', InputOption::VALUE_NONE, 'Activate user, bypass email verification')
-            ->addOption('deactivate', 'd', InputOption::VALUE_NONE, 'Deactivate user, require email verification');
+            ->addOption('activate', 'a', InputOption::VALUE_NONE, 'Activate user, bypass email verification.')
+            ->addOption('deactivate', 'd', InputOption::VALUE_NONE, 'Deactivate user, require email (re)verification.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -44,16 +44,16 @@ class VerifyCommand extends Command
         $user = $this->repository->findOneByUsername($input->getArgument('username'));
 
         if (!$user) {
-            $io->error('User does not exist.');
+            $io->error('User does not exist!');
 
             return Command::FAILURE;
         }
 
         if (!$activate && !$deactivate) {
             if ($user->isVerified) {
-                $io->success('The provided user is verified.');
+                $io->success('The provided user is verified and can login.');
             } else {
-                $io->success('The provided user is unverified.');
+                $io->success('The provided user is unverified and cannot login.');
             }
 
             return Command::SUCCESS;
@@ -63,12 +63,12 @@ class VerifyCommand extends Command
             $user->isVerified = true;
             $this->entityManager->flush();
 
-            $io->success('The user has been activated.');
+            $io->success('The user has been activated and can login.');
         } elseif ($deactivate) {
             $user->isVerified = false;
             $this->entityManager->flush();
 
-            $io->success('The user has been deactivated.');
+            $io->success('The user has been deactivated and cannot login.');
         }
 
         return Command::SUCCESS;


### PR DESCRIPTION
Instance admins have been required to manually modify the `is_verified` user field in the database to activate an account that failed to successfully complete the email verification process. This PR adds the following `php bin/console` command to remove the need for manual database interaction:

```
mbin:user:verify [-a|--activate] [-d|--deactivate] [--] <username>
```

Example output:

![image](https://github.com/MbinOrg/mbin/assets/35878315/7c9b3a30-9a47-4612-a10c-ac677e8e53c7)

