### PR TITLE
Add setting to restrict sidebar sections to local only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,7 @@ KBIN_META_DESCRIPTION="content aggregator, content voting, discussion and micro-
 KBIN_META_KEYWORDS="mbin, content aggregator, open source, fediverse"
 KBIN_HEADER_LOGO=false
 KBIN_FEDERATION_PAGE_ENABLED=true
+KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY=true
 MBIN_DEFAULT_THEME=default
 
 # Captcha (also enable in admin panel/settings)

--- a/.env.example_docker
+++ b/.env.example_docker
@@ -30,6 +30,7 @@ KBIN_META_DESCRIPTION="content aggregator, content voting, discussion and micro-
 KBIN_META_KEYWORDS="mbin, content aggregator, open source, fediverse"
 KBIN_HEADER_LOGO=false
 KBIN_FEDERATION_PAGE_ENABLED=true
+KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY=false
 MBIN_DEFAULT_THEME=default
 
 # Captcha (also enable in admin panel/settings)

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -143,6 +143,7 @@ services:
             $kbinCaptchaEnabled: "%env(bool:KBIN_CAPTCHA_ENABLED)%"
             $kbinFederationPageEnabled: "%env(bool:KBIN_FEDERATION_PAGE_ENABLED)%"
             $kbinAdminOnlyOauthClients: "%env(bool:KBIN_ADMIN_ONLY_OAUTH_CLIENTS)%"
+            $kbinSidebarSectionsLocalOnly: "%env(bool:KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY)%"
 
     # Markdown
     App\Markdown\Factory\EnvironmentFactory:

--- a/src/DTO/SettingsDto.php
+++ b/src/DTO/SettingsDto.php
@@ -29,7 +29,8 @@ class SettingsDto implements \JsonSerializable
         public bool $KBIN_MERCURE_ENABLED,
         public bool $KBIN_FEDERATION_PAGE_ENABLED,
         public bool $KBIN_ADMIN_ONLY_OAUTH_CLIENTS,
-        public bool $KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN
+        public bool $KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN,
+        public bool $KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY
     ) {
     }
 
@@ -54,6 +55,7 @@ class SettingsDto implements \JsonSerializable
         $dto->KBIN_FEDERATION_PAGE_ENABLED = $this->KBIN_FEDERATION_PAGE_ENABLED ?? $dto->KBIN_FEDERATION_PAGE_ENABLED;
         $dto->KBIN_ADMIN_ONLY_OAUTH_CLIENTS = $this->KBIN_ADMIN_ONLY_OAUTH_CLIENTS ?? $dto->KBIN_ADMIN_ONLY_OAUTH_CLIENTS;
         $dto->KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN = $this->KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN ?? $dto->KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN;
+        $dto->KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY = $this->KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY ?? $dto->KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY;
 
         return $dto;
     }
@@ -80,6 +82,7 @@ class SettingsDto implements \JsonSerializable
             'KBIN_FEDERATION_PAGE_ENABLED' => $this->KBIN_FEDERATION_PAGE_ENABLED,
             'KBIN_ADMIN_ONLY_OAUTH_CLIENTS' => $this->KBIN_ADMIN_ONLY_OAUTH_CLIENTS,
             'KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN' => $this->KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN,
+            'KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY' => $this->KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY,
         ];
     }
 }

--- a/src/Form/SettingsType.php
+++ b/src/Form/SettingsType.php
@@ -36,6 +36,7 @@ class SettingsType extends AbstractType
             ->add('KBIN_FEDERATION_PAGE_ENABLED', CheckboxType::class, ['required' => false])
             ->add('KBIN_ADMIN_ONLY_OAUTH_CLIENTS', CheckboxType::class, ['required' => false])
             ->add('KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN', CheckboxType::class, ['required' => false])
+            ->add('KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY', CheckboxType::class, ['required' => false])
             ->add('submit', SubmitType::class);
     }
 

--- a/src/Repository/EntryRepository.php
+++ b/src/Repository/EntryRepository.php
@@ -371,6 +371,7 @@ class EntryRepository extends ServiceEntityRepository implements TagRepositoryIn
         if ($this->settingsManager->get('KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY')) {
             $qb = $qb->andWhere('e.apId IS NULL');
         }
+
         return $qb->join('e.magazine', 'm')
             ->join('e.user', 'u')
             ->orderBy('e.createdAt', 'DESC')

