### PR TITLE
remove forced line break on timestamps from sidebar components

### DIFF
--- a/assets/styles/components/_sidebar.scss
+++ b/assets/styles/components/_sidebar.scss
@@ -143,10 +143,6 @@
         color: var(--kbin-meta-text-color);
         text-align: right;
       }
-
-      figcaption time {
-        display: block;
-      }
     }
   }
 


### PR DESCRIPTION
this is a very opinionated change

there's a lot on unused space in the random components due to the large amount of space to the left of timestamps / magazine. To me it doesn't feel too cramped on a single line, there's still quite a lot of spacing to break up the descriptions from the post info, even on mobile, but if people think it's easier to read on multiple lines I don't mind closing this either

edit: I was also considering adding the user posting / avatar / magazine icon (based on display settings) but decided against it for now. I think username at least could be useful in some situations (I constantly see "10 minutes ago posted to random" thinking what could this possibly be, but then I go and see it was posted by "daily ferrets" and realize oh it's a picture of a ferret), but didn't want to overload the component

before:

desktop:
![image](https://github.com/MbinOrg/mbin/assets/146029455/4c597f79-89b3-442f-be02-ca8563a321ea)
mobile:
![image](https://github.com/MbinOrg/mbin/assets/146029455/ef7f568d-92aa-4728-ac7b-e4cfa5bf688a)

after:

desktop:
![image](https://github.com/MbinOrg/mbin/assets/146029455/94af083a-4f8d-4b8b-91fc-5934b8df73b6)
mobile:
![image](https://github.com/MbinOrg/mbin/assets/146029455/ab62b44d-64ef-4adf-b12d-7ed3c5393068)
