### PR TITLE
Improve handling of images

### DIFF
--- a/migrations/Version20240217103834.php
+++ b/migrations/Version20240217103834.php
@@ -11,7 +11,7 @@ final class Version20240217103834 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return '';
+        return 'This will make the file_path nullable, so we can store links to remote images, which could not be cached locally';
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version20240217103834.php
+++ b/migrations/Version20240217103834.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240217103834 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE image ALTER file_path DROP NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE image ALTER file_path SET NOT NULL');
+    }
+}

--- a/src/DTO/ImageDto.php
+++ b/src/DTO/ImageDto.php
@@ -26,7 +26,7 @@ class ImageDto implements \JsonSerializable
     #[Ignore]
     public ?int $id = null;
 
-    public static function create(int $id, string $filePath, int $width = null, int $height = null, string $altText = null, string $sourceUrl = null, string $storageUrl = null): self
+    public static function create(int $id, ?string $filePath, int $width = null, int $height = null, string $altText = null, string $sourceUrl = null, string $storageUrl = null): self
     {
         $dto = new ImageDto();
         $dto->filePath = $filePath;

--- a/src/Entity/Image.php
+++ b/src/Entity/Image.php
@@ -20,8 +20,11 @@ use Doctrine\ORM\Mapping\UniqueConstraint;
 #[Cache(usage: 'NONSTRICT_READ_WRITE')]
 class Image
 {
-    #[Column(type: 'string', nullable: false)]
-    public string $filePath;
+    #[Column(type: 'string', nullable: true)]
+    /**
+     * If this is NULL it is only a remote image, probably because the image was too big.
+     */
+    public ?string $filePath;
     #[Column(type: 'string', nullable: false)]
     public string $fileName;
     #[Column(type: 'binary', length: 32, nullable: false)]

--- a/src/MessageHandler/AttachEntryEmbedHandler.php
+++ b/src/MessageHandler/AttachEntryEmbedHandler.php
@@ -57,7 +57,9 @@ class AttachEntryEmbedHandler
 
         $entry->type = $type;
         $entry->hasEmbed = $html || $isImage;
-        $entry->image = $cover;
+        if ($cover) {
+            $entry->image = $cover;
+        }
 
         $this->entityManager->flush();
     }

--- a/src/Repository/ImageRepository.php
+++ b/src/Repository/ImageRepository.php
@@ -95,7 +95,6 @@ class ImageRepository extends ServiceEntityRepository
 
         try {
             $this->imageManager->store($source, $filePath);
-            $this->logger->debug('stored the image');
 
             return $image;
         } catch (ImageDownloadTooLargeException $e) {

--- a/src/Repository/ImageRepository.php
+++ b/src/Repository/ImageRepository.php
@@ -6,6 +6,7 @@ namespace App\Repository;
 
 use App\Entity\Image;
 use App\Event\ImagePostProcessEvent;
+use App\Exception\ImageDownloadTooLargeException;
 use App\Service\ImageManager;
 use App\Utils\ImageOrigin;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -60,10 +61,8 @@ class ImageRepository extends ServiceEntityRepository
     /**
      * Process and store an image from source file given path.
      *
-     * @param source file path of the image
-     * @param origin where the image comes from
-     *
-     * @throws RuntimeException if image type can't be identified
+     * @param string      $source file path of the image
+     * @param ImageOrigin $origin where the image comes from
      */
     private function findOrCreateFromSource(string $source, ImageOrigin $origin): ?Image
     {
@@ -75,6 +74,8 @@ class ImageRepository extends ServiceEntityRepository
             if (file_exists($source)) {
                 unlink($source);
             }
+
+            $this->logger->debug('found image by Sha256, imageId: {id}', ['id' => $image->getId()]);
 
             return $image;
         }
@@ -94,20 +95,36 @@ class ImageRepository extends ServiceEntityRepository
 
         try {
             $this->imageManager->store($source, $filePath);
+            $this->logger->debug('stored the image');
+
+            return $image;
+        } catch (ImageDownloadTooLargeException $e) {
+            if (ImageOrigin::External === $origin) {
+                $this->logger->warning(
+                    'findOrCreateFromSource: failed to store image file, because it is too big. Storing only a reference',
+                    ['origin' => $origin, 'type' => \gettype($e)],
+                );
+                $image->filePath = null;
+
+                return $image;
+            } else {
+                $this->logger->error(
+                    'findOrCreateFromSource: failed to store image file, because it is too big',
+                    ['origin' => $origin, 'type' => \gettype($e)],
+                );
+            }
         } catch (\Exception $e) {
             $this->logger->error(
                 'findOrCreateFromSource: failed to store image file: '.$e->getMessage(),
-                ['origin' => $origin],
+                ['origin' => $origin, 'type' => \gettype($e)],
             );
-
-            return null;
         } finally {
             if (file_exists($source)) {
                 unlink($source);
             }
         }
 
-        return $image;
+        return null;
     }
 
     public function blurhash(string $filePath): ?string

--- a/src/Service/ActivityPub/Note.php
+++ b/src/Service/ActivityPub/Note.php
@@ -23,10 +23,12 @@ use App\Service\PostCommentManager;
 use App\Service\PostManager;
 use App\Service\SettingsManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 
 class Note
 {
     public function __construct(
+        private readonly LoggerInterface $logger,
         private readonly ApActivityRepository $repository,
         private readonly PostManager $postManager,
         private readonly EntryCommentManager $entryCommentManager,
@@ -188,11 +190,9 @@ class Note
                 throw new \Exception('User is banned.');
             }
 
-            if (
-                isset($object['attachment'])
-                && $image = $this->activityPubManager->handleImages($object['attachment'])
-            ) {
+            if (isset($object['attachment']) && $image = $this->activityPubManager->handleImages($object['attachment'])) {
                 $dto->image = $this->imageFactory->createDto($image);
+                $this->logger->debug("adding image to post '{title}', {image}", ['title' => $dto->slug, 'image' => $image->getId()]);
             }
 
             $dto->body = $this->objectExtractor->getMarkdownBody($object);

--- a/src/Service/ActivityPub/Page.php
+++ b/src/Service/ActivityPub/Page.php
@@ -63,10 +63,8 @@ class Page
             $dto->title = $object['name'];
             $dto->apId = $object['id'];
 
-            if (
-                (isset($object['attachment']) || isset($object['image']))
-                && $image = $this->activityPubManager->handleImages($object['attachment'])
-            ) {
+            if ((isset($object['attachment']) || isset($object['image'])) && $image = $this->activityPubManager->handleImages($object['attachment'])) {
+                $this->logger->debug("adding image to entry '{title}', {image}", ['title' => $dto->title, 'image' => $image->getId()]);
                 $dto->image = $this->imageFactory->createDto($image);
             }
 

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -286,7 +286,7 @@ class ActivityPubManager
             if (isset($actor['icon'])) {
                 $newImage = $this->handleImages([$actor['icon']]);
                 if ($user->avatar && $newImage !== $user->avatar) {
-                    $this->bus->dispatch(new DeleteImageMessage($user->avatar->filePath));
+                    $this->bus->dispatch(new DeleteImageMessage($user->avatar->getId()));
                 }
                 $user->avatar = $newImage;
             }
@@ -295,7 +295,7 @@ class ActivityPubManager
             if (isset($actor['image'])) {
                 $newImage = $this->handleImages([$actor['image']]);
                 if ($user->cover && $newImage !== $user->cover) {
-                    $this->bus->dispatch(new DeleteImageMessage($user->cover->filePath));
+                    $this->bus->dispatch(new DeleteImageMessage($user->cover->getId()));
                 }
                 $user->cover = $newImage;
             }
@@ -331,9 +331,12 @@ class ActivityPubManager
             try {
                 if ($tempFile = $this->imageManager->download($images[0]['url'])) {
                     $image = $this->imageRepository->findOrCreateFromPath($tempFile);
+                    $image->sourceUrl = $images[0]['url'];
                     if ($image && isset($images[0]['name'])) {
                         $image->altText = $images[0]['name'];
                     }
+                    $this->entityManager->persist($image);
+                    $this->entityManager->flush();
                 }
             } catch (\Exception $e) {
                 return null;
@@ -385,7 +388,7 @@ class ActivityPubManager
             if (isset($actor['icon'])) {
                 $newImage = $this->handleImages([$actor['icon']]);
                 if ($magazine->icon && $newImage !== $magazine->icon) {
-                    $this->bus->dispatch(new DeleteImageMessage($magazine->icon->filePath));
+                    $this->bus->dispatch(new DeleteImageMessage($magazine->icon->getId()));
                 }
                 $magazine->icon = $newImage;
             }

--- a/src/Service/EntryCommentManager.php
+++ b/src/Service/EntryCommentManager.php
@@ -111,7 +111,7 @@ class EntryCommentManager implements ContentManagerInterface
         $this->entityManager->flush();
 
         if ($oldImage && $comment->image !== $oldImage) {
-            $this->bus->dispatch(new DeleteImageMessage($oldImage->filePath));
+            $this->bus->dispatch(new DeleteImageMessage($oldImage->getId()));
         }
 
         $this->dispatcher->dispatch(new EntryCommentEditedEvent($comment));
@@ -156,7 +156,7 @@ class EntryCommentManager implements ContentManagerInterface
         $this->dispatcher->dispatch(new EntryCommentBeforePurgeEvent($comment, $user));
 
         $magazine = $comment->entry->magazine;
-        $image = $comment->image?->filePath;
+        $image = $comment->image?->getId();
         $comment->entry->removeComment($comment);
 
         $this->entityManager->remove($comment);
@@ -195,7 +195,7 @@ class EntryCommentManager implements ContentManagerInterface
 
     public function detachImage(EntryComment $comment): void
     {
-        $image = $comment->image->filePath;
+        $image = $comment->image->getId();
 
         $comment->image = null;
 

--- a/src/Service/EntryManager.php
+++ b/src/Service/EntryManager.php
@@ -27,6 +27,7 @@ use App\Utils\UrlCleaner;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
@@ -37,6 +38,7 @@ use Webmozart\Assert\Assert;
 class EntryManager implements ContentManagerInterface
 {
     public function __construct(
+        private readonly LoggerInterface $logger,
         private readonly TagManager $tagManager,
         private readonly MentionManager $mentionManager,
         private readonly EntryCommentManager $entryCommentManager,
@@ -68,12 +70,14 @@ class EntryManager implements ContentManagerInterface
             throw new UserBannedException();
         }
 
+        $this->logger->debug('creating entry from dto');
         $entry = $this->factory->createFromDto($dto, $user);
 
         $entry->lang = $dto->lang;
         $entry->isAdult = $dto->isAdult || $entry->magazine->isAdult;
         $entry->slug = $this->slugger->slug($dto->title);
         $entry->image = $dto->image ? $this->imageRepository->find($dto->image->id) : null;
+        $this->logger->debug('setting image to {imageId}, dto was {dtoImageId}', ['imageId' => $entry->image?->getId() ?? 'none', 'dtoImageId' => $dto->image?->id ?? 'none']);
         if ($entry->image && !$entry->image->altText) {
             $entry->image->altText = $dto->imageAlt;
         }
@@ -168,7 +172,7 @@ class EntryManager implements ContentManagerInterface
         $this->entityManager->flush();
 
         if ($oldImage && $entry->image !== $oldImage) {
-            $this->bus->dispatch(new DeleteImageMessage($oldImage->filePath));
+            $this->bus->dispatch(new DeleteImageMessage($oldImage->getId()));
         }
 
         $this->dispatcher->dispatch(new EntryEditedEvent($entry));
@@ -212,7 +216,7 @@ class EntryManager implements ContentManagerInterface
     {
         $this->dispatcher->dispatch(new EntryBeforePurgeEvent($entry, $user));
 
-        $image = $entry->image?->filePath;
+        $image = $entry->image?->getId();
 
         $sort = new Criteria(null, ['createdAt' => Criteria::DESC]);
         foreach ($entry->comments->matching($sort) as $comment) {
@@ -259,7 +263,7 @@ class EntryManager implements ContentManagerInterface
 
     public function detachImage(Entry $entry): void
     {
-        $image = $entry->image->filePath;
+        $image = $entry->image->getId();
 
         $entry->image = null;
 

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -6,7 +6,6 @@ namespace App\Service;
 
 use App\Exception\CorruptedFileException;
 use App\Exception\ImageDownloadTooLargeException;
-use Exception;
 use League\Flysystem\FilesystemOperator;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
@@ -50,7 +49,7 @@ class ImageManager
     }
 
     /**
-     * @throws Exception if the file could not be found
+     * @throws \Exception if the file could not be found
      */
     public function store(string $source, string $filePath): bool
     {
@@ -66,7 +65,7 @@ class ImageManager
             $this->publicUploadsFilesystem->writeStream($filePath, $fh);
 
             if (!$this->publicUploadsFilesystem->has($filePath)) {
-                throw new Exception('File not found');
+                throw new \Exception('File not found');
             }
 
             return true;
@@ -121,7 +120,7 @@ class ImageManager
 
             $this->validate($tempFile);
             $this->logger->debug('downloaded file from {url}', ['url' => $url]);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             if ($fh && \is_resource($fh)) {
                 fclose($fh);
             }
@@ -189,7 +188,7 @@ class ImageManager
     {
         try {
             return $this->publicUploadsFilesystem->mimeType($image->filePath);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return 'none';
         }
     }

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -7,6 +7,7 @@ namespace App\Service;
 use App\Exception\CorruptedFileException;
 use App\Exception\ImageDownloadTooLargeException;
 use League\Flysystem\FilesystemOperator;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Mime\MimeTypesInterface;
 use Symfony\Component\Validator\Constraints\Image;
@@ -29,6 +30,7 @@ class ImageManager
         private readonly HttpClientInterface $httpClient,
         private readonly MimeTypesInterface $mimeTypeGuesser,
         private readonly ValidatorInterface $validator,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -46,6 +48,10 @@ class ImageManager
         return \in_array($mediaType, self::IMAGE_MIMETYPES);
     }
 
+    /**
+     * @throws \Exception                     if the file could not be found
+     * @throws ImageDownloadTooLargeException
+     */
     public function store(string $source, string $filePath): bool
     {
         $fh = fopen($source, 'rb');
@@ -64,8 +70,6 @@ class ImageManager
             }
 
             return true;
-        } catch (\Exception $e) {
-            throw new \Exception($e->getMessage());
         } finally {
             \is_resource($fh) and fclose($fh);
         }
@@ -103,18 +107,9 @@ class ImageManager
                 $url,
                 [
                     'timeout' => 5,
-                    'max_duration' => 5,
                     'headers' => [
                         'Accept' => implode(', ', array_diff(self::IMAGE_MIMETYPES, ['image/webp', 'image/avif'])),
                     ],
-                    'on_progress' => function (int $downloaded, int $downloadSize) {
-                        if (
-                            $downloaded > self::MAX_IMAGE_BYTES
-                            || $downloadSize > self::MAX_IMAGE_BYTES
-                        ) {
-                            throw new ImageDownloadTooLargeException();
-                        }
-                    },
                 ]
             );
 
@@ -125,11 +120,13 @@ class ImageManager
             fclose($fh);
 
             $this->validate($tempFile);
+            $this->logger->debug('downloaded file from {url}', ['url' => $url]);
         } catch (\Exception $e) {
             if ($fh && \is_resource($fh)) {
                 fclose($fh);
             }
             unlink($tempFile);
+            $this->logger->warning("couldn't download file from {url}", ['url' => $url]);
 
             return null;
         }
@@ -181,7 +178,11 @@ class ImageManager
             return null;
         }
 
-        return $this->storageUrl.'/'.$image->filePath;
+        if ($image->filePath) {
+            return $this->storageUrl.'/'.$image->filePath;
+        }
+
+        return $image->sourceUrl;
     }
 
     public function getMimetype(\App\Entity\Image $image): string

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -6,6 +6,7 @@ namespace App\Service;
 
 use App\Exception\CorruptedFileException;
 use App\Exception\ImageDownloadTooLargeException;
+use Exception;
 use League\Flysystem\FilesystemOperator;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
@@ -49,8 +50,7 @@ class ImageManager
     }
 
     /**
-     * @throws \Exception                     if the file could not be found
-     * @throws ImageDownloadTooLargeException
+     * @throws Exception if the file could not be found
      */
     public function store(string $source, string $filePath): bool
     {
@@ -66,7 +66,7 @@ class ImageManager
             $this->publicUploadsFilesystem->writeStream($filePath, $fh);
 
             if (!$this->publicUploadsFilesystem->has($filePath)) {
-                throw new \Exception('File not found');
+                throw new Exception('File not found');
             }
 
             return true;
@@ -121,7 +121,7 @@ class ImageManager
 
             $this->validate($tempFile);
             $this->logger->debug('downloaded file from {url}', ['url' => $url]);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             if ($fh && \is_resource($fh)) {
                 fclose($fh);
             }
@@ -189,7 +189,7 @@ class ImageManager
     {
         try {
             return $this->publicUploadsFilesystem->mimeType($image->filePath);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             return 'none';
         }
     }

--- a/src/Service/MagazineManager.php
+++ b/src/Service/MagazineManager.php
@@ -295,7 +295,7 @@ class MagazineManager
             return;
         }
 
-        $image = $magazine->icon->filePath;
+        $image = $magazine->icon->getId();
 
         $magazine->icon = null;
 

--- a/src/Service/PostCommentManager.php
+++ b/src/Service/PostCommentManager.php
@@ -111,7 +111,7 @@ class PostCommentManager implements ContentManagerInterface
         $this->entityManager->flush();
 
         if ($oldImage && $comment->image !== $oldImage) {
-            $this->bus->dispatch(new DeleteImageMessage($oldImage->filePath));
+            $this->bus->dispatch(new DeleteImageMessage($oldImage->getId()));
         }
 
         $this->dispatcher->dispatch(new PostCommentEditedEvent($comment));
@@ -156,7 +156,7 @@ class PostCommentManager implements ContentManagerInterface
         $this->dispatcher->dispatch(new PostCommentBeforePurgeEvent($comment, $user));
 
         $magazine = $comment->post->magazine;
-        $image = $comment->image?->filePath;
+        $image = $comment->image?->getId();
         $comment->post->removeComment($comment);
         $this->entityManager->remove($comment);
         $this->entityManager->flush();
@@ -194,7 +194,7 @@ class PostCommentManager implements ContentManagerInterface
 
     public function detachImage(PostComment $comment): void
     {
-        $image = $comment->image->filePath;
+        $image = $comment->image->getId();
 
         $comment->image = null;
 

--- a/src/Service/UserManager.php
+++ b/src/Service/UserManager.php
@@ -214,11 +214,11 @@ readonly class UserManager
         }
 
         if ($oldAvatar && $user->avatar !== $oldAvatar) {
-            $this->bus->dispatch(new DeleteImageMessage($oldAvatar->filePath));
+            $this->bus->dispatch(new DeleteImageMessage($oldAvatar->getId()));
         }
 
         if ($oldCover && $user->cover !== $oldCover) {
-            $this->bus->dispatch(new DeleteImageMessage($oldCover->filePath));
+            $this->bus->dispatch(new DeleteImageMessage($oldCover->getId()));
         }
 
         if ($mailUpdated) {
@@ -282,7 +282,7 @@ readonly class UserManager
             return;
         }
 
-        $image = $user->avatar->filePath;
+        $image = $user->avatar->getId();
 
         $user->avatar = null;
 
@@ -298,7 +298,7 @@ readonly class UserManager
             return;
         }
 
-        $image = $user->cover->filePath;
+        $image = $user->cover->getId();
 
         $user->cover = null;
 

--- a/src/Twig/Runtime/MediaExtensionRuntime.php
+++ b/src/Twig/Runtime/MediaExtensionRuntime.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Twig\Runtime;
 
+use App\Entity\Image;
 use Twig\Extension\RuntimeExtensionInterface;
 
 class MediaExtensionRuntime implements RuntimeExtensionInterface
@@ -13,8 +14,12 @@ class MediaExtensionRuntime implements RuntimeExtensionInterface
     ) {
     }
 
-    public function getPublicPath(string $path): string
+    public function getPublicPath(Image $image): string
     {
-        return $this->storageUrl.'/'.$path;
+        if ($image->filePath) {
+            return $this->storageUrl.'/'.$image->filePath;
+        }
+
+        return $image->sourceUrl;
     }
 }

