### PR TITLE
add missing translation for `edited`

### DIFF
--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -796,3 +796,4 @@ spoiler: Spoiler
 all_time: All time
 show: Show
 hide: Hide
+edited: edited


### PR DESCRIPTION
the word that appears when posts are edited in the date template was missing the translation

https://github.com/MbinOrg/mbin/blob/430520f58b62dd88f88ebf8786fc073594fd5b9c/templates/components/date_edited.html.twig#L3

![image](https://github.com/MbinOrg/mbin/assets/146029455/8b57372b-8c14-4673-b530-37fce1f0d10d)
