### PR TITLE
feat: implement microsoft azure oidc connector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,11 @@ S3_VERSION=
 KBIN_ADMIN_ONLY_OAUTH_CLIENTS=false
 
 # oAuth (optional)
+OAUTH_AZURE_ID=
+OAUTH_AZURE_SECRET=
+# If you want people from an enterprise to connect your instance, set the tenant id here.
+# If you want people from anywhere to connect with either their personnal or professionnal microsoft account, use "common"
+OAUTH_AZURE_TENANT=
 OAUTH_FACEBOOK_ID=
 OAUTH_FACEBOOK_SECRET=
 OAUTH_GOOGLE_ID=

--- a/.env.example_docker
+++ b/.env.example_docker
@@ -56,6 +56,11 @@ S3_VERSION=
 KBIN_ADMIN_ONLY_OAUTH_CLIENTS=false
 
 # oAuth (optional)
+OAUTH_AZURE_ID=
+OAUTH_AZURE_SECRET=
+# If you want people from an enterprise to connect your instance, set the tenant id here.
+# If you want people from anywhere to connect with either their personnal or professionnal microsoft account, use "common"
+OAUTH_AZURE_TENANT=
 OAUTH_FACEBOOK_ID=
 OAUTH_FACEBOOK_SECRET=
 OAUTH_GOOGLE_ID=

--- a/composer.json
+++ b/composer.json
@@ -104,6 +104,7 @@
         "symfonycasts/reset-password-bundle": "^1.13",
         "symfonycasts/verify-email-bundle": "^1.2",
         "tchoulom/view-counter-bundle": "^6.0",
+        "thenetworg/oauth2-azure": "^2.2",
         "twig/cssinliner-extra": "^3.7",
         "twig/extra-bundle": "^3.7",
         "twig/html-extra": "^3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58834f07680b378c54b3d649ba180d19",
+    "content-hash": "52f492698400dbb3cf9cf3bf8f9e70da",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -14293,6 +14293,66 @@
                 "source": "https://github.com/tchoulom/ViewCounterBundle/tree/6.1.0"
             },
             "time": "2022-12-13T21:53:08+00:00"
+        },
+        {
+            "name": "thenetworg/oauth2-azure",
+            "version": "v2.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/TheNetworg/oauth2-azure.git",
+                "reference": "be204a5135f016470a9c33e82ab48785bbc11af2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/TheNetworg/oauth2-azure/zipball/be204a5135f016470a9c33e82ab48785bbc11af2",
+                "reference": "be204a5135f016470a9c33e82ab48785bbc11af2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "firebase/php-jwt": "~3.0||~4.0||~5.0||~6.0",
+                "league/oauth2-client": "~2.0",
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "TheNetworg\\OAuth2\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Hajek",
+                    "email": "jan.hajek@thenetw.org",
+                    "homepage": "https://thenetw.org"
+                }
+            ],
+            "description": "Azure Active Directory OAuth 2.0 Client Provider for The PHP League OAuth2-Client",
+            "keywords": [
+                "SSO",
+                "aad",
+                "authorization",
+                "azure",
+                "azure active directory",
+                "client",
+                "microsoft",
+                "oauth",
+                "oauth2",
+                "windows azure"
+            ],
+            "support": {
+                "issues": "https://github.com/TheNetworg/oauth2-azure/issues",
+                "source": "https://github.com/TheNetworg/oauth2-azure/tree/v2.2.2"
+            },
+            "time": "2023-12-19T12:10:48+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",

--- a/config/kbin_routes/security.yaml
+++ b/config/kbin_routes/security.yaml
@@ -43,6 +43,16 @@ app_logout:
   path: /logout
   methods: [ GET ]
 
+oauth_azure_connect:
+  controller: App\Controller\Security\AzureController::connect
+  path: /oauth/azure/connect
+  methods: [ GET ]
+
+oauth_azure_verify:
+  controller: App\Controller\Security\AzureController::verify
+  path: /oauth/azure/verify
+  methods: [ GET ]
+
 oauth_facebook_connect:
   controller: App\Controller\Security\FacebookController::connect
   path: /oauth/facebook/connect

--- a/config/packages/knpu_oauth2_client.yaml
+++ b/config/packages/knpu_oauth2_client.yaml
@@ -1,5 +1,12 @@
 knpu_oauth2_client:
   clients:
