### PR TITLE
Longer http timeout

### DIFF
--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -33,7 +33,7 @@ enum ApRequestType
 
 class ApHttpClient
 {
-    public const TIMEOUT = 5;
+    public const TIMEOUT = 15;
 
     public function __construct(
         private readonly string $kbinDomain,


### PR DESCRIPTION
So, I get HTTP timeouts talking to lemmy.world with a 5 second timeout. It sounds like there's agreement that increasing the timeout to 15 seconds would be good.

It's not quite that simple, though - there are 2 Lemmy hosts that are unreachable to me for some reason. Even though my instance has basically 0 load, increasing the timeout to 15 seconds means that messages stack up in the queue while the attempts to process the messages are waiting to time out talking with these hosts, and the Rabbit queue grows basically without limit.

So, increasing the timeout is a good idea, but maybe not safe to do without further discussion / more associated changes.