### PR TITLE
Remove unused environment vars for API platform

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,12 +148,6 @@ CORS_ALLOW_ORIGIN="^https?://(${KBIN_DOMAIN}|127\.0\.0\.1)(:[0-9]+)?$"
 LOCK_DSN=flock
 ###< symfony/lock ###
 
-###> lexik/jwt-authentication-bundle ###
-JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
-JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
-JWT_PASSPHRASE=
-###< lexik/jwt-authentication-bundle ###
-
 ###> league/oauth2-server-bundle ###
 OAUTH_PRIVATE_KEY=
 OAUTH_PUBLIC_KEY=

--- a/.env.example_docker
+++ b/.env.example_docker
@@ -143,13 +143,6 @@ CORS_ALLOW_ORIGIN="^https?://(${KBIN_DOMAIN}|127\.0\.0\.1)(:[0-9]+)?$"
 LOCK_DSN=flock
 ###< symfony/lock ###
 
-###> lexik/jwt-authentication-bundle ###
-# Used for Kbin API authentication
-JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
-JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
-JWT_PASSPHRASE=
-###< lexik/jwt-authentication-bundle ###
-
 ###> league/oauth2-server-bundle ###
 OAUTH_PRIVATE_KEY=
 OAUTH_PUBLIC_KEY=


### PR DESCRIPTION
As noted by @Jerry-infosecexchange:

The original jwt API system was removed in this commit  https://github.com/MbinOrg/mbin/commit/ad23b452d489b7f12551c04348156a105a48c294 and has been replaced by swagger

Most of it has been cleaned up from composer.lock / routes but the env vars had remained in the example files. This removes them. Instance owners should be able to remove them from their own `.env` files without issue