### PR TITLE
adjust external link icon size

### DIFF
--- a/assets/styles/components/_entry.scss
+++ b/assets/styles/components/_entry.scss
@@ -339,6 +339,10 @@
     a {
       color: var(--kbin-meta-text-color);
     }
+
+    i {
+      font-size: .6rem;
+    }
   }
 
   .loader {


### PR DESCRIPTION
based on recommendation from @asdfzdfj to make the external link icon slightly smaller to match the url it's next to

before

![image](https://github.com/MbinOrg/mbin/assets/146029455/a848ce80-04ec-48b6-8a35-f96f112343fa)

after

![image](https://github.com/MbinOrg/mbin/assets/146029455/ad4e3b52-be27-413c-a337-54b8d0c4eef3)
