### PR TITLE
add route requirements for filter options

### DIFF
--- a/config/kbin_routes/domain.yaml
+++ b/config/kbin_routes/domain.yaml
@@ -4,9 +4,9 @@ domain_entries:
   path: /d/{name}/{sortBy}/{time}/{type}
   methods: [ GET ]
   requirements:
-    sortBy: "%front_sort_options%"
-    time: "%front_time_options%"
-    type: "%front_type_options%"
+    sortBy: "%default_sort_options%"
+    time: "%default_time_options%"
+    type: "%default_type_options%"
 
 domain_comments:
   controller: App\Controller\Domain\DomainCommentFrontController
@@ -14,8 +14,8 @@ domain_comments:
   path: /d/{name}/comments/{sortBy}/{time}
   methods: [GET]
   requirements:
-    sortBy: "%front_sort_options%"
-    time: "%front_time_options%"
+    sortBy: "%comment_sort_options%"
+    time: "%default_time_options%"
 
 domain_subscribe:
   controller: App\Controller\Domain\DomainSubController::subscribe

--- a/config/kbin_routes/domain.yaml
+++ b/config/kbin_routes/domain.yaml
@@ -3,14 +3,19 @@ domain_entries:
   defaults: { sortBy: hot, time: '∞', type: ~ }
   path: /d/{name}/{sortBy}/{time}/{type}
   methods: [ GET ]
-  requirements: { sortBy: "%front_sort_options%" }
+  requirements:
+    sortBy: "%front_sort_options%"
+    time: "%front_time_options%"
+    type: "%front_type_options%"
 
 domain_comments:
   controller: App\Controller\Domain\DomainCommentFrontController
   defaults: { sortBy: hot, time: ~ }
   path: /d/{name}/comments/{sortBy}/{time}
   methods: [GET]
-  requirements: { sortBy: "%front_sort_options%" }
+  requirements:
+    sortBy: "%front_sort_options%"
+    time: "%front_time_options%"
 
 domain_subscribe:
   controller: App\Controller\Domain\DomainSubController::subscribe

--- a/config/kbin_routes/entry.yaml
+++ b/config/kbin_routes/entry.yaml
@@ -71,8 +71,8 @@ entry_comments_front:
   path: /comments/{sortBy}/{time}
   methods: [ GET ]
   requirements:
-    sortBy: "%front_sort_options%"
-    time: "%front_time_options%"
+    sortBy: "%comment_sort_options%"
+    time: "%default_time_options%"
 
 entry_comments_subscribed:
   controller: App\Controller\Entry\Comment\EntryCommentFrontController::subscribed
@@ -80,8 +80,8 @@ entry_comments_subscribed:
   path: /sub/comments/{sortBy}/{time}
   methods: [ GET ]
   requirements:
-    sortBy: "%front_sort_options%"
-    time: "%front_time_options%"
+    sortBy: "%comment_sort_options%"
+    time: "%default_time_options%"
 
 entry_comments_moderated:
   controller: App\Controller\Entry\Comment\EntryCommentFrontController::moderated
@@ -89,8 +89,8 @@ entry_comments_moderated:
   path: /mod/comments/{sortBy}/{time}
   methods: [ GET ]
   requirements:
-    sortBy: "%front_sort_options%"
-    time: "%front_time_options%"
+    sortBy: "%comment_sort_options%"
+    time: "%default_time_options%"
 
 entry_comments_favourite:
   controller: App\Controller\Entry\Comment\EntryCommentFrontController::favourite
@@ -98,8 +98,8 @@ entry_comments_favourite:
   path: /fav/comments/{sortBy}/{time}
   methods: [ GET ]
   requirements:
-    sortBy: "%front_sort_options%"
-    time: "%front_time_options%"
+    sortBy: "%comment_sort_options%"
+    time: "%default_time_options%"
 
 magazine_entry_comments:
   controller: App\Controller\Entry\Comment\EntryCommentFrontController::front
