### PR TITLE
Update InlineParserMatch regex in MentionLinkParser to correctly process usernames with hyphens

### DIFF
--- a/src/Markdown/CommonMark/MentionLinkParser.php
+++ b/src/Markdown/CommonMark/MentionLinkParser.php
@@ -31,7 +31,7 @@ class MentionLinkParser implements InlineParserInterface
     public function getMatchDefinition(): InlineParserMatch
     {
         // support for unicode international domains
-        return InlineParserMatch::regex('\B@(\w{1,30})(?:@)?((?:[\pL\pN\pS\pM\-\_]++\.)+[\pL\pN\pM]++|[a-z0-9\-\_]++)?');
+        return InlineParserMatch::regex('\B@([a-zA-Z0-9\-\_]{1,30})(?:@)?((?:[\pL\pN\pS\pM\-\_]++\.)+[\pL\pN\pM]++|[a-z0-9\-\_]++)?');
     }
 
     public function parse(InlineParserContext $ctx): bool


### PR DESCRIPTION
Existing `\w` in `InlineParserMatch` regex does not include hyphens (-) thereby breaking user mentions on usernames that include hyphens. PR explicitly enumerates all allowed characters in username.