--- a/templates/components/_figure_entry.html.twig
+++ b/templates/components/_figure_entry.html.twig
@@ -5,7 +5,7 @@
     {% set lightbox_alt_id = 'thumb-alt-%s-%s'|format(entry.id, image.id) %}
 
     {% if type is same as 'image' %}
-        {% set route = is_single ? uploaded_asset(image.filePath) : entry_url(entry) %}
+        {% set route = is_single ? uploaded_asset(image) : entry_url(entry) %}
     {% elseif type is same as 'link' %}
         {% set route = is_single ? entry.url : entry_url(entry) %}
     {% endif %}
@@ -35,7 +35,7 @@
            data-description="{{ is_single_image and image.altText ? '.'~lightbox_alt_id : '' }}">
             <img class="thumb-subject"
                  loading="lazy"
-                 src="{{ asset(image.filePath)|imagine_filter('entry_thumb') }}"
+                 src="{{ image.filePath ? asset(image.filePath)|imagine_filter('entry_thumb') : image.sourceUrl }}"
                  alt="{{ image.altText }}">
         </a>
         {% if entry.isAdult %}

--- a/templates/components/_figure_image.html.twig
+++ b/templates/components/_figure_image.html.twig
@@ -11,11 +11,11 @@
         <div class="figure-container">
             <div class="figure-thumb">
                 <a
