### PR TITLE
Only count content from the last 30 days for active people

### DIFF
--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -503,7 +503,7 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
         UNION
         (SELECT count(id), user_id FROM post WHERE magazine_id = :magazineId $timeWhere GROUP BY user_id ORDER BY count DESC LIMIT 50)
         UNION
-        (SELECT count(id), user_id FROM post_comment WHERE magazine_id = :magazineId AND $timeWhere GROUP BY user_id ORDER BY count DESC LIMIT 50)
+        (SELECT count(id), user_id FROM post_comment WHERE magazine_id = :magazineId $timeWhere GROUP BY user_id ORDER BY count DESC LIMIT 50)
         ORDER BY count DESC";
 
         $stmt = $conn->prepare($sql);

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -496,13 +496,13 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
     {
         $conn = $this->_em->getConnection();
         $sql = '
-        (SELECT count(id), user_id FROM entry WHERE magazine_id = :magazineId GROUP BY user_id ORDER BY count DESC LIMIT 50)
+        (SELECT count(id), user_id FROM entry WHERE magazine_id = :magazineId AND created_at > now() - \'30 days\'::interval GROUP BY user_id ORDER BY count DESC LIMIT 50)
         UNION
-        (SELECT count(id), user_id FROM entry_comment WHERE magazine_id = :magazineId GROUP BY user_id ORDER BY count DESC LIMIT 50)
+        (SELECT count(id), user_id FROM entry_comment WHERE magazine_id = :magazineId AND created_at > now() - \'30 days\'::interval GROUP BY user_id ORDER BY count DESC LIMIT 50)
         UNION
-        (SELECT count(id), user_id FROM post WHERE magazine_id = :magazineId GROUP BY user_id ORDER BY count DESC LIMIT 50)
+        (SELECT count(id), user_id FROM post WHERE magazine_id = :magazineId AND created_at > now() - \'30 days\'::interval GROUP BY user_id ORDER BY count DESC LIMIT 50)
         UNION
-        (SELECT count(id), user_id FROM post_comment WHERE magazine_id = :magazineId GROUP BY user_id ORDER BY count DESC LIMIT 50)
+        (SELECT count(id), user_id FROM post_comment WHERE magazine_id = :magazineId AND created_at > now() - \'30 days\'::interval GROUP BY user_id ORDER BY count DESC LIMIT 50)
         ORDER BY count DESC';
 
         $stmt = $conn->prepare($sql);

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -492,18 +492,19 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
             ->getResult();
     }
 
-    public function findPeople(Magazine $magazine, ?bool $federated = false, $limit = 200): array
+    public function findPeople(Magazine $magazine, ?bool $federated = false, $limit = 200, bool $limitTime = false): array
     {
         $conn = $this->_em->getConnection();
-        $sql = '
-        (SELECT count(id), user_id FROM entry WHERE magazine_id = :magazineId AND created_at > now() - \'30 days\'::interval GROUP BY user_id ORDER BY count DESC LIMIT 50)
+        $timeWhere = $limitTime ? "AND created_at > now() - '30 days'::interval" : '';
+        $sql = "
+        (SELECT count(id), user_id FROM entry WHERE magazine_id = :magazineId $timeWhere GROUP BY user_id ORDER BY count DESC LIMIT 50)
         UNION
-        (SELECT count(id), user_id FROM entry_comment WHERE magazine_id = :magazineId AND created_at > now() - \'30 days\'::interval GROUP BY user_id ORDER BY count DESC LIMIT 50)
+        (SELECT count(id), user_id FROM entry_comment WHERE magazine_id = :magazineId $timeWhere GROUP BY user_id ORDER BY count DESC LIMIT 50)
         UNION
-        (SELECT count(id), user_id FROM post WHERE magazine_id = :magazineId AND created_at > now() - \'30 days\'::interval GROUP BY user_id ORDER BY count DESC LIMIT 50)
+        (SELECT count(id), user_id FROM post WHERE magazine_id = :magazineId $timeWhere GROUP BY user_id ORDER BY count DESC LIMIT 50)
         UNION
-        (SELECT count(id), user_id FROM post_comment WHERE magazine_id = :magazineId AND created_at > now() - \'30 days\'::interval GROUP BY user_id ORDER BY count DESC LIMIT 50)
-        ORDER BY count DESC';
+        (SELECT count(id), user_id FROM post_comment WHERE magazine_id = :magazineId AND $timeWhere GROUP BY user_id ORDER BY count DESC LIMIT 50)
+        ORDER BY count DESC";
 
         $stmt = $conn->prepare($sql);
         $stmt->bindValue('magazineId', $magazine->getId());
@@ -563,7 +564,7 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
     public function findActiveUsers(Magazine $magazine = null)
     {
         if ($magazine) {
-            $results = $this->findPeople($magazine, null, 35);
+            $results = $this->findPeople($magazine, null, 35, true);
         } else {
             $results = $this->createQueryBuilder('u')
                 ->andWhere('u.lastActive >= :lastActive')


### PR DESCRIPTION
calculating the active people for a magazine can take quite some time (3 - 8 **seconds**), because literally all content in this magazine is counted by `user_id`, change that to only content from the last 30 days and voilá it takes <1 second. 

Granted the call is cached for an hour, but it is annoying to be the user that has to wait for that calculation. 

Additionally I think counting only 30 days of content results in a better picture of the "active users"