### PR TITLE
Fix infinite scrolling on domain pages

### DIFF
--- a/src/Controller/Domain/DomainFrontController.php
+++ b/src/Controller/Domain/DomainFrontController.php
@@ -10,6 +10,7 @@ use App\Repository\Criteria;
 use App\Repository\DomainRepository;
 use App\Repository\EntryRepository;
 use Pagerfanta\PagerfantaInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -34,6 +35,19 @@ class DomainFrontController extends AbstractController
             ->setDomain($name);
         $method = $criteria->resolveSort($sortBy);
         $listing = $this->$method($criteria);
+
+        if ($request->isXmlHttpRequest()) {
+            return new JsonResponse(
+                [
+                    'html' => $this->renderView(
+                        'entry/_list.html.twig',
+                        [
+                            'entries' => $listing,
+                        ]
+                    ),
+                ]
+            );
+        }
 
         return $this->render(
             'domain/front.html.twig',


### PR DESCRIPTION
Right now enabling infinite scrolling and browsing a domain page (e.g. `/d/youtube.com`) does not allow infinite scrolling to function

Instead users will see the loading wheel, followed by the pagination showing up instead

This is because the domain controller had no handling for XML requests. Instead, it would load the _entire_ HTML response of the next page. That would fail, and https://github.com/MbinOrg/mbin/blob/47931a28bf8902806136ea94b3b3a83782093f77/assets/controllers/infinite_scroll_controller.js#L52-L53 would be loaded instead

```
Uncaught (in promise) Error: Invalid JSON response
```

This change handles getting an ajax request with loading the next result set similar to entry controller

https://github.com/MbinOrg/mbin/blob/e0773152f100408769ff2e93cf9043ae4aa63a9e/src/Controller/Entry/EntryFrontController.php#L69-L80