--- a/src/Repository/MagazineRepository.php
+++ b/src/Repository/MagazineRepository.php
@@ -481,6 +481,11 @@ class MagazineRepository extends ServiceEntityRepository
         $conn = $this->getEntityManager()->getConnection();
         $sql = '
             SELECT id FROM magazine
+            ';
+        if ($this->settingsManager->get('KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY')) {
+            $sql .= 'WHERE ap_id IS NULL';
+        }
+        $sql .= '
             ORDER BY random()
             LIMIT 5
             ';

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -22,6 +22,7 @@ use App\PageView\EntryPageView;
 use App\PageView\PostPageView;
 use App\Pagination\AdapterFactory;
 use App\Repository\Contract\TagRepositoryInterface;
+use App\Service\SettingsManager;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Types\Types;
@@ -52,6 +53,7 @@ class PostRepository extends ServiceEntityRepository implements TagRepositoryInt
         private readonly Security $security,
         private readonly CacheInterface $cache,
         private readonly AdapterFactory $adapterFactory,
+        private readonly SettingsManager $settingsManager,
     ) {
         parent::__construct($registry, Post::class);
     }
@@ -335,11 +337,13 @@ class PostRepository extends ServiceEntityRepository implements TagRepositoryInt
     {
         $qb = $this->createQueryBuilder('p');
 
-        return $qb
-            ->where('p.isAdult = false')
+        $qb = $qb->where('p.isAdult = false')
             ->andWhere('p.visibility = :visibility')
-            ->andWhere('m.isAdult = false')
-            ->join('p.magazine', 'm')
+            ->andWhere('m.isAdult = false');
+        if ($this->settingsManager->get('KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY')) {
+            $qb = $qb->andWhere('p.apId IS NULL');
+        }
+        return $qb->join('p.magazine', 'm')
             ->orderBy('p.createdAt', 'DESC')
             ->setParameters(['visibility' => VisibilityInterface::VISIBILITY_VISIBLE])
             ->setMaxResults($limit)

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -343,6 +343,7 @@ class PostRepository extends ServiceEntityRepository implements TagRepositoryInt
         if ($this->settingsManager->get('KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY')) {
             $qb = $qb->andWhere('p.apId IS NULL');
         }
+
         return $qb->join('p.magazine', 'm')
             ->orderBy('p.createdAt', 'DESC')
             ->setParameters(['visibility' => VisibilityInterface::VISIBILITY_VISIBLE])

--- a/src/Service/SettingsManager.php
+++ b/src/Service/SettingsManager.php
@@ -32,6 +32,7 @@ class SettingsManager
         private readonly bool $kbinHeaderLogo,
         private readonly bool $kbinCaptchaEnabled,
         private readonly bool $kbinFederationPageEnabled,
+        private readonly bool $kbinSidebarSectionsLocalOnly,
         private readonly bool $kbinAdminOnlyOauthClients,
     ) {
         if (!self::$dto) {
@@ -64,7 +65,8 @@ class SettingsManager
                 $this->find($results, 'KBIN_MERCURE_ENABLED', FILTER_VALIDATE_BOOLEAN) ?? true,
                 $this->find($results, 'KBIN_FEDERATION_PAGE_ENABLED', FILTER_VALIDATE_BOOLEAN) ?? $this->kbinFederationPageEnabled,
                 $this->find($results, 'KBIN_ADMIN_ONLY_OAUTH_CLIENTS', FILTER_VALIDATE_BOOLEAN) ?? $this->kbinAdminOnlyOauthClients,
-                $this->find($results, 'KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN', FILTER_VALIDATE_BOOLEAN) ?? true
+                $this->find($results, 'KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN', FILTER_VALIDATE_BOOLEAN) ?? true,
+                $this->find($results, 'KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY', FILTER_VALIDATE_BOOLEAN) ?? $this->kbinSidebarSectionsLocalOnly
             );
         }
     }

--- a/src/Twig/Extension/SettingsExtension.php
+++ b/src/Twig/Extension/SettingsExtension.php
@@ -25,6 +25,7 @@ final class SettingsExtension extends AbstractExtension
             new TwigFunction('kbin_captcha_enabled', [SettingsExtensionRuntime::class, 'kbinCaptchaEnabled']),
             new TwigFunction('kbin_mercure_enabled', [SettingsExtensionRuntime::class, 'kbinMercureEnabled']),
             new TwigFunction('kbin_federation_page_enabled', [SettingsExtensionRuntime::class, 'kbinFederationPageEnabled']),
