### PR TITLE
Update console commands to use mbin naming convention

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -149,7 +149,7 @@ sudo supervisorctl restart all
 If you want to update all the remote users on your instance, you can execute the following command (which will also re-download the avatars):
 
 ```bash
-./bin/console kbin:ap:actor:update
+./bin/console mbin:ap:actor:update
 ```
 
 _Important:_ This might have quite a performance impact (temporally), if you are running a very large instance. Due to the huge amount of remote users.

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -956,12 +956,12 @@ sudo supervisorctl restart all
 Create new admin user (without email verification), please change the `username`, `email` and `password` below:
 
 ```bash
-php bin/console kbin:user:create <username> <email@example.com> <password>
-php bin/console kbin:user:admin <username>
+php bin/console mbin:user:create <username> <email@example.com> <password>
+php bin/console mbin:user:admin <username>
 ```
 
 ```bash
-php bin/console kbin:ap:keys:update
+php bin/console mbin:ap:keys:update
 ```
 
 Next, log in and create a magazine named "random" to which unclassified content from the fediverse will flow.

--- a/docs/docker_deployment_guide.md
+++ b/docs/docker_deployment_guide.md
@@ -160,12 +160,12 @@ You can also access RabbitMQ management UI via [http://localhost:15672](http://l
 Create new admin user (without email verification), please change the `username`, `email` and `password` below:
 
 ```bash
-docker compose exec php bin/console kbin:user:create <username> <email@example.com> <password>
-docker compose exec php bin/console kbin:user:admin <username>
+docker compose exec php bin/console mbin:user:create <username> <email@example.com> <password>
+docker compose exec php bin/console mbin:user:admin <username>
 ```
 
 ```bash
-docker compose exec php bin/console kbin:ap:keys:update
+docker compose exec php bin/console mbin:ap:keys:update
 ```
 
 Next, log in and create a magazine named "random" to which unclassified content from the fediverse will flow.

--- a/src/Command/ActorUpdateCommand.php
+++ b/src/Command/ActorUpdateCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsCommand(
-    name: 'kbin:actor:update',
+    name: 'mbin:actor:update',
     description: 'This command will allow you to update remote user info.',
 )]
 class ActorUpdateCommand extends Command

--- a/src/Command/AdminCommand.php
+++ b/src/Command/AdminCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
-    name: 'kbin:user:admin',
+    name: 'mbin:user:admin',
     description: 'This command allows you to grant administrator privileges to the user.',
 )]
 class AdminCommand extends Command

--- a/src/Command/ApImportObject.php
+++ b/src/Command/ApImportObject.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsCommand(
-    name: 'kbin:ap:import',
+    name: 'mbin:ap:import',
     description: 'This command allows you import AP resource.'
 )]
 class ApImportObject extends Command

--- a/src/Command/AwesomeBot/AwesomeBotEntries.php
+++ b/src/Command/AwesomeBot/AwesomeBotEntries.php
@@ -20,12 +20,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpClient\HttpClient;
 
