### PR TITLE
Add missing flash on contact form

### DIFF
--- a/templates/page/contact.html.twig
+++ b/templates/page/contact.html.twig
@@ -14,6 +14,7 @@
 
 {% block body %}
     <h1 hidden>{{ 'contact'|trans }}</h1>
+    {% include 'layout/_flash.html.twig' %}
     <div id="content" class="section section--top">
         <div class="container">
             {{ form_start(form) }}


### PR DESCRIPTION
Add missing `flash` section, which show you either an success or error message on the contact form. Currently the user will see nothing...

After:
![image](https://github.com/MbinOrg/mbin/assets/628926/e8b246e4-738d-42e8-a69d-068cb4c0a3b6)
