### PR TITLE
Fix User Statistics page not allowing federated filter

### DIFF
--- a/config/kbin_routes/user.yaml
+++ b/config/kbin_routes/user.yaml
@@ -252,8 +252,8 @@ user_settings_toggle_theme:
 
 user_settings_stats:
     controller: App\Controller\User\Profile\UserStatsController
-    defaults: { statsType: content, statsPeriod: ~ }
-    path: /settings/stats/{statsType}/{statsPeriod}
+    defaults: { statsType: content, statsPeriod: -1, withFederated: false }
+    path: /settings/stats/{statsType}/{statsPeriod}/{withFederated}
     methods: [GET]
 
 theme_settings:

--- a/config/kbin_routes/user.yaml
+++ b/config/kbin_routes/user.yaml
@@ -252,7 +252,7 @@ user_settings_toggle_theme:
 
 user_settings_stats:
     controller: App\Controller\User\Profile\UserStatsController
-    defaults: { statsType: content, statsPeriod: -1, withFederated: false }
+    defaults: { statsType: content, statsPeriod: 31, withFederated: false }
     path: /settings/stats/{statsType}/{statsPeriod}/{withFederated}
     methods: [GET]
 


### PR DESCRIPTION
If you navigate to `/settings/stats` while logged in to an account, you'll see a normal stats page for users that we use for magazines and the overall site as well.

However, if you attempt to use the dropdown that says `Local` and change it to `Federated`, the page will be reloaded and the URL will get `?withFederated=1` and the dropdown will stay `Local`. This is because the route and controller did not allow for setting federated status on the user stats page

This fixes the route and passes that through the controller into the stat manager, just like magazine/overall do

There might be a bit of an investigation into _why_ it was this way. Was it just never hooked up, or was there an issue? I don't see how this would be worse than magazine or overall stats. We could go the opposite way and just remove the dropdown from the user stat page so only local statistics are possible to view

---

I tested this with my dev environment... which only has local posts. So although I didn't see any issues with errors, I can't tell whether the numbers would be accurate as all my content is local