### PR TITLE
add back magazine to post dto when in magazine view

### DIFF
--- a/src/Controller/Entry/EntryFrontController.php
+++ b/src/Controller/Entry/EntryFrontController.php
@@ -166,7 +166,11 @@ class EntryFrontController extends AbstractController
     {
         $baseData = ['criteria' => $criteria] + $data;
         if ('microblog' === $content) {
-            $baseData['form'] = $this->createForm(PostType::class)->setData(new PostDto())->createView();
+            $dto = new PostDto();
+            if (isset($data['magazine'])) {
+                $dto->magazine = $data['magazine'];
+            }
+            $baseData['form'] = $this->createForm(PostType::class)->setData($dto)->createView();
         }
 
         if ($request->isXmlHttpRequest()) {


### PR DESCRIPTION
noticed that the microblog form for new post wasn't automatically populating with magazine when on the magazine view. tracked it down to this value https://github.com/MbinOrg/mbin/blob/dbf876fd1d7cd95570bdc1e5ab9d0837e277acbc/src/Controller/Post/PostFrontController.php#L217 being not set after the move to the combined front controller. should work now

before (on magazine microblog page load without doing anything)

![image](https://github.com/MbinOrg/mbin/assets/146029455/e3c1c5b0-15f0-41e3-8ae1-796a5f75fe32)

after (on magazine microblog page load without doing anything)

![image](https://github.com/MbinOrg/mbin/assets/146029455/56e3a230-897d-4a9e-a7d2-110b05aa2988)

related #453