### PR TITLE
adding alt text as caption in lightbox

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -1,6 +1,7 @@
 @import '@fortawesome/fontawesome-free/scss/fontawesome';
 @import '@fortawesome/fontawesome-free/scss/solid';
 @import '@fortawesome/fontawesome-free/scss/brands';
+@import 'glightbox/dist/css/glightbox.min.css';
 @import 'mixins/animations';
 @import 'mixins/kbin';
 @import 'mixins/theme-dark';
@@ -31,6 +32,7 @@
 @import 'components/entry';
 @import 'components/comment';
 @import 'components/figure_image';
+@import 'components/figure_lightbox';
 @import 'components/post';
 @import 'components/subject';
 @import 'components/login';
@@ -52,4 +54,3 @@
 @import 'themes/default';
 @import 'themes/solarized';
 @import 'themes/tokyo-night';
-@import 'glightbox/dist/css/glightbox.min.css';

--- a/assets/styles/components/_figure_image.scss
+++ b/assets/styles/components/_figure_image.scss
@@ -42,6 +42,46 @@ input.sensitive-state {
   width: 0;
   height: 0;
   opacity: 0;
+  z-index: -1;
+}
+
+.figure-badge {
+  position: absolute;
+  pointer-events: none;
+
+  &-label {
+    background: var(--kbin-button-secondary-bg);
+    padding: .5rem;
+
+    font-weight: normal;
+    font-size: .8rem;
+    text-align: center;
+
+    opacity: .5;
+
+    i {
+      font-size: 1rem;
+    }
+
+    .rounded-edges & {
+      border-radius: var(--kbin-rounded-edges-radius);
+    }
+
+    &:hover,
+    &:active {
+      opacity: .7;
+    }
+  }
+
+  &.alt {
+    bottom: .5rem;
+    right: .5rem;
+
+    .figure-badge-label {
+      font-weight: 500;
+      line-height: .8rem;
+    }
+  }
 }
 
 // button to toggle sensitive

--- a/assets/styles/components/_figure_lightbox.scss
+++ b/assets/styles/components/_figure_lightbox.scss
@@ -1,0 +1,71 @@
+.glightbox-container {
+  .goverlay {
+    background: rgba(0, 0, 0, 0.7);
+  }
+
+  .gslide-description {
+    font-family: var(--kbin-body-font-family);
+    background: var(--kbin-body-bg);
+  }
+
+  .gdesc-inner {
+    padding: 1rem;
+  }
+
+  .gslide-title,
+  .gslide-desc {
+    font-family: var(--kbin-body-font-family);
+    font-size: 0.9rem;
+    color: var(--kbin-text-color);
+  }
+
+  .gslide-image img {
+    max-height: 95vh;
+  }
+}
+
+.glightbox-mobile .glightbox-container {
+  .goverlay {
+    background: rgba(0, 0, 0, 0.7);
+  }
+
+  .gslide-description {
+    font-family: var(--kbin-body-font-family);
+    background: color-mix(in srgb, var(--kbin-body-bg) 85%, transparent);
+  }
+
+  .gslide-title,
+  .gslide-desc {
+    font-family: var(--kbin-body-font-family);
+    font-size: 0.9rem;
+    color: var(--kbin-text-color);
+  }
+
+  .gslide-image img {
+    max-width: 95vw;
+  }
+}
+
+.gdesc-open {
+  .gslide-media {
+    filter: brightness(.7);
+    opacity: 1;
+
+    -webkit-transition: filter .5s ease;
+    transition: filter .5s ease;
+  }
+
+  &.glightbox-mobile {
+    .gslide-description {
+      background: var(--kbin-body-bg);
+    }
+  }
+}
+
+.gdesc-closed .gslide-media {
+  filter: brightness(1);
+  opacity: 1;
+
+  -webkit-transition: filter .5s ease;
+  transition: filter .5s ease;
+}

