### PR TITLE
Update Symfony console recipe

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -3,41 +3,19 @@
 
 use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\ErrorHandler\Debug;
 
-if (!in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
-    echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.PHP_SAPI.' SAPI'.PHP_EOL;
+if (!is_dir(dirname(__DIR__).'/vendor')) {
+    throw new LogicException('Dependencies are missing. Try running "composer install".');
 }
 
-set_time_limit(0);
-
-require dirname(__DIR__).'/vendor/autoload.php';
-
-if (!class_exists(Application::class) || !class_exists(Dotenv::class)) {
-    throw new LogicException('You need to add "symfony/framework-bundle" and "symfony/dotenv" as Composer dependencies.');
+if (!is_file(dirname(__DIR__).'/vendor/autoload_runtime.php')) {
+    throw new LogicException('Symfony Runtime is missing. Try running "composer require symfony/runtime".');
 }
 
-$input = new ArgvInput();
-if (null !== $env = $input->getParameterOption(['--env', '-e'], null, true)) {
-    putenv('APP_ENV='.$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env);
-}
+require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
-if ($input->hasParameterOption('--no-debug', true)) {
-    putenv('APP_DEBUG='.$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
-}
+return function (array $context) {
+    $kernel = new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
 
-(new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
-
-if ($_SERVER['APP_DEBUG']) {
-    umask(0000);
-
-    if (class_exists(Debug::class)) {
-        Debug::enable();
-    }
-}
-
-$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
-$application = new Application($kernel);
-$application->run($input);
+    return new Application($kernel);
+};

--- a/symfony.lock
+++ b/symfony.lock
@@ -413,12 +413,12 @@
         "version": "v5.3.3"
     },
     "symfony/console": {
-        "version": "5.3",
+        "version": "6.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
-            "branch": "master",
+            "branch": "main",
             "version": "5.3",
-            "ref": "da0c8be8157600ad34f10ff0c9cc91232522e047"
+            "ref": "1781ff40d8a17d87cf53f8d4cf0c8346ed2bb461"
         },
         "files": [
             "bin/console"


### PR DESCRIPTION
I noticed this was our only Symfony recipe that hasn't been updated... not sure why, but I went ahead and pulled in the "latest".

Current version? (version number doesn't match what's specified in our `symfony.lock` file): https://github.com/symfony/recipes/blob/main/symfony/console/5.1/bin/console

Latest version: https://github.com/symfony/recipes/blob/main/symfony/console/5.3/bin/console

Seems like they greatly simplified the code over the version we're using... not sure that it matters much, but figured might as well clear the available update message.

And after looking at the `symfony.lock` file, I think this (`bin/console`) might have got left behind due to an unresolved merge conflict on accident... the existing version numbers don't make sense vs. what I found in the Symfony repo above... or it really is a carry over from Symfony 5.3...