### PR TITLE
Fix circular ChainActivityMessage again again

### DIFF
--- a/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
@@ -26,7 +26,6 @@ class ChainActivityHandler
 {
     public function __construct(
         private readonly LoggerInterface $logger,
-        private readonly ActivityPubManager $activityPubManager,
         private readonly ApHttpClient $client,
         private readonly MessageBusInterface $bus,
         private readonly ApActivityRepository $repository,
@@ -102,15 +101,19 @@ class ChainActivityHandler
             switch ($object['type']) {
                 case 'Question':
                 case 'Note':
+                    $this->logger->debug('creating note {o}', ['o' => $object]);
+
                     return $this->note->create($object);
                 case 'Page':
                 case 'Article':
+                    $this->logger->debug('creating page {o}', ['o' => $object]);
+
                     return $this->page->create($object);
                 default:
                     $this->logger->warning('Could not create an object from type {t} on {url}: {o}', ['t' => $object['type'], 'url' => $apUrl, 'o' => $object]);
             }
         } catch (\Exception $e) {
-            $this->logger->error('There was an exception while getting {url}: {ex} - {m}', ['url' => $apUrl, 'ex' => \get_class($e), 'm' => $e->getMessage()]);
+            $this->logger->error('There was an exception while getting {url}: {ex} - {m}. {o}', ['url' => $apUrl, 'ex' => \get_class($e), 'm' => $e->getMessage(), 'o' => $e]);
         }
 
         return null;

--- a/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
@@ -16,7 +16,6 @@ use App\Repository\ApActivityRepository;
 use App\Service\ActivityPub\ApHttpClient;
 use App\Service\ActivityPub\Note;
 use App\Service\ActivityPub\Page;
-use App\Service\ActivityPubManager;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -733,16 +733,19 @@ class ActivityPubManager
     }
 
     /**
-     * @param string|array $apObject      the object that should be like, so a post of any kind in its AP array representation or a URL
-     * @param array        $fullPayload   the full message payload, only used to log it
-     * @param callable     $chainDispatch if we do not have the object in our db this is called to dispatch a new ChainActivityMessage.
-     *                                    Since the explicit object has to be set in the message this has to be done as a callback method
+     * @param string|array                                       $apObject      the object that should be like, so a post of any kind in its AP array representation or a URL
+     * @param array                                              $fullPayload   the full message payload, only used to log it
+     * @param callable(array $object, ?string $adjustedUrl):void $chainDispatch if we do not have the object in our db this is called to dispatch a new ChainActivityMessage.
+     *                                                                          Since the explicit object has to be set in the message this has to be done as a callback method.
+     *                                                                          The object parameter is an associative array representing the first dependency of the activity.
+     *                                                                          The $adjustedUrl parameter is only set if the object was fetched from a different url than the id of the object might suggest
      *
      * @see ChainActivityMessage
      */
     public function getEntityObject(string|array $apObject, array $fullPayload, callable $chainDispatch): null|Entry|EntryComment|Post|PostComment
     {
         $object = null;
+        $calledUrl = null;
         if (\is_string($apObject)) {
             if (false === filter_var($apObject, FILTER_VALIDATE_URL)) {
                 $this->logger->error('The like activity references an object by string, but that is not a URL, discarding the message', $fullPayload);
@@ -750,12 +753,16 @@ class ActivityPubManager
                 return null;
             }
             $activity = $this->activityRepository->findByObjectId($apObject);
+            $calledUrl = $apObject;
             if (!$activity) {
+                $this->logger->debug('object is fetched from {url} because it is a string and could not be found in our repo', ['url' => $apObject]);
                 $object = $this->apHttpClient->getActivityObject($apObject);
             }
         } else {
             $activity = $this->activityRepository->findByObjectId($apObject['id']);
+            $calledUrl = $apObject['id'];
             if (!$activity) {
+                $this->logger->debug('object is fetched from {url} because it is not a string and could not be found in our repo', ['url' => $apObject['id']]);
                 $object = $apObject;
             }
         }
@@ -767,7 +774,15 @@ class ActivityPubManager
         }
 
         if ($object) {
-            $chainDispatch($object);
+            $adjustedUrl = null;
+            if ($object['id'] !== $calledUrl) {
+                $this->logger->warning('the url {url} returned a different object id: {id}', ['url' => $calledUrl, 'id' => $object['id']]);
+                $adjustedUrl = $object['id'];
+            }
+
+            $this->logger->debug('dispatching a ChainActivityMessage, because the object could not be found: {o}', ['o' => $apObject]);
+            $this->logger->debug('the object for ChainActivityMessage with object {o}', ['o' => $object]);
+            $chainDispatch($object, $adjustedUrl);
 
             return null;
         }


### PR DESCRIPTION
when we get a like message which has url A as the "object" (or as the "id" of the "object") and the returned json has a different url B as the "id", then we went to a circular message, because the ChainActivityHandler would create the object with id B, but Like-, Dislike- and AnnounceHandler would search for an object with id A.

If that occurs now, a warning will be logged and the Like-, Dislike- and AnnounceMessage that will be dispatched by the ChainActivityHandler will be adjusted to use the id that is actually in the json response from the url

Closes #668 