### PR TITLE
Update admin docs for manual user activation

### DIFF
--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -976,6 +976,14 @@ If you perform a Mbin upgrade (eg. `git pull`), be aware to _always_ execute the
 
 And when needed also execute: `sudo redis-cli FLUSHDB` to get rid of Redis cache issues. And reload the PHP FPM service if you have OPCache enabled.
 
+### Manual user activation
+
+Activate a user account (bypassing email verification), please change the `username` below:
+
+```bash
+php bin/console mbin:user:verify <username> -a
+```
+
 ### Backup and restore
 
 ```bash

--- a/docs/docker_deployment_guide.md
+++ b/docs/docker_deployment_guide.md
@@ -307,7 +307,7 @@ docker compose exec redis redis-cli
 > FLUSHDB
 ```
 
-### Manual user activation
+## Manual user activation
 
 Activate a user account (bypassing email verification), please change the `username` below:
 

--- a/docs/docker_deployment_guide.md
+++ b/docs/docker_deployment_guide.md
@@ -307,6 +307,14 @@ docker compose exec redis redis-cli
 > FLUSHDB
 ```
 
+### Manual user activation
+
+Activate a user account (bypassing email verification), please change the `username` below:
+
+```bash
+docker compose exec php bin/console mbin:user:verify <username> -a
+```
+
 ## Backup and restore
 
 Backup:


### PR DESCRIPTION
Update the bare metal and docker admin guides to call out manual user activation capability.