### PR TITLE
redirect `/instances` to `/federation`

### DIFF
--- a/config/kbin_routes/page.yaml
+++ b/config/kbin_routes/page.yaml
@@ -29,3 +29,9 @@ page_federation:
   path: /federation
   methods: [ GET ]
 
+page_instances:
+  controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController
+  path: /instances
+  defaults:
+    route: page_federation
+    permanent: true

--- a/config/kbin_routes/page.yaml
+++ b/config/kbin_routes/page.yaml
@@ -29,7 +29,7 @@ page_federation:
   path: /federation
   methods: [ GET ]
 
-page_instances:
+redirect_instances:
   controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController
   path: /instances
   defaults:


### PR DESCRIPTION
this simply makes a permanent redirect of `/instances` to `/federation`. lemmy users may be more familiar with the `/instances` route and we aren't currently using it, so didn't see a reason to not allow this for now. it's only an issue for people that might manually type out `example.com/instances` into their url bar as it isn't linked anywhere