### PR TITLE
fix microblog post form missing from microblog pages

### DIFF
--- a/templates/post/front.html.twig
+++ b/templates/post/front.html.twig
@@ -47,15 +47,15 @@
     {% else %}
         <h1 hidden>{{ get_active_sort_option()|trans }}</h1>
     {% endif %}
-    
-    {% if user is defined and user and user.visibility is same as 'visible' %}
+
+    {% if app.user is defined and app.user and app.user.visibility is same as 'visible' %}
     <section class="section section--top">
         {% include 'post/_form_post.html.twig' %}
     </section>
     {% endif %}
     {% include 'post/_options.html.twig' %}
     {% include 'layout/_flash.html.twig' %}
-    {% if user is defined and user %}
+    {% if app.user is defined and app.user %}
         {% include('user/_visibility_info.html.twig') %}
     {% endif %}
     {% if magazine is defined and magazine %}

--- a/templates/user/_visibility_info.html.twig
+++ b/templates/user/_visibility_info.html.twig
@@ -1,5 +1,5 @@
-{% if user is defined and user and user.visibility is same as 'trashed' %}
+{% if app.user is defined and app.user and app.user.visibility is same as 'trashed' %}
     <div class="alert alert__danger">
         <p>{{ 'account_is_suspended'|trans }}</p>
     </div>
-{% endif %} 
+{% endif %}


### PR DESCRIPTION
I missed in review the rendering of the post template [previously passed in the `$user` field](https://github.com/MbinOrg/mbin/pull/453/files#diff-4cecfa123ba50e00edd7655ce3144df2b30fea2b3e3d6ad5a31057b2a8c52a94L53) and that was dropped when moving it to its new home

This caused the microblog pages to not render the form for making a new microblog post as there was no user, so it reacting as if they were not logged in

Rather than passing it in, I switched it to the global `app.user` var which works much more reliably. Now that I learned this (after seeing benti not have issues with it on the account deletion PR when I did with password  2fa PR), it might be worth removing all `user` and replace with `app.user` and stop fetching the user to send into templates / passing through to components, assuming they are indeed equivalent.

Before

![image](https://github.com/MbinOrg/mbin/assets/146029455/7b344429-2adb-48af-8648-5c467ebfaf46)

After

![image](https://github.com/MbinOrg/mbin/assets/146029455/bd870c14-733b-4b74-bcc3-ad46da55fd3a)
