### PR TITLE
Set BaseEntityAutocompleteType with Ajax Form

### DIFF
--- a/src/Form/Type/MagazineAutocompleteType.php
+++ b/src/Form/Type/MagazineAutocompleteType.php
@@ -12,7 +12,7 @@ use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
-use Symfony\UX\Autocomplete\Form\ParentEntityAutocompleteType;
+use Symfony\UX\Autocomplete\Form\BaseEntityAutocompleteType;
 
 #[AsEntityAutocompleteField]
 class MagazineAutocompleteType extends AbstractType
@@ -54,6 +54,6 @@ class MagazineAutocompleteType extends AbstractType
 
     public function getParent(): string
     {
-        return ParentEntityAutocompleteType::class;
+        return BaseEntityAutocompleteType::class;
     }
 }


### PR DESCRIPTION
Use `ParentEntityAutocompleteType::class` as return value on the `getParent()` method, since we are using Ajax forms.

https://symfony.com/bundles/ux-autocomplete/current/index.html#usage-in-a-form-with-ajax

See also: https://github.com/symfony/ux/issues/1541
