### PR TITLE
Update user popover for remote users

### DIFF
--- a/assets/styles/components/_magazine.scss
+++ b/assets/styles/components/_magazine.scss
@@ -25,6 +25,10 @@
 
   &__name {
     margin-top: 0;
+
+    i {
+      font-size: 0.7rem;
+    }
   }
 
   &__description,

--- a/assets/styles/components/_user.scss
+++ b/assets/styles/components/_user.scss
@@ -39,6 +39,12 @@
 
     opacity: .75;
   }
+
+  &__name {
+    i {
+      font-size: 0.7rem;
+    }
+  }
 }
 
 .user-inline {

--- a/assets/styles/layout/_alerts.scss
+++ b/assets/styles/layout/_alerts.scss
@@ -8,8 +8,13 @@
     margin: 0;
   }
 
-  a{
+  a {
     font-weight: bold;
+  }
+
+  i {
+    font-size: 0.8rem;
+    vertical-align: middle;
   }
 
   &__info {
@@ -18,7 +23,7 @@
     color: var(--kbin-alert-info-text-color);
 
     a {
-      color: var(--kbin-alert-info-link-color);    
+      color: var(--kbin-alert-info-link-color);
     }
   }
 

--- a/templates/components/magazine_box.html.twig
+++ b/templates/components/magazine_box.html.twig
@@ -23,7 +23,7 @@
             <p class="magazine__name">
                 <span>{{ ('@'~magazine.name)|username(true) }} {% if magazine.isAdult %}<small class="badge danger">18+</small>{% endif %}</span>
                 {% if magazine.apId %}
-                    <a href="{{ magazine.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank" title="{{ 'go_to_original_instance'|trans }}" aria-label="{{ 'go_to_original_instance'|trans }}">
+                    <a href="{{ magazine.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank" title="{{ 'open_original_magazine'|trans }}" aria-label="{{ 'open_original_magazine'|trans }}">
                     <i class="fa-solid fa-circle-nodes" aria-hidden="true"></i></a>
                 {% endif %}
             </p>

--- a/templates/components/magazine_box.html.twig
+++ b/templates/components/magazine_box.html.twig
@@ -23,8 +23,8 @@
             <p class="magazine__name">
                 <span>{{ ('@'~magazine.name)|username(true) }} {% if magazine.isAdult %}<small class="badge danger">18+</small>{% endif %}</span>
                 {% if magazine.apId %}
-                    <a href="{{ magazine.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank" title="{{ 'open_original_magazine'|trans }}" aria-label="{{ 'open_original_magazine'|trans }}">
-                    <i class="fa-solid fa-circle-nodes" aria-hidden="true"></i></a>
+                    <a href="{{ magazine.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank" title="{{ 'go_to_original_instance'|trans }}" aria-label="{{ 'go_to_original_instance'|trans }}">
+                    <i class="fa-solid fa-external-link" aria-hidden="true"></i></a>
                 {% endif %}
             </p>
         </header>

--- a/templates/entry/_info.html.twig
+++ b/templates/entry/_info.html.twig
@@ -10,9 +10,14 @@
                      alt="{{ entry.user.username ~' '~ 'avatar'|trans|lower }}">
             </figure>
         {% endif %}
-        <h4><a href="{{ path('user_overview', {username:entry.user.username}) }}"
-               class="stretched-link">{{ entry.user.username|username(false) }}</a></h4>
-        <p class="user__name">{{ entry.user.username|username(true) }}</p>
+        <h4><a href="{{ path('user_overview', {username:entry.user.username}) }}">{{ entry.user.username|username(false) }}</a></h4>
+        <p>
+            <span>{{ entry.user.username|username(true) }}</span>
+            {% if entry.user.apProfileId %}
+                <a href="{{ entry.user.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank" title="{{ 'go_to_original_instance'|trans }}" aria-label="{{ 'go_to_original_instance'|trans }}">
+                <i class="fa-solid fa-external-link" aria-hidden="true"></i></a>
+            {% endif %}
+        </p>
     </div>
     {{ component('user_actions', {user: entry.user}) }}
     <ul class="info">

--- a/templates/entry/_info.html.twig
+++ b/templates/entry/_info.html.twig
@@ -11,7 +11,7 @@
             </figure>
         {% endif %}
         <h4><a href="{{ path('user_overview', {username:entry.user.username}) }}">{{ entry.user.username|username(false) }}</a></h4>
-        <p>
+        <p class="user__name">
             <span>{{ entry.user.username|username(true) }}</span>
             {% if entry.user.apProfileId %}
                 <a href="{{ entry.user.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank" title="{{ 'go_to_original_instance'|trans }}" aria-label="{{ 'go_to_original_instance'|trans }}">

--- a/templates/post/_info.html.twig
+++ b/templates/post/_info.html.twig
@@ -10,9 +10,14 @@
                      alt="{{ post.user.username ~' '~ 'avatar'|trans|lower }}">
             </figure>
         {% endif %}
-        <h4><a href="{{ path('user_overview', {username:post.user.username}) }}"
-               class="stretched-link">{{ post.user.username|username(false) }}</a></h4>
-        <p class="user__name">{{ post.user.username|username(true) }}</p>
+        <h4><a href="{{ path('user_overview', {username:post.user.username}) }}">{{ post.user.username|username(false) }}</a></h4>
+        <p>
+            <span>{{ post.user.username|username(true) }}</span>
+            {% if post.user.apProfileId %}
+                <a href="{{ post.user.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank" title="{{ 'go_to_original_instance'|trans }}" aria-label="{{ 'go_to_original_instance'|trans }}">
+                <i class="fa-solid fa-external-link" aria-hidden="true"></i></a>
+            {% endif %}
+        </p>
     </div>
     {{ component('user_actions', {user: post.user}) }}
     <ul class="info">

--- a/templates/post/_info.html.twig
+++ b/templates/post/_info.html.twig
@@ -11,7 +11,7 @@
             </figure>
         {% endif %}
         <h4><a href="{{ path('user_overview', {username:post.user.username}) }}">{{ post.user.username|username(false) }}</a></h4>
-        <p>
+        <p class="user__name">
             <span>{{ post.user.username|username(true) }}</span>
             {% if post.user.apProfileId %}
                 <a href="{{ post.user.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank" title="{{ 'go_to_original_instance'|trans }}" aria-label="{{ 'go_to_original_instance'|trans }}">

--- a/templates/user/_user_popover.html.twig
+++ b/templates/user/_user_popover.html.twig
@@ -15,8 +15,8 @@
             <p>
                 <span>{{ user.username|username(true) }}</span>
                 {% if user.apProfileId %}
-                    <a href="{{ user.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank" title="{{ 'open_original_profile'|trans }}" aria-label="{{ 'open_original_profile'|trans }}">
-                    <i class="fa-solid fa-circle-nodes" aria-hidden="true"></i></a>
+                    <a href="{{ user.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank" title="{{ 'go_to_original_instance'|trans }}" aria-label="{{ 'go_to_original_instance'|trans }}">
+                    <i class="fa-solid fa-external-link" aria-hidden="true"></i></a>
                 {% endif %}
             </p>
             <ul>

--- a/templates/user/_user_popover.html.twig
+++ b/templates/user/_user_popover.html.twig
@@ -12,7 +12,7 @@
             <h3>
                 <a class="link-muted" href="{{ path('user_overview', {username: user.username}) }}">{{ user.username|username }}</a>
             </h3>
-            <p>
+            <p class="user__name">
                 <span>{{ user.username|username(true) }}</span>
                 {% if user.apProfileId %}
                     <a href="{{ user.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank" title="{{ 'go_to_original_instance'|trans }}" aria-label="{{ 'go_to_original_instance'|trans }}">

--- a/templates/user/_user_popover.html.twig
+++ b/templates/user/_user_popover.html.twig
@@ -9,10 +9,16 @@
             }) }}
         {% endif %}
         <div>