--- a/templates/components/_figure_entry.html.twig
+++ b/templates/components/_figure_entry.html.twig
@@ -1,52 +1,59 @@
 {# this fragment is only meant to be used in entry component #}
-{% with {
-    sensitive_id: 'sensitive-check-%s-%s'|format(entry.id, entry.image.id),
-    is_single: is_route_name('entry_single'),
-} %}
-{% if type is same as 'image' %}
-    {% set route = is_single ? uploaded_asset(entry.image.filePath) : entry_url(entry) %}
-{% elseif type is same as 'link' %}
-    {% set route = is_single ? entry.url : entry_url(entry) %}
-{% endif %}
-<figure>
-    <div class="image-filler" aria-hidden="true">
-        {% if entry.image.blurhash %}
-            {{ component('blurhash_image', {blurhash: entry.image.blurhash}) }}
+{% with {is_single: is_route_name('entry_single'), image: entry.image} %}
+
+    {% set sensitive_id = 'sensitive-check-%s-%s'|format(entry.id, image.id) %}
+    {% set lightbox_alt_id = 'thumb-alt-%s-%s'|format(entry.id, image.id) %}
+
+    {% if type is same as 'image' %}
+        {% set route = is_single ? uploaded_asset(image.filePath) : entry_url(entry) %}
+    {% elseif type is same as 'link' %}
+        {% set route = is_single ? entry.url : entry_url(entry) %}
+    {% endif %}
+
+    {% set is_single_image = is_single and type is same as 'image' %}
+
+    <figure>
+        {% if image.altText %}
+            <figcaption class="{{ html_classes('hidden', 'glightbox-desc', lightbox_alt_id) }}">
+                {{ image.altText|nl2br }}
+            </figcaption>
         {% endif %}
-    </div>
-    {% if entry.isAdult %}
-        <input id="{{ sensitive_id }}"
-               type="checkbox"
-               class="sensitive-state"
-               aria-label="{{ 'sensitive_toggle'|trans }}">
-    {% endif %}
-    <a href="{{ route }}"
-       class="{{ html_classes('sensitive-checked--show', {
-            'thumb': is_single and (type is same as 'image')
-       }) }}"
-       rel="{{ (type is same as 'link') ? get_rel(route) : '' }}"
-    >
-        <img class="thumb-subject"
-             src="{{ asset(entry.image.filePath)|imagine_filter('entry_thumb') }}"
-             alt="{{ entry.image.altText }}">
-    </a>
-    {% if entry.isAdult %}
-        <label for="{{ sensitive_id }}"
-               class="sensitive-button sensitive-button-show sensitive-checked--hide"
-               title="{{ 'sensitive_show'|trans }}"
-               aria-label="{{ 'sensitive_show'|trans }}">
-            <div class="sensitive-button-label">
-                <i class="fa-solid fa-eye" aria-hidden="true"></i>
-            </div>
-        </label>
-        <label for="{{ sensitive_id }}"
-               class="sensitive-button sensitive-button-hide sensitive-checked--show"
-               title="{{ 'sensitive_hide'|trans }}"
-               aria-label="{{ 'sensitive_hide'|trans }}">
-            <div class="sensitive-button-label">
-                <i class="fa-solid fa-eye-slash" aria-hidden="true"></i>
-            </div>
-        </label>
-    {% endif %}
-</figure>
+        <div class="image-filler" aria-hidden="true">
+            {% if image.blurhash %}
+                {{ component('blurhash_image', {blurhash: image.blurhash}) }}
+            {% endif %}
+        </div>
+        {% if entry.isAdult %}
+            <input id="{{ sensitive_id }}"
+                   type="checkbox"
+                   class="sensitive-state"
+                   aria-label="{{ 'sensitive_toggle'|trans }}">
+        {% endif %}
+        <a href="{{ route }}"
+           class="{{ html_classes('sensitive-checked--show', {'thumb': is_single_image}) }}"
+           rel="{{ (type is same as 'link') ? get_rel(route) : '' }}"
+           data-description="{{ is_single_image and image.altText ? '.'~lightbox_alt_id : '' }}">
+            <img class="thumb-subject"
+                 src="{{ asset(image.filePath)|imagine_filter('entry_thumb') }}"
+                 alt="{{ image.altText }}">
+        </a>
+        {% if entry.isAdult %}
+            <label for="{{ sensitive_id }}"
+                   class="sensitive-button sensitive-button-show sensitive-checked--hide"
+                   title="{{ 'sensitive_show'|trans }}"
+                   aria-label="{{ 'sensitive_show'|trans }}">
+                <div class="sensitive-button-label">
+                    <i class="fa-solid fa-eye" aria-hidden="true"></i>
+                </div>
+            </label>
+            <label for="{{ sensitive_id }}"
+                   class="sensitive-button sensitive-button-hide sensitive-checked--show"
+                   title="{{ 'sensitive_hide'|trans }}"
+                   aria-label="{{ 'sensitive_hide'|trans }}">
+                <div class="sensitive-button-label">
+                    <i class="fa-solid fa-eye-slash" aria-hidden="true"></i>
+                </div>
+            </label>
+        {% endif %}
+    </figure>
 {% endwith %}

