### PR TITLE
load custom css from routes instead of inline

### DIFF
--- a/config/kbin_routes/custom_style.yaml
+++ b/config/kbin_routes/custom_style.yaml
@@ -1,0 +1,4 @@
+custom_style:
+    controller: App\Controller\CustomStyleController
+    path: /custom-style
+    methods: [ GET ]

--- a/src/Controller/CustomStyleController.php
+++ b/src/Controller/CustomStyleController.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Repository\MagazineRepository;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CustomStyleController extends AbstractController
+{
+    public function __invoke(Request $request, MagazineRepository $repository): Response
+    {
+        $magazineName = $request->query->get('magazine');
+        $magazine = $repository->findOneByName($magazineName);
+
+        $css = $this->renderView('styles/custom.css.twig', [
+            'magazine' => $magazine,
+        ]);
+
+        return $this->createResponse($request, $css);
+    }
+
+    private function createResponse(Request $request, ?string $customCss): Response
+    {
+        $response = new Response();
+        $response->headers->set('Content-Type', 'text/css');
+        $response->setPrivate();
+
+        if (!empty($customCss)) {
+            $response->setContent($customCss);
+            $response->setEtag(md5($response->getContent()));
+            $response->isNotModified($request);
+        } else {
+            $response->setStatusCode(Response::HTTP_NOT_FOUND);
+        }
+
+        return $response;
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -24,9 +24,7 @@
 
     {% block stylesheets %}
         {{ encore_entry_link_tags('app') }}
-        <style>
-            {% include 'components/_details_label.css.twig' %}
-        </style>
+        <link rel="stylesheet" href="{{ path('custom_style', {magazine: magazine.name|default(null)}) }}">
     {% endblock %}
 
     {% block javascripts %}
@@ -43,19 +41,6 @@
             }
         </script>
     {% endblock %}
-
-    {% if not app.user or not app.user.ignoreMagazinesCustomCss %}
-        {% if magazine is defined and magazine %}
-            <style>
-                {{ magazine.customCss }}
-            </style>
-        {% endif %}
-    {% endif %}
-    {% if app.user and app.user.customCss %}
-        <style>
-            {{ app.user.customCss }}
-        </style>
-    {% endif %}
 </head>
 <body class="{{ html_classes(app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_THEME'))
     ? 'theme--'~app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_THEME'))

--- a/templates/styles/custom.css.twig
+++ b/templates/styles/custom.css.twig
@@ -1,0 +1,18 @@
+{#
+    using |raw here should be somewhat safe
+    since the next thing you fight should be the browser's css parser
+#}
+/* site dynamic styles */
+{{ include('components/_details_label.css.twig') }}
+
+{% if not app.user or not app.user.ignoreMagazinesCustomCss %}
+    {% if magazine is defined and magazine.customCss %}
+        /* magazine styles */
+        {{ magazine.customCss|raw }}
+    {% endif %}
+{% endif %}
+
+{% if app.user is defined and app.user.customCss %}
+    /* user styles */
+    {{ app.user.customCss|raw }}
+{% endif %}


### PR DESCRIPTION
added a controller that returns custom css for both user and magazines at `/custom-style` endpoint, and change template to load custom css from this endpoint instead

this should fix the problem of being unable to use quotes and stuff in custom css, most likely due to twig autoescaping templated values as html (as it usually does) which results in malformed css

simply tacking on `|raw` after value in base template for a fix is just an open invitation for something like `</style><script></script><style>` or worse to happen