### PR TITLE
Specify project name attribute in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
     "packages": {
         "": {
             "name": "mbin",
-            "license": "UNLICENSED",
+            "license": "AGPL-3.0",
             "devDependencies": {
                 "@babel/core": "^7.23.6",
                 "@babel/preset-env": "^7.23.6",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
         "webpack-cli": "^5.1.4",
         "webpack-notifier": "^1.15.0"
     },
-    "license": "UNLICENSED",
+    "name": "mbin",
+    "license": "AGPL-3.0",
     "private": true,
     "scripts": {
         "dev-server": "encore dev-server",


### PR DESCRIPTION
npm will "randomly" change the `package-lock.json` file with the name attribute based on the local directory where the project is being built, this specifics a name in `package.json` to stop this behavior, see: https://github.com/npm/cli/issues/2264

Also add proper license attribute.