@@ -107,8 +107,8 @@ magazine_entry_comments:
   path: /m/{name}/comments/{sortBy}/{time}
   methods: [ GET ]
   requirements:
-    sortBy: "%front_sort_options%"
-    time: "%front_time_options%"
+    sortBy: "%comment_sort_options%"
+    time: "%default_time_options%"
 
 entry_comment_vote:
   controller: App\Controller\VoteController
@@ -231,7 +231,7 @@ entry_single:
   path: /m/{magazine_name}/t/{entry_id}/{slug}/{sortBy}
   methods: [ GET ]
   requirements:
-    sortBy: "%front_sort_options%"
+    sortBy: "%comment_sort_options%"
 
 entry_single_comments:
   controller: App\Controller\Entry\EntrySingleController
@@ -239,7 +239,7 @@ entry_single_comments:
   path: /m/{magazine_name}/t/{entry_id}/{slug}/comments/{sortBy}
   methods: [ GET ]
   requirements:
-    sortBy: "%front_sort_options%"
+    sortBy: "%comment_sort_options%"
 
 entry_vote:
   controller: App\Controller\VoteController

--- a/config/kbin_routes/entry.yaml
+++ b/config/kbin_routes/entry.yaml
@@ -70,35 +70,45 @@ entry_comments_front:
   defaults: { sortBy: hot, time: ~ }
   path: /comments/{sortBy}/{time}
   methods: [ GET ]
-  requirements: { sortBy: "%front_sort_options%" }
+  requirements:
+    sortBy: "%front_sort_options%"
+    time: "%front_time_options%"
 
 entry_comments_subscribed:
   controller: App\Controller\Entry\Comment\EntryCommentFrontController::subscribed
   defaults: { sortBy: hot, time: ~ }
   path: /sub/comments/{sortBy}/{time}
   methods: [ GET ]
-  requirements: { sortBy: "%front_sort_options%" }
+  requirements:
+    sortBy: "%front_sort_options%"
+    time: "%front_time_options%"
 
 entry_comments_moderated:
   controller: App\Controller\Entry\Comment\EntryCommentFrontController::moderated
   defaults: { sortBy: hot, time: ~ }
   path: /mod/comments/{sortBy}/{time}
   methods: [ GET ]
-  requirements: { sortBy: "%front_sort_options%" }
+  requirements:
+    sortBy: "%front_sort_options%"
+    time: "%front_time_options%"
 
 entry_comments_favourite:
   controller: App\Controller\Entry\Comment\EntryCommentFrontController::favourite
   defaults: { sortBy: hot, time: ~ }
   path: /fav/comments/{sortBy}/{time}
   methods: [ GET ]
-  requirements: { sortBy: "%front_sort_options%" }
+  requirements:
+    sortBy: "%front_sort_options%"
+    time: "%front_time_options%"
 
 magazine_entry_comments:
   controller: App\Controller\Entry\Comment\EntryCommentFrontController::front
   defaults: { sortBy: hot, time: ~ }
   path: /m/{name}/comments/{sortBy}/{time}
   methods: [ GET ]
-  requirements: { sortBy: "%front_sort_options%" }
+  requirements:
+    sortBy: "%front_sort_options%"
+    time: "%front_time_options%"
 
 entry_comment_vote:
   controller: App\Controller\VoteController
@@ -174,8 +184,7 @@ entry_image_delete:
 
 entry_change_magazine:
   controller: App\Controller\Entry\EntryChangeMagazineController
-  defaults: { slug:
-                - }
+  defaults: { slug: - }
   path: /m/{magazine_name}/e/{entry_id}/{slug}/change_magazine
   methods: [ POST ]
 
@@ -221,12 +230,16 @@ entry_single:
   defaults: { slug: -, sortBy: hot }
   path: /m/{magazine_name}/t/{entry_id}/{slug}/{sortBy}
   methods: [ GET ]
