### PR TITLE
fix extra padding on password preview icon

### DIFF
--- a/assets/controllers/password_preview_controller.js
+++ b/assets/controllers/password_preview_controller.js
@@ -2,7 +2,7 @@ import {Controller} from '@hotwired/stimulus';
 
 /* stimulusFetch: 'lazy' */
 export default class extends Controller {
-   
+
     previewButton;
 
     previewIcon;
@@ -24,7 +24,7 @@ export default class extends Controller {
         previewButton.classList.add('password-preview-button','btn','btn__secondary')
         this.previewButton = previewButton;
 
-        let previewIcon = document.createElement("span");
+        let previewIcon = document.createElement("i");
         previewIcon.classList.add('fas', 'fa-eye-slash');
         this.previewIcon = previewIcon;
 
@@ -41,7 +41,7 @@ export default class extends Controller {
      * On press, switch out the input 'type' to show or hide the password
      */
     onPreviewButtonClick(){
-        
+
         let inputType = this.input.getAttribute('type');
         if(inputType === 'password'){
             this.input.setAttribute('type', 'text');
@@ -54,5 +54,5 @@ export default class extends Controller {
             this.previewIcon.classList.add('fa-eye-slash');
         }
     }
-   
+
 }


### PR DESCRIPTION
the password preview element was `span` rather than `i`. normally icons are `i` and have a `span` next to them if there is text needed

also wanted to add a title/aria label for accessibility but realized this is done in javascript so, same problem we've had in the past where we wouldn't be able to translate it without a bunch of work. maybe we should just add it at least as english even if it's untranslated though

---

before

![image](https://github.com/MbinOrg/mbin/assets/146029455/1d7c56f3-0043-43c5-b577-85db094f19ec)
![image](https://github.com/MbinOrg/mbin/assets/146029455/3004b029-2b23-4fb1-9b07-501160045a65)

---

after

![image](https://github.com/MbinOrg/mbin/assets/146029455/642e3810-046d-4e1c-b2c4-80219c3d2ca7)
![image](https://github.com/MbinOrg/mbin/assets/146029455/172293c2-66ff-4f64-99be-3ec7d1fec55c)

