### PR TITLE
Fix clipping / z-index on visibility private posts

### DIFF
--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -8,8 +8,7 @@
 
 {% if not app.user or (app.user and not app.user.isBlocked(comment.user)) %}
     {% if comment.visibility is same as 'private' and (not app.user or not app.user.isFollower(comment.user)) %}
-        <div class="section section--small {{ 'comment-level--' ~ this.getLevel() }}"
-             style="z-index:3; position:relative;margin-bottom:0;">
+        <div class="section section--small {{ 'comment-level--' ~ this.getLevel() }}">
             Private
         </div>
     {% else %}

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -5,8 +5,7 @@
 
 {% if not app.user or (app.user and not app.user.isBlocked(post.user)) %}
     {% if post.visibility is same as 'private' and (not app.user or not app.user.isFollower(post.user)) %}
-        <div class="section section--small"
-             style="z-index:3; position:relative;margin-bottom:0;">
+        <div class="section section--small">
             Private
         </div>
     {% else %}

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -10,8 +10,7 @@
 {% endif %}
 {% if not app.user or (app.user and not app.user.isBlocked(comment.user)) %}
     {% if comment.visibility is same as 'private' and (not app.user or not app.user.isFollower(comment.user)) %}
-        <div class="section section--small {{ 'comment-level--' ~ this.getLevel() }}"
-             style="z-index:3; position:relative;margin-bottom:0;">
+        <div class="section section--small {{ 'comment-level--' ~ this.getLevel() }}">
             Private
         </div>
     {% else %}


### PR DESCRIPTION
remove inline styles from private posts and comments

saw this in the wild, seems pretty rare but for posts and post/entry comments with a private visibility, they end up with this hardcoded block. It probably needs more work, private is untranslated for instance, and of course there's the bigger can of worms on using visibility at all. but for now, wanted to make the styling look not broken, ideally. I tried to test out with the scenario I saw it in, which was post, but couldn't repro how exactly it looks for post comment or entry comment (the comments just disappear, unlike post which shows up with the word "Private"), but I assumed they might be acting similar

before:

(note in first image the comment clips into the post it's replying to)
![image](https://github.com/MbinOrg/mbin/assets/146029455/45ce85b4-84cf-4c79-b8dc-a6b2e7c30ea9)
![image](https://github.com/MbinOrg/mbin/assets/146029455/fc95e8d2-44ee-4332-a39e-933f972e2f8f)

---

after

![image](https://github.com/MbinOrg/mbin/assets/146029455/b9d04b70-9494-415f-bcff-e05c88831315)
