### PR TITLE
limit image caption height and make it scroll

### DIFF
--- a/assets/styles/components/_figure_lightbox.scss
+++ b/assets/styles/components/_figure_lightbox.scss
@@ -17,6 +17,10 @@
     font-family: var(--kbin-body-font-family);
     font-size: 0.9rem;
     color: var(--kbin-text-color);
+    max-height: 12rem;
+    overflow-wrap: break-word;
+    overflow-x: hidden;
+    overflow-y: scroll;
   }
 
   .gslide-image img {
@@ -39,6 +43,8 @@
     font-family: var(--kbin-body-font-family);
     font-size: 0.9rem;
     color: var(--kbin-text-color);
+    overflow: unset;
+    max-height: unset;
   }
 
   .gslide-image img {


### PR DESCRIPTION
for some image where its caption is _very_ long, the caption could fill the screen and cause the image in lightbox to not showed up properly

![image](https://github.com/MbinOrg/mbin/assets/20770492/ab3a5432-19e8-4cc8-825a-6091fb1aec74)

this limits the description box max height to avoid the above situation, the overflowing caption text is scrollable inside the description box

![image](https://github.com/MbinOrg/mbin/assets/20770492/52883d22-626e-4889-ac57-e158a50bd0b2)

it's still somewhat borked on mobile but at least this should fix one of them
(there's see more button, but the full caption that's shown after that can't be scrolled, looks like it intercepted touch events and sent it to the image on the back instead)