### PR TITLE
Only do an update actor if it is actually necessary

### DIFF
--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -265,6 +265,10 @@ class ActivityPubManager
         $this->logger->info('updating user {name}', ['name' => $actorUrl]);
         $user = $this->userRepository->findOneBy(['apProfileId' => $actorUrl]);
 
+        if ($user instanceof User && $user->apFetchedAt > (new \DateTime())->modify('-1 hour')) {
+            return $user;
+        }
+
         $actor = $this->apHttpClient->getActorObject($actorUrl);
         // Check if actor isn't empty (not set/null/empty array/etc.)
         if (isset($actor['endpoints']['sharedInbox']) || isset($actor['inbox'])) {
@@ -385,6 +389,12 @@ class ActivityPubManager
     {
         $this->logger->info('updating magazine "{magName}"', ['magName' => $actorUrl]);
         $magazine = $this->magazineRepository->findOneBy(['apProfileId' => $actorUrl]);
+
+
+        if ($magazine instanceof Magazine && $magazine->apFetchedAt > (new \DateTime())->modify('-1 hour')) {
+            return $magazine;
+        }
+
         $actor = $this->apHttpClient->getActorObject($actorUrl);
         // Check if actor isn't empty (not set/null/empty array/etc.)
         if (isset($actor['endpoints']['sharedInbox']) || isset($actor['inbox'])) {

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -390,7 +390,6 @@ class ActivityPubManager
         $this->logger->info('updating magazine "{magName}"', ['magName' => $actorUrl]);
         $magazine = $this->magazineRepository->findOneBy(['apProfileId' => $actorUrl]);
 
-
         if ($magazine instanceof Magazine && $magazine->apFetchedAt > (new \DateTime())->modify('-1 hour')) {
             return $magazine;
         }


### PR DESCRIPTION
This has an enourmous impact. In the Activity Handler we dispatch an `UpdateActorMessage` every time an Activity comes on for a user which has not been fetched for an hour or two. If the server is down for a bit we end up with an enourmus amount of these messages. Now we didn't check if we actually need to update an actor in the Handler for the message. This PR adds that 