### PR TITLE
Fix notifications of blocked users

### DIFF
--- a/src/Service/MentionManager.php
+++ b/src/Service/MentionManager.php
@@ -7,6 +7,7 @@ namespace App\Service;
 use App\Entity\Contracts\ActivityPubActivityInterface;
 use App\Entity\EntryComment;
 use App\Entity\PostComment;
+use App\Entity\User;
 use App\Repository\UserRepository;
 use App\Utils\RegPatterns;
 
@@ -23,6 +24,9 @@ class MentionManager
     ) {
     }
 
+    /**
+     * @return User[]
+     */
     public function getUsersFromArray(?array $users): array
     {
         if ($users) {

--- a/src/Service/Notification/PostCommentNotificationManager.php
+++ b/src/Service/Notification/PostCommentNotificationManager.php
@@ -67,7 +67,7 @@ class PostCommentNotificationManager implements ContentNotificationManagerInterf
         $mentions = MentionManager::clearLocal($this->mentionManager->extract($subject->body));
 
         foreach ($this->mentionManager->getUsersFromArray($mentions) as $user) {
-            if (!$user->apId) {
+            if (!$user->apId and !$user->isBlocked($subject->getUser())) {
                 $notification = new PostCommentMentionedNotification($user, $subject);
                 $this->entityManager->persist($notification);
             }
@@ -99,13 +99,15 @@ class PostCommentNotificationManager implements ContentNotificationManagerInterf
             return $exclude;
         }
 
-        $notification = new PostCommentReplyNotification($comment->parent->user, $comment);
-        $this->notifyUser($notification);
+        if (!$comment->parent->user->isBlocked($comment->user)) {
+            $notification = new PostCommentReplyNotification($comment->parent->user, $comment);
+            $this->notifyUser($notification);
 
-        $this->entityManager->persist($notification);
-        $this->entityManager->flush();
+            $this->entityManager->persist($notification);
+            $this->entityManager->flush();
 
-        $exclude[] = $notification->user;
+            $exclude[] = $notification->user;
+        }
 
         return $exclude;
     }


### PR DESCRIPTION
User A got notifications from a blocked user B when B:
- mentioned A in a post or entry
- replied to a post/-comment or entry/-comment of A

This should of course not happen, so don't notify A in these cases if B is on the block list.