### PR TITLE
Fix missing delete cascade on MessageThread

### DIFF
--- a/migrations/Version20240402190028.php
+++ b/migrations/Version20240402190028.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240402190028 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Make the foreign keys in the message, message_thread and message_thread_participants tables cascade delete';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE message_thread_participants DROP CONSTRAINT FK_F2DE92908829462F');
+        $this->addSql('ALTER TABLE message_thread_participants DROP CONSTRAINT FK_F2DE9290A76ED395');
+        $this->addSql('ALTER TABLE message DROP CONSTRAINT FK_B6BD307FE2904019');
+        $this->addSql('ALTER TABLE message_thread_participants ADD CONSTRAINT FK_F2DE92908829462F FOREIGN KEY (message_thread_id) REFERENCES message_thread (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE message_thread_participants ADD CONSTRAINT FK_F2DE9290A76ED395 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE message ADD CONSTRAINT FK_B6BD307FE2904019 FOREIGN KEY (thread_id) REFERENCES message_thread (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE message DROP CONSTRAINT fk_b6bd307fe2904019');
+        $this->addSql('ALTER TABLE message_thread_participants DROP CONSTRAINT fk_f2de92908829462f');
+        $this->addSql('ALTER TABLE message_thread_participants DROP CONSTRAINT fk_f2de9290a76ed395');
+        $this->addSql('ALTER TABLE message ADD CONSTRAINT fk_b6bd307fe2904019 FOREIGN KEY (thread_id) REFERENCES message_thread (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE message_thread_participants ADD CONSTRAINT fk_f2de92908829462f FOREIGN KEY (message_thread_id) REFERENCES message_thread (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE message_thread_participants ADD CONSTRAINT fk_f2de9290a76ed395 FOREIGN KEY (user_id) REFERENCES "user" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+}

--- a/src/Entity/Message.php
+++ b/src/Entity/Message.php
@@ -29,7 +29,7 @@ class Message
     ];
 
     #[ManyToOne(targetEntity: MessageThread::class, cascade: ['persist'], inversedBy: 'messages')]
-    #[JoinColumn(nullable: false)]
+    #[JoinColumn(nullable: false, onDelete: 'CASCADE')]
     public MessageThread $thread;
     #[ManyToOne(targetEntity: User::class)]
     #[JoinColumn(nullable: false, onDelete: 'CASCADE')]

--- a/src/Entity/Message.php
+++ b/src/Entity/Message.php
@@ -28,7 +28,7 @@ class Message
         self::STATUS_READ,
     ];
 
-    #[ManyToOne(targetEntity: MessageThread::class, cascade: ['persist'], inversedBy: 'messages')]
+    #[ManyToOne(targetEntity: MessageThread::class, inversedBy: 'messages')]
     #[JoinColumn(nullable: false, onDelete: 'CASCADE')]
     public MessageThread $thread;
     #[ManyToOne(targetEntity: User::class)]

--- a/src/Entity/MessageThread.php
+++ b/src/Entity/MessageThread.php
@@ -28,13 +28,13 @@ class MessageThread
     #[JoinTable(
         name: 'message_thread_participants',
         joinColumns: [
-            new JoinColumn(name: 'message_thread_id', referencedColumnName: 'id'),
+            new JoinColumn(name: 'message_thread_id', referencedColumnName: 'id', onDelete: 'CASCADE'),
         ],
         inverseJoinColumns: [
-            new JoinColumn(name: 'user_id', referencedColumnName: 'id'),
+            new JoinColumn(name: 'user_id', referencedColumnName: 'id', onDelete: 'CASCADE'),
         ]
     )]
-    #[ManyToMany(targetEntity: User::class)]
+    #[ManyToMany(targetEntity: User::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
     public Collection $participants;
     #[OneToMany(mappedBy: 'thread', targetEntity: Message::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
     #[OrderBy(['createdAt' => 'DESC'])]


### PR DESCRIPTION
Hopefully solves:

```
{"message":"Error thrown while handling message App\\Message\\DeleteUserMessage. Removing from transport after 7 retries. Error: \"Handling \"App\\Message\\DeleteUserMessage\" failed: An exception occurred while executing a query: SQLSTATE[23503]: Foreign key violation: 7 ERROR:  update or delete on table \"user\" violates foreign key constraint \"fk_f2de9290a76ed395\" on table \"message_thread_participants\"\nDETAIL:  Key (id)=(211639) is still referenced from table \"message_thread_participants\".\"","context":{"class":"App\\Message\\DeleteUserMessage","retryCount":7,"error":"Handling \"App\\Message\\DeleteUserMessage\" failed: An exception occurred while executing a query: SQLSTATE[23503]: Foreign key violation: 7 ERROR:  update or delete on table \"user\" violates foreign key constraint \"fk_f2de9290a76ed395\" on table \"message_thread_participants\"\nDETAIL:  Key (id)=(211639) is still referenced from table \"message_thread_participants\".","exception":{"class":"Symfony\\Component\\Messenger\\Exception\\HandlerFailedException","message":"Handling \"App\\Message\\DeleteUserMessage\" failed: An exception occurred while executing a query: SQLSTATE[23503]: Foreign key violation: 7 ERROR:  update or delete on table \"user\" violates foreign key constraint \"fk_f2de9290a76ed395\" on table \"message_thread_participants\"\nDETAIL:  Key (id)=(211639) is still referenced from table \"message_thread_participants\".","code":7,"file":"/var/www/kbin.melroy.org/html/vendor/symfony/messenger/Middleware/HandleMessageMiddleware.php:124","previous":{"class":"Doctrine\\DBAL\\Exception\\ForeignKeyConstraintViolationException","message":"An exception occurred while executing a query: SQLSTATE[23503]: Foreign key violation: 7 ERROR:  update or delete on table \"user\" violates foreign key constraint \"fk_f2de9290a76ed395\" on table \"message_thread_participants\"\nDETAIL:  Key (id)=(211639) is still referenced from table \"message_thread_participants\".","code":7,"file":"/var/www/kbin.melroy.org/html/vendor/doctrine/dbal/src/Driver/API/PostgreSQL/ExceptionConverter.php:50","previous":{"class":"Doctrine\\DBAL\\Driver\\PDO\\Exception","message":"SQLSTATE[23503]: Foreign key violation: 7 ERROR:  update or delete on table \"user\" violates foreign key constraint \"fk_f2de9290a76ed395\" on table \"message_thread_participants\"\nDETAIL:  Key (id)=(211639) is still referenced from table \"message_thread_participants\".","code":7,"file":"/var/www/kbin.melroy.org/html/vendor/doctrine/dbal/src/Driver/PDO/Exception.php:28","previous":{"class":"PDOException","message":"SQLSTATE[23503]: Foreign key violation: 7 ERROR:  update or delete on table \"user\" violates foreign key constraint \"fk_f2de9290a76ed395\" on table \"message_thread_participants\"\nDETAIL:  Key (id)=(211639) is still referenced from table \"message_thread_participants\".","code":23503,"file":"/var/www/kbin.melroy.org/html/vendor/doctrine/dbal/src/Driver/PDO/Statement.php:130"}}}}},"level":500,"level_name":"CRITICAL","channel":"messenger","datetime":"2024-03-30T19:49:43.138338+00:00","extra":{}}
```