### PR TITLE
Fix error on entries with an empty body

### DIFF
--- a/src/Service/ActivityPub/ApObjectExtractor.php
+++ b/src/Service/ActivityPub/ApObjectExtractor.php
@@ -33,11 +33,13 @@ class ApObjectExtractor
             // markdown source isn't found but object's content is specified
             // to be markdown, also return them
             return $content;
-        } else {
+        } elseif ($content && \is_string($content)) {
             // assuming default content mediaType of text/html,
             // returning html -> markdown conversion of content
             return $this->markdownConverter->convert($content);
         }
+
+        return null;
     }
 
     public function getExternalMediaBody(array $object): ?string


### PR DESCRIPTION
before this fix you would get errors like this on `CreateMessage`s
> (Symfony\\Component\\Messenger\\Exception\\HandlerFailedException(code: 0): Handling \"App\\Message\\ActivityPub\\Inbox\\CreateMessage\" failed: App\\Service\\ActivityPub\\MarkdownConverter::convert(): Argument #1 ($value) must be of type string, null given, called in /var/www/mbin/src/Service/ActivityPub/ApObjectExtractor.php on line 39 at /var/www/mbin/vendor/symfony/messenger/Middleware/HandleMessageMiddleware.php:124)
(TypeError(code: 0): App\\Service\\ActivityPub\\MarkdownConverter::convert(): Argument #1 ($value) must be of type string, null given, called in /var/www/mbin/src/Service/ActivityPub/ApObjectExtractor.php on line 39 at /var/www/mbin/src/Service/ActivityPub/MarkdownConverter.php:22)

e.g. when posting a link without a description (without a body). Since this code is able to handle null returns, we can just do that on a null body.

Steps to reproduce:
1. Click "Add a new link"
2. insert the link
3. publish it
4. You will not see that post on another mbin instance since it creates the error when handling the create message for it