### PR TITLE
use title instead of body for federated entry summary

### DIFF
--- a/src/Factory/ActivityPub/EntryPageFactory.php
+++ b/src/Factory/ActivityPub/EntryPageFactory.php
@@ -64,7 +64,7 @@ class EntryPageFactory
                 $entry->body,
                 [MarkdownConverter::RENDER_TARGET => RenderTarget::ActivityPub]
             ) : null,
-            'summary' => $entry->getShortDesc().' '.implode(
+            'summary' => $entry->getShortTitle().' '.implode(
                 ' ',
                 array_map(fn ($val) => '#'.$val, $tags)
             ),


### PR DESCRIPTION
changed entries summary in AP representation to draw from title instead from body, this way the title will be shown along with 'show more' button in most of other fediverse software, which should feel more intuitive and avoids repeating the body twice

this is what it looks like, current state on the left (Jerry's post), proposed patch on the right:

![image](https://github.com/MbinOrg/mbin/assets/20770492/869727ca-506a-443c-9f9b-e6a7609de7ce)
