### PR TITLE
Open remote mag/user links in new window, add mag link to sidebar

### DIFF
--- a/templates/components/magazine_box.html.twig
+++ b/templates/components/magazine_box.html.twig
@@ -21,8 +21,11 @@
             <h4><a href="{{ path('front_magazine', {name: magazine.name}) }}"
                    class="{{ html_classes({'stretched-link': false}) }}">{{ computed.magazine.title }}</a></h4>
             <p class="magazine__name">
-                {{ ('@'~magazine.name)|username(true) }}
-                {% if magazine.isAdult %}<small class="badge danger">18+</small>{% endif %}
+                <span>{{ ('@'~magazine.name)|username(true) }} {% if magazine.isAdult %}<small class="badge danger">18+</small>{% endif %}</span>
+                {% if magazine.apId %}
+                    <a href="{{ magazine.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank" aria-label="{{ 'go_to_original_instance'|trans }}">
+                    <i class="fa-solid fa-circle-nodes" aria-hidden="true"></i></a>
+                {% endif %}
             </p>
         </header>
     </div>

--- a/templates/components/magazine_box.html.twig
+++ b/templates/components/magazine_box.html.twig
@@ -23,7 +23,7 @@
             <p class="magazine__name">
                 <span>{{ ('@'~magazine.name)|username(true) }} {% if magazine.isAdult %}<small class="badge danger">18+</small>{% endif %}</span>
                 {% if magazine.apId %}
-                    <a href="{{ magazine.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank" aria-label="{{ 'go_to_original_instance'|trans }}">
+                    <a href="{{ magazine.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank" title="{{ 'go_to_original_instance'|trans }}" aria-label="{{ 'go_to_original_instance'|trans }}">
                     <i class="fa-solid fa-circle-nodes" aria-hidden="true"></i></a>
                 {% endif %}
             </p>

--- a/templates/magazine/_federated_info.html.twig
+++ b/templates/magazine/_federated_info.html.twig
@@ -3,7 +3,7 @@
         {# Then show a link to original if we're at the end of content #}
         <div class="alert alert__info">
             <p>
-                {{ 'federated_magazine_info'|trans }} <a href="{{ magazine.apProfileId }}">{{ 'go_to_original_instance'|trans }}</a>
+                {{ 'federated_magazine_info'|trans }} <a href="{{ magazine.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank"><span>{{ 'go_to_original_instance'|trans }}</span> <i class="fa-solid fa-external-link" aria-hidden="true"></i></a>
             </p>
         </div>
     {% endif %}

--- a/templates/user/_federated_info.html.twig
+++ b/templates/user/_federated_info.html.twig
@@ -1,6 +1,6 @@
 {% if user.apId %}
     <div class="alert alert__info">
         <p>{{ 'federated_user_info'|trans }} <a
-                    href="{{ user.apProfileId }}">{{ 'go_to_original_instance'|trans }}</a></p>
+                    href="{{ user.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank"><span>{{ 'go_to_original_instance'|trans }}</span> <i class="fa-solid fa-external-link" aria-hidden="true"></i></a></p>
     </div>
 {% endif %}

--- a/templates/user/_user_popover.html.twig
+++ b/templates/user/_user_popover.html.twig
@@ -22,7 +22,10 @@
                     </a>
                 </li>
                 {% if user.apProfileId %}
-                    <li><a href="{{ user.apProfileId }}">{{ 'go_to_original_instance'|trans|trim('.', 'right') }}</a>
+                    <li>
+                        <a href="{{ user.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank">
+                            <span>{{ 'go_to_original_instance'|trans|trim('.', 'right') }}</span> <i class="fa-solid fa-external-link" aria-hidden="true"></i>
+                        </a>
                     </li>
                 {% endif %}
             </ul>


### PR DESCRIPTION
- Makes the "Go to original instance" links open in a new window
- Adds `noopener noreferrer nofollow` to them all
- Adds a sidebar icon next to magazine name for remote magazines to go to the remote magazine
  - Now that there isn't a banner for remote magazines when they are getting updates, there isn't an easy way to jump to the original magazine if you want to view it. Compare with lemmy that makes the entire magazine name the link to the original location. If people prefer that, I could go with that instead

the only visual difference is the popout icons and federation icon

---

remote magazines

![image](https://github.com/MbinOrg/mbin/assets/146029455/9cfe4c60-7c71-4718-8fe7-dcf41d5f9f20)
![image](https://github.com/MbinOrg/mbin/assets/146029455/6e94d702-0952-47b4-8193-2a3ffc1d8ff5)

---

remote users

![image](https://github.com/MbinOrg/mbin/assets/146029455/727c997a-6cb4-4c53-9a46-fcc2e6e5e40e)
![image](https://github.com/MbinOrg/mbin/assets/146029455/a17e7286-e2e9-47de-83c7-9948e638e9c5)

