### PR TITLE
Allow null to be returned from MediaExtensionRuntime getPublicPath

### DIFF
--- a/src/Twig/Runtime/MediaExtensionRuntime.php
+++ b/src/Twig/Runtime/MediaExtensionRuntime.php
@@ -14,7 +14,7 @@ class MediaExtensionRuntime implements RuntimeExtensionInterface
     ) {
     }
 
-    public function getPublicPath(Image $image): string
+    public function getPublicPath(Image $image): ?string
     {
         if ($image->filePath) {
             return $this->storageUrl.'/'.$image->filePath;

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -138,15 +138,27 @@
                         {% endif %}
                         {% if entry.hasEmbed %}
                             {% set image = entry.image ? uploaded_asset(entry.image) : null %}
-                            <li>
-                                <button class="show-preview"
-                                        data-action="preview#show"
-                                        aria-label="{{ 'preview'|trans }}"
-                                        data-preview-url-param="{{ image ?? entry.url }}"
-                                        data-preview-ratio-param="{{ entry.domain and entry.domain.shouldRatio ? true : false }}">
-                                    <i class="fa-solid fa-photo-film" aria-hidden="true"></i>
-                                </button>
-                            </li>
+                            {% if image %}
+                                <li>
+                                    <button class="show-preview"
+                                            data-action="preview#show"
+                                            aria-label="{{ 'preview'|trans }}"
+                                            data-preview-url-param="{{ image ?? entry.url }}"
+                                            data-preview-ratio-param="{{ entry.domain and entry.domain.shouldRatio ? true : false }}">
+                                        <i class="fa-solid fa-photo-film" aria-hidden="true"></i>
+                                    </button>
+                                </li>
+                            {% elseif entry.url %}
+                                <li>
+                                    <button class="show-preview"
+                                            data-action="preview#show"
+                                            aria-label="{{ 'preview'|trans }}"
+                                            data-preview-url-param="{{ entry.url }}"
+                                            data-preview-ratio-param="{{ entry.domain and entry.domain.shouldRatio ? true : false }}">
+                                        <i class="fa-solid fa-photo-film" aria-hidden="true"></i>
+                                    </button>
+                                </li>
+                            {% endif %}
                         {% endif %}
                         <li>
                             <a class="stretched-link"

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -137,17 +137,16 @@
                             </li>
                         {% endif %}
                         {% if entry.hasEmbed %}
-                                {% set image = entry.image ? uploaded_asset(entry.image) : null %}
-                                <li>
-                                    <button class="show-preview"
-                                            data-action="preview#show"
-                                            aria-label="{{ 'preview'|trans }}"
-                                            data-preview-url-param="{{ image ?? entry.url }}"
-                                            data-preview-ratio-param="{{ entry.domain and entry.domain.shouldRatio ? true : false }}">
-                                        <i class="fa-solid fa-photo-film" aria-hidden="true"></i>
-                                    </button>
-                                </li>
-                            {% endif %}
+                            {% set image = entry.image ? uploaded_asset(entry.image) : null %}
+                            <li>
+                                <button class="show-preview"
+                                        data-action="preview#show"
+                                        aria-label="{{ 'preview'|trans }}"
+                                        data-preview-url-param="{{ image ?? entry.url }}"
+                                        data-preview-ratio-param="{{ entry.domain and entry.domain.shouldRatio ? true : false }}">
+                                    <i class="fa-solid fa-photo-film" aria-hidden="true"></i>
+                                </button>
+                            </li>
                         {% endif %}
                         <li>
                             <a class="stretched-link"

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -137,28 +137,16 @@
                             </li>
                         {% endif %}
                         {% if entry.hasEmbed %}
-                            {% set image = entry.image ? uploaded_asset(entry.image) : null %}
-                            {% if image %}
-                                <li>
-                                    <button class="show-preview"
-                                            data-action="preview#show"
-                                            aria-label="{{ 'preview'|trans }}"
-                                            data-preview-url-param="{{ image ?? entry.url }}"
-                                            data-preview-ratio-param="{{ entry.domain and entry.domain.shouldRatio ? true : false }}">
-                                        <i class="fa-solid fa-photo-film" aria-hidden="true"></i>
-                                    </button>
-                                </li>
-                            {% elseif entry.url %}
-                                <li>
-                                    <button class="show-preview"
-                                            data-action="preview#show"
-                                            aria-label="{{ 'preview'|trans }}"
-                                            data-preview-url-param="{{ entry.url }}"
-                                            data-preview-ratio-param="{{ entry.domain and entry.domain.shouldRatio ? true : false }}">
-                                        <i class="fa-solid fa-photo-film" aria-hidden="true"></i>
-                                    </button>
-                                </li>
-                            {% endif %}
+                            {% set image = entry.image ? uploaded_asset(entry.image) : string %}
+                            <li>
+                                <button class="show-preview"
+                                        data-action="preview#show"
+                                        aria-label="{{ 'preview'|trans }}"
+                                        data-preview-url-param="{{ image ?? entry.url }}"
+                                        data-preview-ratio-param="{{ entry.domain and entry.domain.shouldRatio ? true : false }}">
+                                    <i class="fa-solid fa-photo-film" aria-hidden="true"></i>
+                                </button>
+                            </li>
                         {% endif %}
                         <li>
                             <a class="stretched-link"

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -137,16 +137,18 @@
                             </li>
                         {% endif %}
                         {% if entry.hasEmbed %}
-                            {% set image = entry.image ? uploaded_asset(entry.image) : string %}
-                            <li>
-                                <button class="show-preview"
-                                        data-action="preview#show"
-                                        aria-label="{{ 'preview'|trans }}"
-                                        data-preview-url-param="{{ image ?? entry.url }}"
-                                        data-preview-ratio-param="{{ entry.domain and entry.domain.shouldRatio ? true : false }}">
-                                    <i class="fa-solid fa-photo-film" aria-hidden="true"></i>
-                                </button>
-                            </li>
+                            {% if entry.image is defined %}
+                                {% set image = entry.image ? uploaded_asset(entry.image) : null %}
+                                <li>
+                                    <button class="show-preview"
+                                            data-action="preview#show"
+                                            aria-label="{{ 'preview'|trans }}"
+                                            data-preview-url-param="{{ image ?? entry.url }}"
+                                            data-preview-ratio-param="{{ entry.domain and entry.domain.shouldRatio ? true : false }}">
+                                        <i class="fa-solid fa-photo-film" aria-hidden="true"></i>
+                                    </button>
+                                </li>
+                            {% endif %}
                         {% endif %}
                         <li>
                             <a class="stretched-link"

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -137,7 +137,6 @@
                             </li>
                         {% endif %}
                         {% if entry.hasEmbed %}
-                            {% if entry.image is defined %}
                                 {% set image = entry.image ? uploaded_asset(entry.image) : null %}
                                 <li>
                                     <button class="show-preview"


### PR DESCRIPTION
Ignore the branch name, bad initial guess at the problem... `MediaExtensionRuntime->getPublicPath` is now allowed to return `null`.