### PR TITLE
fix DeleteHandler calling getId() on null

### DIFF
--- a/src/MessageHandler/ActivityPub/Inbox/DeleteHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/DeleteHandler.php
@@ -64,15 +64,15 @@ class DeleteHandler
         $entity = $this->entityManager->getRepository($object['type'])->find((int) $object['id']);
 
         if ($entity instanceof Entry) {
-            $this->deleteEntry($object, $actor);
+            $this->deleteEntry($entity, $actor);
         } elseif ($entity instanceof EntryComment) {
-            $this->deleteEntryComment($object, $actor);
+            $this->deleteEntryComment($entity, $actor);
         } elseif ($entity instanceof Post) {
-            $this->deletePost($object, $actor);
+            $this->deletePost($entity, $actor);
         } elseif ($entity instanceof PostComment) {
-            $this->deletePostComment($object, $actor);
+            $this->deletePostComment($entity, $actor);
         } elseif ($entity instanceof User) {
-            $this->bus->dispatch(new DeleteUserMessage($object->getId()));
+            $this->bus->dispatch(new DeleteUserMessage($entity->getId()));
         }
     }
 


### PR DESCRIPTION
fix DeleteHandler errors out when dispatching the delete action

those function needs the resolved `$entity` not the `$object` telling where the entity is