### PR TITLE
Minor install doc updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,17 +14,17 @@
 # https://symfony.com/doc/current/best_practices.html#use-environment-variables-for-infrastructure-configuration
 
 # Mbin variables
-SERVER_NAME=mbin.domain.tdl
-KBIN_DOMAIN=mbin.domain.tdl
+SERVER_NAME=mbin.domain.tld
+KBIN_DOMAIN=mbin.domain.tld
 KBIN_TITLE=Mbin
 KBIN_DEFAULT_LANG=en
 KBIN_FEDERATION_ENABLED=true
-KBIN_CONTACT_EMAIL=contact@mbin.domain.tdl
-KBIN_SENDER_EMAIL=noreply@mbin.domain.tdl
+KBIN_CONTACT_EMAIL=contact@mbin.domain.tld
+KBIN_SENDER_EMAIL=noreply@mbin.domain.tld
 KBIN_JS_ENABLED=true
 KBIN_REGISTRATIONS_ENABLED=true
 KBIN_API_ITEMS_PER_PAGE=25
-KBIN_STORAGE_URL=https://mbin.domain.tdl/media
+KBIN_STORAGE_URL=https://mbin.domain.tld/media
 KBIN_META_TITLE="Mbin"
 KBIN_META_DESCRIPTION="content aggregator, content voting, discussion and micro-blogging platform on the fediverse"
 KBIN_META_KEYWORDS="mbin, content aggregator, open source, fediverse"
@@ -116,9 +116,10 @@ MAILER_DSN=smtp://127.0.0.1 # When you have a local SMTP server listening
 # Explicitly url encode any character in username and password
 # %40 = @
 # Gmail:
-# MAILER_DSN=gmail+smtp://user%40domain.com:pass@default
+# MAILER_DSN=gmail+smtp://user%40domain.com:pass@smtp.gmail.com
 # Our own SMTP server:
-# MAILER_DSN=smtp://user%40domain.com:pass@smtp.example.com:port
+# MAILER_DSN=smtp://username:password@smtpserver.tld:587?encryption=tls&auth_mode=log
+# MAILER_DSN=smtp://username:password@smtpserver.tld:465?encryption=ssl&auth_mode=log
 ###< symfony/mailer ###
 
 ###> symfony/mailgun-mailer ###

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -185,6 +185,7 @@ MAILER_DSN=sendmail://default
 MAILER_DSN=gmail+smtp://user%40domain.com:pass@smtp.gmail.com
 # Or remote SMTP:
 MAILER_DSN=smtp://username:password@smtpserver.tld:587?encryption=tls&auth_mode=log
+# Or remote SMTP with SSL on port 465
 MAILER_DSN=smtp://username:password@smtpserver.tld:465?encryption=ssl&auth_mode=log
 ```
 

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -185,7 +185,7 @@ MAILER_DSN=sendmail://default
 MAILER_DSN=gmail+smtp://user%40domain.com:pass@smtp.gmail.com
 # Or remote SMTP with TLS on port 587:
 MAILER_DSN=smtp://username:password@smtpserver.tld:587?encryption=tls&auth_mode=log
-# Or remote SMTP with SSL on port 465
+# Or remote SMTP with SSL on port 465:
 MAILER_DSN=smtp://username:password@smtpserver.tld:465?encryption=ssl&auth_mode=log
 ```
 

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -183,7 +183,7 @@ MAILER_DSN=smtp://127.0.0.1 # When you have a local SMTP server listening
 MAILER_DSN=sendmail://default
 # Or Gmail (%40 = @-sign) use:
 MAILER_DSN=gmail+smtp://user%40domain.com:pass@smtp.gmail.com
-# Or remote SMTP:
+# Or remote SMTP with TLS on port 587:
 MAILER_DSN=smtp://username:password@smtpserver.tld:587?encryption=tls&auth_mode=log
 # Or remote SMTP with SSL on port 465
 MAILER_DSN=smtp://username:password@smtpserver.tld:465?encryption=ssl&auth_mode=log

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -427,7 +427,7 @@ Make sure you have substituted all the passwords and configured the basic servic
 #### Let's Encrypt (TLS)
 
 > **Note**
