### PR TITLE
restrict login css to main content containers

### DIFF
--- a/assets/styles/components/_login.scss
+++ b/assets/styles/components/_login.scss
@@ -3,7 +3,7 @@
 .page-reset-password,
 .page-reset-password-email-sent,
 .page-resend-activation-email {
-  .container {
+  #content .container {
     margin: 0 auto;
     max-width: 30rem;
 
@@ -36,7 +36,7 @@
 }
 
 .page-2fa {
-  .container {
+  #content .container {
     margin: 0 auto;
     max-width: 30rem;
 


### PR DESCRIPTION
@nobodyatroot noticed that our sidebar was bold on the login page. this is because the css for the login / password / 2fa pages did not restrict this rules to specific `.container`s, and the sidebar contains them. this restricts it to the main content side of things, which should fix any oddities

| before on login/reset pages | after on login/reset pages |
|-|-|
| ![image](https://github.com/MbinOrg/mbin/assets/146029455/d147c08b-324d-4f63-a4b6-b3645c4a7d39) | ![image](https://github.com/MbinOrg/mbin/assets/146029455/1fd44c14-52a8-4b3e-902f-6cd8450f8b5f) |
