### PR TITLE
Fix list display in magazine description

### DIFF
--- a/assets/styles/components/_magazine.scss
+++ b/assets/styles/components/_magazine.scss
@@ -34,19 +34,17 @@
   &__description,
   &__rules {
     ul {
-      padding-left: .5rem;
+      padding-left: .75rem;
 
       li {
-        list-style: none;
         margin-bottom: .5rem;
       }
     }
 
     ol {
-      padding-left: 0.5rem;
+      padding-left: 0.75rem;
 
       li {
-        list-style: circle;
         margin-left: 2px;
         margin-bottom: 0.5rem;
       }


### PR DESCRIPTION
The magazine description used weird list styles which were additionally cut off if it was an ordered list. 

| Before | After |
| ------ | ----- |
| ![Bildschirmfoto vom 2024-03-27 10-20-15](https://github.com/MbinOrg/mbin/assets/25664458/662dd4ad-d89f-4e8a-af94-d81a84e1ca7b) | ![Bildschirmfoto vom 2024-03-27 10-20-06](https://github.com/MbinOrg/mbin/assets/25664458/a3f2827c-564f-4f5a-9670-2986dfe264dd) |