-#[AsCommand(name: 'kbin:awesome-bot:entries:create')]
+#[AsCommand(name: 'mbin:awesome-bot:entries:create')]
 class AwesomeBotEntries extends Command
 {
-    // bin/console kbin:user:create awesome-vue-bot awesome-vue-bot@karab.in awesome-vue-bot
-    // bin/console kbin:awesome-bot:magazine:create ernest vue Vue https://github.com/vuejs/awesome-vue h3
-    // bin/console kbin:awesome-bot:entries:create awesome-vue-bot vue https://github.com/vuejs/awesome-vue h3
+    // bin/console mbin:user:create awesome-vue-bot awesome-vue-bot@karab.in awesome-vue-bot
+    // bin/console mbin:awesome-bot:magazine:create ernest vue Vue https://github.com/vuejs/awesome-vue h3
+    // bin/console mbin:awesome-bot:entries:create awesome-vue-bot vue https://github.com/vuejs/awesome-vue h3
 
     public function __construct(
         private readonly EntryManager $entryManager,

--- a/src/Command/AwesomeBot/AwesomeBotFixtures.php
+++ b/src/Command/AwesomeBot/AwesomeBotFixtures.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpClient\HttpClient;
 
-#[AsCommand(name: 'kbin:awesome-bot:fixtures:create')]
+#[AsCommand(name: 'mbin:awesome-bot:fixtures:create')]
 class AwesomeBotFixtures extends Command
 {
     public function __construct(
@@ -332,7 +332,7 @@ class AwesomeBotFixtures extends Command
     private function preapreMagazines(OutputInterface $output, array $entry)
     {
         try {
-            $command = $this->getApplication()->find('kbin:user:create');
+            $command = $this->getApplication()->find('mbin:user:create');
             $arguments = [
                 'username' => $entry['username'],
                 'email' => $entry['username'].'@karab.in',
@@ -344,7 +344,7 @@ class AwesomeBotFixtures extends Command
         }
 
         try {
-            $command = $this->getApplication()->find('kbin:awesome-bot:magazine:create');
+            $command = $this->getApplication()->find('mbin:awesome-bot:magazine:create');
             $arguments = [
                 'username' => 'demo',
                 'magazine_name' => $entry['magazine_name'],

--- a/src/Command/AwesomeBot/AwesomeBotMagazine.php
+++ b/src/Command/AwesomeBot/AwesomeBotMagazine.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpClient\HttpClient;
 
-#[AsCommand(name: 'kbin:awesome-bot:magazine:create')]
+#[AsCommand(name: 'mbin:awesome-bot:magazine:create')]
 class AwesomeBotMagazine extends Command
 {
     public function __construct(

--- a/src/Command/ImageCacheCommand.php
+++ b/src/Command/ImageCacheCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
-    name: 'kbin:cache:build',
+    name: 'mbin:cache:build',
     description: 'This command allows you to rebuild image thumbs cache.'
 )]
 class ImageCacheCommand extends Command

--- a/src/Command/MagazineUnsubCommand.php
+++ b/src/Command/MagazineUnsubCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[AsCommand(name: 'kbin:magazine:unsub')]
+#[AsCommand(name: 'mbin:magazine:unsub')]
 class MagazineUnsubCommand extends Command
 {
     public function __construct(

--- a/src/Command/MoveEntriesByTagCommand.php
+++ b/src/Command/MoveEntriesByTagCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
-    name: 'kbin:entries:move',
+    name: 'mbin:entries:move',
     description: 'This command will allow you to move the entries to the new magazine based on the tag.'
 )]
 class MoveEntriesByTagCommand extends Command

--- a/src/Command/MovePostsByTagCommand.php
+++ b/src/Command/MovePostsByTagCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
-    name: 'kbin:posts:move',
+    name: 'mbin:posts:move',
     description: 'This command will allow you to move the posts to the new magazine based on the tag.'
 )]
 class MovePostsByTagCommand extends Command

--- a/src/Command/PostMagazinesUpdateCommand.php
+++ b/src/Command/PostMagazinesUpdateCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
-    name: 'kbin:posts:magazines',
+    name: 'mbin:posts:magazines',
     description: 'This command allows assing post to magazine.'
 )]
 class PostMagazinesUpdateCommand extends Command

--- a/src/Command/RemoveDuplicatesCommand.php
+++ b/src/Command/RemoveDuplicatesCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[AsCommand(name: 'kbin:post:remove-duplicates')]
+#[AsCommand(name: 'mbin:post:remove-duplicates')]
 class RemoveDuplicatesCommand extends Command
 {
     public function __construct(

--- a/src/Command/SubMagazineCommand.php
+++ b/src/Command/SubMagazineCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
-    name: 'kbin:magazine:sub',
+    name: 'mbin:magazine:sub',
     description: 'This command allows subscribe magazine.',
 )]
 class SubMagazineCommand extends Command

--- a/src/Command/Update/ApKeysUpdateCommand.php
+++ b/src/Command/Update/ApKeysUpdateCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
-    name: 'kbin:ap:keys:update',
+    name: 'mbin:ap:keys:update',
     description: 'This command allows generate keys for AP Actors.',
 )]
 class ApKeysUpdateCommand extends Command

--- a/src/Command/Update/ImageBlurhashUpdateCommand.php
+++ b/src/Command/Update/ImageBlurhashUpdateCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsCommand(
-    name: 'kbin:blurhash:update',
+    name: 'mbin:blurhash:update',
     description: 'This command allows generate blurhash for images.',
 )]
 class ImageBlurhashUpdateCommand extends Command

--- a/src/Command/Update/LocalMagazineApProfile.php
+++ b/src/Command/Update/LocalMagazineApProfile.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 #[AsCommand(
-    name: 'kbin:update:magazines:ap_profile',
+    name: 'mbin:update:magazines:ap_profile',
     description: 'This command allows generate Ap profile.',
 )]
 class LocalMagazineApProfile extends Command

--- a/src/Command/Update/NoteVisibilityUpdateCommand.php
+++ b/src/Command/Update/NoteVisibilityUpdateCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsCommand(
-    name: 'kbin:ap:actor:update',
+    name: 'mbin:ap:actor:update',
     description: 'This command allows refresh remote users.'
 )]
 class NoteVisibilityUpdateCommand extends Command

--- a/src/Command/Update/PostCommentRootUpdateCommand.php
+++ b/src/Command/Update/PostCommentRootUpdateCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
-    name: 'kbin:post:comments:root:update',
+    name: 'mbin:post:comments:root:update',
     description: 'This command allows generate root id for comments.',
 )]
 class PostCommentRootUpdateCommand extends Command

