### PR TITLE
make search recognize `!group@instance.domain` handle format

### DIFF
--- a/src/ActivityPub/ActorHandle.php
+++ b/src/ActivityPub/ActorHandle.php
@@ -6,11 +6,11 @@ namespace App\ActivityPub;
 
 class ActorHandle
 {
-    public const HANDLE_PATTERN = '/^(?P<prefix>[@!])?(?P<user>[\w\-\.]+)@(?P<host>[\w\.\-]+)(?P<port>:[\d]+)?$/';
+    public const HANDLE_PATTERN = '/^(?P<prefix>[@!])?(?P<name>[\w\-\.]+)@(?P<host>[\w\.\-]+)(?P<port>:[\d]+)?$/';
 
     public function __construct(
         public ?string $prefix = null,
-        public ?string $username = null,
+        public ?string $name = null,
         public ?string $host = null,
         public ?int $port = null,
     ) {
@@ -26,7 +26,7 @@ class ActorHandle
         if (preg_match(static::HANDLE_PATTERN, $handle, $match)) {
             $new = new static(
                 $match['prefix'] ?? null,
-                $match['user'],
+                $match['name'],
                 $match['host']
             );
             $new->setPort($match['port'] ?? null);
@@ -40,7 +40,7 @@ class ActorHandle
     public static function isHandle(string $handle)
     {
         if (preg_match(static::HANDLE_PATTERN, $handle, $matches)) {
-            return !empty($matches['user']) && !empty($matches['host']);
+            return !empty($matches['name']) && !empty($matches['host']);
         }
 
         return false;
@@ -57,9 +57,7 @@ class ActorHandle
         return !empty($this->port) ? ':'.$this->port : '';
     }
 
-    /**
-     * @param int|string|null $port port as either plain int or string formatted like ':9000'
-     */
+    /** @param int|string|null $port port as either plain int or string formatted like ':9000' */
     public function setPort(int|string|null $port)
     {
         if (\is_string($port)) {
@@ -71,14 +69,16 @@ class ActorHandle
         return $this;
     }
 
+    /** @return string the handle's domain and optionally port in the format `host[:port]` */
     public function getDomain(): string
     {
         return $this->host.$this->getPortString();
     }
 
+    /** @param ?string $domain the domain in the format `host[:port]` to set both handle's host and port */
     public function setDomain(?string $domain)
     {
-        $url = parse_url($domain);
+        $url = parse_url($domain ?? '');
 
         $this->host = $url['host'] ?? null;
         $this->port = $url['port'] ?? null;
@@ -88,22 +88,22 @@ class ActorHandle
 
     public function formatWithPrefix(?string $prefix): string
     {
-        return "{$prefix}{$this->username}@{$this->getDomain()}";
+        return "{$prefix}{$this->name}@{$this->getDomain()}";
     }
 
-    /** @return string handle in the form user@domain */
+    /** @return string handle in the form `name@domain` */
     public function plainHandle(): string
     {
         return $this->formatWithPrefix('');
     }
 
-    /** @return string handle in the form @user@domain */
+    /** @return string handle in the form `@name@domain` */
     public function atHandle(): string
     {
         return $this->formatWithPrefix('@');
     }
 
-    /** @return string handle in the form !user@domain */
+    /** @return string handle in the form `!name@domain` */
     public function bangHandle(): string
     {
         return $this->formatWithPrefix('!');

--- a/src/ActivityPub/ActorHandle.php
+++ b/src/ActivityPub/ActorHandle.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ActivityPub;
+
+class ActorHandle
+{
+    public const HANDLE_PATTERN = '/^(?P<prefix>[@!])?(?P<user>[\w\-\.]+)@(?P<host>[\w\.\-]+)(?P<port>:[\d]+)?$/';
+
+    public function __construct(
+        public ?string $prefix = null,
+        public ?string $username = null,
+        public ?string $host = null,
+        public ?int $port = null,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return $this->formatWithPrefix($this->prefix);
+    }
+
+    public static function parse(string $handle): ?static
+    {
+        if (preg_match(static::HANDLE_PATTERN, $handle, $match)) {
+            $new = new static(
+                $match['prefix'] ?? null,
+                $match['user'],
+                $match['host']
+            );
+            $new->setPort($match['port'] ?? null);
+
+            return $new;
+        }
+
+        return null;
+    }
+
+    public static function isHandle(string $handle)
+    {
+        if (preg_match(static::HANDLE_PATTERN, $handle, $matches)) {
+            return !empty($matches['user']) && !empty($matches['host']);
+        }
+
+        return false;
+    }
+
+    public function isValid(): bool
+    {
+        return static::isHandle((string) $this);
+    }
+
+    /** @return string port as string in the format ':9000' or empty string if it's null */
+    public function getPortString(): string
+    {
+        return !empty($this->port) ? ':'.$this->port : '';
+    }
+
+    /**
+     * @param int|string|null $port port as either plain int or string formatted like ':9000'
+     */
+    public function setPort(int|string|null $port)
+    {
+        if (\is_string($port)) {
+            $this->port = \intval(ltrim($port, ':'));
+        } else {
+            $this->port = $port;
+        }
+
+        return $this;
+    }
+
+    public function getDomain(): string
+    {
+        return $this->host.$this->getPortString();
+    }
+
+    public function setDomain(?string $domain)
+    {
+        $url = parse_url($domain);
+
+        $this->host = $url['host'] ?? null;
+        $this->port = $url['port'] ?? null;
+
+        return $this;
+    }
+
+    public function formatWithPrefix(?string $prefix): string
+    {
+        return "{$prefix}{$this->username}@{$this->getDomain()}";
+    }
+
+    /** @return string handle in the form user@domain */
+    public function plainHandle(): string
+    {
+        return $this->formatWithPrefix('');
+    }
+
+    /** @return string handle in the form @user@domain */
+    public function atHandle(): string
+    {
+        return $this->formatWithPrefix('@');
+    }
+
+    /** @return string handle in the form !user@domain */
+    public function bangHandle(): string
+    {
+        return $this->formatWithPrefix('!');
+    }
+}

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\ActivityPub\ActorHandle;
 use App\Entity\Magazine;
 use App\Entity\User;
 use App\Message\ActivityPub\Inbox\ActivityMessage;
@@ -12,7 +13,6 @@ use App\Service\ActivityPubManager;
 use App\Service\SearchManager;
 use App\Service\SettingsManager;
 use App\Service\SubjectOverviewManager;
-use App\Utils\RegPatterns;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -47,43 +47,20 @@ class SearchController extends AbstractController
         }
 
         $this->logger->debug('searching for {query}', ['query' => $query]);
-        $objects = [];
-        if (str_contains($query, '@') && (!$this->settingsManager->get('KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN') || $this->getUser())) {
-            $name = str_starts_with($query, '@') ? $query : '@'.$query;
-            preg_match(RegPatterns::AP_USER, $name, $matches);
-            if (\count(array_filter($matches)) >= 4) {
-                $this->logger->debug('searching for a matched webfinger {query}', ['query' => $query]);
-                try {
-                    $webfinger = $this->activityPubManager->webfinger($name);
-                    foreach ($webfinger->getProfileIds() as $profileId) {
-                        $this->logger->debug('Found "{pId}" at "{name}"', ['pId' => $profileId, 'name' => $name]);
-                        $object = $this->activityPubManager->findActorOrCreate($profileId);
-                        // Check if object is not empty
-                        if (!empty($object)) {
-                            if ($object instanceof Magazine) {
-                                $type = 'magazine';
-                            } elseif ($object instanceof User) {
-                                $type = 'user';
-                            }
 
-                            $objects[] = [
-                                'type' => $type,
-                                'object' => $object,
-                            ];
-                        }
-                    }
-                } catch (\Exception $e) {
-                    $this->logger->warning('an error occurred during lookup of "{query}": {exClass}: {exMsg}', [
-                        'query' => $query,
-                        'exClass' => \get_class($e),
-                        'exMsg' => $e->getMessage(),
-                    ]);
-                }
+        $objects = [];
+
+        // looking up handles (users and mags)
+        if (str_contains($query, '@') && $this->federatedSearchAllowed()) {
+            if ($handle = ActorHandle::parse($query)) {
+                $this->logger->debug('searching for a matched webfinger {query}', ['query' => $query]);
+                $objects = array_merge($objects, $this->lookupHandle($handle));
             } else {
-                $this->logger->debug("query doesn't match the pattern...", [$matches]);
+                $this->logger->debug("query doesn't look like a valid handle...", ['query' => $query]);
             }
         }
 
+        // looking up object by AP id (i.e. urls)
         if (false !== filter_var($query, FILTER_VALIDATE_URL)) {
             $objects = $this->manager->findByApId($query);
             if (!$objects) {
@@ -103,5 +80,50 @@ class SearchController extends AbstractController
                 'q' => $request->query->get('q'),
             ]
         );
+    }
+
+    private function federatedSearchAllowed(): bool
+    {
+        return !$this->settingsManager->get('KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN')
+            || $this->getUser();
+    }
+
+    private function lookupHandle(ActorHandle $handle): array
+    {
+        $objects = [];
+        $name = $handle->plainHandle();
+
+        try {
+            $webfinger = $this->activityPubManager->webfinger($name);
+            foreach ($webfinger->getProfileIds() as $profileId) {
+                $this->logger->debug('Found "{profileId}" at "{name}"', ['profileId' => $profileId, 'name' => $name]);
+
+                // if actor object exists or successfully created
+                $object = $this->activityPubManager->findActorOrCreate($profileId);
+                if (!empty($object)) {
+                    if ($object instanceof Magazine) {
+                        $type = 'magazine';
+                    } elseif ($object instanceof User && '!' !== $handle->prefix) {
+                        $type = 'user';
+                    }
+
+                    $objects[] = [
+                        'type' => $type,
+                        'object' => $object,
+                    ];
+                }
+            }
+        } catch (\Exception $e) {
+            $this->logger->warning(
+                'an error occurred during webfinger lookup of "{handle}": {exceptionClass}: {message}',
+                [
+                    'handle' => $name,
+                    'exceptionClass' => \get_class($e),
+                    'message' => $e->getMessage(),
+                ]
+            );
+        }
+
+        return $objects;
     }
 }

--- a/tests/Unit/ActivityPub/ActorHandleTest.php
+++ b/tests/Unit/ActivityPub/ActorHandleTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\ActivityPub;
+
+use App\ActivityPub\ActorHandle;
+use PHPUnit\Framework\TestCase;
+
+class ActorHandleTest extends TestCase
+{
+    /**
+     * @dataProvider handleProvider()
+     */
+    public function testHandleIsRecognized(string $input, array $output): void
+    {
+        $this->assertNotNull(ActorHandle::parse($input));
+    }
+
+    /**
+     * @dataProvider handleProvider()
+     */
+    public function testHandleIsParsedProperly(string $input, array $output): void
+    {
+        $handle = ActorHandle::parse($input);
+        $this->assertEquals($handle->prefix, $output['prefix']);
+        $this->assertEquals($handle->name, $output['name']);
+        $this->assertEquals($handle->host, $output['host']);
+        $this->assertEquals($handle->port, $output['port']);
+    }
+
+    public static function handleProvider(): array
+    {
+        $handleSamples = [
+            'user@mbin.instance' => [
+                'prefix' => null,
+                'name' => 'user',
+                'host' => 'mbin.instance',
+                'port' => null,
+            ],
+            '@someone-512@mbin.instance' => [
+                'prefix' => '@',
+                'name' => 'someone-512',
+                'host' => 'mbin.instance',
+                'port' => null,
+            ],
+            '!engineering@ds9.space' => [
+                'prefix' => '!',
+                'name' => 'engineering',
+                'host' => 'ds9.space',
+                'port' => null,
+            ],
+            '@leon@pink.brainrot.internal:11037' => [
+                'prefix' => '@',
+                'name' => 'leon',
+                'host' => 'pink.brainrot.internal',
+                'port' => 11037,
+            ],
+        ];
+
+        $inputs = array_keys($handleSamples);
+        $outputs = array_values($handleSamples);
+
+        return array_combine(
+            $inputs,
+            array_map(fn ($input, $output) => [$input, $output], $inputs, $outputs)
+        );
+    }
+}


### PR DESCRIPTION
problem raised here: https://moist.catsweat.com/m/Mdev@kbin.run/t/133545

adjust search to recognize lemmy styled group handle `!group@instance.domain` and proceed to search without having to edit the handle before searching

also a bit of niceties: if this group handle format is used when searching, then the users will be excluded from search results