+  requirements:
+    sortBy: "%front_sort_options%"
 
 entry_single_comments:
   controller: App\Controller\Entry\EntrySingleController
   defaults: { slug: -, sortBy: hot }
   path: /m/{magazine_name}/t/{entry_id}/{slug}/comments/{sortBy}
   methods: [ GET ]
+  requirements:
+    sortBy: "%front_sort_options%"
 
 entry_vote:
   controller: App\Controller\VoteController

--- a/config/kbin_routes/front.yaml
+++ b/config/kbin_routes/front.yaml
@@ -4,12 +4,12 @@ front:
   path: /{subscription}/{sortBy}/{time}/{type}/{federation}/{content}
   methods: [GET]
   requirements:
-    subscription: "%front_subscription_options%"
-    sortBy: "%front_sort_options%"
-    time: "%front_time_options%"
-    type: "%front_type_options%"
-    federation: "%front_federation_options%"
-    content: "%front_content_options%"
+    subscription: "%default_subscription_options%"
+    sortBy: "%default_sort_options%"
+    time: "%default_time_options%"
+    type: "%default_type_options%"
+    federation: "%default_federation_options%"
+    content: "%default_content_options%"
 
 front_redirect:
   controller: App\Controller\Entry\EntryFrontController::front_redirect
@@ -17,11 +17,11 @@ front_redirect:
   path: /{sortBy}/{time}/{type}/{federation}/{content}
   methods: [GET]
   requirements:
-    sortBy: "%front_sort_options%"
-    time: "%front_time_options%"
-    type: "%front_type_options%"
-    federation: "%front_federation_options%"
-    content: "%front_content_options%"
+    sortBy: "%default_sort_options%"
+    time: "%default_time_options%"
+    type: "%default_type_options%"
+    federation: "%default_federation_options%"
+    content: "%default_content_options%"
 
 front_magazine:
   controller: App\Controller\Entry\EntryFrontController::magazine
@@ -29,11 +29,11 @@ front_magazine:
   path: /m/{name}/{sortBy}/{time}/{type}/{federation}/{content}
   methods: [GET]
   requirements:
-    sortBy: "%front_sort_options%"
-    time: "%front_time_options%"
-    type: "%front_type_options%"
-    federation: "%front_federation_options%"
-    content: "%front_content_options%"
+    sortBy: "%default_sort_options%"
+    time: "%default_time_options%"
+    type: "%default_type_options%"
+    federation: "%default_federation_options%"
+    content: "%default_content_options%"
 
 # Microblog compatibility stuff, redirects from the old routes' URLs
 
@@ -43,8 +43,8 @@ posts_front:
   path: /microblog/{sortBy}/{time}
   methods: [ GET ]
   requirements:
-    sortBy: "%front_sort_options%"
-    time: "%front_time_options%"
+    sortBy: "%default_sort_options%"
+    time: "%default_time_options%"
 
 posts_subscribed:
   controller: App\Controller\Entry\EntryFrontController::front_redirect
@@ -52,8 +52,8 @@ posts_subscribed:
   path: /sub/microblog/{sortBy}/{time}
   methods: [ GET ]
   requirements:
-    sortBy: "%front_sort_options%"
-    time: "%front_time_options%"
+    sortBy: "%default_sort_options%"
+    time: "%default_time_options%"
 
 posts_moderated:
   controller: App\Controller\Entry\EntryFrontController::front_redirect
@@ -61,8 +61,8 @@ posts_moderated:
   path: /mod/microblog/{sortBy}/{time}
   methods: [ GET ]
   requirements:
-    sortBy: "%front_sort_options%"
-    time: "%front_time_options%"
+    sortBy: "%default_sort_options%"
+    time: "%default_time_options%"
 
 posts_favourite:
   controller: App\Controller\Entry\EntryFrontController::front_redirect
