### PR TITLE
slightly fix object body extraction on set but empty body

### DIFF
--- a/src/Service/ActivityPub/ApObjectExtractor.php
+++ b/src/Service/ActivityPub/ApObjectExtractor.php
@@ -22,7 +22,7 @@ class ApObjectExtractor
         $source = $object['source'] ?? null;
 
         // object has no content nor source to extract body from
-        if (empty($content) && empty($source)) {
+        if (null === $content && null === $source) {
             return null;
         }
 
@@ -39,7 +39,7 @@ class ApObjectExtractor
             return $this->markdownConverter->convert($content);
         }
 
-        return null;
+        return '';
     }
 
     public function getExternalMediaBody(array $object): ?string


### PR DESCRIPTION
fix the object markdown body extraction method to return empty body `''` if object's content properties is set but to an empty string

the old body extracting condition could cause comments with empty body (but may have image attached) to be silently discarded