--- a/templates/components/_figure_image.html.twig
+++ b/templates/components/_figure_image.html.twig
@@ -1,37 +1,53 @@
-<figure>
-    <div class="figure-container">
-        <div class="figure-thumb">
-            <a href="{{ uploaded_asset(image.filePath) }}" class="thumb">
-                <img src="{{ asset(image.filePath)|imagine_filter(thumb_filter) }}"
-                     alt="{{ image.altText }}">
-            </a>
-        </div>
-        {% if is_adult %}
-            {% with {sensitive_id: 'sensitive-check-%s-%s'|format(parent_id, image.id) } %}
-            <input id="{{ sensitive_id }}"
-                   type="checkbox"
-                   class="sensitive-state"
-                   aria-label="{{ 'sensitive_toggle'|trans }}">
-            <label for="{{ sensitive_id }}"
-                   class="sensitive-button sensitive-button-show sensitive-checked--hide"
-                   title="{{ 'sensitive_show'|trans }}">
-                <div class="figure-blur" aria-hidden="true">
-                    {{ component('blurhash_image', {blurhash: image.blurhash, width: 32, height: 32}) }}
-                </div>
-                <div class="sensitive-button-label">
-                    {{ 'sensitive_warning'|trans }} <br>
-                    {{ 'sensitive_show'|trans }}
-                </div>
-            </label>
-            <label for="{{ sensitive_id }}"
-                   class="sensitive-button sensitive-button-hide sensitive-checked--show"
-                   title="{{ 'sensitive_hide'|trans }}"
-                   aria-label="{{ 'sensitive_hide'|trans }}">
-                <div class="sensitive-button-label" >
-                    <i class="fa-solid fa-eye-slash" aria-hidden="true"></i>
-                </div>
-            </label>
-            {% endwith %}
+{% with {
+    sensitive_id: 'sensitive-check-%s-%s'|format(parent_id, image.id),
+    lightbox_alt_id: 'thumb-alt-%s-%s'|format(parent_id, image.id),
+} %}
+    <figure>
+        {% if image.altText %}
+            <figcaption class="{{ html_classes('hidden', 'glightbox-desc', lightbox_alt_id) }}">
+                {{ image.altText|nl2br }}
+            </figcaption>
         {% endif %}
-    </div>
-</figure>
+        <div class="figure-container">
+            <div class="figure-thumb">
+                <a
+                    href="{{ uploaded_asset(image.filePath) }}"
+                    class="thumb"
+                    data-description="{{ image.altText ? '.'~lightbox_alt_id : ''}}">
+                    <img src="{{ asset(image.filePath)|imagine_filter(thumb_filter) }}"
+                         alt="{{ image.altText }}">
+                </a>
+            </div>
+            {% if image.altText %}
+                <div class="figure-badge alt">
+                    <div class="figure-badge-label">ALT</div>
+                </div>
+            {% endif %}
+            {% if is_adult %}
+                <input id="{{ sensitive_id }}"
+                       type="checkbox"
+                       class="sensitive-state"
+                       aria-label="{{ 'sensitive_toggle'|trans }}">
+                <label for="{{ sensitive_id }}"
+                       class="sensitive-button sensitive-button-show sensitive-checked--hide"
+                       title="{{ 'sensitive_show'|trans }}">
+                    <div class="figure-blur" aria-hidden="true">
+                        {{ component('blurhash_image', {blurhash: image.blurhash, width: 32, height: 32}) }}
+                    </div>
+                    <div class="sensitive-button-label">
+                        {{ 'sensitive_warning'|trans }} <br>
+                        {{ 'sensitive_show'|trans }}
+                    </div>
+                </label>
+                <label for="{{ sensitive_id }}"
+                       class="sensitive-button sensitive-button-hide sensitive-checked--show"
+                       title="{{ 'sensitive_hide'|trans }}"
+                       aria-label="{{ 'sensitive_hide'|trans }}">
+                    <div class="sensitive-button-label" >
+                        <i class="fa-solid fa-eye-slash" aria-hidden="true"></i>
+                    </div>
+                </label>
+            {% endif %}
+        </div>
+    </figure>
+{% endwith %}


### PR DESCRIPTION
if the attached image (not image links) has alt text then it'll show up as image description in the lightbox view

looks something like this

<details><summary>small badge on image showing alt text exists</summary>

![image](https://github.com/MbinOrg/mbin/assets/20770492/c25210e1-5edd-491c-9d88-880147372323)

</details>

<details><summary>desktop lightbox</summary>

![image](https://github.com/MbinOrg/mbin/assets/20770492/a76ba908-3c7f-471d-a9e4-4c23f663b530)

</details> 

<details><summary>mobile lightbox</summary>

![image](https://github.com/MbinOrg/mbin/assets/20770492/1f008430-307a-409e-ac96-c72e9124c6cc)

</details>

<details><summary>mobile lightbox, showing extended caption</summary>

the image is dimmed a bit, and the caption background is more opaque

![image](https://github.com/MbinOrg/mbin/assets/20770492/dfa878d7-8887-4387-a8bd-8aef9b4467a9)

</details>