### PR TITLE
set user report link to pending by default

### DIFF
--- a/templates/user/settings/_options.html.twig
+++ b/templates/user/settings/_options.html.twig
@@ -1,3 +1,4 @@
+{%- set STATUS_PENDING = constant('App\\Entity\\Report::STATUS_PENDING') -%}
 <aside class="{{ html_classes('options options--top') }}" id="options">
     <div></div>
     <menu class="options__main">
@@ -38,7 +39,7 @@
             </a>
         </li>
         <li>
-            <a href="{{ path('user_settings_reports') }}"
+            <a href="{{ path('user_settings_reports', {status: STATUS_PENDING}) }}"
                class="{{ html_classes({'active': is_route_name('user_settings_reports')}) }}">
                 {{ 'reports'|trans }}
             </a>


### PR DESCRIPTION
I missed this as part of https://github.com/MbinOrg/mbin/pull/320

This makes it so the user link to their reports goes to pending by default. That was already done for admin/magazine report links