### PR TITLE
Do not show debug messages in prod

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -68,12 +68,12 @@ when@prod:
                 type: rotating_file
                 max_files: 7
                 path: '%kernel.logs_dir%/%kernel.environment%.log'
-                level: debug
+                level: error
                 formatter: monolog.formatter.json
             nested_stderr:
                 type: stream
                 path: 'php://stderr'
-                level: debug
+                level: error
                 formatter: monolog.formatter.json
             console:
                 type: console

--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -68,12 +68,12 @@ when@prod:
                 type: rotating_file
                 max_files: 7
                 path: '%kernel.logs_dir%/%kernel.environment%.log'
-                level: error
+                level: warning
                 formatter: monolog.formatter.json
             nested_stderr:
                 type: stream
                 path: 'php://stderr'
-                level: error
+                level: warning
                 formatter: monolog.formatter.json
             console:
                 type: console


### PR DESCRIPTION
In production I do not want to see debug messages, the whole point of production is to minimize logging pollution and disk I/O towards log file(s). Only show error messages.

Ps. I tried to set it to `info`, but that didn't work either, but setting the log level to `error` solved the problem.