### PR TITLE
Add various null/empty checks to abort or do nothing when encountered

### DIFF
--- a/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
@@ -178,7 +178,7 @@ readonly class ActivityHandler
 
     private function verifyInstanceDomain(string $id): bool
     {
-        if (\in_array(
+        if (!$id && \in_array(
             str_replace('www.', '', parse_url($id, PHP_URL_HOST)),
             $this->settingsManager->get('KBIN_BANNED_INSTANCES') ?? []
         )) {

--- a/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
@@ -82,8 +82,12 @@ readonly class ActivityHandler
         $this->handle($payload);
     }
 
-    private function handle(array $payload)
+    private function handle(?array $payload)
     {
+        if (\is_null($payload)) {
+            return;
+        }
+
         if ('Announce' === $payload['type']) {
             if (\is_array($payload['object'])) {
                 $payload = $payload['object'];

--- a/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
@@ -176,7 +176,7 @@ readonly class ActivityHandler
         }
     }
 
-    private function verifyInstanceDomain(string $id): bool
+    private function verifyInstanceDomain(?string $id): bool
     {
         if (!$id && \in_array(
             str_replace('www.', '', parse_url($id, PHP_URL_HOST)),

--- a/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
@@ -178,7 +178,7 @@ readonly class ActivityHandler
 
     private function verifyInstanceDomain(?string $id): bool
     {
-        if (!$id && \in_array(
+        if (!\is_null($id) && \in_array(
             str_replace('www.', '', parse_url($id, PHP_URL_HOST)),
             $this->settingsManager->get('KBIN_BANNED_INSTANCES') ?? []
         )) {

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -585,15 +585,9 @@ class ActivityPubManager
         $this->logger->info('updating actor at {url}', ['url' => $actorUrl]);
         $actor = $this->apHttpClient->getActorObject($actorUrl);
 
-        try {
-            // User (We don't make a distinction between bots with type Service as Lemmy does)
-            if (\in_array($actor['type'], User::USER_TYPES)) {
-                return $this->updateUser($actorUrl);
-            }
-        } catch (\Exception $e) {
-            $this->logger->info('failed to update actor at {url}', ['url' => $actorUrl]);
-
-            return null;
+        // User (We don't make a distinction between bots with type Service as Lemmy does)
+        if (isset($actor['type']) && \in_array($actor['type'], User::USER_TYPES)) {
+            return $this->updateUser($actorUrl);
         }
 
         return $this->updateMagazine($actorUrl);

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -108,8 +108,12 @@ class ActivityPubManager
      *
      * @return User|Magazine|null or Magazine or null on error
      */
-    public function findActorOrCreate(string $actorUrlOrHandle): null|User|Magazine
+    public function findActorOrCreate(?string $actorUrlOrHandle): null|User|Magazine
     {
+        if (\is_null($actorUrlOrHandle)) {
+            return null;
+        }
+
         $this->logger->debug('searching for actor at "{handle}"', ['handle' => $actorUrlOrHandle]);
         if (str_contains($actorUrlOrHandle, $this->settingsManager->get('KBIN_DOMAIN').'/m/')) {
             $magazine = str_replace('https://'.$this->settingsManager->get('KBIN_DOMAIN').'/m/', '', $actorUrlOrHandle);

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -261,7 +261,7 @@ class ActivityPubManager
 
         $actor = $this->apHttpClient->getActorObject($actorUrl);
         // Check if actor isn't empty (not set/null/empty array/etc.)
-        if (!empty($actor)) {
+        if (!empty($actor) && is_array($actor)) {
             // Update the following user columns
             $user->type = $actor['type'] ?? 'Person';
             $user->apInboxUrl = $actor['endpoints']['sharedInbox'] ?? $actor['inbox'];

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -261,7 +261,7 @@ class ActivityPubManager
 
         $actor = $this->apHttpClient->getActorObject($actorUrl);
         // Check if actor isn't empty (not set/null/empty array/etc.)
-        if (!empty($actor) && \is_array($actor)) {
+        if (isset($actor['endpoints']['sharedInbox']) || isset($actor['inbox'])) {
             // Update the following user columns
             $user->type = $actor['type'] ?? 'Person';
             $user->apInboxUrl = $actor['endpoints']['sharedInbox'] ?? $actor['inbox'];
@@ -376,7 +376,7 @@ class ActivityPubManager
         $magazine = $this->magazineRepository->findOneBy(['apProfileId' => $actorUrl]);
         $actor = $this->apHttpClient->getActorObject($actorUrl);
         // Check if actor isn't empty (not set/null/empty array/etc.)
-        if (!empty($actor) && \is_array($actor)) {
+        if (isset($actor['endpoints']['sharedInbox']) || isset($actor['inbox'])) {
             if (isset($actor['summary'])) {
                 $converter = new HtmlConverter(['strip_tags' => true]);
                 $magazine->description = stripslashes($converter->convert($actor['summary']));


### PR DESCRIPTION
Additional null/empty checks to further cleanup message pollution in failed queue. There are still a few more that need further investigation before introducing a fix, but this PR cleans up exceptions that go unhandled, e.g, trying to access a null field in a array, passing null values as function parameters without being a nullable type, etc.

Live testing on [kbin.run](kbin.run) for awhile, nothing out of the ordinary observed so far...