### PR TITLE
Consolidate markdown mention linking

### DIFF
--- a/src/Markdown/CommonMark/CommunityLinkParser.php
+++ b/src/Markdown/CommonMark/CommunityLinkParser.php
@@ -39,24 +39,23 @@ class CommunityLinkParser implements InlineParserInterface
 
         $fullHandle = $handle.'@'.$domain;
         $isRemote = $this->isRemoteCommunity($domain);
+        $magazine = $this->magazineRepository->findOneByName($isRemote ? $fullHandle : $handle);
+
+        if ($magazine) {
+            $ctx->getContainer()->appendChild(
+                new CommunityLink(
+                    $this->urlGenerator->generate('front_magazine', ['name' => $magazine->name]),
+                    '!'.$handle,
+                    '!'.($isRemote ? $magazine->apId : $magazine->name),
+                    $isRemote ? $magazine->apId : $magazine->name,
+                    $isRemote ? MentionType::RemoteMagazine : MentionType::Magazine,
+                ),
+            );
+
+            return true;
+        }
 
         if ($isRemote) {
-            $magazine = $this->magazineRepository->findOneByName($fullHandle);
-
-            if ($magazine && $magazine->apPublicUrl) {
-                $ctx->getContainer()->appendChild(
-                    new CommunityLink(
-                        $magazine->apPublicUrl,
-                        '!'.$handle,
-                        '!'.$magazine->apId,
-                        $magazine->apId,
-                        MentionType::RemoteMagazine,
-                    ),
-                );
-
-                return true;
-            }
-
             $ctx->getContainer()->appendChild(
                 new ActorSearchLink(
                     $this->urlGenerator->generate('search', ['q' => $fullHandle], UrlGeneratorInterface::ABSOLUTE_URL),

--- a/src/Markdown/CommonMark/MentionLinkParser.php
+++ b/src/Markdown/CommonMark/MentionLinkParser.php
@@ -61,24 +61,10 @@ class MentionLinkParser implements InlineParserInterface
             return true;
         }
 
-        if ($data instanceof Magazine && $data->apPublicUrl) {
-            $ctx->getContainer()->appendChild(
-                new ActivityPubMentionLink(
-                    $data->apPublicUrl,
-                    '@'.$username,
-                    '@'.$data->apId,
-                    $data->apId,
-                    MentionType::RemoteMagazine,
-                )
-            );
-
-            return true;
-        }
-
         [$routeDetails, $slug, $label, $title, $kbinUsername] = match ($type) {
-            MentionType::RemoteUser => [$this->resolveRouteDetails($type), '@'.$fullUsername, '@'.$username, '@'.$fullUsername, '@'.$fullUsername],
+            MentionType::RemoteUser => [$this->resolveRouteDetails($type), '@'.$fullUsername, '@'.$username, '@'.$username, '@'.$fullUsername],
             MentionType::RemoteMagazine => [$this->resolveRouteDetails($type), $fullUsername, '@'.$username, '@'.$fullUsername, $fullUsername],
-            MentionType::Magazine => [$this->resolveRouteDetails($type), $username, '@'.$username, '@'.$fullUsername, $username],
+            MentionType::Magazine => [$this->resolveRouteDetails($type), $username, '@'.$username, '@'.$username, $username],
             MentionType::Search => [$this->resolveRouteDetails($type), $fullUsername, '@'.$username, '@'.$fullUsername, $fullUsername],
             MentionType::Unresolvable => [['route' => '', 'param' => ''], '', '@'.$username, '', ''],
             MentionType::User => [$this->resolveRouteDetails($type), $username, '@'.$username, '@'.$fullUsername, $username],


### PR DESCRIPTION
- the `CommunityLinkParser` and the `MentionLinkParser` both do the same job consolidate how they handle mentions
- make remote magazines also link to the local version of them instead of linking to the remote instance

Closes #449 