-                    href="{{ uploaded_asset(image.filePath) }}"
+                    href="{{ uploaded_asset(image) }}"
                     class="thumb"
                     data-description="{{ image.altText ? '.'~lightbox_alt_id : ''}}">
                     <img loading="lazy"
-                         src="{{ asset(image.filePath)|imagine_filter(thumb_filter) }}"
+                         src="{{ image.filePath ? asset(image.filePath)|imagine_filter(thumb_filter) : image.sourceUrl }}"
                          alt="{{ image.altText }}">
                 </a>
             </div>

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -137,7 +137,7 @@
                             </li>
                         {% endif %}
                         {% if entry.hasEmbed %}
-                            {% set image = entry.image ? uploaded_asset(entry.image) : '' %}
+                            {% set image = entry.image ? uploaded_asset(entry.image) : null %}
                             <li>
                                 <button class="show-preview"
                                         data-action="preview#show"

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -137,12 +137,12 @@
                             </li>
                         {% endif %}
                         {% if entry.hasEmbed %}
-                            {% set image = entry.image ? uploaded_asset(entry.image.filePath) : '' %}
+                            {% set image = entry.image ? uploaded_asset(entry.image) : '' %}
                             <li>
                                 <button class="show-preview"
                                         data-action="preview#show"
                                         aria-label="{{ 'preview'|trans }}"
