### PR TITLE
Extend editability of username

### DIFF
--- a/src/Security/Voter/UserVoter.php
+++ b/src/Security/Voter/UserVoter.php
@@ -88,7 +88,14 @@ class UserVoter extends Voter
             && !$user->posts->count()
             && !$user->postComments->count()
             && !$user->subscriptions->count()
+            && !$user->follows->count()
             && !$user->followers->count()
-            && !$user->follows->count();
+            && !$user->entryVotes->count()
+            && !$user->entryVotes->count()
+            && !$user->entryCommentVotes->count()
+            && !$user->postVotes->count()
+            && !$user->postCommentVotes->count()
+            && !$user->blocks->count()
+            && !$user->favourites->count();
     }
 }


### PR DESCRIPTION
Extend the edit-ability (or therefor the lack of editing) of the username, based on threads, post, comments but also votes, blocks and favorites. If `count()` is still false it means it's `0`, so the user didn't do anything yet with their account. 

It's only safe to edit the username when the user didn't do anything yet. After that, editing shouldn't be allowed.

Fixes: https://github.com/MbinOrg/mbin/issues/571