### PR TITLE
Address high severity npm security warning for node_modules/webpack-dev-middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9676,9 +9676,9 @@
             }
         },
         "node_modules/webpack-dev-middleware": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-            "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+            "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
             "dev": true,
             "dependencies": {
                 "colorette": "^2.0.10",
@@ -10077,7 +10077,7 @@
             "devDependencies": {
                 "@hotwired/stimulus": "^3.0.0",
                 "@types/chart.js": "^2.9.34",
-                "chart.js": "^3.4.1 <3.9 || ^4.0",
+                "chart.js": "^3.4.1 || ^4.0",
                 "resize-observer-polyfill": "^1.5.1",
                 "vitest-canvas-mock": "^0.3.3"
             },


### PR DESCRIPTION
Resolve:

```bash
# npm audit report

webpack-dev-middleware  <=5.3.3
Severity: high
Path traversal in webpack-dev-middleware - https://github.com/advisories/GHSA-wr3j-pwj9-hqq6
fix available via `npm audit fix`
node_modules/webpack-dev-middleware
```

Also, `npm audit fix` wants to modify the `chart.js` dependency versioning... not sure if that's a problem.