-                                        data-preview-url-param="{{ entry.url ?? image }}"
+                                        data-preview-url-param="{{ image ?? entry.url }}"
                                         data-preview-ratio-param="{{ entry.domain and entry.domain.shouldRatio ? true : false }}">
                                     <i class="fa-solid fa-photo-film" aria-hidden="true"></i>
                                 </button>

--- a/templates/components/entry_cross.html.twig
+++ b/templates/components/entry_cross.html.twig
@@ -36,12 +36,12 @@
                         </li>
                     {% endif %}
                     {% if entry.hasEmbed %}
-                        {% set image = entry.image ? uploaded_asset(entry.image.filePath) : '' %}
+                        {% set image = entry.image ? uploaded_asset(entry.image) : '' %}
                         <li>
                             <button class="show-preview"
                                     data-action="preview#show"
                                     aria-label="{{ 'preview'|trans }}"
-                                    data-preview-url-param="{{ entry.url ?? image }}"
+                                    data-preview-url-param="{{ image ?? entry.url }}"
                                     data-preview-ratio-param="{{ entry.domain and entry.domain.shouldRatio ? true : false }}">
                                 <i class="fa-solid fa-photo-film" aria-hidden="true"></i>
                             </button>

--- a/templates/components/magazine_box.html.twig
+++ b/templates/components/magazine_box.html.twig
@@ -12,7 +12,7 @@
             <figure>
                 <img class="image-inline {{ magazine.isAdult ? 'image-adult' : '' }}"
                      loading="lazy"