@@ -70,8 +70,8 @@ posts_favourite:
   path: /fav/microblog/{sortBy}/{time}
   methods: [ GET ]
   requirements:
-    sortBy: "%front_sort_options%"
-    time: "%front_time_options%"
+    sortBy: "%default_sort_options%"
+    time: "%default_time_options%"
 
 magazine_posts:
   controller: App\Controller\Entry\EntryFrontController::front_redirect
@@ -79,7 +79,7 @@ magazine_posts:
   path: /m/{name}/microblog/{sortBy}/{time}/{type}/{federation}
   methods: [ GET ]
   requirements:
-    sortBy: "%front_sort_options%"
-    time: "%front_time_options%"
-    type: "%front_type_options%"
-    federation: "%front_federation_options%"
+    sortBy: "%default_sort_options%"
+    time: "%default_time_options%"
+    type: "%default_type_options%"
+    federation: "%default_federation_options%"

--- a/config/kbin_routes/front.yaml
+++ b/config/kbin_routes/front.yaml
@@ -4,8 +4,12 @@ front:
   path: /{subscription}/{sortBy}/{time}/{type}/{federation}/{content}
   methods: [GET]
   requirements:
-    subscription: 'sub|fav|mod|all|home'
+    subscription: "%front_subscription_options%"
     sortBy: "%front_sort_options%"
+    time: "%front_time_options%"
+    type: "%front_type_options%"
+    federation: "%front_federation_options%"
+    content: "%front_content_options%"
 
 front_redirect:
   controller: App\Controller\Entry\EntryFrontController::front_redirect
@@ -14,6 +18,10 @@ front_redirect:
   methods: [GET]
   requirements:
     sortBy: "%front_sort_options%"
+    time: "%front_time_options%"
+    type: "%front_type_options%"
+    federation: "%front_federation_options%"
+    content: "%front_content_options%"
 
 front_magazine:
   controller: App\Controller\Entry\EntryFrontController::magazine
@@ -22,7 +30,10 @@ front_magazine:
   methods: [GET]
   requirements:
     sortBy: "%front_sort_options%"
-
+    time: "%front_time_options%"
+    type: "%front_type_options%"
+    federation: "%front_federation_options%"
+    content: "%front_content_options%"
 
 # Microblog compatibility stuff, redirects from the old routes' URLs
 
@@ -31,32 +42,44 @@ posts_front:
   defaults: { sortBy: hot, time: '∞', type: all, federation: all, content: microblog }
   path: /microblog/{sortBy}/{time}
   methods: [ GET ]
-  requirements: { sortBy: "%front_sort_options%" }
+  requirements:
+    sortBy: "%front_sort_options%"
+    time: "%front_time_options%"
 
 posts_subscribed:
   controller: App\Controller\Entry\EntryFrontController::front_redirect
   defaults: { sortBy: hot, time: '∞', type: all, federation: all, content: microblog, subscription: 'sub' }
   path: /sub/microblog/{sortBy}/{time}
   methods: [ GET ]
-  requirements: { sortBy: "%front_sort_options%" }
+  requirements:
+    sortBy: "%front_sort_options%"
+    time: "%front_time_options%"
 
 posts_moderated:
   controller: App\Controller\Entry\EntryFrontController::front_redirect
   defaults: { sortBy: hot, time: '∞', type: all, federation: all, content: microblog, subscription: 'mod' }
   path: /mod/microblog/{sortBy}/{time}
   methods: [ GET ]
-  requirements: { sortBy: "%front_sort_options%" }
+  requirements:
+    sortBy: "%front_sort_options%"
+    time: "%front_time_options%"
 
 posts_favourite:
   controller: App\Controller\Entry\EntryFrontController::front_redirect
   defaults: { sortBy: hot, time: '∞', type: all, federation: all, content: microblog, subscription: 'fav' }
   path: /fav/microblog/{sortBy}/{time}
   methods: [ GET ]
