### PR TITLE
add editorconfig for more filetypes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,26 @@
+root = true
+
+[*]
+end_of_line = LF
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.php]
+indent_style = space
+indent_size = 4
+
+[*.twig]
+indent_style = space
+indent_size = 4
+
+[*.js]
+indent_style = space
+indent_size = 4
+
+[*.{css,scss}]
+indent_style = space
+indent_size = 2
+
 [*.json]
 indent_style = space
 indent_size = 4
@@ -11,7 +34,6 @@ quote_type = single
 indent_style = space
 indent_size = 2
 quote_type = single
-
 
 [.github/workflows/*.yaml]
 indent_style = space


### PR DESCRIPTION
add some `.editorconfig` configs that should be applicable for all file types in the project, and indent config for more file types used in the project, specifically php, twig, js, and (s)css files

the settings are based on usage in existing files, which should help in ensuring more consistent indent styles for (new) files in the project forward

many editors/IDEs should be able to pick up and apply these settings automatically

~~totally not adding this just so I don't have fiddling with `:setl ts=...` on every file I touched~~