### PR TITLE
move service worker registration into main app bundle

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -4,5 +4,11 @@ import './styles/app.scss';
 import './utils/popover';
 import '@github/markdown-toolbar-element'
 
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', function() {
+        navigator.serviceWorker.register('/sw.js');
+    });
+}
+
 // start the Stimulus application
 Application.start()

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -34,13 +34,6 @@
         {#        <script type="application/json" id="mercure-url">{{ mercure()|raw }}</script> #}
         <script type="application/json" id="mercure-url">{{- 'https://' ~ kbin_domain() ~ '/.well-known/mercure' }}</script>
         {% endif %}
-        <script>
-            if ('serviceWorker' in navigator) {
-                navigator.serviceWorker.register(
-                    '/sw.js'
-                );
-            }
-        </script>
     {% endblock %}
 </head>
 <body class="{{ html_classes(app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_THEME'))


### PR DESCRIPTION
moved service worker registration into main app bundle, and also deferred the service worker registration a bit as recommended by https://web.dev/articles/service-workers-registration#improving_the_boilerplate, though our service worker doesn't seems to be doing anything much.

this removes 1 inline script block from base template