### PR TITLE
use markdown alert syntax for various emphasis in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,12 +25,12 @@ The code is mainly written in PHP using the Symfony framework with Twig templati
 
 With an account on [GitHub](https://github.com) you will be able to [fork this repository](https://github.com/MbinOrg/mbin) and `git clone` the repository locally if you wish.
 
-> _Note_:
+> [!Note]
 > If you are a Maintainer with GitHub org admin rights, you do NOT need to fork the project, instead you are allowed to use git branches. See also [C4](C4.md).
 
 ### Coding Style Guide
 
-We use [php-cs-fixer](https://cs.symfony.com/) to automatically fix code style issues according to [Symfony coding standard](https://symfony.com/doc/current/contributing/code/standards.html).  
+We use [php-cs-fixer](https://cs.symfony.com/) to automatically fix code style issues according to [Symfony coding standard](https://symfony.com/doc/current/contributing/code/standards.html).
 It is based on the [PHP-FIG coding standards](https://www.php-fig.org/psr/).
 
 Install PHP-CS-Fixer first: `composer -d tools install`
@@ -75,7 +75,7 @@ SYMFONY_DEPRECATIONS_HELPER=disabled ./bin/phpunit tests/Unit
 
 ### Fixtures
 
-You might want to load random data to database instead of manually adding magazines, users, posts, comments etc.  
+You might want to load random data to database instead of manually adding magazines, users, posts, comments etc.
 To do so, execute: `bin/console doctrine:fixtures:load --append --no-debug`
 
 If you want to do the same but with the Docker setup, execute: `docker compose exec php bin/console doctrine:fixtures:load --append --no-debug` (from the `docker` directory)

--- a/FAQ.md
+++ b/FAQ.md
@@ -8,7 +8,7 @@ Mbin is an _open-source federated link aggregration, content rating and discussi
 
 ## What is ActivityPub (AP)?
 
-ActivityPub is a open standard protocol that empowers the creation of decentralized social networks, allowing different servers to interact and share content while giving users control over their data.  
+ActivityPub is a open standard protocol that empowers the creation of decentralized social networks, allowing different servers to interact and share content while giving users control over their data.
 It fosters a more user-centric and distributed approach to social networking, promoting interoperability across platforms and safeguarding user privacy and choice.
 
 This protocol is vital for building a more open, inclusive, and user-empowered digital social landscape.
@@ -177,7 +177,8 @@ Running the `post-upgrade` script will also execute `composer dump-env` for you:
 ./bin/post-upgrade
 ```
 
-**Important:** If you want to switch between `prod` to `dev` (or vice versa), you need explicitly execute: `composer dump-env dev` or `composer dump-env prod` respectively.
+> [!Important]
+> If you want to switch between `prod` to `dev` (or vice versa), you need explicitly execute: `composer dump-env dev` or `composer dump-env prod` respectively.
 
 Followed by restarting the services that are depending on the (new) configuration:
 
@@ -197,7 +198,8 @@ If you want to update all the remote users on your instance, you can execute the
 ./bin/console mbin:ap:actor:update
 ```
 
-_Important:_ This might have quite a performance impact (temporally), if you are running a very large instance. Due to the huge amount of remote users.
+> [!Important]
+> This might have quite a performance impact (temporally), if you are running a very large instance. Due to the huge amount of remote users.
 
 ## Running `php bin/console mbin:ap:keys:update` does not appear to set keys
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Mbin is a fork of [/kbin](https://codeberg.org/Kbin/kbin-core), community-focused. Feel free to discuss on [Matrix](https://matrix.to/#/#mbin:melroy.org) and to create Pull Requests.
 
-**Important:** Mbin is focused on what the community wants, pull requests can be merged by any repo maintainer (with merge rights in GitHub). Discussions take place on [Matrix](https://matrix.to/#/#mbin:melroy.org) then _consensus_ has to be reached by the community. If approved by the community, only one approval on the PR is required by one of the Mbin maintainers. It's built entirely on trust.
+> [!Important]
+> Mbin is focused on what the community wants, pull requests can be merged by any repo maintainer (with merge rights in GitHub). Discussions take place on [Matrix](https://matrix.to/#/#mbin:melroy.org) then _consensus_ has to be reached by the community. If approved by the community, only one approval on the PR is required by one of the Mbin maintainers. It's built entirely on trust.
 
 Mbin is a decentralized content aggregator, voting, discussion and microblogging platform running on the fediverse network. It can
 communicate with many other ActivityPub services, including Kbin, Mastodon, Lemmy, Pleroma, Peertube. The initiative aims to

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -12,7 +12,8 @@ And when needed also execute: `sudo redis-cli FLUSHDB` to get rid of Redis cache
 
 ## Docker Upgrade
 
-_Note:_ When you're using the [Docker v2 guide](docker/v2/), then the database migration is executed during the Docker container start-up.
+> [!Note]
+> When you're using the [Docker v2 guide](docker/v2/), then the database migration is executed during the Docker container start-up.
 
 ```bash
 $ docker compose exec php bin/console cache:clear

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -1,19 +1,19 @@
 # Admin Bare Metal/VM Guide
 
-Below is a step-by-step guide of the process for creating your own Mbin instance from the moment a new VPS/VM is created or directly on bare-metal.  
+Below is a step-by-step guide of the process for creating your own Mbin instance from the moment a new VPS/VM is created or directly on bare-metal.
 This is a preliminary outline that will help you launch an instance for your own needs.
 
 For Docker see: [Admin Docker Deployment Guide](./docker_deployment_guide.md).
 
-> **Note**
+> [!Note]
 > Mbin is still in development.
 
 This guide is aimed for Debian / Ubuntu distribution servers, but it could run on any modern Linux distro. This guide will however uses the `apt` commands.
 
 ## Minimum hardware requirements
 
-**CPU:** 2 cores (>2.5 GHz)  
-**RAM:** 4GB (more is recommended for large instances)  
+**CPU:** 2 cores (>2.5 GHz)
+**RAM:** 4GB (more is recommended for large instances)
 **Storage:** 20GB (more is recommended, especially if you have a lot of remote/local magazines and/or have a lot of (local) users)
 
 ## System Prerequisites
@@ -64,7 +64,8 @@ If you have a firewall installed (or you're behind a NAT), be sure to open port 
 
 1. Prepare & download keyring:
 
-_Note:_ we assumes you already installed all the prerequisites packages from the "System prerequisites" chapter.
+> [!Note]
+> This assumes you already installed all the prerequisites packages from the "System prerequisites" chapter.
 
 ```bash
 sudo mkdir -p /etc/apt/keyrings
@@ -103,7 +104,7 @@ sudo chown mbin:www-data /var/www/mbin
 
 ## Generate Secrets
 
-> **Note**
+> [!Note]
 > This will generate several valid tokens for the Mbin setup, you will need quite a few.
 
 ```bash
@@ -157,7 +158,7 @@ nano .env
 
 Make sure you have substituted all the passwords and configured the basic services in `.env` file.
 
-> **Note**
+> [!Note]
 > The snippet below are to variables inside the .env file. Using the keys generated in the section above "Generating Secrets" fill in the values. You should fully review this file to ensure everything is configured correctly.
 
 ```ini
@@ -293,7 +294,7 @@ composer clear-cache
 
 If you run production already then _skip the steps below_.
 
-> **Warning**
+> [!Warning]
 > When running in development mode your instance will make _sensitive information_ available,
 > such as database credentials, via the debug toolbar and/or stack traces.
 > **DOT NOT** expose your development instance to the Internet or you will have a bad time.
@@ -374,7 +375,7 @@ sudo systemctl start keydb-server
 sudo systemctl enable keydb-server
 ```
 
-Configuration file is located at: `/etc/keydb/keydb.conf`. See also: [config documentation](https://docs.keydb.dev/docs/config-file).  
+Configuration file is located at: `/etc/keydb/keydb.conf`. See also: [config documentation](https://docs.keydb.dev/docs/config-file).
 For example, you can also configure Unix socket files if you wish:
 
 ```ini
@@ -465,7 +466,8 @@ random_page_cost = 1.1
 effective_cache_size = 25GB
 ```
 
-**Note:** We try to set `huge_pages` to: `on` in PostgreSQL, in order to make this works you need to [enable huge pages under Linux (click here)](https://www.enterprisedb.com/blog/tuning-debian-ubuntu-postgresql) as well! Please follow that guide. and play around with your kernel configurations.
+> [!Note]
+> We try to set `huge_pages` to: `on` in PostgreSQL, in order to make this works you need to [enable huge pages under Linux (click here)](https://www.enterprisedb.com/blog/tuning-debian-ubuntu-postgresql) as well! Please follow that guide. and play around with your kernel configurations.
 
 ### NPM
 
@@ -479,7 +481,7 @@ Make sure you have substituted all the passwords and configured the basic servic
 
 #### Let's Encrypt (TLS)
 
-> **Note**
+> [!Note]
 > The Certbot authors recommend installing through snap as some distros' versions from APT tend to fall out-of-date; see https://eff-certbot.readthedocs.io/en/latest/install.html#snap-recommended for more.
 
 Install Snapd:
@@ -707,7 +709,8 @@ server {
 }
 ```
 
-**Important:** If also want to also configure your `www.domain.tld` subdomain; our advise is to use a HTTP 301 redirect from the `www` subdomain towards the root domain. Do _NOT_ try to setup a double instance (you want to _avoid_ that ActivityPub will see `www` as a separate instance). See Nginx example below:
+> [!Important]
+> If also want to also configure your `www.domain.tld` subdomain; our advise is to use a HTTP 301 redirect from the `www` subdomain towards the root domain. Do _NOT_ try to setup a double instance (you want to _avoid_ that ActivityPub will see `www` as a separate instance). See Nginx example below:
 
 ```nginx
 # Example of a 301 redirect response for the www subdomain
@@ -767,7 +770,7 @@ _Hint:_ There are also other configuration files, eg. `config/packages/monolog.y
 
 ### Symfony Messenger (Queues)
 
-The symphony messengers are background workers for a lot of different task, the biggest one being handling all the ActivityPub traffic.  
+The symphony messengers are background workers for a lot of different task, the biggest one being handling all the ActivityPub traffic.
 We have a few different queues:
 
 1. `receive` [RabbitMQ]: everything any remote instance sends to us will first end up in this queue.
@@ -792,7 +795,8 @@ We need the `dead` queue so that messages that throw a `UnrecoverableMessageHand
 
 [RabbitMQ Install](https://www.rabbitmq.com/install-debian.html#apt-quick-start-cloudsmith)
 
-_Note:_ we assumes you already installed all the prerequisites packages from the "System prerequisites" chapter.
+> [!Note]
+> This assumes you already installed all the prerequisites packages from the "System prerequisites" chapter.
 
 ```bash
 ## Team RabbitMQ's main signing key
@@ -883,7 +887,7 @@ sudo chown -R mbin:www-data metal/caddy
 
 [Caddyfile Global Options](https://caddyserver.com/docs/caddyfile/options)
 
-> **Note**
+> [!Note]
 > Caddyfiles: The one provided should work for most people, edit as needed via the previous link. Combination of mercure.conf and Caddyfile
 
 Add new `Caddyfile` file:
@@ -985,7 +989,8 @@ process_name=%(program_name)s_%(process_num)02d
 
 Save and close the file.
 
-Note: you can increase the number of running messenger jobs if your queue is building up (i.e. more messages are coming in than your messengers can handle)
+> [!Note]
+> You can increase the number of running messenger jobs if your queue is building up (i.e. more messages are coming in than your messengers can handle)
 
 We also use supervisor for running Mercure job:
 

--- a/docs/docker_deployment_guide.md
+++ b/docs/docker_deployment_guide.md
@@ -2,7 +2,7 @@
 
 For bare metal see: [Admin Bare Metal Guide](./admin_guide.md).
 
-> **Note**
+> [!Note]
 > Mbin is still in development.
 
 ## System Requirements
@@ -44,7 +44,7 @@ cd mbin
 
 ### Docker image preparation
 
-> **Note**
+> [!Note]
 > If you're using a version of Docker Engine earlier than 23.0, run `export DOCKER_BUILDKIT=1`, prior to building the image. This does not apply to users running Docker Desktop. More info can be found [here](https://docs.docker.com/build/buildkit/#getting-started)
 
 1. First go to the _docker directory_:
@@ -86,7 +86,8 @@ And instead use the following line on all places (`www`, `php`, and `messenger` 
 image: "ghcr.io/mbinorg/mbin:latest"
 ```
 
-**Important:** Do _NOT_ forget to change **ALL LINES** in that matches `image: mbin` to: `image: "ghcr.io/mbinorg/mbin:latest"` in the `compose.yml` file (should be 4 matches in total).
+> [!Important]
+> Do _NOT_ forget to change **ALL LINES** in that matches `image: mbin` to: `image: "ghcr.io/mbinorg/mbin:latest"` in the `compose.yml` file (should be 4 matches in total).
 
 3. Create config files and storage directories:
 
@@ -105,7 +106,7 @@ sudo chown $USER:$USER storage/media storage/caddy_config storage/caddy_data sto
 4. Update `APP_SECRET` in `.env`, generate a new one via: `node -e  "console.log(require('crypto').randomBytes(16).toString('hex'))"`
 5. _Optionally_: Use a newer PostgreSQL version (current fallback is v13). Update/set the `POSTGRES_VERSION` variable in your `.env` and `compose.override.yml` under `db`.
 
-> **Note**
+> [!Note]
 > Ensure the `HTTPS` environmental variable is set to `TRUE` in `compose.override.yml` for the `php`, `messenger`, and `messenger_ap` containers **if your environment is using a valid certificate behind a reverse proxy**. This is likely true for most production environments and is required for proper federation, that is, this will ensure the webfinger responses include `https:` in the URLs generated.
 
 ### Configure OAuth2 keys
@@ -152,7 +153,7 @@ docker compose up -d
 
 See your running containers via: `docker ps`.
 
-Then, you should be able to access the new instance via [http://localhost:8008](http://localhost:8008).  
+Then, you should be able to access the new instance via [http://localhost:8008](http://localhost:8008).
 You can also access RabbitMQ management UI via [http://localhost:15672](http://localhost:15672).
 
 ### Mbin first setup
@@ -202,7 +203,8 @@ If you created the file `compose.override.yml` with your configs (`cp compose.pr
 docker compose up -d
 ```
 
-**Important:** The docker instance is can be reached at [http://127.0.0.1:8008](http://127.0.0.1:8008), we strongly advise you to put a reverse proxy (like Nginx) in front of the docker instance. Nginx can could listen on ports 80 and 443 and Nginx should handle SSL/TLS offloading. See also Nginx example below.
+> [!Important]
+> The docker instance is can be reached at [http://127.0.0.1:8008](http://127.0.0.1:8008), we strongly advise you to put a reverse proxy (like Nginx) in front of the docker instance. Nginx can could listen on ports 80 and 443 and Nginx should handle SSL/TLS offloading. See also Nginx example below.
 
 If you want to deploy your app on a cluster of machines, you can
 use [Docker Swarm](https://docs.docker.com/engine/swarm/stack-deploy/), which is compatible with the provided Compose

--- a/docs/oauth2_guide.md
+++ b/docs/oauth2_guide.md
@@ -23,7 +23,8 @@ For all the API endpoints go to the swagger documentation page, which is: `https
 
 ## Obtaining OAuth2 credentials from a new server
 
-_Note: some of these structures contain comments that need to be removed before making the API calls. Copy/paste with care._
+> [!Note]
+> Some of these structures contain comments that need to be removed before making the API calls. Copy/paste with care._
 
 1. Create a private OAuth2 client (for use in secure environments that you control)
 


### PR DESCRIPTION
This uses the newish [github alert markdown syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) in places where I found we were using note/important/warning

| Before | After |
|-|-|
| ![image](https://github.com/MbinOrg/mbin/assets/146029455/adad61f6-2c54-4db6-9dff-1fd7e377cfe1) | ![image](https://github.com/MbinOrg/mbin/assets/146029455/a7e638eb-e760-494a-81e1-0db6ff2dbca5) |
| ![image](https://github.com/MbinOrg/mbin/assets/146029455/6e148561-e48e-4c5f-97f8-9516cb1ba42a) | ![image](https://github.com/MbinOrg/mbin/assets/146029455/a31d5347-9b03-4726-b8ac-271f412ae8e0)
| ![image](https://github.com/MbinOrg/mbin/assets/146029455/9a0f7727-e22a-48f4-adab-f313e7bd8c41) |  ![image](https://github.com/MbinOrg/mbin/assets/146029455/907e38b1-765b-459f-9312-91b95c9eb622) |

