### PR TITLE
Remove empty panel from admin users pages when there is no pagination

### DIFF
--- a/assets/controllers/subject_controller.js
+++ b/assets/controllers/subject_controller.js
@@ -218,7 +218,7 @@ export default class extends Controller {
     async showModPanel(event) {
         event.preventDefault();
 
-        let container = this.element.querySelector('.moderate-inline')
+        let container = this.element.querySelector('.moderate-inline');
         if (null !== container) {
             // moderate panel was already added to this post, toggle
             // hidden on it to show/hide it and exit

--- a/templates/admin/users.html.twig
+++ b/templates/admin/users.html.twig
@@ -54,9 +54,5 @@
     </div>
     {% if(users.haveToPaginate is defined and users.haveToPaginate) %}
         {{ pagerfanta(users, null, {'pageParameter':'[p]'}) }}
-    {% else %}
-        <aside class="section section--muted">
-            <p>{{ 'empty'|trans }}</p>
-        </aside>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Removes the empty block that appears at the bottom of the page here

![image](https://github.com/MbinOrg/mbin/assets/146029455/c0a8fcc9-672b-4bbb-ad11-f0dfb2e708af)

if you don't have enough users to paginate

now when empty it will look like this

![image](https://github.com/MbinOrg/mbin/assets/146029455/4e80b0b2-1db0-4963-a1b6-1f6e5cb947c7)

which I think is ok for now, as an empty table should still be fairly obvious that it's 0 results

I think long term, looking at it we might want to make a user search that can be accessed here to search by criteria like name