### PR TITLE
Fix some API calls

### DIFF
--- a/src/Controller/Api/Domain/DomainRetrieveApi.php
+++ b/src/Controller/Api/Domain/DomainRetrieveApi.php
@@ -160,7 +160,7 @@ class DomainRetrieveApi extends DomainBaseApi
 
         $dtos = [];
         foreach ($domains->getCurrentPageResults() as $value) {
-            \assert($value instanceof DomainDto);
+            \assert($value instanceof Domain);
             array_push($dtos, $this->serializeDomain($value));
         }
 

--- a/src/Controller/Api/Search/SearchRetrieveApi.php
+++ b/src/Controller/Api/Search/SearchRetrieveApi.php
@@ -123,7 +123,7 @@ class SearchRetrieveApi extends BaseApi
         $page = $this->getPageNb($request);
         $perPage = self::constrainPerPage($request->get('perPage', SearchRepository::PER_PAGE));
 
-        $items = $manager->findPaginated($q, $page, $perPage);
+        $items = $manager->findPaginated($this->getUser(), $q, $page, $perPage);
         $dtos = [];
         foreach ($items->getCurrentPageResults() as $value) {
             \assert($value instanceof ContentInterface);

--- a/src/DTO/EntryResponseDto.php
+++ b/src/DTO/EntryResponseDto.php
@@ -126,7 +126,7 @@ class EntryResponseDto implements \JsonSerializable
             'entryId' => $this->entryId,
             'magazine' => $this->magazine->jsonSerialize(),
             'user' => $this->user->jsonSerialize(),
-            'domain' => $this->domain->jsonSerialize(),
+            'domain' => $this->domain?->jsonSerialize(),
             'title' => $this->title,
             'url' => $this->url,
             'image' => $this->image?->jsonSerialize(),

--- a/src/DTO/MagazineResponseDto.php
+++ b/src/DTO/MagazineResponseDto.php
@@ -85,7 +85,7 @@ class MagazineResponseDto implements \JsonSerializable
     {
         return [
             'magazineId' => $this->magazineId,
-            'owner' => $this->owner->jsonSerialize(),
+            'owner' => $this->owner?->jsonSerialize(),
             'icon' => $this->icon ? $this->icon->jsonSerialize() : null,
             'name' => $this->name,
             'title' => $this->title,

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -404,7 +404,8 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
     private function findWithAboutQueryBuilder(string $group): QueryBuilder
     {
         $qb = $this->createQueryBuilder('u')
-            ->andWhere('u.about != :emptyString');
+            ->andWhere('u.about != \'\'')
+            ->andWhere('u.about IS NOT NULL');
 
         switch ($group) {
             case self::USERS_LOCAL:


### PR DESCRIPTION
- `DomainRetrieveApi` asserted the wrong type
- `SearchRetrieveAPI` was missing the querying user parameter
- `EntryResponseDto` did not handle nulls on the `domain` property
- `MagazineResponseDto` did not handle nulls on the `owner` property
- `UserRepository` was missing a parameter and the query was not exactly right

I found a few bugs in the API while working on #654 