### PR TITLE
Fix width class missing if `KBIN_PAGE_WIDTH` has not been set

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -59,7 +59,7 @@
     <div class="kbin-container
       {{ html_classes(app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH'))
         ? 'width--'~app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH'))
-        : '') }}">
+        : 'width--fixed') }}">
         <main id="main"
               data-controller="lightbox timeago confirmation"
               class="{{ html_classes({'view-compact': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT')) is same as 'true'}) }}">


### PR DESCRIPTION
When the page width has not been explicitly set the `width--fixed` class was missing from the kbin contianer. That lead to the subscription sidebar not having a max width leading to this display:
![grafik](https://github.com/MbinOrg/mbin/assets/25664458/febb8e2c-d187-4d4b-80a1-8d5a16129eb4)
