### PR TITLE
somewhat fix phpunit so it could run functional tests again

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,8 +28,12 @@
         <include>
             <directory suffix=".php">src</directory>
         </include>
+        <exclude>
+            <directory suffix=".php">src/DataFixtures</directory>
+        </exclude>
     </source>
 
     <extensions>
+        <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension" />
     </extensions>
 </phpunit>

--- a/tests/Functional/Controller/Magazine/MagazineListControllerTest.php
+++ b/tests/Functional/Controller/Magazine/MagazineListControllerTest.php
@@ -28,7 +28,7 @@ class MagazineListControllerTest extends WebTestCase
         );
     }
 
-    public function magazines(): iterable
+    public static function magazines(): iterable
     {
         return [
             [['query' => 'test'], []],

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Dotenv\Dotenv;
 
 require \dirname(__DIR__).'/vendor/autoload.php';
@@ -14,4 +17,34 @@ if (file_exists(\dirname(__DIR__).'/config/bootstrap.php')) {
 
 if ($_SERVER['APP_DEBUG']) {
     umask(0000);
+}
+
+function bootstrapDatabase(): void
+{
+    $kernel = new Kernel('test', true);
+    $kernel->boot();
+
+    $application = new Application($kernel);
+    $application->setAutoExit(false);
+
+    $application->run(new ArrayInput([
+        'command' => 'doctrine:database:drop',
+        '--if-exists' => '1',
+        '--force' => '1',
+    ]));
+
+    $application->run(new ArrayInput([
+        'command' => 'doctrine:database:create',
+    ]));
+
+    $application->run(new ArrayInput([
+        'command' => 'doctrine:migrations:migrate',
+        '--no-interaction' => true,
+    ]));
+
+    $kernel->shutdown();
+}
+
+if (!empty($_SERVER['BOOTSTRAP_DB'])) {
+    bootstrapDatabase();
 }


### PR DESCRIPTION
who tests the test infrastructure

not sure what happened but it seems to be a combination of:
- symfony/phpunit-bridge doesn't support phpunit 10 yet
- but we're using phpunit 10 anyway
- applied multiple config recipes and overwritten a decent chunk out of them
- dama/doctrine-test-bundle not active when running tests, leading to db error when testing due to data conflict and mismatch between tests data in db and what the tests sees and has access to

included fixes:
- applied a small phpunit config changes just enough to get it back up and running again
- included auto test database bootstrap for phpunit, activate by setting BOOTSTRAP_DB env variable when starting tests (e.g. `BOOTSTRAP_DB=1 ./bin/phpunit`)