### PR TITLE
server assisted comment collapsing

### DIFF
--- a/assets/controllers/comment_collapse_controller.js
+++ b/assets/controllers/comment_collapse_controller.js
@@ -1,0 +1,92 @@
+import { Controller } from '@hotwired/stimulus';
+import { getLevel } from '../utils/kbin';
+
+const COMMENT_ELEMENT_TAG = 'BLOCKQUOTE';
+const COLLAPSIBLE_CLASS = 'collapsible';
+const COLLAPSED_CLASS = 'collapsed';
+const HIDDEN_CLASS = 'hidden'
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    static values = {
+        depth: Number,
+        hiddenBy: Number,
+    };
+    static targets = ['counter'];
+
+    connect() {
+        // derive depth value if it doesn't exist
+        // or when attached depth is 1 but css depth says otherwise (trying to handle dynamic list)
+        let cssLevel = getLevel(this.element);
+        if (!this.hasDepthValue
+            || (1 === this.depthValue && cssLevel > this.depthValue)) {
+            this.depthValue = cssLevel;
+        }
+
+        this.element.classList.add(COLLAPSIBLE_CLASS);
+        this.element.collapse = this;
+    }
+
+    // main function, use this in action
+    toggleCollapse(event) {
+        event.preventDefault();
+
+        for (
+            var nextSibling = this.element.nextElementSibling, collapsed = 0;
+            nextSibling && COMMENT_ELEMENT_TAG === nextSibling.tagName;
+            nextSibling = nextSibling.nextElementSibling
+        ) {
+            let siblingDepth = nextSibling.dataset.commentCollapseDepthValue;
+            if (!siblingDepth || siblingDepth <= this.depthValue) {
+                break;
+            }
+
+            this.toggleHideSibling(nextSibling, this.depthValue);
+            collapsed += 1;
+        }
+
+        this.toggleCollapseSelf();
+
+        if (collapsed > 0) {
+            this.updateCounter(collapsed);
+        }
+    }
+
+    // signals sibling comment element to hide itself
+    toggleHideSibling(element, collapserDepth) {
+        if (!element.collapse.hasHiddenByValue) {
+            element.collapse.hiddenByValue = collapserDepth;
+        } else if (collapserDepth === element.collapse.hiddenByValue) {
+            element.collapse.hiddenByValue = undefined;
+        }
+    }
+
+    // put itself into collapsed state
+    toggleCollapseSelf() {
+        this.element.classList.toggle(COLLAPSED_CLASS);
+    }
+
+    updateCounter(count) {
+        if (!this.hasCounterTarget) {
+            return;
+        }
+
+        if (this.element.classList.contains(COLLAPSED_CLASS)) {
+            this.counterTarget.innerText = `(${count})`;
+        } else {
+            this.counterTarget.innerText = '';
+        }
+    }
+
+    // using value changed callback to enforce proper state appearance
+
+    // existence of hidden-by value means this comment is in hidden state
+    // (basically display: none)
+    hiddenByValueChanged() {
+        if (this.hasHiddenByValue) {
+            this.element.classList.add(HIDDEN_CLASS);
+        } else {
+            this.element.classList.remove(HIDDEN_CLASS);
+        }
+    }
+}

--- a/assets/controllers/subject_controller.js
+++ b/assets/controllers/subject_controller.js
@@ -2,7 +2,7 @@ import {Controller} from '@hotwired/stimulus';
 import {fetch, ok} from "../utils/http";
 import {useIntersection} from 'stimulus-use'
 import router from "../utils/routing";
-import getIntIdFromElement, {getLevel, getTypeFromNotification} from "../utils/kbin";
+import getIntIdFromElement, {getLevel, getDepth, getTypeFromNotification} from "../utils/kbin";
 import GLightbox from 'glightbox';
 
 /* stimulusFetch: 'lazy' */
