### PR TITLE
Remove ratio from entry view

### DIFF
--- a/templates/entry/_info.html.twig
+++ b/templates/entry/_info.html.twig
@@ -22,9 +22,6 @@
     {{ component('user_actions', {user: entry.user}) }}
     <ul class="info">
         <li>{{ 'added'|trans }}: {{ component('date', {date: entry.createdAt}) }}</li>
-        <li>{{ 'ratio'|trans }}:
-            <span>{{ entry.countUpvotes }} {% if entry.countUpvotes %}({{ (entry.countUpvotes / entry.countVotes)|format_percent_number }}){% endif %}</span>
-        </li>
     </ul>
     {% if entry.tags %}
         <h3 class="mt-3">{{ 'tags'|trans }}</h3>

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -144,7 +144,6 @@ columns: Columns
 user: User
 joined: Joined
 moderated: Moderated
-ratio: Ratio
 people_local: Local
 people_federated: Federated
 reputation_points: Reputation points


### PR DESCRIPTION
We can close this PR removing ratio from the entry view if there is significant dissent, alternative is to calculate ratio on upvotes vs. downvotes instead of boosts as it is right now... but honestly I've ignored ratio until now when I noticed it always shows 0 without any boosts:

Does nothing on upvotes:
![image](https://github.com/MbinOrg/mbin/assets/35878315/ae035418-3e4f-4663-a84c-b16fa240ad1c)

Boosts:
![image](https://github.com/MbinOrg/mbin/assets/35878315/af7db3f2-ec0f-4fce-a794-9b673d3164d1)