-            <a class="link-muted" href="{{ path('user_overview', {username: user.username}) }}">
-                <h3>{{ user.username|username }}</h3>
-                <p>{{ user.username|username(true) }}</p>
-            </a>
+            <h3>
+                <a class="link-muted" href="{{ path('user_overview', {username: user.username}) }}">{{ user.username|username }}</a>
+            </h3>
+            <p>
+                <span>{{ user.username|username(true) }}</span>
+                {% if user.apProfileId %}
+                    <a href="{{ user.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank" title="{{ 'open_original_profile'|trans }}" aria-label="{{ 'open_original_profile'|trans }}">
+                    <i class="fa-solid fa-circle-nodes" aria-hidden="true"></i></a>
+                {% endif %}
+            </p>
             <ul>
                 <li>{{ 'joined'|trans }}: {{ component('date', {date: user.createdAt}) }}</li>
                 <li>
@@ -21,13 +27,6 @@
                         {{ 'reputation_points'|trans }}: {{ get_reputation_total(user) }}
                     </a>
                 </li>
-                {% if user.apProfileId %}
-                    <li>
-                        <a href="{{ user.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank">
-                            <span>{{ 'go_to_original_instance'|trans|trim('.', 'right') }}</span> <i class="fa-solid fa-external-link" aria-hidden="true"></i>
-                        </a>
-                    </li>
-                {% endif %}
             </ul>
             {{ component('user_actions', {user: user}) }}
         </div>

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -61,7 +61,7 @@ disconnected_magazine_info: This magazine is not receiving updates (last activit
 always_disconnected_magazine_info: This magazine is not receiving updates.
 subscribe_for_updates: Subscribe to start receiving updates.
 federated_user_info: This profile is from a federated server and may be incomplete.
-go_to_original_instance: For a complete list of posts, visit the original instance.
+go_to_original_instance: View on remote instance
 empty: Empty
 subscribe: Subscribe
 unsubscribe: Unsubscribe
@@ -748,8 +748,6 @@ page_width_max: Max
 page_width_auto: Auto
 page_width_fixed: Fixed
 open_url_to_fediverse: Open original URL
-open_original_magazine: Open original magazine
-open_original_profile: Open original profile
 change_my_avatar: Change my avatar
 change_my_cover: Change my cover
 edit_my_profile: Edit my profile

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -748,6 +748,8 @@ page_width_max: Max
 page_width_auto: Auto
 page_width_fixed: Fixed
 open_url_to_fediverse: Open original URL
+open_original_magazine: Open original magazine
+open_original_profile: Open original profile
 change_my_avatar: Change my avatar
 change_my_cover: Change my cover
 edit_my_profile: Edit my profile


### PR DESCRIPTION
changes loc message to "View on remote instance"

remote user profile page

![image](https://github.com/MbinOrg/mbin/assets/146029455/8c94cb6c-fd66-4c03-a579-d30e6141d7ca)

remote user popup

![image](https://github.com/MbinOrg/mbin/assets/146029455/7b88add7-f3b2-4026-bab3-acf0f13822d6)

remote user OP entry sidebar

![image](https://github.com/MbinOrg/mbin/assets/146029455/b21d2d4b-5152-409d-8797-e4b1edf1e07f)

remote user OP post sidebar

![image](https://github.com/MbinOrg/mbin/assets/146029455/9edcfbf3-020b-4300-9b99-5dbb88251ea5)

---

remote magazine

![image](https://github.com/MbinOrg/mbin/assets/146029455/de88bd47-585c-4659-a43a-fda9e01b4a29)

remote magazine sidebar

![image](https://github.com/MbinOrg/mbin/assets/146029455/a8434924-93de-4195-a4b5-1947b695e910)

---

<details>
<summary>OLD</summary>

- update user popover for remote users
- new loc token for specifying opening original profiles or magazines~
  - changed the magazine loc token that I just added in #616  as I feel it was also unclear as to the function, but wasn't quite convinced to add a new one, but since we might be adding one for opening profiles, felt we should add one to open for magazines. not sure how clear "open original profile/magazine" is

based on conversation from matrix, the user popover text is unclear as to what its function is. A suggestion was to remove the text and just have the icon next to the username like it now appears for remote magazines

now is the chance for any comments. different text? smaller popout icons of the alert banners? remove the alert banner completely from user profiles? add the remote icon next to usernames in the user overview box as well? feel free to give feedback

![image](https://github.com/MbinOrg/mbin/assets/146029455/88ba1b94-1842-4fb0-a239-5fe8d039120a)
![image](https://github.com/MbinOrg/mbin/assets/146029455/422d7863-40e3-45a6-9b94-c37a8249ba4f)

</details>