-                     src="{{ asset(computed.magazine.icon.filePath) | imagine_filter('post_thumb') }}"
+                     src="{{ computed.magazine.icon.filePath ? (asset(computed.magazine.icon.filePath)|imagine_filter('post_thumb')) : computed.magazine.icon.sourceUrl }}"
                      {% if magazine.isAdult %}data-controller="thumb" data-action="mouseover->thumb#adult_image_hover mouseout->thumb#adult_image_hover_out"{% endif %}
                      alt="{{ computed.magazine.name ~ ' ' ~ 'icon'|trans|lower }}" width="260">
             </figure>

--- a/templates/components/magazine_inline.html.twig
+++ b/templates/components/magazine_inline.html.twig
@@ -7,7 +7,7 @@
              loading="lazy"
              style="max-width: 30px; max-height: 30px;"
              {% if magazine.isAdult %}data-controller="thumb" data-action="mouseover->thumb#adult_image_hover mouseout->thumb#adult_image_hover_out"{% endif %}
-             src="{{ asset(magazine.icon.filePath) | imagine_filter('avatar_thumb') }}"
+             src="{{ magazine.icon.filePath ? (asset(magazine.icon.filePath)|imagine_filter('avatar_thumb')) : magazine.icon.sourceUrl }}"
              alt="{{ magazine.name ~ ' ' ~ 'icon'|trans|lower }}">
     {% endif %}
     {% if fullName %}

--- a/templates/components/related_entries.html.twig
+++ b/templates/components/related_entries.html.twig
@@ -7,7 +7,7 @@
                     <div class="row">
                         {% if entry.image %}
                             <img loading="lazy"
