### PR TITLE
ui adjustments

### DIFF
--- a/assets/controllers/kbin_controller.js
+++ b/assets/controllers/kbin_controller.js
@@ -27,6 +27,11 @@ export default class extends ApplicationController {
         if (container) {
             const containerWidth = container.clientWidth;
             const area = container.querySelector('.options__main');
+
+            if (null === area) {
+                return;
+            }
+
             const areaWidth = area.scrollWidth;
 
             if (areaWidth > containerWidth && !area.nextElementSibling) {

--- a/assets/styles/layout/_options.scss
+++ b/assets/styles/layout/_options.scss
@@ -77,10 +77,20 @@
   }
 
   &__filter {
-    button {
-      border-bottom-left-radius: 0px!important;
-      border-bottom-right-radius: 0px!important;
+    li:first-of-type {
+      button {
+          border-bottom-right-radius: 0px!important;
+      }
+    }
 
+    li:not(:first-of-type) {
+      button {
+        border-bottom-right-radius: 0px!important;
+        border-bottom-left-radius: 0px!important;
+      }
+    }
+
+    button {
       font-size: 0;
 
       i {

--- a/config/kbin_routes/front.yaml
+++ b/config/kbin_routes/front.yaml
@@ -1,10 +1,10 @@
 front:
   controller: App\Controller\Entry\EntryFrontController::front
-  defaults: { subscription: def, sortBy: hot, time: '∞', type: all, federation: all, content: threads }
+  defaults: { subscription: home, sortBy: hot, time: '∞', type: all, federation: all, content: threads }
   path: /{subscription}/{sortBy}/{time}/{type}/{federation}/{content}
   methods: [GET]
   requirements:
-    subscription: 'sub|fav|mod|all|def'
+    subscription: 'sub|fav|mod|all|home'
     sortBy: "%front_sort_options%"
 
 front_redirect:

--- a/src/Controller/Domain/DomainFrontController.php
+++ b/src/Controller/Domain/DomainFrontController.php
@@ -54,6 +54,7 @@ class DomainFrontController extends AbstractController
             [
                 'domain' => $domain,
                 'entries' => $listing,
+                'criteria' => $criteria,
             ]
         );
     }

--- a/src/Controller/Entry/EntryFrontController.php
+++ b/src/Controller/Entry/EntryFrontController.php
@@ -36,7 +36,7 @@ class EntryFrontController extends AbstractController
             ->setTime($criteria->resolveTime($time))
             ->setType($criteria->resolveType($type));
 
-        if ('def' === $subscription) {
+        if ('home' === $subscription) {
             $subscription = $this->subscriptionFor($user);
         }
         $this->handleSubscription($subscription, $user, $criteria);

--- a/templates/domain/_options.html.twig
+++ b/templates/domain/_options.html.twig
@@ -1,0 +1,176 @@
+{% set showFilterLabels = app.request.cookies.get('kbin_general_filter_labels')|default('on') %}
+
+<aside class="options options--top" id="options">
+    <div></div>
+    <menu class="options__filter">
+        <li class="dropdown">
+            <button aria-label="{{ 'sort_by'|trans }}"
+                    title="{{ 'sort_by'|trans }}"><i
+                        class="fa-solid fa-sort" aria-hidden="true"></i>
+                <span>{{ criteria.getOption('sort')|trans }}</span>
+            </button>
+            <ul class="dropdown__menu">
+                <li>
+                    <a href="{{ options_url('sortBy', 'top', null, {'p': null}) }}"
+                    class="{{ html_classes({'active': criteria.getOption('sort') == 'top'}) }}">
+                        {{ 'top'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ options_url('sortBy', 'hot', null, {'p': null}) }}"
+                    class="{{ html_classes({'active': criteria.getOption('sort') == 'hot'}) }}">
+                        {{ 'hot'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ options_url('sortBy', 'newest', null, {'p': null}) }}"
+                    class="{{ html_classes({'active': criteria.getOption('sort') == 'newest'}) }}">
+                        {{ 'newest'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ options_url('sortBy', 'active', null, {'p': null}) }}"
+                    class="{{ html_classes({'active': criteria.getOption('sort') == 'active'}) }}">
+                        {{ 'active'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ options_url('sortBy', 'commented', null, {'p': null}) }}"
+                    class="{{ html_classes({'active': criteria.getOption('sort') == 'commented'}) }}">
+                        {{ 'commented'|trans }}
+                    </a>
+                </li>
+            </ul>
+        </li>
+        <li class="dropdown">
+            <button aria-label="{{ 'filter_by_time'|trans }}"
+                    title="{{ 'filter_by_time'|trans }}">
+                <i aria-hidden="true" class="fa-solid fa-clock"></i>
+                {% if showFilterLabels == 'on' or (showFilterLabels == 'auto' and criteria.getOption('time') != 'all') %}
+                    <span>{{ criteria.getOption('time')|trans }}</span>
+                {% endif %}
+            </button>
+            <ul class="dropdown__menu">
+                <li>
+                    <a href="{{ options_url('time', '∞', null, {'p': null}) }}"
+                       class="{{ html_classes({'active': criteria.getOption('time') == 'all'}) }}">
+                        {{ 'all_time'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ options_url('time', '3h', null, {'p': null}) }}"
+                       class="{{ html_classes({'active': criteria.getOption('time') == '3h' }) }}">
+                        {{ '3h'|trans }}
+                    </a></li>
+                <li>
+                    <a href="{{ options_url('time', '6h', null, {'p': null}) }}"
+                       class="{{ html_classes({'active': criteria.getOption('time') == '6h' }) }}">
+                        {{ '6h'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ options_url('time', '12h', null, {'p': null}) }}"
+                       class="{{ html_classes({'active': criteria.getOption('time') == '12h' }) }}">
+                        {{ '12h'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ options_url('time', '1d', null, {'p': null}) }}"
+                       class="{{ html_classes({'active': criteria.getOption('time') == '1d' }) }}">
+                        {{ '1d'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ options_url('time', '1w', null, {'p': null}) }}"
+                       class="{{ html_classes({'active': criteria.getOption('time') == '1w' }) }}">
+                        {{ '1w'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ options_url('time', '1m', null, {'p': null}) }}"
+                       class="{{ html_classes({'active': criteria.getOption('time') == '1m' }) }}">
+                        {{ '1m'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ options_url('time', '1y', null, {'p': null}) }}"
+                       class="{{ html_classes({'active': criteria.getOption('time') == '1y' }) }}">
+                        {{ '1y'|trans }}
+                    </a>
+                </li>
+            </ul>
+        </li>
+        <li class="dropdown">
+            <button aria-label="{{ 'filter_by_type'|trans }}"
+                    title="{{ 'filter_by_type'|trans }}">
+                <i aria-hidden="true" class="
+                    {% if criteria.getOption('type') == 'all' %}
+                        fa-solid fa-file
+                    {% elseif criteria.getOption('type') == 'links' %}
+                        fa-regular fa-file-code
+                    {% elseif criteria.getOption('type') == 'threads' %}
+                        fa-regular fa-file-lines
+                    {% elseif criteria.getOption('type') == 'photos' %}
+                        fa-regular fa-file-image
+                    {% elseif criteria.getOption('type') == 'videos' %}
+                        fa-regular fa-file-video
+                    {% else %}
+                        fa-solid fa-question
+                    {% endif %}">
+                </i>
+                {% if showFilterLabels == 'on' or (showFilterLabels == 'auto' and criteria.getOption('type') != 'all') %}
+                    <span class="hide-on-mobile">{{ criteria.getOption('type')|trans }}</span>
+                {% endif %}
+            </button>
+            <ul class="dropdown__menu">
+                <li>
+                    <a href="{{ options_url('type', 'all', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'all' }) }}">
+                        <i class="fa-solid fa-file" aria-hidden="true"></i> &nbsp; {{ 'all'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ options_url('type', 'links', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'links' }) }}">
+                        <i class="fa-regular fa-file-code" aria-hidden="true"></i> &nbsp; {{ 'links'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ options_url('type', 'articles', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'threads' }) }}">
+                        <i class="fa-regular fa-file-lines" aria-hidden="true"></i> &nbsp; {{ 'threads'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ options_url('type', 'photos', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'photos' }) }}">
+                        <i class="fa-regular fa-file-image" aria-hidden="true"></i> &nbsp; {{ 'photos'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ options_url('type', 'videos', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'videos'}) }}">
+                        <i class="fa-regular fa-file-video" aria-hidden="true"></i> &nbsp; {{ 'videos'|trans }}
+                    </a>
+                </li>
+            </ul>
+        </li>
+    </menu>
+    <menu class="options__view">
+        <li class="dropdown">
+            <button aria-label="{{ 'change_view'|trans }}"
+                    title="{{ 'change_view'|trans }}"><i
+                        class="fa-solid fa-layer-group" aria-hidden="true"></i>
+            </button>
+            <ul class="dropdown__menu">
+                <li>
+                    <a class="{{ html_classes({'active': not app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT')) or app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT')) is same as 'false'}) }}"
+                       href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT'), value: 'false'}) }}">
+                        {{ 'classic_view'|trans }}
+                    </a>
+                </li>
+                <li>
+                    <a class="{{ html_classes({'active': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT')) is same as 'true'}) }}"
+                       href="{{ path('theme_settings', {key: constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT'), value: 'true'}) }}">
+                        {{ 'compact_view'|trans }}
+                    </a>
+                </li>
+            </ul>
+        </li>
+    </menu>
+</aside>

--- a/templates/domain/front.html.twig
+++ b/templates/domain/front.html.twig
@@ -19,9 +19,8 @@
         <h1 hidden>{{ domain.name }}</h1>
         <h2 hidden>{{ get_active_sort_option()|trans }}</h2>
     </header>
-    {% include 'entry/_options.html.twig' %}
+    {% include 'domain/_options.html.twig' %}
     <div id="content">
         {% include 'entry/_list.html.twig' %}
     </div>
 {% endblock %}
-

--- a/templates/entry/_options.html.twig
+++ b/templates/entry/_options.html.twig
@@ -226,11 +226,13 @@
                         <i class="fa-solid fa-house-chimney" aria-hidden="true"></i> &nbsp; {{ 'local'|trans }}
                     </a>
                 </li>
+                {#
                 <li>
                     <a href="{{ options_url('federation', 'federated', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('federation') == 'federated' }) }}">
                         <i class="fa-solid fa-network-wired" aria-hidden="true"></i> &nbsp; {{ 'federated'|trans }}
                     </a>
                 </li>
+                #}
             </ul>
         </li>
     </menu>

--- a/templates/layout/_header_nav.html.twig
+++ b/templates/layout/_header_nav.html.twig
@@ -17,36 +17,36 @@
         <a href="
             {% if magazine is defined and magazine %}
                 {% if is_route_name_starts_with('front') %}
-                    {{ options_url('content', 'threads', 'front_magazine', {'name': magazine.name}) }}
+                    {{ options_url('content', 'threads', 'front_magazine', {'name': magazine.name, 'p': null}) }}
                 {% else %}
                     {{ navbar_threads_url(magazine) }}
                 {% endif %}
             {% else %}
                 {% if is_route_name_starts_with('front') %}
-                    {{ options_url('content', 'threads', 'front') }}
+                    {{ options_url('content', 'threads', 'front', {'p': null}) }}
                 {% else %}
                     {{ navbar_threads_url(null) }}
                 {% endif %}
             {% endif %}
-        " class="{{ html_classes({'active': activeLink == 'threads'}) }}">    
+        " class="{{ html_classes({'active': activeLink == 'threads'}) }}">
             {{ 'threads'|trans }} {% if magazine is defined and magazine %}({{ magazine.entryCount }}){% endif %}
         </a>
     </li>
     <li>
-        <a href=" 
+        <a href="
             {% if magazine is defined and magazine %}
                 {% if is_route_name_starts_with('front') %}
-                    {{ options_url('content', 'microblog', 'front_magazine', {'name': magazine.name}) }}
+                    {{ options_url('content', 'microblog', 'front_magazine', {'name': magazine.name,'p': null}) }}
                 {% else %}
                     {{ navbar_posts_url(magazine) }}
                 {% endif %}
             {% else %}
                 {% if is_route_name_starts_with('front') %}
-                    {{ options_url('content', 'microblog', 'front') }}
+                    {{ options_url('content', 'microblog', 'front', {'p': null}) }}
                 {% else %}
                     {{ navbar_posts_url(null) }}
                 {% endif %}
-            {% endif 
+            {% endif
         %}" class="{{ html_classes({'active': activeLink == 'microblog'}) }}">
             {{ 'microblog'|trans }} {% if magazine is defined and magazine %}({{ magazine.postCount }}){% endif %}
         </a>

--- a/templates/post/_options.html.twig
+++ b/templates/post/_options.html.twig
@@ -100,7 +100,7 @@
                 </li>
             </ul>
         </li>
-  
+
         {% if criteria and criteria.getOption('content') != 'microblog' %}
             <li class="dropdown">
                 <button aria-label="{{ 'filter_by_type'|trans }}"
@@ -152,7 +152,7 @@
                     </li>
                 </ul>
             </li>
-        {% endif %} 
+        {% endif %}
 
         {% if app.user %}
             <li class="dropdown">
@@ -230,11 +230,13 @@
                         <i class="fa-solid fa-house-chimney" aria-hidden="true"></i> &nbsp; {{ 'local'|trans }}
                     </a>
                 </li>
+                {#
                 <li>
                     <a href="{{ options_url('federation', 'federated', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('federation') == 'federated' }) }}">
                         <i class="fa-solid fa-network-wired" aria-hidden="true"></i> &nbsp; {{ 'federated'|trans }}
                     </a>
                 </li>
+                #}
             </ul>
         </li>
     </menu>


### PR DESCRIPTION
based on followup to #453

- null check in JS controller to fix exception, this is needed for the tag rework as well
- minor css change for the rounded edges on filter
- rename def to home, think this makes it clearer, but we can always change it later if people give more feedback
- pass criteria into component in domain controller similar to entry controller (fixes 500 when viewing more from domain in dev mode, prod mode worked but criteria wasn't usable)
- remove federated only drop down option, will implement in the future
- strip pagination from header nav links, matching the regular drop down filters
  - if you were on say page 100 of entries and clicked microblog at the top and there was only 1 page, you'd get a 404, this just resets it as it doesn't seem to make sense to keep pagination when switching between threads/microblogs