### PR TITLE
Fix profile option being marked active when viewing other profiles

### DIFF
--- a/templates/layout/_header.html.twig
+++ b/templates/layout/_header.html.twig
@@ -150,7 +150,7 @@
                     <ul class="dropdown__menu">
                         <li>
                             <a href="{{ path('user_overview', {username: app.user.username}) }}"
-                               class="{{ html_classes({'active': is_route_name_contains('user_overview')}) }}">
+                               class="{{ html_classes({'active': is_route_name_contains('user_overview') and user is same as app.user}) }}">
                                 {{ 'profile'|trans }}
                             </a>
                         </li>


### PR DESCRIPTION
Right now the `Profile` header option gets marked `active` on any user overview page, not just your own. This fixes it so it will only be marked as active when you're viewing your own profile overview.

Before (note looking at `user2` as `user1`)

![image](https://github.com/MbinOrg/mbin/assets/146029455/b71facc2-55b3-4371-9b9c-dc1139e9078e)

---

After `user2`

![image](https://github.com/MbinOrg/mbin/assets/146029455/635311eb-9518-4d8c-adb3-45a1ea6d33dd)

After `user1`

![image](https://github.com/MbinOrg/mbin/assets/146029455/7889f44d-94cf-48db-9b11-12d9e6ba3e44)