-                                src="{{ asset(entry.image.filePath) | imagine_filter('entry_thumb') }}"
+                                src="{{ entry.image.filePath ? (asset(entry.image.filePath)|imagine_filter('entry_thumb')) : entry.image.sourceUrl }}"
                                 alt="{{ entry.image.alt|default('') }}">
                         {% endif %}
                         <blockquote class="content">

--- a/templates/components/related_posts.html.twig
+++ b/templates/components/related_posts.html.twig
@@ -7,9 +7,8 @@
                     <div class="row">
                         {% if post.image %}
                                 <img loading="lazy"
-                                    src="{{ asset(post.image.filePath) | imagine_filter('post_thumb') }}"
+                                    src="{{ post.image.filePath ? (asset(post.image.filePath)|imagine_filter('post_thumb')) : post.image.sourceUrl }}"
                                     alt="{{ post.image.alt|default('') }}">
-                            </a>
                         {% endif %}
                         {% if post.body %}
                             <blockquote class="content">

--- a/templates/components/user_avatar.html.twig
+++ b/templates/components/user_avatar.html.twig
@@ -8,7 +8,7 @@
                  loading="lazy"
                  width="{{ width }}" height="{{ height }}"
                  style="max-width: {{ width }}px; max-height: {{ height }}px;"
-                 src="{{ asset(user.avatar.filePath) | imagine_filter('avatar_thumb') }}"
+                 src="{{ user.avatar.filePath ? (asset(user.avatar.filePath)|imagine_filter('avatar_thumb')) : user.avatar.sourceUrl }}"
                  alt="{{ user.username ~' '~ 'avatar'|trans|lower }}">
         {% else %}
             <div class="no-avatar"></div>

--- a/templates/components/user_box.html.twig
+++ b/templates/components/user_box.html.twig
@@ -8,7 +8,7 @@
                  height="220"
                  width="100%"
                  loading="lazy"
-                 src="{{ asset(user.cover.filePath)|imagine_filter('user_cover') }}"
+                 src="{{ user.cover.filePath ? (asset(user.cover.filePath)|imagine_filter('user_cover')) : user.cover.sourceUrl }}"
                  alt="{{ user.username ~' '~ 'cover'|trans|lower  }}">
           {% if app.user is same as user and is_route_name_starts_with('user') and not is_route_name_contains('settings') %}
             </a>

--- a/templates/components/user_image_component.html.twig
+++ b/templates/components/user_image_component.html.twig
@@ -3,7 +3,7 @@
       class="user-avatar image-inline"
       width="20" height="20"
       loading="lazy"
-      src="{{ asset(user.avatar.filePath) | imagine_filter('avatar_thumb') }}"
+      src="{{ user.avatar.filePath ? (asset(user.avatar.filePath)|imagine_filter('avatar_thumb')) : user.avatar.sourceUrl }}"
       alt="{{ user.username ~ ' avatar' }}"
   >
 {% endif %}

--- a/templates/components/user_inline.html.twig
+++ b/templates/components/user_inline.html.twig
@@ -7,7 +7,7 @@
         <img class="image-inline"
              width="30" height="30"
              loading="lazy"
-             src="{{ asset(user.avatar.filePath ?? "") | imagine_filter('avatar_thumb') }}"
+             src="{{ user.avatar.filePath ? (asset(user.avatar.filePath) | imagine_filter('avatar_thumb')) : user.avatar.sourceUrl }}"
              alt="{{ user.username ~' '~ 'avatar'|trans|lower }}">
     {% endif %}
     {{ user.apPreferredUsername ?? user.username|username -}}

--- a/templates/components/user_inline.html.twig
+++ b/templates/components/user_inline.html.twig
@@ -7,7 +7,7 @@
         <img class="image-inline"
              width="30" height="30"
              loading="lazy"
-             src="{{ asset(user.avatar.filePath) | imagine_filter('avatar_thumb') }}"
+             src="{{ asset(user.avatar.filePath ?? "") | imagine_filter('avatar_thumb') }}"
              alt="{{ user.username ~' '~ 'avatar'|trans|lower }}">
     {% endif %}
     {{ user.apPreferredUsername ?? user.username|username -}}

--- a/templates/entry/_form_article.html.twig
+++ b/templates/entry/_form_article.html.twig
@@ -34,7 +34,7 @@
         {% if hasImage %}
             <img width="40"
                  height="40"
-                 src="{{ asset(entry.image.filePath) |imagine_filter('entry_thumb') }}"
+                 src="{{ entry.image.filePath ? (asset(entry.image.filePath)|imagine_filter('entry_thumb')) : entry.image.sourceUrl }}"
                  alt="{{ entry.image.altText }}">
             <button formaction="{{ path('entry_image_delete', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}"
                     class="btn-link"

--- a/templates/entry/_form_image.html.twig
+++ b/templates/entry/_form_image.html.twig
@@ -24,7 +24,7 @@
         {% if hasImage %}
             <img width="40"
                  height="40"
-                 src="{{ asset(entry.image.filePath) |imagine_filter('entry_thumb') }}"
+                 src="{{ entry.image.filePath ? (asset(entry.image.filePath)|imagine_filter('entry_thumb')) : entry.image.sourceUrl }}"
                  alt="{{ entry.image.altText }}">
             <button formaction="{{ path('entry_image_delete', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}"
                     class="btn-link"

