### PR TITLE
Increase HTTP timeout to 15 seconds

### DIFF
--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -33,7 +33,7 @@ enum ApRequestType
 
 class ApHttpClient
 {
-    public const TIMEOUT = 5;
+    public const TIMEOUT = 15;
 
     public function __construct(
         private readonly string $kbinDomain,


### PR DESCRIPTION
As discussed on matrix; prevent failures talking to some loaded hosts that don't get back to us quickly enough