### PR TITLE
update follow-redirects node module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5276,9 +5276,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.3",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-            "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+            "version": "1.15.4",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+            "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
             "dev": true,
             "funding": [
                 {


### PR DESCRIPTION
was running `npm i` and saw it complained about 1 high severity vulnerability on this module, updated by `npm audit fix` as it recommended

security advisory: https://github.com/advisories/GHSA-jchw-25xp-jwwc