### PR TITLE
exposing jsonld contexts as a separate route

### DIFF
--- a/config/kbin_routes/activity_pub.yaml
+++ b/config/kbin_routes/activity_pub.yaml
@@ -144,3 +144,9 @@ ap_report:
     path: /reports/{report_id}
     methods: [GET]
     condition: '%kbin_ap_route_condition%'
+
+ap_contexts:
+    controller: App\Controller\ActivityPub\ContextsController
+    path: /contexts.{_format}
+    methods: [GET]
+    format: jsonld

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -25,6 +25,9 @@ security:
         image_resolver:
             pattern: ^/media/cache/resolve
             security: false
+        ap_contexts:
+            pattern: ^/contexts(\.jsonld)?$
+            security: false
         main:
             lazy: true
             provider: app_user_provider

--- a/src/Controller/ActivityPub/ContextsController.php
+++ b/src/Controller/ActivityPub/ContextsController.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\ActivityPub;
+
+use App\Service\ActivityPub\ContextsProvider;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class ContextsController
+{
+    public function __invoke(Request $request, ContextsProvider $context): JsonResponse
+    {
+        return new JsonResponse(
+            ['@context' => $context->embeddedContexts()],
+            200,
+            [
+                'Content-Type' => 'application/ld+json',
+                'Access-Control-Allow-Origin' => '*',
+            ]
+        );
+    }
+}

--- a/src/Controller/ActivityPub/User/UserOutboxController.php
+++ b/src/Controller/ActivityPub/User/UserOutboxController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Controller\ActivityPub\User;
 
 use App\Controller\AbstractController;
-use App\Entity\Contracts\ActivityPubActivityInterface;
 use App\Entity\User;
 use App\Repository\UserRepository;
 use App\Service\ActivityPub\Wrapper\CollectionInfoWrapper;
@@ -88,7 +87,6 @@ class UserOutboxController extends AbstractController
             $activity,
             $items,
             $page,
-            ActivityPubActivityInterface::ADDITIONAL_CONTEXTS
         );
     }
 }

--- a/src/Entity/Contracts/ActivityPubActivityInterface.php
+++ b/src/Entity/Contracts/ActivityPubActivityInterface.php
@@ -16,16 +16,24 @@ interface ActivityPubActivityInterface
     public const PUBLIC_URL = 'https://www.w3.org/ns/activitystreams#Public';
 
     public const ADDITIONAL_CONTEXTS = [
+        // namespaces
         'ostatus' => 'http://ostatus.org#',
+        'schema' => 'http://schema.org#',
         'toot' => 'http://joinmastodon.org/ns#',
         'pt' => 'https://joinpeertube.org/ns#',
         'lemmy' => 'https://join-lemmy.org/ns#',
+        // objects
         'Hashtag' => 'as:Hashtag',
+        'PropertyValue' => 'schema:PropertyValue',
+        // properties
+        'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers',
         'sensitive' => 'as:sensitive',
+        'value' => 'schema:value',
         'blurhash' => 'toot:blurhash',
         'focalPoint' => 'toot:focalPoint',
         'votersCount' => 'toot:votersCount',
         'commentsEnabled' => 'pt:commentsEnabled',
+        'postingRestrictedToMods' => 'lemmy:postingRestrictedToMods',
         'stickied' => 'lemmy:stickied',
     ];
 }

--- a/src/Factory/ActivityPub/AddRemoveFactory.php
+++ b/src/Factory/ActivityPub/AddRemoveFactory.php
@@ -7,6 +7,7 @@ namespace App\Factory\ActivityPub;
 use App\Entity\Contracts\ActivityPubActivityInterface;
 use App\Entity\Magazine;
 use App\Entity\User;
+use App\Service\ActivityPub\ContextsProvider;
 use JetBrains\PhpStorm\ArrayShape;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Uid\Uuid;
