### PR TITLE
fix broken entry preview for non-image embeds

### DIFF
--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -149,12 +149,12 @@
                             </li>
                         {% endif %}
                         {% if entry.hasEmbed %}
-                            {% set image = entry.image ? uploaded_asset(entry.image) : null %}
+                            {% set preview_url = entry.type is same as 'image' and entry.image ? uploaded_asset(entry.image) : entry.url %}
                             <li>
                                 <button class="show-preview"
                                         data-action="preview#show"
                                         aria-label="{{ 'preview'|trans }}"
-                                        data-preview-url-param="{{ image ?? entry.url }}"
+                                        data-preview-url-param="{{ preview_url }}"
                                         data-preview-ratio-param="{{ entry.domain and entry.domain.shouldRatio ? true : false }}">
                                     <i class="fa-solid fa-photo-film" aria-hidden="true"></i>
                                 </button>

--- a/templates/components/entry_cross.html.twig
+++ b/templates/components/entry_cross.html.twig
@@ -36,12 +36,12 @@
                         </li>
                     {% endif %}
                     {% if entry.hasEmbed %}
-                        {% set image = entry.image ? uploaded_asset(entry.image) : '' %}
+                        {% set preview_url = entry.type is same as 'image' and entry.image ? uploaded_asset(entry.image) : entry.url %}
                         <li>
                             <button class="show-preview"
                                     data-action="preview#show"
                                     aria-label="{{ 'preview'|trans }}"
-                                    data-preview-url-param="{{ image ?? entry.url }}"
+                                    data-preview-url-param="{{ preview_url }}"
                                     data-preview-ratio-param="{{ entry.domain and entry.domain.shouldRatio ? true : false }}">
                                 <i class="fa-solid fa-photo-film" aria-hidden="true"></i>
                             </button>


### PR DESCRIPTION
the entry preview link order switching from #501 can make some entry that's not an image post but have thumbnail image to have faulty preview when expanded

for example, an entry with link to youtube video would have its thumbnail attached as its image, now when opening the media preview you would get the preview of its thumbnail instead of the embed youtube player like it used to be

([example from kbin.run](https://kbin.run/m/games@lemmy.world/t/280866/Persona-3-Reload-Expansion-Pass-Xbox-Partner-Preview))
![image](https://github.com/MbinOrg/mbin/assets/20770492/96fcbade-cecb-48f9-b89d-1459f576ac95)

this should fix the preview for those entries while still play nice with the new #501 image handling

(fixed/what it once was/what it should be)
![image](https://github.com/MbinOrg/mbin/assets/20770492/66fae483-e812-41e1-8012-4c01c50b936c)