### PR TITLE
correctly fetch display names of remote magazines

### DIFF
--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -394,7 +394,9 @@ class ActivityPubManager
                 $magazine->icon = $newImage;
             }
 
-            if ($actor['preferredUsername']) {
+            if ($actor['name']) {
+                $magazine->title = $actor['name'];
+            } elseif ($actor['preferredUsername']) {
                 $magazine->title = $actor['preferredUsername'];
             }
 


### PR DESCRIPTION
we formerly used the `preferredUsername` property, though mbin and lemmy write the display name to the name field

Lemmy json:
```json
{
    "id": "https://feddit.de/c/main",
    "preferredUsername": "main",
    "name": "Haupteingang",
}
```

mBin json:
```json
{
    "id": "https://gehirneimer.de/m/Test",
    "name": "Testing Magazine",
    "preferredUsername": "Test",
}
```