### PR TITLE
open domain urls in new window by default

### DIFF
--- a/assets/styles/components/_entry.scss
+++ b/assets/styles/components/_entry.scss
@@ -331,6 +331,7 @@
   &__domain {
     color: var(--kbin-meta-text-color);
     font-size: .7rem;
+    white-space: nowrap;
 
     a {
       color: var(--kbin-meta-text-color);

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -39,9 +39,9 @@
 
                             {% if entry.url %}
                                 <span class="entry__domain">
-                                    (<a rel="{{ get_rel(entry.url) }}" href="{{ entry.url }}">
-                                        {{ get_url_domain(entry.url) }}
-                                    </a>)
+                                    ( <a rel="{{ get_rel(entry.url) }}" href="{{ entry.url }}" target="_blank">
+                                        <span>{{ get_url_domain(entry.url) }}</span> <i class="fa-solid fa-external-link" aria-hidden="true"></i>
+                                    </a> )
                                 </span>
                             {% endif %}
 
@@ -57,9 +57,9 @@
 
                             {% if entry.url %}
                                 <span class="entry__domain">
-                                    (<a rel="{{ get_rel(entry.url) }}" href="{{ entry.url }}">
-                                        {{ get_url_domain(entry.url) }}
-                                    </a>)
+                                    ( <a rel="{{ get_rel(entry.url) }}" href="{{ entry.url }}" target="_blank">
+                                        <span>{{ get_url_domain(entry.url) }}</span> <i class="fa-solid fa-external-link" aria-hidden="true"></i>
+                                    </a> )
                                 </span>
                             {% endif %}
 


### PR DESCRIPTION
open domain urls in new window by default
add external link icon to signify leaving the site
add nowrap to entry domain element to prevent awkward line breaks

---

it's probably worth having a discussion about this functionality change. the main thing is it forces the entry urls to open in a new window rather than giving the user the choice to do either. This is sort of why I kept the main title link the same, so there's still a way to open in-window links if desired, but that could be good or bad

Some data:
hacker news - opens external links in same window
slashdot - opens external links in new window
reddit - opens external links in new window
mastodon - opens external links in new window

I ran across this blog post https://css-tricks.com/use-target_blank/ . Granted, it's from a decade ago, but seems to heavily lean anti-new window and gives quite a lengthy list on why. Some of those, I agree with, but the comments go into detail that basically make it seem like saying "non-tech-savvy" could potentially get confused either way (leaving the site suddenly could be confusing _or_ opening a new window could be confusing), so I feel like that data isn't super evident for or against. There was a comment saying inconsistent can be bad, which is technically what I've done here as some links are same, some are new window. In my head, this seemed good, as it gives the user choice, but of course that means people would have to memorize which is which (which is why I added the icon as well, to hopefully assist with that)

---

edit: one thing I wanted to mention was the now whitespace around the entry url `( domain )` now rather than `(domain)`, this happened with a recent PR, and speaking with Benti it was sort of unintentional, but I kind of like the breathing room it gives (especially with the icon added in), so thought to keep it, but just added the nowrap as I was seeing it line break some times where `(` appeared by itself on one line and the rest of the link was on a new line

---

before entry list page:

![image](https://github.com/MbinOrg/mbin/assets/146029455/b651fe2d-2c93-4505-b80f-f9be9bf99619)

before single entry view:

![image](https://github.com/MbinOrg/mbin/assets/146029455/e7818743-e1f9-42ea-89f9-29af44898138)

---

after entry list page:

![image](https://github.com/MbinOrg/mbin/assets/146029455/e244db91-eae9-47b3-ad95-37b1cd20f851)

after single entry view:

![image](https://github.com/MbinOrg/mbin/assets/146029455/d4bfd01a-0abd-40c7-a7be-2befef860377)