@@ -15,6 +16,7 @@ class AddRemoveFactory
 {
     public function __construct(
         private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly ContextsProvider $contextProvider,
     ) {
     }
 
@@ -44,15 +46,29 @@ class AddRemoveFactory
         $id = Uuid::v4()->toRfc4122();
 
         return [
-            '@context' => [ActivityPubActivityInterface::CONTEXT_URL, ActivityPubActivityInterface::SECURITY_URL],
-            'id' => $this->urlGenerator->generate('ap_object', ['id' => $id], UrlGeneratorInterface::ABSOLUTE_URL),
-            'actor' => $actor->apId ?? $this->urlGenerator->generate('ap_user', ['username' => $actor->username], UrlGeneratorInterface::ABSOLUTE_URL),
+            '@context' => $this->contextProvider->referencedContexts(),
+            'id' => $this->urlGenerator->generate(
+                'ap_object', ['id' => $id], UrlGeneratorInterface::ABSOLUTE_URL
+            ),
+            'actor' => $actor->apId ?? $this->urlGenerator->generate(
+                'ap_user', ['username' => $actor->username], UrlGeneratorInterface::ABSOLUTE_URL
+            ),
             'to' => [ActivityPubActivityInterface::PUBLIC_URL],
-            'object' => $targetUser->apId ?? $this->urlGenerator->generate('ap_user', ['username' => $targetUser->username], UrlGeneratorInterface::ABSOLUTE_URL),
-            'cc' => [$magazine->apId ?? $this->urlGenerator->generate('ap_magazine', ['name' => $magazine->name], UrlGeneratorInterface::ABSOLUTE_URL)],
+            'object' => $targetUser->apId ?? $this->urlGenerator->generate(
+                'ap_user', ['username' => $targetUser->username], UrlGeneratorInterface::ABSOLUTE_URL
+            ),
+            'cc' => [
+                $magazine->apId ?? $this->urlGenerator->generate(
+                    'ap_magazine', ['name' => $magazine->name], UrlGeneratorInterface::ABSOLUTE_URL
+                ),
+            ],
             'type' => $type,
-            'target' => $magazine->apAttributedToUrl ?? $this->urlGenerator->generate('ap_magazine_moderators', ['name' => $magazine->name], UrlGeneratorInterface::ABSOLUTE_URL),
-            'audience' => $magazine->apId ?? $this->urlGenerator->generate('ap_magazine', ['name' => $magazine->name], UrlGeneratorInterface::ABSOLUTE_URL),
+            'target' => $magazine->apAttributedToUrl ?? $this->urlGenerator->generate(
+                'ap_magazine_moderators', ['name' => $magazine->name], UrlGeneratorInterface::ABSOLUTE_URL
+            ),
+            'audience' => $magazine->apId ?? $this->urlGenerator->generate(
+                'ap_magazine', ['name' => $magazine->name], UrlGeneratorInterface::ABSOLUTE_URL
+            ),
         ];
     }
 }

--- a/src/Factory/ActivityPub/EntryPageFactory.php
+++ b/src/Factory/ActivityPub/EntryPageFactory.php
@@ -9,6 +9,7 @@ use App\Entity\Entry;
 use App\Markdown\MarkdownConverter;
 use App\Markdown\RenderTarget;
 use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ContextsProvider;
 use App\Service\ActivityPub\Wrapper\ImageWrapper;
 use App\Service\ActivityPub\Wrapper\MentionsWrapper;
 use App\Service\ActivityPub\Wrapper\TagsWrapper;