--- a/templates/entry/_form_link.html.twig
+++ b/templates/entry/_form_link.html.twig
@@ -44,7 +44,7 @@
         {% if hasImage %}
             <img width="40"
                  height="40"
-                 src="{{ asset(entry.image.filePath) |imagine_filter('entry_thumb') }}"
+                 src="{{ entry.image.filePath ? (asset(entry.image.filePath)|imagine_filter('entry_thumb')) : entry.image.sourceUrl }}"
                  alt="{{ entry.image.altText }}">
             <button formaction="{{ path('entry_image_delete', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}"
                     class="btn-link"

--- a/templates/entry/_info.html.twig
+++ b/templates/entry/_info.html.twig
@@ -6,7 +6,7 @@
                 <img class="image-inline"
                      width="100" height="100"
                      loading="lazy"
-                     src="{{ asset(entry.user.avatar.filePath) | imagine_filter('avatar_thumb') }}"
+                     src="{{ entry.user.avatar.filePath ? (asset(entry.user.avatar.filePath)|imagine_filter('avatar_thumb')) : entry.user.avatar.sourceUrl }}"
                      alt="{{ entry.user.username ~' '~ 'avatar'|trans|lower }}">
             </figure>
         {% endif %}

--- a/templates/entry/comment/_form_comment.html.twig
+++ b/templates/entry/comment/_form_comment.html.twig
@@ -27,7 +27,7 @@
         {% if hasImage %}
             <img width="40"
                  height="40"
-                 src="{{ asset(comment.image.filePath) |imagine_filter('post_thumb') }}"
+                 src="{{ comment.image.filePath ? (asset(comment.image.filePath)|imagine_filter('post_thumb')) : comment.image.sourceUrl }}"
                  alt="{{ comment.image.altText }}">
             <button formaction="{{ path('entry_comment_image_delete', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id}) }}"
                     class="btn-link"

--- a/templates/entry/front.html.twig
+++ b/templates/entry/front.html.twig
@@ -26,7 +26,7 @@
 
 {% block image %}
     {%- if magazine is defined and magazine and magazine.icon -%}
-        {{- uploaded_asset(magazine.icon.filePath) -}}
+        {{- uploaded_asset(magazine.icon) -}}
     {%- else -%}
         {{- parent() -}}
     {%- endif -%}

--- a/templates/entry/single.html.twig
+++ b/templates/entry/single.html.twig
@@ -10,9 +10,9 @@
 
 {% block image %}
     {%- if entry.image -%}
-        {{- uploaded_asset(entry.image.filePath) -}}
+        {{- uploaded_asset(entry.image) -}}
     {%- elseif entry.magazine.icon -%}
-        {{- uploaded_asset(entry.magazine.icon.filePath) -}}
+        {{- uploaded_asset(entry.magazine.icon) -}}
     {%- else -%}
         {{- parent() -}}
     {%- endif -%}

--- a/templates/layout/sidebar_subscriptions.html.twig
+++ b/templates/layout/sidebar_subscriptions.html.twig
@@ -60,7 +60,7 @@
 
                             {% if magazine.icon %}
                                 <img loading="lazy"
-                                    src="{{ asset(magazine.icon.filePath) | imagine_filter('avatar_thumb') }}"
+                                    src="{{ magazine.icon.filePath ? (asset(magazine.icon.filePath)|imagine_filter('avatar_thumb')) : magazine.icon.sourceUrl }}"
                                     alt="{{ magazine.name }}'s icon"
                                     class="{{ html_classes('image-inline', 'magazine-subscription-avatar', { 'onlyMobile': app.request.cookies.get(KBIN_SUBSCRIPTIONS_SHOW_MAGAZINE_ICON) is same as V_FALSE }) }}" />
                             {% else %}

--- a/templates/magazine/_list.html.twig
+++ b/templates/magazine/_list.html.twig
@@ -15,7 +15,7 @@
                                 <figure>
                                     <img width="32" height="32"
                                          class="image-inline {{ magazine.isAdult ? 'image-adult' : '' }}"
-                                         src="{{ asset(magazine.icon.filePath) | imagine_filter('avatar_thumb') }}"
+                                         src="{{ magazine.icon.filePath ? (asset(magazine.icon.filePath)|imagine_filter('avatar_thumb')) : magazine.icon.sourceUrl }}"
                                          {% if magazine.isAdult %}data-controller="thumb" data-action="mouseover->thumb#adult_image_hover mouseout->thumb#adult_image_hover_out"{% endif %}
                                          alt="{{ magazine.name ~' '~ 'icon'|trans|lower }}">
                                 </figure>

--- a/templates/magazine/_moderators_sidebar.html.twig
+++ b/templates/magazine/_moderators_sidebar.html.twig
@@ -19,7 +19,7 @@
                            width="30"
                            height="30"
                            loading="lazy"
-                           src="{{ asset(moderator.user.avatar.filePath) | imagine_filter('avatar_thumb') }}"
+                           src="{{ moderator.user.avatar.filePath ? (asset(moderator.user.avatar.filePath)|imagine_filter('avatar_thumb')) : moderator.user.avatar.sourceUrl }}"
                            alt="{{ moderator.user.username ~ ' ' ~ 'avatar'|trans|lower }}">
                     {% endif %}
                     <a href="{{ path('user_overview', {username: moderator.user.username}) }}"

