### PR TITLE
Only update lastOriginUpdate of magazines on announces

### DIFF
--- a/src/Service/EntryCommentManager.php
+++ b/src/Service/EntryCommentManager.php
@@ -70,9 +70,6 @@ class EntryCommentManager implements ContentManagerInterface
         $comment->visibility = $dto->visibility;
         $comment->apId = $dto->apId;
         $comment->magazine->lastActive = new \DateTime();
-        if (null !== $comment->user->apDomain && $comment->magazine->apDomain === $comment->user->apDomain) {
-            $comment->magazine->lastOriginUpdate = new \DateTime();
-        }
         $comment->user->lastActive = new \DateTime();
         $comment->lastActive = $dto->lastActive ?? $comment->lastActive;
         $comment->createdAt = $dto->createdAt ?? $comment->createdAt;

--- a/src/Service/EntryManager.php
+++ b/src/Service/EntryManager.php
@@ -89,9 +89,6 @@ class EntryManager implements ContentManagerInterface
         $entry->visibility = $dto->visibility;
         $entry->apId = $dto->apId;
         $entry->magazine->lastActive = new \DateTime();
-        if (null !== $entry->user->apDomain && $entry->magazine->apDomain === $entry->user->apDomain) {
-            $entry->magazine->lastOriginUpdate = new \DateTime();
-        }
         $entry->user->lastActive = new \DateTime();
         $entry->lastActive = $dto->lastActive ?? $entry->lastActive;
         $entry->createdAt = $dto->createdAt ?? $entry->createdAt;

--- a/src/Service/PostCommentManager.php
+++ b/src/Service/PostCommentManager.php
@@ -70,9 +70,6 @@ class PostCommentManager implements ContentManagerInterface
         $comment->visibility = $dto->visibility;
         $comment->apId = $dto->apId;
         $comment->magazine->lastActive = new \DateTime();
-        if (null !== $comment->user->apDomain && $comment->magazine->apDomain === $comment->user->apDomain) {
-            $comment->magazine->lastOriginUpdate = new \DateTime();
-        }
         $comment->user->lastActive = new \DateTime();
         $comment->lastActive = $dto->lastActive ?? $comment->lastActive;
         $comment->createdAt = $dto->createdAt ?? $comment->createdAt;

--- a/src/Service/PostManager.php
+++ b/src/Service/PostManager.php
@@ -81,9 +81,6 @@ class PostManager implements ContentManagerInterface
         $post->visibility = $dto->visibility;
         $post->apId = $dto->apId;
         $post->magazine->lastActive = new \DateTime();
-        if (null !== $post->user->apDomain && $post->magazine->apDomain === $post->user->apDomain) {
-            $post->magazine->lastOriginUpdate = new \DateTime();
-        }
         $post->user->lastActive = new \DateTime();
         $post->lastActive = $dto->lastActive ?? $post->lastActive;
         $post->createdAt = $dto->createdAt ?? $post->createdAt;


### PR DESCRIPTION
right now we can't be sure that the lastOriginUpdate actually comes from being subscribed to the magazine and receiving updates from it, because someone could follow a user and get the content from there. This commit fixes that. `lastOriginUpdate` will only get set to the current datetime if we receive an `Announce` activity from the magazine which will only be sent if we are subscribed to the magazine

For context see #436 

Fixes #583 