### PR TITLE
AttachEntryEmbedHandler add missing image source url (take 2)

### DIFF
--- a/src/MessageHandler/AttachEntryEmbedHandler.php
+++ b/src/MessageHandler/AttachEntryEmbedHandler.php
@@ -67,16 +67,27 @@ class AttachEntryEmbedHandler
     private function fetchCover(Entry $entry, Embed $embed): ?Image
     {
         if (!$entry->image) {
-            $tempFile = null;
-            if ($embed->image) {
-                $tempFile = $this->fetchImage($embed->image);
-            } elseif ($embed->isImageUrl()) {
-                $tempFile = $this->fetchImage($entry->url);
-            }
+            if ($imageUrl = $this->getCoverUrl($entry, $embed)) {
+                if ($tempFile = $this->fetchImage($imageUrl)) {
+                    $image = $this->imageRepository->findOrCreateFromPath($tempFile);
+                    if ($image && !$image->filePath) {
+                        $image->sourceUrl = $imageUrl;
+                    }
 
-            if ($tempFile) {
-                return $this->imageRepository->findOrCreateFromPath($tempFile);
+                    return $image;
+                }
             }
+        }
+
+        return null;
+    }
+
+    private function getCoverUrl(Entry $entry, Embed $embed): ?string
+    {
+        if ($embed->image) {
+            return $embed->image;
+        } elseif ($embed->isImageUrl()) {
+            return $entry->url;
         }
 
         return null;

--- a/src/MessageHandler/AttachEntryEmbedHandler.php
+++ b/src/MessageHandler/AttachEntryEmbedHandler.php
@@ -70,7 +70,7 @@ class AttachEntryEmbedHandler
             if ($imageUrl = $this->getCoverUrl($entry, $embed)) {
                 if ($tempFile = $this->fetchImage($imageUrl)) {
                     $image = $this->imageRepository->findOrCreateFromPath($tempFile);
-                    if ($image && !$image->filePath) {
+                    if ($image && !$image->sourceUrl) {
                         $image->sourceUrl = $imageUrl;
                     }
 


### PR DESCRIPTION
let's try this again, apparently the old take on this patch broke link cover fetching, so this one only contains just the fix and nothing else

it seems like #501 strikes again, occasionally leaving entries with broken thumbnail when it was attached using AttachEntryEmbedHandler

fix the AttachEntryEmbedHandler to properly attach a link to the created cover image entity if the resulting entity doesn't have their filePath set, most likely because the image is too big