### PR TITLE
adjust tag matching to better handle some eastern scripts

### DIFF
--- a/src/Utils/RegPatterns.php
+++ b/src/Utils/RegPatterns.php
@@ -12,6 +12,6 @@ class RegPatterns
     public const LOCAL_USER = '/^@[a-zA-Z0-9_-]{1,30}\b/';
     public const AP_MAGAZINE = '/^(!\w{2,25})(@)(([a-z0-9|-]+\.)*[a-z0-9|-]+\.[a-z]+)/';
     public const AP_USER = '/^(@\w{1,30})(@)(([a-z0-9|-]+\.)*[a-z0-9|-]+\.[a-z]+)/';
-    public const LOCAL_TAG_REGEX = '\B#(\w{2,45})';
+    public const LOCAL_TAG_REGEX = '\B#([\w][\w\p{M}·・]+)';
     public const LOCAL_TAG = '/'.self::LOCAL_TAG_REGEX.'/u';
 }

--- a/tests/Unit/Service/TagManagerTest.php
+++ b/tests/Unit/Service/TagManagerTest.php
@@ -32,6 +32,12 @@ class TagManagerTest extends TestCase
             ['Teraz #zażółć #gęślą #jaźń', ['zazolc', 'gesla', 'jazn']],
             ['#Göbeklitepe #çarpıcı #eğlence #şarkı #ören', ['gobeklitepe', 'carpici', 'eglence', 'sarki', 'oren']],
             ['#Viva #España #senõr', ['viva', 'espana', 'senor']],
+            ['#イラスト # #一次創作', ['イラスト', '一次創作']],
+            ['#ทำตัวไม่ถูกเลยเรา', ['ทำตัวไม่ถูกเลยเรา']],
+            ['#ไกด์ช้างม่วง #ทวิตล่ม', ['ไกด์ช้างม่วง', 'ทวิตล่ม']],
+            ['#Ｓｙｎｔｈｗａｖｅ', ['synthwave']],
+            ['#ｼｰｻｲﾄﾞﾗｲﾅｰ', ['シーサイドライナー']],
+            ['#ぼっち・ざ・ろっく', ['ぼっち・ざ・ろっく']],
         ];
     }
 }


### PR DESCRIPTION
the current hashtags matching and normalizing works fine with latin scripts, but it often breaks when having to deal with e.g. Japanese hashtags, which can results in hashtags not being extracted properly or worse, the posts being dropped entirely

the hashtags matching has beed extended to allow for more characters to match, and normalization process has been adjusted to better handle nonlatin script (e.g. Japanese, Thai)

most of the process is a recreation of Mastodon hastags normalization process (see https://docs.joinmastodon.org/spec/activitypub/#Hashtag and the [linked normalizer](https://github.com/mastodon/mastodon/blob/main/app/lib/hashtag_normalizer.rb))