### PR TITLE
fix js error when clicking home button on mobile sidebar

### DIFF
--- a/templates/layout/_sidebar.html.twig
+++ b/templates/layout/_sidebar.html.twig
@@ -34,7 +34,6 @@
                 <li class='home-button'>
                     <a
                             href="/"
-                            data-action="options#home"
                             title="{{ 'homepage'|trans }}"
                             aria-label="{{ 'homepage'|trans }}">
                         <i class="fa-solid fa-home"></i>


### PR DESCRIPTION
prior to this, clicking on the home button in the sidebar generated the error:

```
Error invoking action "click->options#home"
Error: Action "click->options#home" references undefined method "home"
```

this is because no `home` action exists in https://github.com/MbinOrg/mbin/blob/main/assets/controllers/options_controller.js
the button still functioned, however, so functionally this changes nothing, just wanted to clean up the js exception