### PR TITLE
add preview grid areas to compact views

### DIFF
--- a/assets/styles/components/_entry.scss
+++ b/assets/styles/components/_entry.scss
@@ -23,6 +23,7 @@
                        "vote meta"
                        "vote footer"
                        "moderate moderate"
+                       "preview preview"
                        "body body";
     grid-template-columns: min-content 1fr;
   }
@@ -62,6 +63,7 @@
                            "meta meta"
                            "footer footer"
                            "moderate moderate"
+                           "preview preview"
                            "body body";
       grid-template-columns: min-content 1fr;
     }
@@ -92,6 +94,7 @@
                        "meta meta"
                        "footer footer"
                        "moderate moderate"
+                       "preview preview"
                        "body body";
       grid-template-columns: 1fr min-content;
     }


### PR DESCRIPTION
the compact and no-thumbnail css grid areas were missing the `preview` section, which still is used when opening the inline preview. this led to the preview being super padded to the right and throwing off the rest of the elements

before:

![image](https://github.com/MbinOrg/mbin/assets/146029455/20460cf4-5d01-420b-960c-4bd6a682244d)

after:

![image](https://github.com/MbinOrg/mbin/assets/146029455/6dea4f5e-c997-4e30-b146-1ac83705d927)

fixes #499