### PR TITLE
Introducing /api/info - general info API

### DIFF
--- a/config/kbin_routes/instance_api.yaml
+++ b/config/kbin_routes/instance_api.yaml
@@ -33,3 +33,9 @@ api_instance_retrieve_defederated_instances:
   path: /api/defederated
   methods: [ GET ]
   format: json
+
+api_instance_retrieve_info:
+  controller: App\Controller\Api\Instance\InstanceRetrieveInfoApi
+  path: /api/info
+  methods: [ GET ]
+  format: json

--- a/src/Controller/Api/Instance/InstanceModLogApi.php
+++ b/src/Controller/Api/Instance/InstanceModLogApi.php
@@ -38,11 +38,6 @@ class InstanceModLogApi extends InstanceBaseApi
         ]
     )]
     #[OA\Response(
-        response: 401,
-        description: 'Permission denied due to expired token',
-        content: new OA\JsonContent(ref: new Model(type: \App\Schema\Errors\UnauthorizedErrorSchema::class))
-    )]
-    #[OA\Response(
         response: 404,
         description: 'Page not found',
         content: new OA\JsonContent(ref: new Model(type: \App\Schema\Errors\NotFoundErrorSchema::class))

--- a/src/Controller/Api/Instance/InstanceRetrieveFederationApi.php
+++ b/src/Controller/Api/Instance/InstanceRetrieveFederationApi.php
@@ -24,11 +24,6 @@ class InstanceRetrieveFederationApi extends InstanceBaseApi
         ]
     )]
     #[OA\Response(
-        response: 401,
-        description: 'Permission denied due to expired token',
-        content: new OA\JsonContent(ref: new Model(type: \App\Schema\Errors\UnauthorizedErrorSchema::class))
-    )]
-    #[OA\Response(
         response: 429,
         description: 'You are being rate limited',
         content: new OA\JsonContent(ref: new Model(type: \App\Schema\Errors\TooManyRequestsErrorSchema::class)),

--- a/src/Controller/Api/Instance/InstanceRetrieveStatsApi.php
+++ b/src/Controller/Api/Instance/InstanceRetrieveStatsApi.php
@@ -42,11 +42,6 @@ class InstanceRetrieveStatsApi extends InstanceBaseApi
         content: new OA\JsonContent(ref: new Model(type: \App\Schema\Errors\BadRequestErrorSchema::class))
     )]
     #[OA\Response(
-        response: 401,
-        description: 'Permission denied due to missing or expired token',
-        content: new OA\JsonContent(ref: new Model(type: \App\Schema\Errors\UnauthorizedErrorSchema::class))
-    )]
-    #[OA\Response(
         response: 429,
         description: 'You are being rate limited',
         content: new OA\JsonContent(ref: new Model(type: \App\Schema\Errors\TooManyRequestsErrorSchema::class)),
@@ -170,11 +165,6 @@ class InstanceRetrieveStatsApi extends InstanceBaseApi
         content: new OA\JsonContent(ref: new Model(type: \App\Schema\Errors\BadRequestErrorSchema::class))
     )]
     #[OA\Response(
-        response: 401,
-        description: 'Permission denied due to missing or expired token',
-        content: new OA\JsonContent(ref: new Model(type: \App\Schema\Errors\UnauthorizedErrorSchema::class))
-    )]
-    #[OA\Response(
         response: 429,
         description: 'You are being rate limited',
         content: new OA\JsonContent(ref: new Model(type: \App\Schema\Errors\TooManyRequestsErrorSchema::class)),
@@ -294,11 +284,6 @@ class InstanceRetrieveStatsApi extends InstanceBaseApi
         response: 400,
         description: 'Invalid parameters',
         content: new OA\JsonContent(ref: new Model(type: \App\Schema\Errors\BadRequestErrorSchema::class))
-    )]
-    #[OA\Response(
-        response: 401,
-        description: 'Permission denied due to missing or expired token',
-        content: new OA\JsonContent(ref: new Model(type: \App\Schema\Errors\UnauthorizedErrorSchema::class))
     )]
     #[OA\Response(
         response: 429,

--- a/src/Schema/InfoSchema.php
+++ b/src/Schema/InfoSchema.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Schema;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    type: 'object',
+    properties: [
+        new OA\Property('softwareName', example: 'mbin', type: 'string'),
+        new OA\Property('softwareVersion', example: '2.0.0', type: 'string'),
+        new OA\Property('softwareRepository', example: 'https://github.com/MbinOrg/mbin', type: 'string'),
+        new OA\Property('websiteDomain', example: 'https://mbin.social', type: 'string'),
+        new OA\Property('websiteContactEmail', example: 'contact@mbin.social', type: 'string'),
+        new OA\Property('websiteTitle', example: 'Mbin', type: 'string'),
+        new OA\Property('websiteOpenRegistrations', example: true, type: 'boolean'),
+        new OA\Property('websiteFederationEnabled', example: true, type: 'boolean'),
+        new OA\Property('websiteDefaultLang', example: 'en', type: 'string'),
+    ]
+)]
+class InfoSchema
+{
+}


### PR DESCRIPTION
Rationale: Improve Mobile client integration with Mbin, same PR should actually be merged into /kbin, allowing mobile developers to use the same end-point.

- Introduce a new info API (`/api/info`), inspired by NodeInfo and reuse our internal `ProjectInfoService`.
- Introduce a dedicated Schema file
- Remove 401 token error response messages for API's that are not behind oauth authentication (thus never give this error).