### PR TITLE
fix nodeinfo schema wrong version, add metadata

### DIFF
--- a/src/Controller/ActivityPub/NodeInfoController.php
+++ b/src/Controller/ActivityPub/NodeInfoController.php
@@ -46,11 +46,11 @@ class NodeInfoController
             'links' => [
                 [
                     'rel' => self::NODE_REL_v21,
-                    'href' => $this->urlGenerator->generate('ap_node_info_v2', ['version' => '2.0'], UrlGeneratorInterface::ABSOLUTE_URL),
+                    'href' => $this->urlGenerator->generate('ap_node_info_v2', ['version' => '2.1'], UrlGeneratorInterface::ABSOLUTE_URL),
                 ],
                 [
                     'rel' => self::NODE_REL_v20,
-                    'href' => $this->urlGenerator->generate('ap_node_info_v2', ['version' => '2.1'], UrlGeneratorInterface::ABSOLUTE_URL),
+                    'href' => $this->urlGenerator->generate('ap_node_info_v2', ['version' => '2.0'], UrlGeneratorInterface::ABSOLUTE_URL),
                 ],
             ],
         ];

--- a/src/Factory/ActivityPub/NodeInfoFactory.php
+++ b/src/Factory/ActivityPub/NodeInfoFactory.php
@@ -64,7 +64,10 @@ class NodeInfoFactory
                 'localComments' => $this->repository->countLocalComments(),
             ],
             'openRegistrations' => $this->settingsManager->get('KBIN_REGISTRATIONS_ENABLED'),
-            'metadata' => (object) [],
+            'metadata' => [
+                'nodeName' => $this->settingsManager->get('KBIN_META_TITLE'),
+                'nodeDescription' => $this->settingsManager->get('KBIN_META_DESCRIPTION'),
+            ],
         ];
     }
 }


### PR DESCRIPTION
- fix nodeinfo schema version criss-crossing (rel nodeinfo 2.1 has link to nodeinfo 2.0 endpoint and vice versa)
- add `node{Name,Description}` to nodeinfo metadata, corresponding to `KBIN_META_{NAME,DESCRIPTION}` value respectively