### PR TITLE
Preload our logos

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -19,6 +19,7 @@
     <link rel="icon" href="{{ asset('favicon.ico') }}" sizes="any">
     <link rel="apple-touch-icon" href="{{ asset('assets/icons/apple-touch-icon.png') }}">
     <link rel="icon" href="{{ asset('favicon.svg') }}" type="image/svg+xml">
+    <link rel="preload" href="{{ asset('mbin_logo.svg') }}" as="image">
 
     <link rel="manifest" href="{{ asset('manifest.json') }}"/>
 

--- a/templates/layout/_sidebar.html.twig
+++ b/templates/layout/_sidebar.html.twig
@@ -181,7 +181,7 @@
     </div>
 </section>
 <div class="section section--no-bg kbin-promo">
-    <img height="47" src="{{ asset('favicon.svg') }}" alt="Clone repo">
+    <img height="47" loading="lazy" src="{{ asset('favicon.svg') }}" alt="Clone repo">
     <div>
         <h4>{{ 'kbin_promo_title'|trans }}</h4>
         <p>{{ 'kbin_promo_desc'|trans({


### PR DESCRIPTION
Preload our header logo, since that is always loaded and at the top of the page. And just lazy load the favicon.svg (which is further down the page anyway).

This will have maybe 1% speed improvement, but after https://github.com/MbinOrg/mbin/pull/491. I would like to finish it once and for all now.

https://phuoc.ng/collection/this-vs-that/preload-vs-prefetch/