### PR TITLE
cap max creation time used in ranking calculation

### DIFF
--- a/src/Entity/Traits/RankingTrait.php
+++ b/src/Entity/Traits/RankingTrait.php
@@ -26,7 +26,13 @@ trait RankingTrait
 
         $advantage = max(min($scoreAdvantage + $commentAdvantage, self::MAX_ADVANTAGE), -self::MAX_PENALTY);
 
-        $this->ranking = $this->getCreatedAt()->getTimestamp() + $advantage;
+        // cap max date advantage at the time of calculation to cope with posts
+        // that have funny dates (e.g. 4200-06-09)
+        // which can cause int overflow (int32?) on ranking score
+        $dateAdvantage = min($this->getCreatedAt()->getTimestamp(), (new \DateTimeImmutable())->getTimestamp());
+
+        // also cap the final score to not exceed int32 size for the time being
+        $this->ranking = min($dateAdvantage + $advantage, 2 ** 31 - 1);
     }
 
     public function getRanking(): int


### PR DESCRIPTION
added a cap on creation timestamp used in ranking calculation to not exceeds the current time while performing calculation to cope with posts' that have funny created date far into the future, also cap the final score value to not exceed int32 max size (`2**31 - 1`)

the current ranking function involves using the posts' object creation timestamp as part of the calculation, but if the datetime is too far in the future (e.g. 4200-06-09, as seen in [this example][ex1]), it can cause the ranking score value to exceeds the ranking score field size, which appears to be int32 sized

technically we'll still be running into year 2038 problem on this field, but there's some discussion on adjusting the ranking score and keep that below int32 sized altogether, so that's left for the future exercise

also see #622 for more context, this only deals with a specific problem that's observed from that issue but by no means a definitive solution for the problem

[ex1]: https://myfriendsare.gay/notice/APx5K7aeglknMfm1A0