### PR TITLE
Rename yarn to npm

### DIFF
--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -467,7 +467,7 @@ effective_cache_size = 25GB
 
 **Note:** We try to set `huge_pages` to: `on` in PostgreSQL, in order to make this works you need to [enable huge pages under Linux (click here)](https://www.enterprisedb.com/blog/tuning-debian-ubuntu-postgresql) as well! Please follow that guide. and play around with your kernel configurations.
 
-### Yarn
+### NPM
 
 ```bash
 cd /var/www/mbin


### PR DESCRIPTION
During the docker setup debugging/rework. I notice it says "Yarn" in the bare metal docs, while we are using just `npm` for quite some time now.