### PR TITLE
hotfix: allow custom style while still in 2fa

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -58,6 +58,8 @@ security:
         # This makes the logout route accessible during two-factor authentication. Allows the user to
         # cancel two-factor authentication, if they need to.
         - { path: ^/logout, role: PUBLIC_ACCESS }
+        # allow custom style route access during two-factor authentication
+        # to avoid redirecting (wrongly) to this route after two-factor authentication is completed
         - { path: ^/custom-style, role: PUBLIC_ACCESS }
         # This ensures that the form can only be accessed when two-factor authentication is in progress.
         - { path: ^/2fa, role: IS_AUTHENTICATED_2FA_IN_PROGRESS }

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -58,6 +58,7 @@ security:
         # This makes the logout route accessible during two-factor authentication. Allows the user to
         # cancel two-factor authentication, if they need to.
         - { path: ^/logout, role: PUBLIC_ACCESS }
+        - { path: ^/custom-style, role: PUBLIC_ACCESS }
         # This ensures that the form can only be accessed when two-factor authentication is in progress.
         - { path: ^/2fa, role: IS_AUTHENTICATED_2FA_IN_PROGRESS }
 

--- a/templates/styles/custom.css.twig
+++ b/templates/styles/custom.css.twig
@@ -6,13 +6,13 @@
 {{ include('components/_details_label.css.twig') }}
 
 {% if not app.user or not app.user.ignoreMagazinesCustomCss %}
-    {% if magazine is defined and magazine.customCss %}
+    {% if magazine is defined and magazine and magazine.customCss %}
         /* magazine styles */
         {{ magazine.customCss|raw }}
     {% endif %}
 {% endif %}
 
-{% if app.user is defined and app.user.customCss %}
+{% if app.user is defined and app.user and app.user.customCss %}
     /* user styles */
     {{ app.user.customCss|raw }}
 {% endif %}


### PR DESCRIPTION
this is a hotfix of a problem where users with 2fa enabled will get wrongly redirected to `/custom-style` custom style route after completing 2fa, most likely because this route will be loaded after the challenge page was loaded as part of the base template, and that seems to confuse 2fa system into misremembering that the custom style route is where the users came from

by allowing public access it should now be accessible while 2fa is in progress and not trip the aforementioned 2fa route redirection