### PR TITLE
Use title in "related magazines" panel

### DIFF
--- a/templates/components/magazine_inline.html.twig
+++ b/templates/components/magazine_inline.html.twig
@@ -13,6 +13,6 @@
     {% if fullName %}
         {{ magazine.name }} {% if magazine.isAdult %}<small class="badge danger">18+</small>{% endif %}
     {% else %}
-        {{ ('@'~magazine.name)|username(false) -}}
+        {{ magazine.title }}
     {% endif %}
 </a>

--- a/templates/components/related_magazines.html.twig
+++ b/templates/components/related_magazines.html.twig
@@ -5,7 +5,7 @@
             <ul class="meta">
                 {% for magazine in magazines %}
                     <li>
-                        {{ component('magazine_inline', {magazine: magazine, showAvatar: true, fullName:true, stretchedLink:true}) }}
+                        {{ component('magazine_inline', {magazine: magazine, showAvatar: true, fullName:false, stretchedLink:true}) }}
                     </li>
                 {% endfor %}
             </ul>


### PR DESCRIPTION
- change the inline magazine component to use the title of the magazine if the full name is not needed
- set full name to false for related magazines

| Before | After |
| ------ | ----- |
| ![grafik](https://github.com/MbinOrg/mbin/assets/25664458/0cc743b2-ec29-49fd-bbd1-600c6e81e755) | ![grafik](https://github.com/MbinOrg/mbin/assets/25664458/4721adb1-b5fb-4752-b001-3eb1b13d0328) |