### PR TITLE
restore css to limit figure preview size

### DIFF
--- a/assets/styles/components/_figure_image.scss
+++ b/assets/styles/components/_figure_image.scss
@@ -15,6 +15,8 @@
     display: block;
     width: 100%;
     height: 100%;
+    max-width: 600px;
+    max-height: 500px;
   }
 }
 


### PR DESCRIPTION
added back css that limits the size of attached figure image to not exceeds 600x500px, the same size used when generating the thumbnails

back when making the new sensitive figure, there was a bit of problem in keeping the image size limited without destroying the aspect ratio or causes image stretching, so that was left out and relied on generated thumbnails for limiting the figure size, however with the later introduced large image handling where the link to original image may be used for the figure instead, which can make the rendered figure bigger than what it should be