### PR TITLE
delete image handler only delete image when not null

### DIFF
--- a/src/Entity/Image.php
+++ b/src/Entity/Image.php
@@ -89,11 +89,6 @@ class Image
         }
     }
 
-    public function getPath(): string
-    {
-        return $this->filePath;
-    }
-
     public function getId(): int
     {
         return $this->id;

--- a/src/MessageHandler/DeleteImageHandler.php
+++ b/src/MessageHandler/DeleteImageHandler.php
@@ -34,6 +34,10 @@ class DeleteImageHandler
                 $this->entityManager->flush();
 
                 $this->entityManager->commit();
+
+                if ($image->filePath) {
+                    $this->imageManager->remove($image->filePath);
+                }
             } catch (\Exception $e) {
                 $this->entityManager->rollback();
                 $this->managerRegistry->resetManager();
@@ -41,7 +45,5 @@ class DeleteImageHandler
                 return;
             }
         }
-
-        $this->imageManager->remove($image->getPath());
     }
 }


### PR DESCRIPTION
only call ImageManager::remove when image entity is not null

noticed a couple of 'Call to a member function getPath() on null' message error in my setup, and this seems to be the case