### PR TITLE
Fix rename of findUsersPaginated to findWithAboutPaginated

### DIFF
--- a/src/Controller/Api/User/UserRetrieveApi.php
+++ b/src/Controller/Api/User/UserRetrieveApi.php
@@ -287,7 +287,7 @@ class UserRetrieveApi extends UserBaseApi
         $request = $this->request->getCurrentRequest();
         $group = $request->get('group', UserRepository::USERS_ALL);
 
-        $users = $userRepository->findUsersPaginated(
+        $users = $userRepository->findWithAboutPaginated(
             $this->getPageNb($request),
             $group,
             $this->constrainPerPage($request->get('perPage', UserRepository::PER_PAGE))


### PR DESCRIPTION
Fixes:

```
{"message":"Uncaught PHP Exception BadMethodCallException: \"Undefined method \"findUsersPaginated\". The method name must start with either findBy, findOneBy or countBy!\" at EntityRepository.php line 283","context":{"exception":{"class":"BadMethodCallException","message":"Undefined method \"findUsersPaginated\". The method name must start with either findBy, findOneBy or countBy!","code":0,"file":"/var/www/kbin.melroy.org/html/vendor/doctrine/orm/src/EntityRepository.php:283"}},"level":500,"level_name":"CRITICAL","channel":"request","datetime":"2024-03-01T20:51:59.226533+01:00","extra":{}}
```