@@ -118,8 +118,11 @@ export default class extends Controller {
                 div.innerHTML = response.html;
 
                 let level = getLevel(this.element);
+                let depth = getDepth(this.element);
 
+                div.firstElementChild.classList.remove('comment-level--1');
                 div.firstElementChild.classList.add('comment-level--' + (level >= 10 ? 10 : level + 1));
+                div.firstElementChild.dataset.commentCollapseDepthValue = depth + 1;
 
                 if (this.element.nextElementSibling && this.element.nextElementSibling.classList.contains('comments')) {
                     this.element.nextElementSibling.appendChild(div.firstElementChild);
@@ -132,6 +135,7 @@ export default class extends Controller {
                 this.containerTarget.innerHTML = '';
             }
         } catch (e) {
+            console.error(e);
             // this.containerTarget.innerHTML = '';
         } finally {
             this.application

--- a/assets/controllers/subject_list_controller.js
+++ b/assets/controllers/subject_list_controller.js
@@ -1,7 +1,7 @@
 import {Controller} from '@hotwired/stimulus';
 import router from "../utils/routing";
 import {fetch, ok} from "../utils/http";
-import {getLevel, getTypeFromNotification} from "../utils/kbin";
+import {getLevel, getDepth, getTypeFromNotification} from "../utils/kbin";
 
 /* stimulusFetch: 'lazy' */
 export default class extends Controller {
@@ -36,8 +36,11 @@ export default class extends Controller {
                 div.innerHTML = response.html;
 
                 let level = getLevel(parent);
+                let depth = getDepth(parent);
 
+                div.firstElementChild.classList.remove('comment-level--1');
                 div.firstElementChild.classList.add('comment-level--' + (level >= 10 ? 10 : level + 1));
+                div.firstElementChild.dataset.commentCollapseDepthValue = depth + 1;
 
                 let current = parent;
                 while (current) {

--- a/assets/styles/components/_comment.scss
+++ b/assets/styles/components/_comment.scss
@@ -27,7 +27,7 @@ $comment-margin-sm: .3rem;
   display: grid;
   font-size: .9rem;
   grid-gap: .5rem;
-  grid-template-areas: "avatar header vote"
+  grid-template-areas: "avatar header aside"
                          "avatar body body"
                          "avatar footer footer"
                          "moderate moderate moderate";
@@ -38,7 +38,7 @@ $comment-margin-sm: .3rem;
   z-index: 2;
 
   @include media-breakpoint-down(sm) {
-    grid-template-areas: "avatar header vote"
+    grid-template-areas: "avatar header aside"
                          "body body body"
                          "footer footer footer"
                          "moderate moderate moderate";
@@ -78,8 +78,24 @@ $comment-margin-sm: .3rem;
     }
   }
 
-  aside {
-    grid-area: vote;
+  .aside {
+    grid-area: aside;
+    display: flex;
+    gap: .5rem;
+  }
+
+  .comment-collapse {
+    cursor: pointer;
+    display: none;
+    white-space: nowrap;
+
+    > a {
+      padding: 0 .25rem;
+    }
+  }
+
+  .expand-label {
+    display: none;
   }
 
   div {
@@ -96,8 +112,8 @@ $comment-margin-sm: .3rem;
     display: none;
     margin: 0;
 
-
-    img{
+    img {
+      display: block;
       width: 30px;
       height: 30px;
     }
@@ -110,7 +126,6 @@ $comment-margin-sm: .3rem;
       }
     }
   }
-
 
   .vote {
     display: flex;
@@ -131,10 +146,8 @@ $comment-margin-sm: .3rem;
 
     menu {
       column-gap: 1rem;
-      display: grid;
+      display: flex;
       grid-area: meta;
-      grid-auto-columns: max-content;
-      grid-auto-flow: column;
       list-style: none;
       opacity: .75;
       position: relative;
@@ -149,6 +162,10 @@ $comment-margin-sm: .3rem;
       a {
         font-size: .8rem;
         @include kbin-btn-link;
+      }
+
+      > li {
+        width: max-content;
       }
 
       li:first-child a {
@@ -176,6 +193,50 @@ $comment-margin-sm: .3rem;
     width: 20px;
   }
 
+  &.collapsible {
+    .comment-collapse {
+      display: revert;
+    }
+  }
+
+  &.collapsed {
+    border-style: dashed;
+    grid-template-areas: "avatar header aside";
+    grid-template-columns: min-content auto min-content;
+
+    > :not(header, figure, .aside) {
+      display: none;
+    }
+
+    .aside > :not(.comment-collapse) {
+      display: none;
+    }
+
+    header a {
+      color: var(--kbin-text-muted-color);
+    }
+
+    > figure img {
+      filter: grayscale(.25) opacity(.75);
+    }
+
+    .comment-collapse {
+      opacity: .75;
+    }
+
+    .collapse-label {
+      display: none;
+    }
+
+    .expand-label {
+      display: revert;
+    }
+  }
+
+  &.hidden {
+    display: none;
+  }
+
   &:hover,
   &:focus-within {
     header, footer menu, footer .boosts {
@@ -192,9 +253,9 @@ $comment-margin-sm: .3rem;
 
 .comments-view-style--tree,
 .comments-view-style--classic {
-    .comment-level--1:not(:first-child) {
-        margin-top: 0.5rem;
-    }
+  .comment-level--1:not(:first-child) {
+    margin-top: 0.5rem;
+  }
 }
 
 .comments-tree {

--- a/assets/styles/components/_post.scss
+++ b/assets/styles/components/_post.scss
@@ -110,7 +110,7 @@
     font-weight: 300;
     grid-area: footer;
 
-    menu, .boosts {
+    .boosts {
       font-size: .75rem;
       opacity: .75;
     }
@@ -122,6 +122,7 @@
       grid-auto-columns: max-content;
       grid-auto-flow: column;
       list-style: none;
+      font-size: .8rem;
       opacity: .75;
       position: relative;
       z-index: 4;

--- a/assets/utils/kbin.js
+++ b/assets/utils/kbin.js
@@ -36,3 +36,8 @@ export function getLevel(element) {
     let level = parseInt(element.className.replace('comment-level--1', '').split('--')[1]);
     return isNaN(level) ? 1 : level;
 }
+
+export function getDepth(element) {
+    let depth = parseInt(element.dataset.commentCollapseDepthValue);
+    return isNaN(depth) ? 1 : depth;
+}

--- a/templates/components/_comment_collapse_button.html.twig
+++ b/templates/components/_comment_collapse_button.html.twig
@@ -1,0 +1,20 @@
+<aside class="comment-collapse">
+    <a data-action="comment-collapse#toggleCollapse">
+        <span data-comment-collapse-target="counter"></span>
+        {% if showNested and comment.children|length > 0 %}
+            <span class="collapse-label" aria-label="{{ 'collapse'|trans }}" title="{{ 'collapse'|trans }}">
+                <i class="fa-solid fa-angles-up"></i>
+            </span>
+            <span class="expand-label" aria-label="{{ 'expand'|trans }}" title="{{ 'expand'|trans }}">
+                <i class="fa-solid fa-angles-down"></i>
+            </span>
+        {% else %}
+            <span class="collapse-label" aria-label="{{ 'hide'|trans }}" title="{{ 'hide'|trans }}">
+                <i class="fa-solid fa-angle-up"></i>
+            </span>
+            <span class="expand-label" aria-label="{{ 'show'|trans }}" title="{{ 'show'|trans }}">
+                <i class="fa-solid fa-angle-down"></i>
+            </span>
+        {% endif %}
+    </a>
+</aside>

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -1,6 +1,7 @@
 {%- set V_TRUE = constant('App\\Controller\\User\\ThemeSettingsController::TRUE') -%}
 {%- set V_FALSE = constant('App\\Controller\\User\\ThemeSettingsController::FALSE') -%}
 {%- set V_TREE = constant('App\\Controller\\User\\ThemeSettingsController::TREE') -%}
+{%- set V_CLASSIC = constant('App\\Controller\\User\\ThemeSettingsController::CLASSIC') -%}
 
 {%- set SHOW_PREVIEW = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_PREVIEW'), V_FALSE) -%}
 {%- set DYNAMIC_LISTS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_DYNAMIC_LISTS'), V_FALSE) -%}
@@ -14,13 +15,14 @@
         </div>
     {% else %}
         <blockquote{{ attributes.defaults({
-            class: html_classes('section comment entry-comment subject ' ~ 'comment-level--' ~ this.getLevel(),{
+            class: html_classes('section comment entry-comment subject', 'comment-level--' ~ this.getLevel(), {
                 'own': app.user and comment.isAuthor(app.user),
                 'author': comment.isAuthor(comment.entry.user),
-                'show-preview': SHOW_PREVIEW is same as V_TRUE and not comment.isAdult
+                'show-preview': SHOW_PREVIEW is same as V_TRUE and not comment.isAdult,
             })}).without('id') }}
                 id="entry-comment-{{ comment.id }}"
-                data-controller="comment subject mentions"
+                data-controller="comment subject mentions comment-collapse"
+                data-comment-collapse-depth-value="{{ level }}"
                 data-subject-parent-value="{{ comment.parent ? comment.parent.id : '' }}"
                 data-action="{{- DYNAMIC_LISTS is same as V_TRUE ? 'notifications:Notification@window->subject#notification' : '' -}}">
             <header>
@@ -72,9 +74,15 @@
                     <p class="text-muted">&lsqb;<i>{{ 'deleted_by_author'|trans }}</i>&rsqb;</p>
                 {% endif %}
             </div>
-            {% if comment.visibility in ['visible', 'private'] %}
-                {{ component('vote', {subject: comment}) }}
-            {% endif %}
+            <div class="aside">
+                {% if comment.visibility in ['visible', 'private'] %}
+                    {{ component('vote', { subject: comment }) }}
+                {% endif %}
+                {{ include('components/_comment_collapse_button.html.twig', {
+                    comment: comment,
+                    showNested: showNested,
+                }) }}
+            </div>
             <footer>
                 {% if (comment.visibility in ['visible', 'private'] or comment.visibility is same as 'trashed' and this.canSeeTrashed) and comment.image %}
                     {{ include('components/_figure_image.html.twig', {

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -1,7 +1,6 @@
 {%- set V_TRUE = constant('App\\Controller\\User\\ThemeSettingsController::TRUE') -%}
 {%- set V_FALSE = constant('App\\Controller\\User\\ThemeSettingsController::FALSE') -%}
 {%- set V_TREE = constant('App\\Controller\\User\\ThemeSettingsController::TREE') -%}
-{%- set V_CLASSIC = constant('App\\Controller\\User\\ThemeSettingsController::CLASSIC') -%}
 
 {%- set SHOW_PREVIEW = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_SHOW_PREVIEW'), V_FALSE) -%}
 {%- set DYNAMIC_LISTS = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_DYNAMIC_LISTS'), V_FALSE) -%}

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -1,6 +1,7 @@
 {%- set V_TRUE = constant('App\\Controller\\User\\ThemeSettingsController::TRUE') -%}
 {%- set V_FALSE = constant('App\\Controller\\User\\ThemeSettingsController::FALSE') -%}
 {%- set V_TREE = constant('App\\Controller\\User\\ThemeSettingsController::TREE') -%}
+{%- set V_CLASSIC = constant('App\\Controller\\User\\ThemeSettingsController::CLASSIC') -%}
 
 {%- set SHOW_PREVIEW = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_PREVIEW'), V_FALSE) -%}
 {%- set VIEW_STYLE = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW'), V_TREE) -%}
@@ -16,13 +17,14 @@
         </div>
     {% else %}
         <blockquote{{ attributes.defaults({
-            class: html_classes('section comment post-comment subject ' ~ 'comment-level--' ~ this.getLevel(),{
+            class: html_classes('section comment post-comment subject', 'comment-level--' ~ this.getLevel(), {
                 'own': app.user and comment.isAuthor(app.user),
                 'author': comment.isAuthor(comment.post.user),
-                'show-preview': SHOW_PREVIEW is same as V_TRUE and not comment.isAdult
+                'show-preview': SHOW_PREVIEW is same as V_TRUE and not comment.isAdult,
             })}).without('id') }}
                 id="post-comment-{{ comment.id }}"
-                data-controller="comment subject mentions"
+                data-controller="comment subject mentions comment-collapse"
+                data-comment-collapse-depth-value="{{ level }}"
                 data-subject-parent-value="{{ comment.parent ? comment.parent.id : '' }}"
                 data-action="notifications:Notification@window->subject#notification">
             <header>
@@ -70,12 +72,15 @@
                     <p class="text-muted">&lsqb;<i>{{ 'deleted_by_author'|trans }}</i>&rsqb;</p>
                 {% endif %}
             </div>
-            {% if comment.visibility in ['visible', 'private'] %}
-                {{ component('vote', {
-                    subject: comment,
-                    showDownvote: false
+            <div class="aside">
+                {% if comment.visibility in ['visible', 'private'] %}
+                    {{ component('vote', { subject: comment, showDownvote: false }) }}
+                {% endif %}
+                {{ include('components/_comment_collapse_button.html.twig', {
+                    comment: comment,
+                    showNested: showNested,
                 }) }}
-            {% endif %}
+            </div>
             <footer>
                 {% if (comment.visibility in ['visible', 'private'] or comment.visibility is same as 'trashed' and this.canSeeTrashed) and comment.image %}
                     {{ include('components/_figure_image.html.twig', {

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -1,7 +1,6 @@
 {%- set V_TRUE = constant('App\\Controller\\User\\ThemeSettingsController::TRUE') -%}
 {%- set V_FALSE = constant('App\\Controller\\User\\ThemeSettingsController::FALSE') -%}
 {%- set V_TREE = constant('App\\Controller\\User\\ThemeSettingsController::TREE') -%}
-{%- set V_CLASSIC = constant('App\\Controller\\User\\ThemeSettingsController::CLASSIC') -%}
 
 {%- set SHOW_PREVIEW = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_PREVIEW'), V_FALSE) -%}
 {%- set VIEW_STYLE = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW'), V_TREE) -%}

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -790,3 +790,5 @@ sensitive_hide: Click to hide
 details: Details
 spoiler: Spoiler
 all_time: All time
+show: Show
+hide: Hide


### PR DESCRIPTION
*NOTE: ~~this is very much a WIP, things may change wildly, expect frequent rebase/force push~~ a lot of things has settled down, but still definitely needs some real world tests and feedback, not a UI/UX person*

add ability to collapse a comment's replies, hiding them away and minimized the parent comment

somewhat based on klin's work (https://codeberg.org/Kbin/kbin-core/pulls/167) but with a few of my own differences:
- use depth information from twig side, rather than sleuthing from css `comment-level--` class.
  this means it can collapse comments with >10 depth more accurately
- if collapsing a comment's replies and then collapse/expand this comment's parent, the nested reply collapse will be retained (klin's work will always expand all replies although it was collapsed by a different, nested parent)
- visual changes only, no dom node insertion/deletion used, nor planned to

the collapse button is placed at the top right corner of the comments, after the vote button

![image](https://github.com/MbinOrg/mbin/assets/20770492/f08c5bbc-6f84-4589-b576-2b302f03c2d9)
![image](https://github.com/MbinOrg/mbin/assets/20770492/58cb916c-bac9-41ee-9f6b-51ca28a89703)

since collapsing comments will also minimize the parent, it can be attached to comment with no replies for minimizing effect.
the collapse button will use slightly different icons to signify this

it all look something like this

![image](https://github.com/MbinOrg/mbin/assets/20770492/0d8fe829-85fd-4c0a-af0b-d2448b0ee2cf)

---

<details><summary>previous concerns</summary>

latest version (both commit): icon button at the top right of the comment
![image](https://github.com/MbinOrg/mbin/assets/20770492/f08c5bbc-6f84-4589-b576-2b302f03c2d9)
![image](https://github.com/MbinOrg/mbin/assets/20770492/58cb916c-bac9-41ee-9f6b-51ca28a89703)

first commit version: text button at the bottom right of the comment
![image](https://github.com/MbinOrg/mbin/assets/20770492/6a7eddeb-a1c8-4229-9bf9-48ef066c04d0)
![image](https://github.com/MbinOrg/mbin/assets/20770492/53cd97d3-0617-4835-88c5-b6c5bcda4a2e)

the top corner one seems to be more preferred, if this is settled then I'll squashed both version/commits together so I could focus on refining the patch

---

there are quite a lot of things that I'm not sure how to go with it, there's probably more but this is what I could think of at the moment:

1. should the collapsing process strictly relies on visual depth, real comment depth, or some mix of both
   - klin's work and kbin impl only uses existing depth from `comment-level--{1..10}` css class
   - my impl used depth from twig side and without cap, which means it could collapse deeper (>10 depth) comment more accurately but could lead to a rather unintuitive experience since you could collapse comments that appeared to be on the same depth (which happens quite often when you're reading [Foone](https://digipres.club/users/foone) posts, [see this in action](https://kbin.asdfzdfj.xyz/m/random/p/3509/I-wonder-what-the-easiest-way-to-generate-4-3-NTSC#post-comment-11147))

     ![image](https://github.com/MbinOrg/mbin/assets/20770492/3fec07d4-5e67-40f1-9585-407db94e7c92)

   - but then I have decided to only enable collapse button on top level comments in classic view, which aligns more with the visual depth

2. should collapsing action only fold the replies or should it 'minimize' the parent? (the one you clicked collapse)
    klin's work and my old impl does this, kbin ~~and this impl~~ doesn't. it does now.

3. where should the collapse button be?
   - ~~(currently)~~ in menu bar, like the post replies' expand/collapse button

     ![image](https://github.com/MbinOrg/mbin/assets/20770492/272a19b8-f3a0-4df0-ae80-f3cd9208cbde)
     ![image](https://github.com/MbinOrg/mbin/assets/20770492/92853ea8-3a8b-499c-aaec-8020b3ab088f)

   - left corner, like kbin  

     ![image](https://github.com/MbinOrg/mbin/assets/20770492/cd887fb7-eb1f-474f-806a-01f705343871)
     ![image](https://github.com/MbinOrg/mbin/assets/20770492/f728e6bc-e603-465d-ba1e-e829761ce2d2)

   - right corner, my old impl does this. now this patch does too
     perhaps it make a bit more sense with minimizing parents, as the expand button is there when minimized, and so the collapse/expand wouldn't move too far when toggling them

     ![image](https://github.com/MbinOrg/mbin/assets/20770492/6a7eddeb-a1c8-4229-9bf9-48ef066c04d0)
     ![image](https://github.com/MbinOrg/mbin/assets/20770492/53cd97d3-0617-4835-88c5-b6c5bcda4a2e)

my old impl attempt for reference: https://github.com/asdfzdfj/mbin/tree/monkey/server-assisted-comment-collapse-old

</details>