### PR TITLE
set default of local sidebar sections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,6 @@ KBIN_META_DESCRIPTION="content aggregator, content voting, discussion and micro-
 KBIN_META_KEYWORDS="mbin, content aggregator, open source, fediverse"
 KBIN_HEADER_LOGO=false
 KBIN_FEDERATION_PAGE_ENABLED=true
-MBIN_SIDEBAR_SECTIONS_LOCAL_ONLY=false
 MBIN_DEFAULT_THEME=default
 
 # Captcha (also enable in admin panel/settings)

--- a/.env.example_docker
+++ b/.env.example_docker
@@ -30,7 +30,6 @@ KBIN_META_DESCRIPTION="content aggregator, content voting, discussion and micro-
 KBIN_META_KEYWORDS="mbin, content aggregator, open source, fediverse"
 KBIN_HEADER_LOGO=false
 KBIN_FEDERATION_PAGE_ENABLED=true
-MBIN_SIDEBAR_SECTIONS_LOCAL_ONLY=false
 MBIN_DEFAULT_THEME=default
 
 # Captcha (also enable in admin panel/settings)

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -143,7 +143,6 @@ services:
             $kbinCaptchaEnabled: "%env(bool:KBIN_CAPTCHA_ENABLED)%"
             $kbinFederationPageEnabled: "%env(bool:KBIN_FEDERATION_PAGE_ENABLED)%"
             $kbinAdminOnlyOauthClients: "%env(bool:KBIN_ADMIN_ONLY_OAUTH_CLIENTS)%"
-            $mbinSidebarSectionsLocalOnly: "%env(bool:MBIN_SIDEBAR_SECTIONS_LOCAL_ONLY)%"
 
     # Markdown
     App\Markdown\Factory\EnvironmentFactory:

--- a/src/Service/SettingsManager.php
+++ b/src/Service/SettingsManager.php
@@ -32,7 +32,6 @@ class SettingsManager
         private readonly bool $kbinHeaderLogo,
         private readonly bool $kbinCaptchaEnabled,
         private readonly bool $kbinFederationPageEnabled,
-        private readonly bool $mbinSidebarSectionsLocalOnly,
         private readonly bool $kbinAdminOnlyOauthClients,
     ) {
         if (!self::$dto) {
@@ -66,7 +65,7 @@ class SettingsManager
                 $this->find($results, 'KBIN_FEDERATION_PAGE_ENABLED', FILTER_VALIDATE_BOOLEAN) ?? $this->kbinFederationPageEnabled,
                 $this->find($results, 'KBIN_ADMIN_ONLY_OAUTH_CLIENTS', FILTER_VALIDATE_BOOLEAN) ?? $this->kbinAdminOnlyOauthClients,
                 $this->find($results, 'KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN', FILTER_VALIDATE_BOOLEAN) ?? true,
-                $this->find($results, 'MBIN_SIDEBAR_SECTIONS_LOCAL_ONLY', FILTER_VALIDATE_BOOLEAN) ?? $this->mbinSidebarSectionsLocalOnly
+                $this->find($results, 'MBIN_SIDEBAR_SECTIONS_LOCAL_ONLY', FILTER_VALIDATE_BOOLEAN) ?? false
             );
         }
     }


### PR DESCRIPTION
move out from env var similar to federated search

mentioned in #446 adding a new env var comes with the price of either breaking existing instance owners or defaulting, but the defaulting in symfony always appears to have a lot of issues, especially with non-string types like `int`s and `bool`s (e.g. `Invalid env fallback in \"default:false:MBIN_SIDEBAR_SECTIONS_LOCAL_ONLY\"`)

I think it might be best if we keep new settings to having sane defaults in php, and using the db as the source of truth for when set