### PR TITLE
add remote url image detection for incoming images

### DIFF
--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -662,10 +662,15 @@ class ActivityPubManager
             return false;
         }
 
-        // attachment is either:
-        // - has `mediaType` field and is a recognized image types
-        // - image url looks like a link to image
+        /*
+         * attachment is either:
+         * - has `mediaType` field and is a recognized image types
+         * - image url looks like a link to image
+         * - detected mime type from the image file is recognized image type
+         *   (yes it'll download the file to inspect, hope this doesn't happen too often)
+         */
         return (!empty($object['mediaType']) && ImageManager::isImageType($object['mediaType']))
-            || ImageManager::isImageUrl($object['url']);
+            || ImageManager::isImageUrl($object['url'])
+            || $this->imageManager->isRemoteImage($object['url']);
     }
 }

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -46,6 +46,25 @@ class ImageManager
         return \in_array($mediaType, self::IMAGE_MIMETYPES);
     }
 
+    public function isRemoteImage(string $url): bool
+    {
+        $isImage = false;
+
+        if ($tempFile = $this->download($url)) {
+            try {
+                if ($mimeDetected = $this->mimeTypeGuesser->guessMimeType($tempFile)) {
+                    $isImage = self::isImageType($mimeDetected);
+                }
+            } catch (\Exception $e) {
+                // don't do anything, wait for clean up and return false
+            } finally {
+                unlink($tempFile);
+            }
+        }
+
+        return $isImage;
+    }
+
     public function store(string $source, string $filePath): bool
     {
         $fh = fopen($source, 'rb');


### PR DESCRIPTION
adjust incoming image detection to also try and detect if the given url leads to an image by downloading and inspecting it with symfony mime type guesser.

because sometimes a valid url to image doesn't end with image extension and the path is mostly generated (e.g. uuid filename), in such case there's no good way to check if it's actually an image besides actually inspecting the contents

this can be a relatively expensive operation and I can only hope that most of the url can be detected by preceding checks, and that this check doesn't get called too often