### PR TITLE
add mention to Mdev@kbin.run magazine in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For developers:
 
 - [Official repository on GitHub](https://github.com/MbinOrg/mbin)
 - [Matrix Space for discussions](https://matrix.to/#/#mbin:melroy.org)
-- [Unofficial magazine for discussions within fediverse](https://kbin.run/m/Mdev)
+- [Unofficial magazine for discussions within the fediverse](https://kbin.run/m/Mdev)
 - [Translations](https://hosted.weblate.org/engage/mbin/)
 - [Contribution guidelines](CONTRIBUTING.md) - please read first, including before opening an issue!
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ For developers:
 
 - [Official repository on GitHub](https://github.com/MbinOrg/mbin)
 - [Matrix Space for discussions](https://matrix.to/#/#mbin:melroy.org)
+- [Unofficial magazine for discussions within fediverse](https://kbin.run/m/Mdev)
 - [Translations](https://hosted.weblate.org/engage/mbin/)
 - [Contribution guidelines](CONTRIBUTING.md) - please read first, including before opening an issue!
 


### PR DESCRIPTION
add a mention to [Mdev@kbin.run](https://kbin.run/m/Mdev) magazine in README for discussions about mbin within fediverse

although unofficial, it's the kind of place that means nothing if no people knows about it, especially when we don't have the luxury of flagship instance like [kbinMeta@kbin.social](https://kbin.social/m/kbinMeta) have, and having to spread it essentially by word of mouth hinders its usefulness