@@ -20,6 +21,7 @@ class EntryPageFactory
 {
     public function __construct(
         private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly ContextsProvider $contextProvider,
         private readonly GroupFactory $groupFactory,
         private readonly ImageManager $imageManager,
         private readonly ImageWrapper $imageWrapper,
@@ -34,11 +36,7 @@ class EntryPageFactory
     public function create(Entry $entry, bool $context = false): array
     {
         if ($context) {
-            $page['@context'] = [
-                ActivityPubActivityInterface::CONTEXT_URL,
-                ActivityPubActivityInterface::SECURITY_URL,
-                ActivityPubActivityInterface::ADDITIONAL_CONTEXTS,
-            ];
+            $page['@context'] = $this->contextProvider->referencedContexts();
         }
 
         $tags = $entry->tags ?? [];

--- a/src/Factory/ActivityPub/FlagFactory.php
+++ b/src/Factory/ActivityPub/FlagFactory.php
@@ -33,32 +33,53 @@ class FlagFactory
     ])]
     public function build(Report $report, string $objectUrl): array
     {
-        $context = [ActivityPubActivityInterface::CONTEXT_URL];
-
-        // mastodon does not accept a report that does not have an array as object. I created an issue for it: https://github.com/mastodon/mastodon/issues/28159
+        // mastodon does not accept a report that does not have an array as object.
+        // I created an issue for it: https://github.com/mastodon/mastodon/issues/28159
         $mastodonObject = [
             $objectUrl,
-            $report->reported->apPublicUrl ?? $this->urlGenerator->generate('ap_user', ['username' => $report->reported->username], UrlGeneratorInterface::ABSOLUTE_URL),
+            $report->reported->apPublicUrl ?? $this->urlGenerator->generate(
+                'ap_user',
+                ['username' => $report->reported->username],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            ),
         ];
 
-        // lemmy does not accept a report that does have an array as object. I created an issue for it: https://github.com/LemmyNet/lemmy/issues/4217
+        // lemmy does not accept a report that does have an array as object.
+        // I created an issue for it: https://github.com/LemmyNet/lemmy/issues/4217
         $lemmyObject = $objectUrl;
 
         if ('random' !== $report->magazine->name or $report->magazine->apId) {
-            // apAttributedToUrl is not a standardized field, so it is not implemented by every software that supports groups.
+            // apAttributedToUrl is not a standardized field,
+            //  so it is not implemented by every software that supports groups.
             // Some don't have moderation at all, so it will probably remain optional in the future.
-            $audience = $report->magazine->apPublicUrl ?? $this->urlGenerator->generate('ap_magazine', ['name' => $report->magazine->name], UrlGeneratorInterface::ABSOLUTE_URL);
+            $audience = $report->magazine->apPublicUrl ?? $this->urlGenerator->generate(
+                'ap_magazine',
+                ['name' => $report->magazine->name],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            );
             $object = $lemmyObject;
         } else {
-            $audience = $report->reported->apPublicUrl ?? $this->urlGenerator->generate('ap_user', ['username' => $report->reported->username], UrlGeneratorInterface::ABSOLUTE_URL);
+            $audience = $report->reported->apPublicUrl ?? $this->urlGenerator->generate(
+                'ap_user',
+                ['username' => $report->reported->username],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            );
             $object = $mastodonObject;
         }
 
         $result = [
-            '@context' => $context,
-            'id' => $this->urlGenerator->generate('ap_report', ['report_id' => $report->uuid], UrlGeneratorInterface::ABSOLUTE_URL),
+            '@context' => ActivityPubActivityInterface::CONTEXT_URL,
+            'id' => $this->urlGenerator->generate(
+                'ap_report',
+                ['report_id' => $report->uuid],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            ),
             'type' => 'Flag',
-            'actor' => $report->reporting->apPublicUrl ?? $this->urlGenerator->generate('ap_user', ['username' => $report->reporting->username], UrlGeneratorInterface::ABSOLUTE_URL),
+            'actor' => $report->reporting->apPublicUrl ?? $this->urlGenerator->generate(
+                'ap_user',
+                ['username' => $report->reporting->username],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            ),
             'object' => $object,
             'audience' => $audience,
             'summary' => $report->reason,
@@ -66,7 +87,13 @@ class FlagFactory
         ];
 
         if ('random' !== $report->magazine->name or $report->magazine->apId) {
-            $result['to'] = [$report->magazine->apPublicUrl ?? $this->urlGenerator->generate('ap_magazine', ['name' => $report->magazine->name], UrlGeneratorInterface::ABSOLUTE_URL)];
+            $result['to'] = [
+                $report->magazine->apPublicUrl ?? $this->urlGenerator->generate(
+                    'ap_magazine',
+                    ['name' => $report->magazine->name],
+                    UrlGeneratorInterface::ABSOLUTE_URL
+                ),
+            ];
         }
 
         return $result;

--- a/src/Factory/ActivityPub/GroupFactory.php
+++ b/src/Factory/ActivityPub/GroupFactory.php
@@ -4,21 +4,16 @@ declare(strict_types=1);
 
 namespace App\Factory\ActivityPub;
 
-use App\Entity\Contracts\ActivityPubActivityInterface;
 use App\Entity\Magazine;
+use App\Service\ActivityPub\ContextsProvider;
 use App\Service\ImageManager;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class GroupFactory
 {
-    public const ADDITIONAL_CONTEXTS = [
-        'lemmy' => 'https://join-lemmy.org/ns#',
-        'sensitive' => 'as:sensitive',
-        'postingRestrictedToMods' => 'lemmy:postingRestrictedToMods',
-    ];
-
     public function __construct(
         private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly ContextsProvider $contextProvider,
         private readonly ImageManager $imageManager
     ) {
     }
@@ -27,11 +22,7 @@ class GroupFactory
     {
         $group = [
             'type' => 'Group',
-            '@context' => [
-                ActivityPubActivityInterface::CONTEXT_URL,
-                ActivityPubActivityInterface::SECURITY_URL,
-                self::ADDITIONAL_CONTEXTS,
-            ],
+            '@context' => $this->contextProvider->referencedContexts(),
             'id' => $this->getActivityPubId($magazine),
             'name' => $magazine->title, // lemmy
             'preferredUsername' => $magazine->name,

--- a/src/Factory/ActivityPub/InstanceFactory.php
+++ b/src/Factory/ActivityPub/InstanceFactory.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Factory\ActivityPub;
 
-use App\Entity\Contracts\ActivityPubActivityInterface;
 use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ContextsProvider;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class InstanceFactory
@@ -14,6 +14,7 @@ class InstanceFactory
         private string $kbinDomain,
         private readonly ApHttpClient $client,
         private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly ContextsProvider $contextProvider,
     ) {
     }
 
@@ -22,13 +23,7 @@ class InstanceFactory
         $actor = 'https://'.$this->kbinDomain.'/i/actor';
 
         return [
-            '@context' => [
-                ActivityPubActivityInterface::CONTEXT_URL,
-                ActivityPubActivityInterface::SECURITY_URL,
-                [
-                    'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers',
-                ],
-            ],
+            '@context' => $this->contextProvider->referencedContexts(),
             'id' => $actor,
             'type' => 'Application',
             'name' => 'Mbin',

--- a/src/Factory/ActivityPub/PersonFactory.php
+++ b/src/Factory/ActivityPub/PersonFactory.php
@@ -4,24 +4,18 @@ declare(strict_types=1);
 
 namespace App\Factory\ActivityPub;
 
-use App\Entity\Contracts\ActivityPubActivityInterface;
 use App\Entity\User;
 use App\Markdown\MarkdownConverter;
 use App\Markdown\RenderTarget;
+use App\Service\ActivityPub\ContextsProvider;
 use App\Service\ImageManager;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class PersonFactory
 {
-    public const ADDITIONAL_CONTEXTS = [
-        'schema' => 'http://schema.org#',
-        'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers',
-        'PropertyValue' => 'schema:PropertyValue',
-        'value' => 'schema:value',
-    ];
-
     public function __construct(
         private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly ContextsProvider $contextProvider,
         private readonly ImageManager $imageManager,
         private readonly MarkdownConverter $markdownConverter
     ) {
@@ -30,11 +24,7 @@ class PersonFactory
     public function create(User $user, bool $context = true): array
     {
         if ($context) {
-            $person['@context'] = [
-                ActivityPubActivityInterface::CONTEXT_URL,
-                ActivityPubActivityInterface::SECURITY_URL,
-                self::ADDITIONAL_CONTEXTS,
-            ];
+            $person['@context'] = $this->contextProvider->referencedContexts();
         }
 
         $person = array_merge(

--- a/src/Factory/ActivityPub/PostCommentNoteFactory.php
+++ b/src/Factory/ActivityPub/PostCommentNoteFactory.php
@@ -9,6 +9,7 @@ use App\Entity\PostComment;
 use App\Markdown\MarkdownConverter;
 use App\Markdown\RenderTarget;
 use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ContextsProvider;
 use App\Service\ActivityPub\Wrapper\ImageWrapper;
 use App\Service\ActivityPub\Wrapper\MentionsWrapper;
 use App\Service\ActivityPub\Wrapper\TagsWrapper;
@@ -20,6 +21,7 @@ class PostCommentNoteFactory
 {
     public function __construct(
         private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly ContextsProvider $contextProvider,
         private readonly PostNoteFactory $postNoteFactory,
         private readonly ImageWrapper $imageWrapper,
         private readonly GroupFactory $groupFactory,
@@ -35,11 +37,7 @@ class PostCommentNoteFactory
     public function create(PostComment $comment, bool $context = false): array
     {
         if ($context) {
-            $note['@context'] = [
-                ActivityPubActivityInterface::CONTEXT_URL,
-                ActivityPubActivityInterface::SECURITY_URL,
-                ActivityPubActivityInterface::ADDITIONAL_CONTEXTS,
-            ];
+            $note['@context'] = $this->contextProvider->referencedContexts();
         }
 
         $tags = $comment->tags ?? [];

--- a/src/Factory/ActivityPub/PostNoteFactory.php
+++ b/src/Factory/ActivityPub/PostNoteFactory.php
@@ -9,6 +9,7 @@ use App\Entity\Post;
 use App\Markdown\MarkdownConverter;
 use App\Markdown\RenderTarget;
 use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ContextsProvider;
 use App\Service\ActivityPub\Wrapper\ImageWrapper;
 use App\Service\ActivityPub\Wrapper\MentionsWrapper;
 use App\Service\ActivityPub\Wrapper\TagsWrapper;
@@ -21,6 +22,7 @@ class PostNoteFactory
 {
     public function __construct(
         private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly ContextsProvider $contextProvider,
         private readonly GroupFactory $groupFactory,
         private readonly ImageWrapper $imageWrapper,
         private readonly TagsWrapper $tagsWrapper,
@@ -36,11 +38,7 @@ class PostNoteFactory
     public function create(Post $post, bool $context = false): array
     {
         if ($context) {
-            $note['@context'] = [
-                ActivityPubActivityInterface::CONTEXT_URL,
-                ActivityPubActivityInterface::SECURITY_URL,
-                ActivityPubActivityInterface::ADDITIONAL_CONTEXTS,
-            ];
+            $note['@context'] = $this->contextProvider->referencedContexts();
         }
 
         $tags = $post->tags ?? [];

--- a/src/Service/ActivityPub/ContextsProvider.php
+++ b/src/Service/ActivityPub/ContextsProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\ActivityPub;
+
+use App\Entity\Contracts\ActivityPubActivityInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class ContextsProvider
+{
+    public function __construct(
+        private readonly UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    public static function embeddedContexts(): array
+    {
+        return [
+            ActivityPubActivityInterface::CONTEXT_URL,
+            ActivityPubActivityInterface::SECURITY_URL,
+            ActivityPubActivityInterface::ADDITIONAL_CONTEXTS,
+        ];
+    }
+
+    public function referencedContexts(): array
+    {
+        return [
+            ActivityPubActivityInterface::CONTEXT_URL,
+            $this->urlGenerator->generate('ap_contexts', [], UrlGeneratorInterface::ABSOLUTE_URL),
+        ];
+    }
+}

--- a/src/Service/ActivityPub/Wrapper/CollectionItemsWrapper.php
+++ b/src/Service/ActivityPub/Wrapper/CollectionItemsWrapper.php
@@ -11,8 +11,9 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class CollectionItemsWrapper
 {
-    public function __construct(private readonly UrlGeneratorInterface $urlGenerator)
-    {
+    public function __construct(
+        private readonly UrlGeneratorInterface $urlGenerator,
+    ) {
     }
 
     #[ArrayShape([
@@ -30,14 +31,15 @@ class CollectionItemsWrapper
         PagerfantaInterface $pagerfanta,
         array $items,
         int $page,
-        array $context = null
     ): array {
         $result = [
-            '@context' => $context
-                ? array_merge([ActivityPubActivityInterface::CONTEXT_URL], [$context])
-                : ActivityPubActivityInterface::CONTEXT_URL,
+            '@context' => ActivityPubActivityInterface::CONTEXT_URL,
             'type' => 'OrderedCollectionPage',
-            'partOf' => $this->urlGenerator->generate($routeName, $routeParams, UrlGeneratorInterface::ABSOLUTE_URL),
+            'partOf' => $this->urlGenerator->generate(
+                $routeName,
+                $routeParams,
+                UrlGeneratorInterface::ABSOLUTE_URL
+            ),
             'id' => $this->urlGenerator->generate(
                 $routeName,
                 $routeParams + ['page' => $page],

--- a/src/Service/ActivityPub/Wrapper/FollowWrapper.php
+++ b/src/Service/ActivityPub/Wrapper/FollowWrapper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service\ActivityPub\Wrapper;
 
+use App\Entity\Contracts\ActivityPubActivityInterface;
 use JetBrains\PhpStorm\ArrayShape;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Uid\Uuid;
@@ -28,7 +29,7 @@ class FollowWrapper
         $id = Uuid::v4()->toRfc4122();
 
         return [
-            '@context' => 'https://www.w3.org/ns/activitystreams',
+            '@context' => ActivityPubActivityInterface::CONTEXT_URL,
             'id' => $this->urlGenerator->generate('ap_object', ['id' => $id], UrlGeneratorInterface::ABSOLUTE_URL),
             'type' => 'Follow',
             'actor' => $follower,

--- a/src/Service/ActivityPub/Wrapper/UndoWrapper.php
+++ b/src/Service/ActivityPub/Wrapper/UndoWrapper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service\ActivityPub\Wrapper;
 
+use App\Entity\Contracts\ActivityPubActivityInterface;
 use JetBrains\PhpStorm\ArrayShape;
 
 class UndoWrapper
@@ -21,7 +22,7 @@ class UndoWrapper
         unset($object['@context']);
 
         return [
-            '@context' => 'https://www.w3.org/ns/activitystreams',
+            '@context' => ActivityPubActivityInterface::CONTEXT_URL,
             'id' => $object['id'].'#unfollow',
             'type' => 'Undo',
             'actor' => $object['actor'],


### PR DESCRIPTION
this problem was pointed out by piefed author
(https://join.piefed.social/2023/11/18/you-can-ignore-json-ld/):
- for the most part, barely any application actually bothers to parse AP objects as json-ld and just treat it as some shaped json
- for some type of messages, the overhead of sending json-ld `@contexts` is bigger than what the message is about, combined with the above point then it's just a waste of data transfers

added a route that returns extra ActivityPub json-ld contexts and uses it as an extra `@context` in emitted AP objects

a good tradeoff between not wasting data transferring unneeded contexts while still being able parse as a valid json-ld if needed be

this solution is more or less shamelessly replicated from Akkoma/Pleroma, thanks for that.