### PR TITLE
Fix 500 on parsed unresolved remote mags (might be specific to Flipboard)

### DIFF
--- a/src/Markdown/CommonMark/CommunityLinkParser.php
+++ b/src/Markdown/CommonMark/CommunityLinkParser.php
@@ -42,7 +42,7 @@ class CommunityLinkParser implements InlineParserInterface
 
         if ($isRemote) {
             $magazine = $this->magazineRepository->findOneByName($fullHandle);
-        
+
             if ($magazine && $magazine->apPublicUrl) {
                 $ctx->getContainer()->appendChild(
                     new CommunityLink(
@@ -53,9 +53,10 @@ class CommunityLinkParser implements InlineParserInterface
                         MentionType::RemoteMagazine,
                     ),
                 );
+
                 return true;
             }
-        
+
             $ctx->getContainer()->appendChild(
                 new ActorSearchLink(
                     $this->urlGenerator->generate('search', ['q' => $fullHandle], UrlGeneratorInterface::ABSOLUTE_URL),
@@ -63,6 +64,7 @@ class CommunityLinkParser implements InlineParserInterface
                     '!'.$fullHandle,
                 )
             );
+
             return true;
         }
 

--- a/src/Markdown/CommonMark/CommunityLinkParser.php
+++ b/src/Markdown/CommonMark/CommunityLinkParser.php
@@ -41,13 +41,9 @@ class CommunityLinkParser implements InlineParserInterface
         $isRemote = $this->isRemoteCommunity($domain);
 
         if ($isRemote) {
-            if ($magazine = $this->magazineRepository->findOneByName($fullHandle)) {
-                if (!$magazine->apPublicUrl) {
-                    $ctx->getContainer()->appendChild(new UnresolvableLink('!'.$handle));
+            $magazine = $this->magazineRepository->findOneByName($fullHandle);
 
-                    return true;
-                }
-
+            if (!$magazine->apPublicUrl) {
                 $ctx->getContainer()->appendChild(
                     new CommunityLink(
                         $magazine->apPublicUrl,
@@ -57,17 +53,15 @@ class CommunityLinkParser implements InlineParserInterface
                         MentionType::RemoteMagazine,
                     ),
                 );
-
-                return true;
+            } elseif (!$magazine) {
+                $ctx->getContainer()->appendChild(
+                    new ActorSearchLink(
+                        $this->urlGenerator->generate('search', ['q' => $fullHandle], UrlGeneratorInterface::ABSOLUTE_URL),
+                        '!'.$handle,
+                        '!'.$fullHandle,
+                    )
+                );
             }
-
-            $ctx->getContainer()->appendChild(
-                new ActorSearchLink(
-                    $this->urlGenerator->generate('search', ['q' => $fullHandle], UrlGeneratorInterface::ABSOLUTE_URL),
-                    '!'.$handle,
-                    '!'.$fullHandle,
-                )
-            );
 
             return true;
         }

--- a/src/Markdown/CommonMark/CommunityLinkParser.php
+++ b/src/Markdown/CommonMark/CommunityLinkParser.php
@@ -43,7 +43,7 @@ class CommunityLinkParser implements InlineParserInterface
         if ($isRemote) {
             $magazine = $this->magazineRepository->findOneByName($fullHandle);
 
-            if (!$magazine->apPublicUrl) {
+            if ($magazine->apPublicUrl) {
                 $ctx->getContainer()->appendChild(
                     new CommunityLink(
                         $magazine->apPublicUrl,

--- a/src/Markdown/CommonMark/CommunityLinkParser.php
+++ b/src/Markdown/CommonMark/CommunityLinkParser.php
@@ -42,8 +42,8 @@ class CommunityLinkParser implements InlineParserInterface
 
         if ($isRemote) {
             $magazine = $this->magazineRepository->findOneByName($fullHandle);
-
-            if ($magazine->apPublicUrl) {
+        
+            if ($magazine && $magazine->apPublicUrl) {
                 $ctx->getContainer()->appendChild(
                     new CommunityLink(
                         $magazine->apPublicUrl,
@@ -53,16 +53,16 @@ class CommunityLinkParser implements InlineParserInterface
                         MentionType::RemoteMagazine,
                     ),
                 );
-            } elseif (!$magazine) {
-                $ctx->getContainer()->appendChild(
-                    new ActorSearchLink(
-                        $this->urlGenerator->generate('search', ['q' => $fullHandle], UrlGeneratorInterface::ABSOLUTE_URL),
-                        '!'.$handle,
-                        '!'.$fullHandle,
-                    )
-                );
+                return true;
             }
-
+        
+            $ctx->getContainer()->appendChild(
+                new ActorSearchLink(
+                    $this->urlGenerator->generate('search', ['q' => $fullHandle], UrlGeneratorInterface::ABSOLUTE_URL),
+                    '!'.$handle,
+                    '!'.$fullHandle,
+                )
+            );
             return true;
         }
 

--- a/src/Markdown/CommonMark/CommunityLinkParser.php
+++ b/src/Markdown/CommonMark/CommunityLinkParser.php
@@ -42,6 +42,12 @@ class CommunityLinkParser implements InlineParserInterface
 
         if ($isRemote) {
             if ($magazine = $this->magazineRepository->findOneByName($fullHandle)) {
+                if (!$magazine->apPublicUrl) {
+                    $ctx->getContainer()->appendChild(new UnresolvableLink('!'.$handle));
+
+                    return true;
+                }
+
                 $ctx->getContainer()->appendChild(
                     new CommunityLink(
                         $magazine->apPublicUrl,


### PR DESCRIPTION
Prevent `CommunityLink` object getting created with a null URL due to unresolved remote object (looks like it might be a compatibility issue with Flipboard), it's causing 500 errors on several (but not all) Mbin instances with `https://slrpnk.net/post/5064803` containing ([!dot_social](https://flipboard.video/video-channels/dot_social)...

fedia.io: https://fedia.io/search?q=https%3A%2F%2Fslrpnk.net%2Fpost%2F5064803 (500)

kbin.melroy.org: https://kbin.melroy.org/m/fediverse@lemmy.world/t/82868/Flipboard-Starts-a-PeerTube-Instance (redirect back to search?)

kbin.social: https://kbin.social/m/fediverse@lemmy.world/t/715501/Flipboard-Starts-a-PeerTube-Instance (seems to resolve ok?)
