### PR TITLE
apply padding around reduce option similar to other items

### DIFF
--- a/assets/styles/layout/_options.scss
+++ b/assets/styles/layout/_options.scss
@@ -87,6 +87,15 @@
     margin: 0;
     padding: 0;
 
+    .options__nolink {
+      background: none;
+      border: 0;
+      border-bottom: 3px solid transparent;
+      display: block;
+      padding: .5rem 1rem;
+      text-decoration: none;
+    }
+
     a, button {
       background: none;
       border: 0;

--- a/templates/entry/_options_activity.html.twig
+++ b/templates/entry/_options_activity.html.twig
@@ -16,7 +16,7 @@
             </a>
         </li>
         <li>
-            <span>{{ 'down_votes'|trans }} ({{ entry.countDownVotes }})</span>
+            <span class="options__nolink">{{ 'down_votes'|trans }} ({{ entry.countDownVotes }})</span>
         </li>
     </menu>
 </aside>

--- a/templates/entry/comment/_options_activity.html.twig
+++ b/templates/entry/comment/_options_activity.html.twig
@@ -16,7 +16,7 @@
             </a>
         </li>
         <li>
-            <span>{{ 'down_votes'|trans }} ({{ comment.countDownVotes }})</span>
+            <span class="options__nolink">{{ 'down_votes'|trans }} ({{ comment.countDownVotes }})</span>
         </li>
     </menu>
 </aside>


### PR DESCRIPTION
this simply copy-pastes the styling of the options link (minus the link color and active/hover/focus states) to the reduce option item, as it had lost is becoming a span. I was hoping to not copy paste, but it was a bit frustrating trying to get scss to do an inclusive list that excluded the unwanted bits, maybe a mixin/include could be used but that seemed a bit overkill

before (note how it appears slightly down and to the left compared to the other elements):

![image](https://github.com/MbinOrg/mbin/assets/146029455/7a12bfa3-7f0d-4c71-8291-aeebb403ccbe)
![image](https://github.com/MbinOrg/mbin/assets/146029455/68ee0c3e-34e7-4987-bf90-77f5de96d9c3)

after:

![image](https://github.com/MbinOrg/mbin/assets/146029455/4b063fe8-2665-4f18-9093-5a87d5b65c74)
![image](https://github.com/MbinOrg/mbin/assets/146029455/609005a1-70eb-46f7-8e2e-3ae472b2a8c2)