-> The certbot authors recommend installing through snap as some distros' versions from apt tend to fall out of date; see https://eff-certbot.readthedocs.io/en/latest/install.html for more.
+> The Certbot authors recommend installing through snap as some distros' versions from APT tend to fall out-of-date; see https://eff-certbot.readthedocs.io/en/latest/install.html#snap-recommended for more.
 
 Install Snapd:
 

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -452,6 +452,9 @@ Follow the prompts to create TLS certificates for your domain(s). If you don't a
 
 ```bash
 sudo certbot certonly
+
+# Or if you wish not to use the standalone mode but the Nginx plugin:
+sudo certbot --nginx -d domain.tld
 ```
 
 ### NGINX

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -178,11 +178,14 @@ KBIN_STORAGE_URL=https://domain.tld/media
 POSTGRES_VERSION=14
 
 # Configure email, eg. using SMTP
-MAILER_DSN=smtp://127.0.0.1:25?encryption=ssl&auth_mode=login&username=&password=
+MAILER_DSN=smtp://127.0.0.1 # When you have a local SMTP server listening
 # But if already have Postfix configured, just use sendmail:
 MAILER_DSN=sendmail://default
 # Or Gmail (%40 = @-sign) use:
-MAILER_DSN=gmail+smtp://user%40domain.com:pass@default
+MAILER_DSN=gmail+smtp://user%40domain.com:pass@smtp.gmail.com
+# Or remote SMTP:
+MAILER_DSN=smtp://username:password@smtpserver.tld:587?encryption=tls&auth_mode=log
+MAILER_DSN=smtp://username:password@smtpserver.tld:465?encryption=ssl&auth_mode=log
 ```
 
 OAuth2 keys for API credential grants:
@@ -421,6 +424,36 @@ npm run build # Builds frontend
 
 Make sure you have substituted all the passwords and configured the basic services.
 
+#### Let's Encrypt (TLS)
+
+> **Note**
+> The certbot authors recommend installing through snap as some distros' versions from apt tend to fall out of date; see https://eff-certbot.readthedocs.io/en/latest/install.html for more.
+
+Install Snapd:
+
+```bash
+sudo apt-get install snapd
+```
+
+Install Certbot:
+
+```bash
+sudo snap install core; sudo snap refresh core
+sudo snap install --classic certbot
+```
+
+Add symlink:
+
+```bash
+sudo ln -s /snap/bin/certbot /usr/bin/certbot
+```
+
+Follow the prompts to create TLS certificates for your domain(s). If you don't already have NGINX up, you can use standalone mode.
+
+```bash
+sudo certbot certonly
+```
+
 ### NGINX
 
 We will use NGINX as reverse proxy between the public site and various backend services (static files, PHP and Mercure).
@@ -443,7 +476,6 @@ Edit the main NGINX config file: `sudo nano /etc/nginx/nginx.conf` with the foll
 
 ```nginx
 ssl_protocols TLSv1.2 TLSv1.3; # Requires nginx >= 1.13.0 else only use TLSv1.2
-ssl_prefer_server_ciphers on;
 ssl_dhparam /etc/nginx/dhparam.pem;
 ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
 ssl_prefer_server_ciphers off;
@@ -657,39 +689,6 @@ Restart (or reload) NGINX:
 
 ```bash
 sudo systemctl restart nginx
-```
-
-#### Let's Encrypt (TLS)
-
-> **Note**
-> This is installed via snap to reduce system dependencies ran, and the preferred way. Run in standalone mode to not mess with the default config and minimize errors all around. If you prefer no snaps you can install other ways though, however is the preferred way to install from let's encrypt.
-
-Install Snapd:
-
-```bash
-sudo apt-get install snapd
-```
-
-Install Certbot:
-
-```bash
-sudo snap install core; sudo snap refresh core
-sudo snap install --classic certbot
-```
-
-Add symlink:
-
-```bash
-sudo ln -s /snap/bin/certbot /usr/bin/certbot
-```
-
-Generate a TLS certificate for your domain(s):
-
-```bash
-sudo certbot certonly --standalone -d domain.tld -d www.domain.tld
-
-# Or if you wish not to use the standalone mode but the Nginx plugin:
-sudo certbot --nginx -d domain.tld -d www.domain.tld
 ```
 
 ### Additional Mbin configuration files


### PR DESCRIPTION
Minor installation updates, pretty self explanatory:

* s/domain.tdl/domain.tld/
* Better examples for remote SMTP servers
* ~~Install certbot from apt, and before nginx so nginx doesn't have failures trying to load the certificates~~ Store certbot via snap and explain why
* ~~Blank out postgres version since there's no sensible default~~
* ~~Load opcache extension in addition to configuring the options~~
* Don't have conflicting ssl_prefer_server_ciphers options (I did "off", for compatibility over security)

Added later by Melroy:

* Minor language changes or additional comment lines.