### PR TITLE
Increase time-out to 8 seconds

### DIFF
--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -33,7 +33,7 @@ enum ApRequestType
 
 class ApHttpClient
 {
-    public const TIMEOUT = 5;
+    public const TIMEOUT = 8;
 
     public function __construct(
         private readonly string $kbinDomain,


### PR DESCRIPTION
We can slightly increase the time-out from 5 to 8 seconds, without too much impact.