### PR TITLE
Fix error on local user comments on local users

### DIFF
--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -131,7 +131,7 @@ class ActivityPubManager
             if (!substr_count(ltrim($actorUrl, '@'), '@')) {
                 $user = $this->userRepository->findOneBy(['username' => ltrim($actorUrl, '@')]);
                 if ($user instanceof User) {
-                    if ($user->apFetchedAt->modify('+1 hour') < (new \DateTime())) {
+                    if (isset($user->apId) && $user->apFetchedAt->modify('+1 hour') < (new \DateTime())) {
                         $this->bus->dispatch(new UpdateActorMessage($user->apProfileId));
                     }
 


### PR DESCRIPTION
When fetching the AP for a local user replying to a local user, a 500 was being thrown:

```
Error:
Call to a member function modify() on null

  at src/Service/ActivityPubManager.php:134
  at App\Service\ActivityPubManager-&gt;findActorOrCreate('@user1')
     (src/Service/ActivityPub/Wrapper/MentionsWrapper.php:29)
  at App\Service\ActivityPub\Wrapper\MentionsWrapper-&gt;build(array('@user1'), 'remote entry comment')
     (src/Factory/ActivityPub/EntryCommentNoteFactory.php:71)
  at App\Factory\ActivityPub\EntryCommentNoteFactory-&gt;create(object(EntryComment), true)
     (src/Controller/ActivityPub/EntryCommentController.php:41)
  at App\Controller\ActivityPub\EntryCommentController-&gt;__invoke(object(Magazine), object(Entry), object(EntryComment), object(Request))
     (vendor/symfony/http-kernel/HttpKernel.php:181)
  at Symfony\Component\HttpKernel\HttpKernel-&gt;handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel-&gt;handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:197)
  at Symfony\Component\HttpKernel\Kernel-&gt;handle(object(Request))
     (vendor/symfony/runtime/Runner/Symfony/HttpKernelRunner.php:35)
  at Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner-&gt;run()
     (vendor/autoload_runtime.php:29)
  at require_once('/var/www/mbin/vendor/autoload_runtime.php')
     (public/index.php:7)
```

this line https://github.com/MbinOrg/mbin/blob/823c83ca9f92fa4da42f6aba861012cfb97b8f5f/src/Service/ActivityPubManager.php#L134

was being run on local users, and modify was throwing an error when it was null. this check makes it only emit the dispatch if the user is remote