### PR TITLE
Revert "Increase HTTP timeout to 15 seconds"

### DIFF
--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -33,7 +33,7 @@ enum ApRequestType
 
 class ApHttpClient
 {
-    public const TIMEOUT = 15;
+    public const TIMEOUT = 5;
 
     public function __construct(
         private readonly string $kbinDomain,


### PR DESCRIPTION
Reverts MbinOrg/mbin#417

This needs further testing. I thought that it was a simple change that wouldn't have a lot of negative effects, but it might lead to a long processing time in general, not only in timeout scenarios. 