### PR TITLE
Fix circular like/announce message

### DIFF
--- a/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
@@ -101,6 +101,16 @@ readonly class ActivityHandler
             }
             if (\is_array($payload['object'])) {
                 $payload = $payload['object'];
+                $actor = $payload['actor'] ?? $payload['attributedTo'] ?? null;
+                if ($actor) {
+                    $user = $this->manager->findActorOrCreate($actor);
+                    if ($user instanceof User && null === $user->apId) {
+                        // don't do anything if we get an announce activity for something a local user did
+                        $this->logger->warning('ignoring this message because it announces an activity from a local user');
+
+                        return;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Under certain circumstances there could be a loop where instance A notifies instance B that a user liked something, B announces it to A which triggered A to notify B, etc. etc. (not sure that this is exactly what happened, but something like it) 

Anyway, the solution is easy and should have been done ages ago: do nothing if an activity from a local user is announced. No server should ever announce something to our server that originates from our server, but every software has bugs (ours is a nest if you ask me) and therefore we should account for that