### PR TITLE
Remove route for down votes and make it a span

### DIFF
--- a/config/kbin_routes/entry.yaml
+++ b/config/kbin_routes/entry.yaml
@@ -49,7 +49,7 @@ entry_comment_image_delete:
 entry_comment_voters:
   controller: App\Controller\Entry\Comment\EntryCommentVotersController
   defaults: { slug: -, }
-  requirements: { type: 'up|down' }
+  requirements: { type: 'up' }
   path: /m/{magazine_name}/t/{entry_id}/{slug}/comment/{comment_id}/votes/{type}
   methods: [ GET ]
 
@@ -200,7 +200,7 @@ entry_pin:
 entry_voters:
   controller: App\Controller\Entry\EntryVotersController
   defaults: { slug: -, sortBy: hot }
-  requirements: { type: 'up|down' }
+  requirements: { type: 'up' }
   path: /m/{magazine_name}/t/{entry_id}/{slug}/votes/{type}
   methods: [ GET ]
 

--- a/templates/entry/_options_activity.html.twig
+++ b/templates/entry/_options_activity.html.twig
@@ -10,16 +10,13 @@
             </a>
         </li>
         <li>
-            <a href="{{ entry_voters_url(entry, 'down') }}"
-               class="{{ html_classes({'active': is_route_name('entry_voters') and route_has_param('type', 'down')}) }}">
-                {{ 'down_votes'|trans }} ({{ entry.countDownVotes }})
-            </a>
-        </li>
-        <li>
             <a href="{{ entry_favourites_url(entry) }}"
                class="{{ html_classes({'active': is_route_name('entry_fav')}) }}">
                 {{ 'favourites'|trans }} ({{ entry.favouriteCount }})
             </a>
+        </li>
+        <li>
+            <span>{{ 'down_votes'|trans }} ({{ entry.countDownVotes }})</span>
         </li>
     </menu>
 </aside>

--- a/templates/entry/comment/_options_activity.html.twig
+++ b/templates/entry/comment/_options_activity.html.twig
@@ -10,16 +10,13 @@
             </a>
         </li>
         <li>
-            <a href="{{ entry_comment_voters_url(comment, 'down') }}"
-               class="{{ html_classes({'active': is_route_name('entry_comment_voters') and route_has_param('type', 'down')}) }}">
-                {{ 'down_votes'|trans }} ({{ comment.countDownVotes }})
-            </a>
-        </li>
-        <li>
             <a href="{{ entry_comment_favourites_url(comment) }}"
                class="{{ html_classes({'active': is_route_name('entry_comment_favourites')}) }}">
                 {{ 'favourites'|trans }} ({{ comment.favouriteCount }})
             </a>
+        </li>
+        <li>
+            <span>{{ 'down_votes'|trans }} ({{ comment.countDownVotes }})</span>
         </li>
     </menu>
 </aside>


### PR DESCRIPTION
As discussed in #513 we remove the ability to view who has down voted a post in the activity tab. You can still see how many down votes there are, it just is not a link anymore that leads to a page where you can see who down voted