### PR TITLE
Handle exception on long embed URL length causing messages to go to failed queue

### DIFF
--- a/src/Repository/EmbedRepository.php
+++ b/src/Repository/EmbedRepository.php
@@ -7,6 +7,7 @@ namespace App\Repository;
 use App\Entity\Embed;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Psr\Log\LoggerInterface;
 
 /**
  * @method Embed|null find($id, $lockMode = null, $lockVersion = null)
@@ -17,7 +18,9 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 class EmbedRepository extends ServiceEntityRepository
 {
-    public function __construct(ManagerRegistry $registry)
+    public function __construct(
+        ManagerRegistry $registry,
+        private readonly LoggerInterface $logger, )
     {
         parent::__construct($registry, Embed::class);
     }
@@ -27,8 +30,7 @@ class EmbedRepository extends ServiceEntityRepository
         // Check if embed url does not exists yet (null),
         // before we try to insert a new DB record
         if (null === $this->findOneByUrl($entity->url)) {
-
-            //Do not exceed URL length limit defined by db schema
+            // Do not exceed URL length limit defined by db schema
             try {
                 $this->_em->persist($entity);
 
@@ -36,6 +38,7 @@ class EmbedRepository extends ServiceEntityRepository
                     $this->_em->flush();
                 }
             } catch (\Exception $e) {
+                $this->logger->debug('URL exceeds allowed length: {url}', ['url' => $entity->url]);
             }
         }
     }

--- a/src/Repository/EmbedRepository.php
+++ b/src/Repository/EmbedRepository.php
@@ -28,13 +28,14 @@ class EmbedRepository extends ServiceEntityRepository
         // before we try to insert a new DB record
         if (null === $this->findOneByUrl($entity->url)) {
 
-            // Limited by VARCHAR(255) in db schema
-            if (strlen($entity->url) <= 255){
+            //URL length limitation of VARCHAR(255) in db schema
+            try {
                 $this->_em->persist($entity);
 
                 if ($flush) {
                     $this->_em->flush();
                 }
+            } catch (\Exception $e) {
             }
         }
     }

--- a/src/Repository/EmbedRepository.php
+++ b/src/Repository/EmbedRepository.php
@@ -27,9 +27,14 @@ class EmbedRepository extends ServiceEntityRepository
         // Check if embed url does not exists yet (null),
         // before we try to insert a new DB record
         if (null === $this->findOneByUrl($entity->url)) {
-            $this->_em->persist($entity);
-            if ($flush) {
-                $this->_em->flush();
+
+            // Limited by VARCHAR(255) in db schema
+            if (strlen($entity->url) <= 255){
+                $this->_em->persist($entity);
+
+                if ($flush) {
+                    $this->_em->flush();
+                }
             }
         }
     }

--- a/src/Repository/EmbedRepository.php
+++ b/src/Repository/EmbedRepository.php
@@ -28,7 +28,7 @@ class EmbedRepository extends ServiceEntityRepository
         // before we try to insert a new DB record
         if (null === $this->findOneByUrl($entity->url)) {
 
-            //URL length limitation of VARCHAR(255) in db schema
+            //Do not exceed URL length limit defined by db schema
             try {
                 $this->_em->persist($entity);
 

--- a/src/Repository/EmbedRepository.php
+++ b/src/Repository/EmbedRepository.php
@@ -38,7 +38,7 @@ class EmbedRepository extends ServiceEntityRepository
                     $this->_em->flush();
                 }
             } catch (\Exception $e) {
-                $this->logger->debug('URL exceeds allowed length: {url}', ['url' => $entity->url]);
+                $this->logger->debug('Embed URL exceeds allowed length: {url, length}', ['url' => $entity->url, \strlen($entity->url)]);
             }
         }
     }

--- a/src/Repository/EmbedRepository.php
+++ b/src/Repository/EmbedRepository.php
@@ -38,7 +38,7 @@ class EmbedRepository extends ServiceEntityRepository
                     $this->_em->flush();
                 }
             } catch (\Exception $e) {
-                $this->logger->debug('Embed URL exceeds allowed length: {url, length}', ['url' => $entity->url, \strlen($entity->url)]);
+                $this->logger->warning('Embed URL exceeds allowed length: {url, length}', ['url' => $entity->url, \strlen($entity->url)]);
             }
         }
     }


### PR DESCRIPTION
PR "handles" this exception that's causing messages to be dumped into the failed queue... which will never succeed unless the DB schema is updated. Regardless, this PR code won't have to change since it won't cause an exception if the URL column datatype is "fixed" / adjusted:

```
Failed Message Details
======================

 ------------- -------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Class         App\Message\LinkEmbedMessage                                                                                                                            
  Message Id    16855846                                                                                                                                                
  Failed at     2024-01-03 21:01:45                                                                                                                                     
  Error         An exception occurred while executing a query: SQLSTATE[22001]: String data, right truncated: 7 ERROR:  value too long for type character varying(255)  
  Error Code    7                                                                                                                                                       
  Error Class   Doctrine\DBAL\Exception\DriverException                                                                                                                 
  Transport     failed                                                                                                                                                  
 ------------- -------------------------------------------------------------------------------------------------------------------------------------------------------- 
```

Embed URLs are limited to VARCHAR(255) by current DB schema:

![image](https://github.com/MbinOrg/mbin/assets/35878315/31136ba7-52da-4cb8-b071-d247e1dfe119)

Tested on a local 3 node federated cluster, works as expected: valid links (255 chars or less) still get entries put into the db, URLs that violate the current length limit are logged to debug channel.