+    azure:
+      type: azure
+      client_id: '%oauth_azure_id%'
+      client_secret: '%oauth_azure_secret%'
+      tenant: '%oauth_azure_tenant%'
+      redirect_route: oauth_azure_verify
+      redirect_params: { }
     facebook:
       type: facebook
       client_id: '%oauth_facebook_id%'

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -33,6 +33,7 @@ security:
             provider: app_user_provider
             custom_authenticators:
                 - App\Security\KbinAuthenticator
+                - App\Security\AzureAuthenticator
                 - App\Security\FacebookAuthenticator
                 - App\Security\GoogleAuthenticator
                 - App\Security\GithubAuthenticator

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -34,6 +34,10 @@ parameters:
     hcaptcha_site_key: "%env(resolve:HCAPTCHA_SITE_KEY)%"
     hcaptcha_secret: "%env(resolve:HCAPTCHA_SECRET)%"
 
+    oauth_azure_id: "%env(default::OAUTH_AZURE_ID)%"
+    oauth_azure_secret: "%env(OAUTH_AZURE_SECRET)%"
+    oauth_azure_tenant: "%env(OAUTH_AZURE_TENANT)%"
+
     oauth_facebook_id: "%env(default::OAUTH_FACEBOOK_ID)%"
     oauth_facebook_secret: "%env(OAUTH_FACEBOOK_SECRET)%"
 

--- a/migrations/Version20240405134821.php
+++ b/migrations/Version20240405134821.php
@@ -24,7 +24,6 @@ final class Version20240405134821 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE "user" DROP oauth_azure_id');
     }
 }

--- a/migrations/Version20240405134821.php
+++ b/migrations/Version20240405134821.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240405134821 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" ADD oauth_azure_id VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE "user" DROP oauth_azure_id');
+    }
+}