--- a/src/Command/Update/RemoveMagazineNameFromTagsCommand.php
+++ b/src/Command/Update/RemoveMagazineNameFromTagsCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
-    name: 'kbin:magazine:tags',
+    name: 'mbin:magazine:tags',
     description: 'This command allows remove magazine name from tags.'
 )]
 class RemoveMagazineNameFromTagsCommand extends Command

--- a/src/Command/Update/SlugUpdateCommand.php
+++ b/src/Command/Update/SlugUpdateCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
-    name: 'kbin:slug:update',
+    name: 'mbin:slug:update',
     description: 'This command allows refresh entries slugs.'
 )]
 class SlugUpdateCommand extends Command

--- a/src/Command/Update/TagsToJsonbUpdateCommand.php
+++ b/src/Command/Update/TagsToJsonbUpdateCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
-    name: 'kbin:tags:update',
+    name: 'mbin:tags:update',
     description: 'This command allows update tags columns.',
 )]
 class TagsToJsonbUpdateCommand extends Command

--- a/src/Command/Update/TagsUpdateCommand.php
+++ b/src/Command/Update/TagsUpdateCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
-    name: 'kbin:tag:update',
+    name: 'mbin:tag:update',
     description: 'This command allows refresh entries tags.'
 )]
 class TagsUpdateCommand extends Command

--- a/src/Command/Update/UserLastActiveUpdateCommand.php
+++ b/src/Command/Update/UserLastActiveUpdateCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
-    name: 'kbin:users:lastActive:update',
+    name: 'mbin:users:lastActive:update',
     description: 'This command allows set user last active date.'
 )]
 class UserLastActiveUpdateCommand extends Command

--- a/src/Command/UserCommand.php
+++ b/src/Command/UserCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
-    name: 'kbin:user:create',
+    name: 'mbin:user:create',
     description: 'This command allows you to create user, optionally granting administrator privileges.',
 )]
 class UserCommand extends Command

--- a/src/Command/UserUnsubCommand.php
+++ b/src/Command/UserUnsubCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[AsCommand(name: 'kbin:user:unsub')]
+#[AsCommand(name: 'mbin:user:unsub')]
 class UserUnsubCommand extends Command
 {
     public function __construct(

--- a/src/Command/VerifyCommand.php
+++ b/src/Command/VerifyCommand.php
@@ -49,16 +49,6 @@ class VerifyCommand extends Command
             return Command::FAILURE;
         }
 
-        if (!$activate && !$deactivate) {
-            if ($user->isVerified) {
-                $io->success('The user is verified and can login.');
-            } else {
-                $io->success('The user is unverified and cannot login.');
-            }
-
-            return Command::SUCCESS;
-        }
-
         if ($activate) {
             $user->isVerified = true;
             $this->entityManager->flush();
@@ -69,6 +59,13 @@ class VerifyCommand extends Command
             $this->entityManager->flush();
 
             $io->success('The user has been deactivated and cannot login.');
+        }
+        else {
+            if ($user->isVerified) {
+                $io->success('The user is verified and can login.');
+            } else {
+                $io->success('The user is unverified and cannot login.');
+            }
         }
 
         return Command::SUCCESS;

--- a/src/Command/VerifyCommand.php
+++ b/src/Command/VerifyCommand.php
@@ -59,8 +59,7 @@ class VerifyCommand extends Command
             $this->entityManager->flush();
 
             $io->success('The user has been deactivated and cannot login.');
-        }
-        else {
+        } else {
             if ($user->isVerified) {
                 $io->success('The user is verified and can login.');
             } else {

--- a/tests/Functional/Command/AdminCommandTest.php
+++ b/tests/Functional/Command/AdminCommandTest.php
@@ -38,7 +38,7 @@ class AdminCommandTest extends KernelTestCase
     {
         $application = new Application(self::bootKernel());
 
-        $this->command = $application->find('kbin:user:admin');
+        $this->command = $application->find('mbin:user:admin');
         $this->repository = $this->getContainer()->get(UserRepository::class);
     }
 }

--- a/tests/Functional/Command/UserCommandTest.php
+++ b/tests/Functional/Command/UserCommandTest.php
@@ -54,7 +54,7 @@ class UserCommandTest extends KernelTestCase
     {
         $application = new Application(self::bootKernel());
 
-        $this->command = $application->find('kbin:user:create');
+        $this->command = $application->find('mbin:user:create');
         $this->repository = $this->getContainer()->get(UserRepository::class);
     }
 }


### PR DESCRIPTION
Update all `php bin/console` commands to use mbin naming convention.

I also refactored the `mbin:user:verify user` logic since I was not thinking clearly last night.