--- a/templates/post/_form_post.html.twig
+++ b/templates/post/_form_post.html.twig
@@ -38,7 +38,7 @@
         {% if hasImage %}
             <img width="40"
                  height="40"
-                 src="{{ asset(post.image.filePath) |imagine_filter('post_thumb') }}"
+                 src="{{ post.image.filePath ? (asset(post.image.filePath)|imagine_filter('post_thumb')) : post.image.sourceUrl }}"
                  alt="{{ post.image.altText }}">
             <button formaction="{{ path('post_image_delete', {magazine_name: post.magazine.name, post_id: post.id}) }}"
                     class="btn-link"

--- a/templates/post/_info.html.twig
+++ b/templates/post/_info.html.twig
@@ -6,7 +6,7 @@
                 <img class="image-inline"
                      width="100" height="100"
                      loading="lazy"
-                     src="{{ asset(post.user.avatar.filePath) | imagine_filter('avatar_thumb') }}"
+                     src="{{ post.user.avatar.filePath ? (asset(post.user.avatar.filePath)|imagine_filter('avatar_thumb')) : post.user.avatar.sourceUrl }}"
                      alt="{{ post.user.username ~' '~ 'avatar'|trans|lower }}">
             </figure>
         {% endif %}

--- a/templates/post/comment/_form_comment.html.twig
+++ b/templates/post/comment/_form_comment.html.twig
@@ -30,7 +30,7 @@
         {% if hasImage %}
             <img width="40"
                  height="40"
-                 src="{{ asset(comment.image.filePath) |imagine_filter('post_thumb') }}"
+                 src="{{ comment.image.filePath ? (asset(comment.image.filePath)|imagine_filter('post_thumb')) : comment.image.sourceUrl }}"
                  alt="{{ comment.image.altText }}">
             <button formaction="{{ path('post_comment_image_delete', {magazine_name: comment.magazine.name, post_id: comment.post.id, comment_id: comment.id}) }}"
                     class="btn-link"

--- a/templates/post/front.html.twig
+++ b/templates/post/front.html.twig
@@ -26,7 +26,7 @@
 
 {% block image %}
     {%- if magazine is defined and magazine and magazine.icon -%}
-        {{- uploaded_asset(magazine.icon.filePath) -}}
+        {{- uploaded_asset(magazine.icon) -}}
     {%- else -%}
         {{- parent() -}}
     {%- endif -%}

--- a/templates/post/single.html.twig
+++ b/templates/post/single.html.twig
@@ -8,9 +8,9 @@
 
 {% block image %}
     {%- if post.image -%}
-        {{- uploaded_asset(post.image.filePath) -}}
+        {{- uploaded_asset(post.image) -}}
     {%- elseif post.magazine.icon -%}
-        {{- uploaded_asset(post.magazine.icon.filePath) -}}
+        {{- uploaded_asset(post.magazine.icon) -}}
     {%- else -%}
         {{- parent() -}}
     {%- endif -%}

--- a/templates/user/_info.html.twig
+++ b/templates/user/_info.html.twig
@@ -7,7 +7,7 @@
                     <img class="image-inline"
                          width="100" height="100"
                          loading="lazy"
-                         src="{{ asset(user.avatar.filePath) | imagine_filter('avatar_thumb') }}"
+                         src="{{ user.avatar.filePath ? (asset(user.avatar.filePath)|imagine_filter('avatar_thumb')) : user.avatar.sourceUrl }}"
                          alt="{{ user.username ~' '~ 'avatar'|trans|lower }}">
                 </figure>
             {% endif %}

--- a/templates/user/_list.html.twig
+++ b/templates/user/_list.html.twig
@@ -16,7 +16,7 @@
                                     <img class="image-inline"
                                          width="32" height="32"
                                          loading="lazy"
-                                         src="{{ asset(user.avatar.filePath) | imagine_filter('avatar_thumb') }}"
+                                         src="{{ user.avatar.filePath ? (asset(user.avatar.filePath)|imagine_filter('avatar_thumb')) : user.avatar.sourceUrl }}"
                                          alt="{{ user.username ~' '~ 'avatar'|trans|lower }}">
                                 </figure>
                             {% endif %}

--- a/templates/user/consent.html.twig
+++ b/templates/user/consent.html.twig
@@ -22,7 +22,7 @@
                     <figure>
                         <img class="thumb-subject oauth-client-logo"
                                 loading="lazy"
-                                src="{{ asset(image.filePath) |imagine_filter('entry_thumb') }}"
+                                src="{{ image.filePath ? (asset(image.filePath)|imagine_filter('entry_thumb')) : image.sourceUrl }}"
                                 alt="{{ image.altText }}">
                     </figure>
                 {% endif %}


### PR DESCRIPTION
- when an attached image is too large, safe a reverence (`filePath` -> `null`) instead of discarding the image.
- `DeleteImageMessage` now uses the id as parameter
- fix `sourceUrl` being overwritten to `null` by `AttachEntryEmbedHandler`
- adjust twig function `uploaded_asset` (`MediaExtensionRuntime.getPublicPath`) to use the source url if there is no file path
- fix preview button using the entry url before the stored image url
- improve the exception logging by not catching any exception in `ImageManager.store` and just rethrowing it. That removed the exception type as a possible indicator as to what went wrong

This fixes #498 and #457 