--- a/src/Controller/Security/AzureController.php
+++ b/src/Controller/Security/AzureController.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Security;
+
+use App\Controller\AbstractController;
+use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AzureController extends AbstractController
+{
+    public function connect(ClientRegistry $clientRegistry): Response
+    {
+        return $clientRegistry
+            ->getClient('azure')
+            ->redirect([
+                'User.Read.All',
+            ]);
+    }
+
+    public function verify(Request $request, ClientRegistry $client)
+    {
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -109,6 +109,8 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Visibil
     #[Column(type: 'json', nullable: true, options: ['jsonb' => true])]
     public ?array $fields = null;
     #[Column(type: 'string', nullable: true)]
+    public ?string $oauthAzureId = null;
+    #[Column(type: 'string', nullable: true)]
     public ?string $oauthGithubId = null;
     #[Column(type: 'string', nullable: true)]
     public ?string $oauthGoogleId = null;
@@ -765,7 +767,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Visibil
 
     public function isSsoControlled(): bool
     {
-        return $this->oauthGithubId || $this->oauthGoogleId || $this->oauthFacebookId || $this->oauthKeycloakId || $this->oauthZitadelId;
+        return $this->oauthAzureId || $this->oauthGithubId || $this->oauthGoogleId || $this->oauthFacebookId || $this->oauthKeycloakId || $this->oauthZitadelId;
     }
 
     public function getCustomCss(): ?string

--- a/src/Security/AzureAuthenticator.php
+++ b/src/Security/AzureAuthenticator.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\DTO\UserDto;
+use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Service\IpResolver;
+use App\Service\SettingsManager;
+use App\Service\UserManager;
+use App\Utils\Slugger;
+use Doctrine\ORM\EntityManagerInterface;
+use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
+use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
+use TheNetworg\OAuth2\Client\Provider\AzureResourceOwner;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+
+class AzureAuthenticator extends OAuth2Authenticator
+{
+    public function __construct(
+        private readonly ClientRegistry $clientRegistry,
+        private readonly RouterInterface $router,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly UserManager $userManager,
+        private readonly IpResolver $ipResolver,
+        private readonly Slugger $slugger,
+        private readonly UserRepository $userRepository,
+        private readonly SettingsManager $settingsManager,
+    ) {
+    }
+
+    public function supports(Request $request): ?bool
+    {
+        return 'oauth_azure_verify' === $request->attributes->get('_route');
+    }
+
+    public function authenticate(Request $request): Passport
+    {
+        $client = $this->clientRegistry->getClient('azure');
+        $slugger = $this->slugger;
+
+        $provider = $client->getOAuth2Provider();
+
+        $accessToken = $provider->getAccessToken('authorization_code', [
+            'code' => $request->query->get('code'),
+        ]);
+
+        $rememberBadge = new RememberMeBadge();
+        $rememberBadge = $rememberBadge->enable();
+
+        return new SelfValidatingPassport(
+            new UserBadge($accessToken->getToken(), function () use ($accessToken, $client, $slugger) {
+                /** @var AzureResourceOwner $azureUser */
+                $azureUser = $client->fetchUserFromToken($accessToken);
+
+                $existingUser = $this->entityManager->getRepository(User::class)->findOneBy(
+                    ['oauthAzureId' => $azureUser->getUpn()]
+                );
+
+                if ($existingUser) {
+                    return $existingUser;
+                }
+
+                $user = $this->userRepository->findOneBy(['email' => $azureUser->getUpn()]);
+
+                if ($user) {
+                    $user->oauthAzureId = $azureUser->getUpn();
+
+                    $this->entityManager->persist($user);
+                    $this->entityManager->flush();
+
+                    return $user;
+                }
+
+                if (false === $this->settingsManager->get('MBIN_SSO_REGISTRATIONS_ENABLED')) {
+                    throw new CustomUserMessageAuthenticationException('MBIN_SSO_REGISTRATIONS_ENABLED');
+                }
+
+                $username = $slugger->slug($azureUser->toArray()['name']);
+
+                if ($this->userRepository->count(['username' => $username]) > 0) {
+                    $username .= rand(1, 999);
+                }
+
+                $dto = (new UserDto())->create(
+                    $username,
+                    $azureUser->getUpn()
+                );
+
+                $dto->plainPassword = bin2hex(random_bytes(20));
+                $dto->ip = $this->ipResolver->resolve();
+
+                $user = $this->userManager->create($dto, false);
+                $user->oauthAzureId = $azureUser->getUpn();
+                $user->isVerified = true;
+
+                $this->entityManager->persist($user);
+                $this->entityManager->flush();
+
+                return $user;
+            }),
+            [
+                $rememberBadge,
+            ]
+        );
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        $targetUrl = $this->router->generate('user_settings_profile');
+
+        return new RedirectResponse($targetUrl);
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        $message = strtr($exception->getMessageKey(), $exception->getMessageData());
+
+        if ('MBIN_SSO_REGISTRATIONS_ENABLED' === $message) {
+            $session = $request->getSession();
+            $session->getFlashBag()->add('error', 'sso_registrations_enabled.error');
+
+            return new RedirectResponse($this->router->generate('app_login'));
+        }
+
+        return new Response($message, Response::HTTP_FORBIDDEN);
+    }
+}

--- a/src/Security/AzureAuthenticator.php
+++ b/src/Security/AzureAuthenticator.php
@@ -14,7 +14,6 @@ use App\Utils\Slugger;
 use Doctrine\ORM\EntityManagerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
-use TheNetworg\OAuth2\Client\Provider\AzureResourceOwner;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,6 +25,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use TheNetworg\OAuth2\Client\Provider\AzureResourceOwner;
 
 class AzureAuthenticator extends OAuth2Authenticator
 {

--- a/src/Twig/Components/LoginSocialsComponent.php
+++ b/src/Twig/Components/LoginSocialsComponent.php
@@ -21,6 +21,8 @@ final class LoginSocialsComponent
         private readonly ?string $oauthKeycloakId,
         #[Autowire('%oauth_zitadel_id%')]
         private readonly ?string $oauthZitadelId,
+        #[Autowire('%oauth_azure_id%')]
+        private readonly ?string $oauthAzureId,
     ) {
     }
 
@@ -47,5 +49,10 @@ final class LoginSocialsComponent
     public function zitadelEnabled(): bool
     {
         return !empty($this->oauthZitadelId);
+    }
+
+    public function azureEnabled(): bool
+    {
+        return !empty($this->oauthAzureId);
     }
 }

--- a/templates/components/login_socials.html.twig
+++ b/templates/components/login_socials.html.twig
@@ -20,4 +20,8 @@
         <a href="{{ path('oauth_zitadel_connect') }}" class="btn btn__secondary"><i class="fa-solid fa-lock" aria-hidden="true"></i>
             Zitadel</a>
     {% endif %}
+    {% if this.azureEnabled %}
+        <a href="{{ path('oauth_azure_connect') }}" class="btn btn__secondary"><i class="fa-brands fa-microsoft" aria-hidden="true"></i>
+            Microsoft</a>
+    {% endif %}
 </div>


### PR DESCRIPTION
Implement an OIDC connector for Azure AD.
Supports general microsoft authentication with `common` tenant, and tenant-specific authentication for closed instances.

References #575