### PR TITLE
Update delete image message and handler to use object ids

### DIFF
--- a/src/Entity/Image.php
+++ b/src/Entity/Image.php
@@ -89,6 +89,11 @@ class Image
         }
     }
 
+    public function getPath(): string
+    {
+        return $this->filePath;
+    }
+
     public function getId(): int
     {
         return $this->id;

--- a/src/Message/DeleteImageMessage.php
+++ b/src/Message/DeleteImageMessage.php
@@ -8,7 +8,7 @@ use App\Message\Contracts\AsyncMessageInterface;
 
 class DeleteImageMessage implements AsyncMessageInterface
 {
-    public function __construct(public string $path, public bool $force = false)
+    public function __construct(public int $id, public bool $force = false)
     {
     }
 }

--- a/src/MessageHandler/DeleteImageHandler.php
+++ b/src/MessageHandler/DeleteImageHandler.php
@@ -24,7 +24,7 @@ class DeleteImageHandler
 
     public function __invoke(DeleteImageMessage $message)
     {
-        $image = $this->imageRepository->findOneBy(['filePath' => $message->path]);
+        $image = $this->imageRepository->find($message->id);
 
         if ($image) {
             $this->entityManager->beginTransaction();
@@ -42,6 +42,8 @@ class DeleteImageHandler
             }
         }
 
-        $this->imageManager->remove($message->path);
+        $this->imageManager->remove($image->getPath());
+
+        
     }
 }

--- a/src/MessageHandler/DeleteImageHandler.php
+++ b/src/MessageHandler/DeleteImageHandler.php
@@ -43,7 +43,5 @@ class DeleteImageHandler
         }
 
         $this->imageManager->remove($image->getPath());
-
-        
     }
 }


### PR DESCRIPTION
Delete image handler and message was still using paths instead of IDs added in https://github.com/MbinOrg/mbin/pull/501 causing 500s to be generated when image removal was attempted. Path is still needed to remove from filesystem, so method added to image entity class to get path from image to be compatible with existing `imageManager->remove` method.