### PR TITLE
Fix GitHub oauth getId() type mismatch on assignment

### DIFF
--- a/src/Security/GithubAuthenticator.php
+++ b/src/Security/GithubAuthenticator.php
@@ -50,7 +50,7 @@ class GithubAuthenticator extends OAuth2Authenticator
                 $githubUser = $client->fetchUserFromToken($accessToken);
 
                 $existingUser = $this->entityManager->getRepository(User::class)->findOneBy(
-                    ['oauthGithubId' => $githubUser->getId()]
+                    ['oauthGithubId' => strval($githubUser->getId())]
                 );
 
                 if ($existingUser) {
@@ -62,7 +62,7 @@ class GithubAuthenticator extends OAuth2Authenticator
                 );
 
                 if ($user) {
-                    $user->oauthGithubId = $githubUser->getId();
+                    $user->oauthGithubId = strval($githubUser->getId());
                 } else {
                     $dto = (new UserDto())->create(
                         $slugger->slug($githubUser->getNickname()).rand(1, 999),
@@ -73,7 +73,7 @@ class GithubAuthenticator extends OAuth2Authenticator
                     $dto->plainPassword = bin2hex(random_bytes(20));
 
                     $user = $this->userManager->create($dto, false);
-                    $user->oauthGithubId = $githubUser->getId();
+                    $user->oauthGithubId = strval($githubUser->getId());
                     $user->isVerified = true;
                 }
 

--- a/src/Security/GithubAuthenticator.php
+++ b/src/Security/GithubAuthenticator.php
@@ -50,7 +50,7 @@ class GithubAuthenticator extends OAuth2Authenticator
                 $githubUser = $client->fetchUserFromToken($accessToken);
 
                 $existingUser = $this->entityManager->getRepository(User::class)->findOneBy(
-                    ['oauthGithubId' => strval($githubUser->getId())]
+                    ['oauthGithubId' => \strval($githubUser->getId())]
                 );
 
                 if ($existingUser) {
@@ -62,7 +62,7 @@ class GithubAuthenticator extends OAuth2Authenticator
                 );
 
                 if ($user) {
-                    $user->oauthGithubId = strval($githubUser->getId());
+                    $user->oauthGithubId = \strval($githubUser->getId());
                 } else {
                     $dto = (new UserDto())->create(
                         $slugger->slug($githubUser->getNickname()).rand(1, 999),
@@ -73,7 +73,7 @@ class GithubAuthenticator extends OAuth2Authenticator
                     $dto->plainPassword = bin2hex(random_bytes(20));
 
                     $user = $this->userManager->create($dto, false);
-                    $user->oauthGithubId = strval($githubUser->getId());
+                    $user->oauthGithubId = \strval($githubUser->getId());
                     $user->isVerified = true;
                 }
 


### PR DESCRIPTION
Fixes 500 on getId() assignment. The oauth providers are not providing consistent return types... GitHub function returns an int, Google returns a mixed type, Facebook returns a string, etc.... our code has them all set to expect strings or null.