+            new TwigFunction('kbin_sidebar_sections_local_only', [SettingsExtensionRuntime::class, 'kbinSidebarSectionsLocalOnly']),
             new TwigFunction('mbin_current_version', [SettingsExtensionRuntime::class, 'mbinCurrentVersion']),
         ];
     }

--- a/src/Twig/Runtime/SettingsExtensionRuntime.php
+++ b/src/Twig/Runtime/SettingsExtensionRuntime.php
@@ -88,6 +88,11 @@ class SettingsExtensionRuntime implements RuntimeExtensionInterface
         return $this->settings->get('KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN');
     }
 
+    public function kbinSidebarSectionsLocalOnly(): bool
+    {
+        return $this->settings->get('KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY');
+    }
+
     public function mbinCurrentVersion(): string
     {
         return $this->projectInfo->getVersion();

--- a/templates/admin/settings.html.twig
+++ b/templates/admin/settings.html.twig
@@ -63,6 +63,10 @@
                 {{ form_label(form.KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN, 'federated_search_only_loggedin') }}
                 {{ form_widget(form.KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN) }}
             </div>
+            <div class="checkbox">
+                {{ form_label(form.KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY, 'sidebar_sections_local_only') }}
+                {{ form_widget(form.KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY) }}
+            </div>
             <div class="row actions">
                 {{ form_row(form.submit, {label: 'save', attr: {class: 'btn btn__primary'}}) }}
             </div>

--- a/tests/Functional/Controller/Api/Instance/Admin/InstanceSettingsRetrieveApiTest.php
+++ b/tests/Functional/Controller/Api/Instance/Admin/InstanceSettingsRetrieveApiTest.php
@@ -28,6 +28,7 @@ class InstanceSettingsRetrieveApiTest extends WebTestCase
         'KBIN_FEDERATION_PAGE_ENABLED',
         'KBIN_ADMIN_ONLY_OAUTH_CLIENTS',
         'KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN',
+        'KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY',
     ];
 
     public function testApiCannotRetrieveInstanceSettingsAnonymous(): void

--- a/tests/Functional/Controller/Api/Instance/Admin/InstanceSettingsUpdateApiTest.php
+++ b/tests/Functional/Controller/Api/Instance/Admin/InstanceSettingsUpdateApiTest.php
@@ -28,6 +28,7 @@ class InstanceSettingsUpdateApiTest extends WebTestCase
         'KBIN_FEDERATION_PAGE_ENABLED',
         'KBIN_ADMIN_ONLY_OAUTH_CLIENTS',
         'KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN',
+        'KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY',
     ];
 
     public function testApiCannotUpdateInstanceSettingsAnonymous(): void
@@ -102,6 +103,7 @@ class InstanceSettingsUpdateApiTest extends WebTestCase
             'KBIN_FEDERATION_PAGE_ENABLED' => false,
             'KBIN_ADMIN_ONLY_OAUTH_CLIENTS' => true,
             'KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN' => false,
+            'KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY' => false,
         ];
 
         $client->jsonRequest('PUT', '/api/instance/settings', $settings, server: ['HTTP_AUTHORIZATION' => $token]);
@@ -134,6 +136,7 @@ class InstanceSettingsUpdateApiTest extends WebTestCase
             'KBIN_FEDERATION_PAGE_ENABLED' => true,
             'KBIN_ADMIN_ONLY_OAUTH_CLIENTS' => false,
             'KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN' => true,
+            'KBIN_SIDEBAR_SECTIONS_LOCAL_ONLY' => true,
         ];
 
         $client->jsonRequest('PUT', '/api/instance/settings', $settings, server: ['HTTP_AUTHORIZATION' => $token]);

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -435,6 +435,7 @@ federation_page_enabled: Federation page enabled
 federation_page_allowed_description: Known instances we federate with
 federation_page_disallowed_description: Instances we do not federate with
 federated_search_only_loggedin: Federated search limited if not logged in
+sidebar_sections_local_only: Restrict "Random X" and "Active People" sections to local only
 request_account_deletion_title: Account deletion
 request_account_deletion_description: The administrator will be notified that you
   want your account deleted.


### PR DESCRIPTION
When enabled by an admin, this will make the random magazines, active people, random posts, and random threads only show the local items of those types. This does not affect the sections when looking at a specific community.