### PR TITLE
Fix error pollution on null $user object

### DIFF
--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -130,7 +130,7 @@ class ActivityPubManager
         if (false === filter_var($actorUrl, FILTER_VALIDATE_URL)) {
             if (!substr_count(ltrim($actorUrl, '@'), '@')) {
                 $user = $this->userRepository->findOneBy(['username' => ltrim($actorUrl, '@')]);
-                if (!empty($user)) {
+                if ($user instanceof User) {
                     if ($user->apFetchedAt->modify('+1 hour') < (new \DateTime())) {
                         $this->bus->dispatch(new UpdateActorMessage($user->apProfileId));
                     }

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -130,11 +130,13 @@ class ActivityPubManager
         if (false === filter_var($actorUrl, FILTER_VALIDATE_URL)) {
             if (!substr_count(ltrim($actorUrl, '@'), '@')) {
                 $user = $this->userRepository->findOneBy(['username' => ltrim($actorUrl, '@')]);
-                if ($user->apFetchedAt->modify('+1 hour') < (new \DateTime())) {
-                    $this->bus->dispatch(new UpdateActorMessage($user->apProfileId));
-                }
+                if (!empty($user)) {
+                    if ($user->apFetchedAt->modify('+1 hour') < (new \DateTime())) {
+                        $this->bus->dispatch(new UpdateActorMessage($user->apProfileId));
+                    }
 
-                return $user;
+                    return $user;
+                }
             }
 
             $actorUrl = $this->webfinger($actorUrl)->getProfileId();


### PR DESCRIPTION
Add missing `$user` check on possible empty/null object. Causing errors:

```
{"message":"Warning: Attempt to read property \"apFetchedAt\" on null","context":{"exception":{"class":"ErrorException","message":"Warning: Attempt to read property \"apFetchedAt\" on null","code":0,"file":"/var/www/kbin.melroy.org/html/src/Service/ActivityPubManager.php:133"}},"level":300,"level_name":"WARNING","channel":"php","datetime":"2024-03-25T00:47:01.732142+01:00","extra":{}}
```