### PR TITLE
add alt text as title as well

### DIFF
--- a/templates/components/_figure_entry.html.twig
+++ b/templates/components/_figure_entry.html.twig
@@ -37,6 +37,7 @@
             <img class="thumb-subject"
                  loading="lazy"
                  src="{{ image_path }}"
+                 title="{{ image.altText }}"
                  alt="{{ image.altText }}">
         </a>
         <div class="figure-badge sensitive-checked--show">

--- a/templates/components/_figure_image.html.twig
+++ b/templates/components/_figure_image.html.twig
@@ -17,6 +17,7 @@
                     data-description="{{ image.altText ? '.'~lightbox_alt_id : ''}}">
                     <img loading="lazy"
                          src="{{ image_path }}"
+                         title="{{ image.altText }}"
                          alt="{{ image.altText }}">
                 </a>
             </div>


### PR DESCRIPTION
Spoke with @asdfzdfj about adding the alt text of images to title as well. Of course this isn't specifically accessibility related as that isn't what the title attribute is for, but it seems very common (at least see it done this way on mastodon) so that it appears as the tooltip when hovering over it

![image](https://github.com/MbinOrg/mbin/assets/146029455/64718d4b-a455-4b42-9322-a1326ce230e9)
