### PR TITLE
add default check to local sidebar only env var

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -143,7 +143,7 @@ services:
             $kbinCaptchaEnabled: "%env(bool:KBIN_CAPTCHA_ENABLED)%"
             $kbinFederationPageEnabled: "%env(bool:KBIN_FEDERATION_PAGE_ENABLED)%"
             $kbinAdminOnlyOauthClients: "%env(bool:KBIN_ADMIN_ONLY_OAUTH_CLIENTS)%"
-            $mbinSidebarSectionsLocalOnly: "%env(bool:MBIN_SIDEBAR_SECTIONS_LOCAL_ONLY)%"
+            $mbinSidebarSectionsLocalOnly: "%env(bool:default::MBIN_SIDEBAR_SECTIONS_LOCAL_ONLY)%"
 
     # Markdown
     App\Markdown\Factory\EnvironmentFactory:


### PR DESCRIPTION
after #435 

@nobodyatroot reported getting `Environment variable not found: \"MBIN_SIDEBAR_SECTIONS_LOCAL_ONLY\"`

I'm not able to repro this currently, with no `.env` changes at all on main, clearing all my caches, but understood in the PR that it seemed like what would happen. Sadly that means I can't even check if this fixes it or not, but followed the pattern of https://github.com/MbinOrg/mbin/blob/main/config/services.yaml#L70