-  requirements: { sortBy: "%front_sort_options%" }
+  requirements:
+    sortBy: "%front_sort_options%"
+    time: "%front_time_options%"
 
 magazine_posts:
   controller: App\Controller\Entry\EntryFrontController::front_redirect
   defaults: { sortBy: hot, time: '∞', type: all, federation: all, content: microblog }
   path: /m/{name}/microblog/{sortBy}/{time}/{type}/{federation}
   methods: [ GET ]
-  requirements: { sortBy: "%front_sort_options%" }
+  requirements:
+    sortBy: "%front_sort_options%"
+    time: "%front_time_options%"
+    type: "%front_type_options%"
+    federation: "%front_federation_options%"

--- a/config/kbin_routes/post.yaml
+++ b/config/kbin_routes/post.yaml
@@ -171,7 +171,7 @@ post_single:
   path: /m/{magazine_name}/p/{post_id}/{slug}/{sortBy}
   methods: [ GET ]
   requirements:
-    sortBy: "%front_sort_options%"
+    sortBy: "%comment_sort_options%"
 
 post_vote:
   controller: App\Controller\VoteController

--- a/config/kbin_routes/post.yaml
+++ b/config/kbin_routes/post.yaml
@@ -170,6 +170,8 @@ post_single:
   defaults: { slug: -, sortBy: hot }
   path: /m/{magazine_name}/p/{post_id}/{slug}/{sortBy}
   methods: [ GET ]
+  requirements:
+    sortBy: "%front_sort_options%"
 
 post_vote:
   controller: App\Controller\VoteController

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -60,7 +60,11 @@ parameters:
     html5_validation: true
 
     front_sort_options: top|hot|active|newest|oldest|commented
-    front_time_options: 6h|12h|1d|1w|1m|1y|all|∞
+    front_time_options: 3h|6h|12h|1d|1w|1m|1y|all|∞
+    front_type_options: article|articles|link|links|video|videos|photo|photos|image|images|all
+    front_subscription_options: sub|fav|mod|all|home
+    front_federation_options: local|all
+    front_content_options: threads|microblog
     stats_type: general|content|views|votes
 
     number_regex: "[1-9][0-9]{0,17}"
@@ -205,4 +209,3 @@ services:
     debril.rss_atom.provider:
         class: App\Feed\Provider
         arguments: ['@App\Service\FeedManager']
-

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -59,12 +59,16 @@ parameters:
 
     html5_validation: true
 
-    front_sort_options: top|hot|active|newest|oldest|commented
-    front_time_options: 3h|6h|12h|1d|1w|1m|1y|all|∞
-    front_type_options: article|articles|link|links|video|videos|photo|photos|image|images|all
-    front_subscription_options: sub|fav|mod|all|home
-    front_federation_options: local|all
-    front_content_options: threads|microblog
+    front_sort_options: top|hot|active|newest|oldest|commented # TODO remove fallback after tag rework
+    default_sort_options: top|hot|active|newest|oldest|commented
+    default_time_options: 3h|6h|12h|1d|1w|1m|1y|all|∞
+    default_type_options: article|articles|link|links|video|videos|photo|photos|image|images|all
+    default_subscription_options: sub|fav|mod|all|home
+    default_federation_options: local|all
+    default_content_options: threads|microblog
+
+    comment_sort_options: top|hot|active|newest|oldest
+
     stats_type: general|content|views|votes
 
     number_regex: "[1-9][0-9]{0,17}"


### PR DESCRIPTION
this adds filter options similar to what was done for `sortBy` to all other filters

right now if you go to say `/all/hot/4h` it will load but the time selection is invalid and it won't affect anything. This instead makes that route 404 as it is not a valid time option. This seems like where we'd want to stop invalid options first before they get to us and we have to constantly filter out bad data (it does duplicate the values from `Criteria`, but hopefully it isn't too bad to be in two main places