### PR TITLE
front controller path/routing adjustment

### DIFF
--- a/config/kbin_routes/domain.yaml
+++ b/config/kbin_routes/domain.yaml
@@ -1,12 +1,11 @@
 domain_entries:
   controller: App\Controller\Domain\DomainFrontController
-  defaults: { sortBy: hot, time: '∞', type: ~ }
-  path: /d/{name}/{sortBy}/{time}/{type}
+  defaults: { sortBy: hot, time: '∞'}
+  path: /d/{name}/{sortBy}/{time}
   methods: [ GET ]
   requirements:
     sortBy: "%default_sort_options%"
     time: "%default_time_options%"
-    type: "%default_type_options%"
 
 domain_comments:
   controller: App\Controller\Domain\DomainCommentFrontController

--- a/config/kbin_routes/front.yaml
+++ b/config/kbin_routes/front.yaml
@@ -1,45 +1,55 @@
 front:
   controller: App\Controller\Entry\EntryFrontController::front
-  defaults: { subscription: home, sortBy: hot, time: '∞', type: all, federation: all, content: threads }
-  path: /{subscription}/{sortBy}/{time}/{type}/{federation}/{content}
+  defaults: &front_defaults { subscription: home, content: threads, sortBy: hot, time: '∞', federation: all }
+  path: /{subscription}/{content}/{sortBy}/{time}/{federation}
   methods: [GET]
-  requirements:
+  requirements: &front_requirement
     subscription: "%default_subscription_options%"
     sortBy: "%default_sort_options%"
     time: "%default_time_options%"
-    type: "%default_type_options%"
     federation: "%default_federation_options%"
     content: "%default_content_options%"
 
-front_redirect:
-  controller: App\Controller\Entry\EntryFrontController::front_redirect
-  defaults: { sortBy: hot, time: '∞', type: all, federation: all, content: threads }
-  path: /{sortBy}/{time}/{type}/{federation}/{content}
+front_sub:
+  controller: App\Controller\Entry\EntryFrontController::front
+  defaults: *front_defaults
+  path: /{subscription}/{sortBy}/{time}/{federation}
   methods: [GET]
-  requirements:
-    sortBy: "%default_sort_options%"
-    time: "%default_time_options%"
-    type: "%default_type_options%"
-    federation: "%default_federation_options%"
-    content: "%default_content_options%"
+  requirements: *front_requirement
+
+front_content:
+  controller: App\Controller\Entry\EntryFrontController::front
+  defaults: *front_defaults
+  path: /{content}/{sortBy}/{time}/{federation}
+  methods: [GET]
+  requirements: *front_requirement
+
+front_short:
+  controller: App\Controller\Entry\EntryFrontController::front
+  defaults: *front_defaults
+  path: /{sortBy}/{time}/{federation}
+  methods: [GET]
+  requirements: *front_requirement
 
 front_magazine:
   controller: App\Controller\Entry\EntryFrontController::magazine
-  defaults: { sortBy: hot, time: '∞', type: all, federation: all, content: threads }
-  path: /m/{name}/{sortBy}/{time}/{type}/{federation}/{content}
+  defaults: &front_magazine_defaults { content: threads, sortBy: hot, time: '∞', federation: all }
+  path: /m/{name}/{content}/{sortBy}/{time}/{federation}
   methods: [GET]
-  requirements:
-    sortBy: "%default_sort_options%"
-    time: "%default_time_options%"
-    type: "%default_type_options%"
-    federation: "%default_federation_options%"
-    content: "%default_content_options%"
+  requirements: *front_requirement
+
+front_magazine_short:
+  controller: App\Controller\Entry\EntryFrontController::magazine
+  defaults: &front_magazine_defaults
+  path: /m/{name}/{sortBy}/{time}/{federation}
+  methods: [GET]
+  requirements: *front_requirement
 
 # Microblog compatibility stuff, redirects from the old routes' URLs
 
 posts_front:
-  controller: App\Controller\Entry\EntryFrontController::front_redirect
-  defaults: { sortBy: hot, time: '∞', type: all, federation: all, content: microblog }
+  controller: App\Controller\Entry\EntryFrontController::frontRedirect
+  defaults: { sortBy: hot, time: '∞', federation: all, content: microblog }
   path: /microblog/{sortBy}/{time}
   methods: [ GET ]
   requirements:
@@ -47,8 +57,8 @@ posts_front:
     time: "%default_time_options%"
 
 posts_subscribed:
-  controller: App\Controller\Entry\EntryFrontController::front_redirect
-  defaults: { sortBy: hot, time: '∞', type: all, federation: all, content: microblog, subscription: 'sub' }
+  controller: App\Controller\Entry\EntryFrontController::frontRedirect
+  defaults: { sortBy: hot, time: '∞', federation: all, content: microblog, subscription: 'sub' }
   path: /sub/microblog/{sortBy}/{time}
   methods: [ GET ]
   requirements:
@@ -56,8 +66,8 @@ posts_subscribed:
     time: "%default_time_options%"
 
 posts_moderated:
-  controller: App\Controller\Entry\EntryFrontController::front_redirect
-  defaults: { sortBy: hot, time: '∞', type: all, federation: all, content: microblog, subscription: 'mod' }
+  controller: App\Controller\Entry\EntryFrontController::frontRedirect
+  defaults: { sortBy: hot, time: '∞', federation: all, content: microblog, subscription: 'mod' }
   path: /mod/microblog/{sortBy}/{time}
   methods: [ GET ]
   requirements:
@@ -65,8 +75,8 @@ posts_moderated:
     time: "%default_time_options%"
 
 posts_favourite:
-  controller: App\Controller\Entry\EntryFrontController::front_redirect
-  defaults: { sortBy: hot, time: '∞', type: all, federation: all, content: microblog, subscription: 'fav' }
+  controller: App\Controller\Entry\EntryFrontController::frontRedirect
+  defaults: { sortBy: hot, time: '∞', federation: all, content: microblog, subscription: 'fav' }
   path: /fav/microblog/{sortBy}/{time}
   methods: [ GET ]
   requirements:
@@ -74,12 +84,11 @@ posts_favourite:
     time: "%default_time_options%"
 
 magazine_posts:
-  controller: App\Controller\Entry\EntryFrontController::front_redirect
-  defaults: { sortBy: hot, time: '∞', type: all, federation: all, content: microblog }
-  path: /m/{name}/microblog/{sortBy}/{time}/{type}/{federation}
+  controller: App\Controller\Entry\EntryFrontController::magazineRedirect
+  defaults: { sortBy: hot, time: '∞', federation: all, content: microblog }
+  path: /m/{name}/microblog/{sortBy}/{time}/{federation}
   methods: [ GET ]
   requirements:
     sortBy: "%default_sort_options%"
     time: "%default_time_options%"
-    type: "%default_type_options%"
     federation: "%default_federation_options%"

--- a/src/Controller/Domain/DomainFrontController.php
+++ b/src/Controller/Domain/DomainFrontController.php
@@ -13,6 +13,7 @@ use Pagerfanta\PagerfantaInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
 
 class DomainFrontController extends AbstractController
 {
@@ -22,8 +23,14 @@ class DomainFrontController extends AbstractController
     ) {
     }
 
-    public function __invoke(?string $name, ?string $sortBy, ?string $time, ?string $type, Request $request): Response
-    {
+    public function __invoke(
+        ?string $name,
+        ?string $sortBy,
+        ?string $time,
+        #[MapQueryParameter]
+        ?string $type,
+        Request $request
+    ): Response {
         if (!$domain = $this->domainRepository->findOneBy(['name' => $name])) {
             throw $this->createNotFoundException();
         }

--- a/src/Repository/Criteria.php
+++ b/src/Repository/Criteria.php
@@ -230,22 +230,13 @@ abstract class Criteria
 
     public function resolveType(?string $value): ?string
     {
-        // @todo
-        $routes = [
-            'all' => 'all',
-            'article' => Entry::ENTRY_TYPE_ARTICLE,
-            'articles' => Entry::ENTRY_TYPE_ARTICLE,
-            'link' => Entry::ENTRY_TYPE_LINK,
-            'links' => Entry::ENTRY_TYPE_LINK,
-            'video' => Entry::ENTRY_TYPE_VIDEO,
-            'videos' => Entry::ENTRY_TYPE_VIDEO,
-            'photo' => Entry::ENTRY_TYPE_IMAGE,
-            'photos' => Entry::ENTRY_TYPE_IMAGE,
-            'image' => Entry::ENTRY_TYPE_IMAGE,
-            'images' => Entry::ENTRY_TYPE_IMAGE,
-        ];
-
-        return $routes[$value] ?? 'all';
+        return match ($value) {
+            'article', 'articles' => Entry::ENTRY_TYPE_ARTICLE,
+            'link', 'links' => Entry::ENTRY_TYPE_LINK,
+            'video', 'videos' => Entry::ENTRY_TYPE_VIDEO,
+            'photo', 'photos', 'image', 'images' => Entry::ENTRY_TYPE_IMAGE,
+            default => 'all'
+        };
     }
 
     public function translateType(): string

--- a/src/Twig/Extension/FrontExtension.php
+++ b/src/Twig/Extension/FrontExtension.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig\Extension;
+
+use App\Twig\Runtime\FrontExtensionRuntime;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class FrontExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('front_options_url', [FrontExtensionRuntime::class, 'frontOptionsUrl']),
+        ];
+    }
+}

--- a/src/Twig/Runtime/FrontExtensionRuntime.php
+++ b/src/Twig/Runtime/FrontExtensionRuntime.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig\Runtime;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Extension\RuntimeExtensionInterface;
+
+class FrontExtensionRuntime implements RuntimeExtensionInterface
+{
+    public function __construct(
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    // effectively a specialized version of UrlExtensionRuntime::optionsUrl for front routes
+    // used for filtering link generation
+    public function frontOptionsUrl(
+        string $name,
+        ?string $value,
+        string $routeName = null,
+        array $additionalParams = [],
+    ): string {
+        $request = $this->requestStack->getCurrentRequest();
+        $attrs = $request->attributes;
+        $route = $routeName ?? $attrs->get('_route');
+
+        $params = array_merge($attrs->get('_route_params', []), $request->query->all());
+        $params = array_replace($params, $additionalParams);
+        $params = array_filter($params, fn ($v) => null !== $v);
+
+        $params[$name] = $value;
+
+        if (str_starts_with($route, 'front') && !str_contains($route, '_magazine')) {
+            $route = $this->getFrontRoute($route, $params);
+        }
+
+        return $this->urlGenerator->generate($route, $params);
+    }
+
+    /**
+     * Upgrades shorter `front_*` routes to a front route that can fit all specified params.
+     */
+    private function getFrontRoute(string $currentRoute, array $params): string
+    {
+        $content = $params['content'] ?? null;
+        $subscription = $params['subscription'] ?? null;
+
+        if (\in_array($currentRoute, ['front_sub', 'front_content']) && $content && $subscription) {
+            return 'front';
+        } elseif ('front_short' === $currentRoute) {
+            return match (true) {
+                !empty($content) => 'front_content',
+                !empty($subscription) => 'front_sub',
+                default => 'front',
+            };
+        }
+
+        return 'front';
+    }
+}

--- a/src/Twig/Runtime/UrlExtensionRuntime.php
+++ b/src/Twig/Runtime/UrlExtensionRuntime.php
@@ -265,7 +265,7 @@ class UrlExtensionRuntime implements RuntimeExtensionInterface
     // $additionalParams indicates extra parameters to set in addition to [$name] = $value
     // Set $value to null to indicate deleting a parameter
     // TODO: It'd be better to have just a single $params which is an associative array
-    public function optionsUrl(string $name, string $value, string $routeName = null, array $additionalParams = []): string
+    public function optionsUrl(string $name, ?string $value, string $routeName = null, array $additionalParams = []): string
     {
         $route = $routeName ?? $this->requestStack->getCurrentRequest()->attributes->get('_route');
         $params = $this->requestStack->getCurrentRequest()->attributes->get('_route_params', []);

--- a/templates/domain/_options.html.twig
+++ b/templates/domain/_options.html.twig
@@ -124,7 +124,7 @@
             </button>
             <ul class="dropdown__menu">
                 <li>
-                    <a href="{{ options_url('type', 'all', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'all' }) }}">
+                    <a href="{{ options_url('type', null, null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'all' }) }}">
                         <i class="fa-solid fa-file" aria-hidden="true"></i> &nbsp; {{ 'all'|trans }}
                     </a>
                 </li>

--- a/templates/entry/_options.html.twig
+++ b/templates/entry/_options.html.twig
@@ -11,31 +11,31 @@
             </button>
             <ul class="dropdown__menu">
                 <li>
-                    <a href="{{ options_url('sortBy', 'top', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('sortBy', 'top', null, {'p': null}) }}"
                     class="{{ html_classes({'active': criteria.getOption('sort') == 'top'}) }}">
                         {{ 'top'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('sortBy', 'hot', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('sortBy', 'hot', null, {'p': null}) }}"
                     class="{{ html_classes({'active': criteria.getOption('sort') == 'hot'}) }}">
                         {{ 'hot'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('sortBy', 'newest', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('sortBy', 'newest', null, {'p': null}) }}"
                     class="{{ html_classes({'active': criteria.getOption('sort') == 'newest'}) }}">
                         {{ 'newest'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('sortBy', 'active', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('sortBy', 'active', null, {'p': null}) }}"
                     class="{{ html_classes({'active': criteria.getOption('sort') == 'active'}) }}">
                         {{ 'active'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('sortBy', 'commented', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('sortBy', 'commented', null, {'p': null}) }}"
                     class="{{ html_classes({'active': criteria.getOption('sort') == 'commented'}) }}">
                         {{ 'commented'|trans }}
                     </a>
@@ -52,48 +52,48 @@
             </button>
             <ul class="dropdown__menu">
                 <li>
-                    <a href="{{ options_url('time', '∞', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('time', '∞', null, {'p': null}) }}"
                        class="{{ html_classes({'active': criteria.getOption('time') == 'all'}) }}">
                         {{ 'all_time'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('time', '3h', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('time', '3h', null, {'p': null}) }}"
                        class="{{ html_classes({'active': criteria.getOption('time') == '3h' }) }}">
                         {{ '3h'|trans }}
                     </a></li>
                 <li>
-                    <a href="{{ options_url('time', '6h', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('time', '6h', null, {'p': null}) }}"
                        class="{{ html_classes({'active': criteria.getOption('time') == '6h' }) }}">
                         {{ '6h'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('time', '12h', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('time', '12h', null, {'p': null}) }}"
                        class="{{ html_classes({'active': criteria.getOption('time') == '12h' }) }}">
                         {{ '12h'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('time', '1d', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('time', '1d', null, {'p': null}) }}"
                        class="{{ html_classes({'active': criteria.getOption('time') == '1d' }) }}">
                         {{ '1d'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('time', '1w', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('time', '1w', null, {'p': null}) }}"
                        class="{{ html_classes({'active': criteria.getOption('time') == '1w' }) }}">
                         {{ '1w'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('time', '1m', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('time', '1m', null, {'p': null}) }}"
                        class="{{ html_classes({'active': criteria.getOption('time') == '1m' }) }}">
                         {{ '1m'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('time', '1y', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('time', '1y', null, {'p': null}) }}"
                        class="{{ html_classes({'active': criteria.getOption('time') == '1y' }) }}">
                         {{ '1y'|trans }}
                     </a>
@@ -124,27 +124,27 @@
             </button>
             <ul class="dropdown__menu">
                 <li>
-                    <a href="{{ options_url('type', 'all', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'all' }) }}">
+                    <a href="{{ front_options_url('type', null, null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'all' }) }}">
                         <i class="fa-solid fa-file" aria-hidden="true"></i> &nbsp; {{ 'all'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('type', 'links', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'links' }) }}">
+                    <a href="{{ front_options_url('type', 'links', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'links' }) }}">
                         <i class="fa-regular fa-file-code" aria-hidden="true"></i> &nbsp; {{ 'links'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('type', 'articles', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'threads' }) }}">
+                    <a href="{{ front_options_url('type', 'articles', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'threads' }) }}">
                         <i class="fa-regular fa-file-lines" aria-hidden="true"></i> &nbsp; {{ 'threads'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('type', 'photos', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'photos' }) }}">
+                    <a href="{{ front_options_url('type', 'photos', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'photos' }) }}">
                         <i class="fa-regular fa-file-image" aria-hidden="true"></i> &nbsp; {{ 'photos'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('type', 'videos', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'videos'}) }}">
+                    <a href="{{ front_options_url('type', 'videos', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'videos'}) }}">
                         <i class="fa-regular fa-file-video" aria-hidden="true"></i> &nbsp; {{ 'videos'|trans }}
                     </a>
                 </li>
@@ -172,24 +172,24 @@
                 </button>
                 <ul class="dropdown__menu">
                     <li>
-                        <a href="{{ options_url('subscription', 'all', null, {'p': null}) }}" class="{{ html_classes({'active': not criteria.favourite and not criteria.moderated and not criteria.subscribed}) }}">
+                        <a href="{{ front_options_url('subscription', 'all', null, {'p': null}) }}" class="{{ html_classes({'active': not criteria.favourite and not criteria.moderated and not criteria.subscribed}) }}">
                             <i class="fa-solid fa-earth-americas" aria-hidden="true"></i> &nbsp; {{ 'all'|trans }}
                         </a>
                     </li>
                     {% if not is_route_name_contains('_magazine') %}
                         <li>
-                            <a href="{{ options_url('subscription', 'sub', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.subscribed }) }}">
+                            <a href="{{ front_options_url('subscription', 'sub', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.subscribed }) }}">
                                 <i class="fa-solid fa-folder-plus" aria-hidden="true"></i> &nbsp; {{ 'subscribed'|trans }}
                             </a>
                         </li>
                         <li>
-                            <a href="{{ options_url('subscription', 'mod', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.moderated }) }}">
+                            <a href="{{ front_options_url('subscription', 'mod', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.moderated }) }}">
                                 <i class="fa-solid fa-shield-halved" aria-hidden="true"></i> &nbsp;{{ 'moderated'|trans }}
                             </a>
                         </li>
                     {% endif %}
                     <li>
-                        <a href="{{ options_url('subscription', 'fav', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.favourite }) }}">
+                        <a href="{{ front_options_url('subscription', 'fav', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.favourite }) }}">
                             <i class="fa-solid fa-heart" aria-hidden="true"></i> &nbsp; {{ 'favourites'|trans }}
                         </a>
                     </li>
@@ -217,18 +217,18 @@
             </button>
             <ul class="dropdown__menu">
                 <li>
-                    <a href="{{ options_url('federation', 'all', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('federation') == 'all' }) }}">
+                    <a href="{{ front_options_url('federation', 'all', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('federation') == 'all' }) }}">
                         <i class="fa-solid fa-circle-nodes" aria-hidden="true"></i> &nbsp; {{ 'all'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('federation', 'local', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('federation') == 'local' }) }}">
+                    <a href="{{ front_options_url('federation', 'local', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('federation') == 'local' }) }}">
                         <i class="fa-solid fa-house-chimney" aria-hidden="true"></i> &nbsp; {{ 'local'|trans }}
                     </a>
                 </li>
                 {#
                 <li>
-                    <a href="{{ options_url('federation', 'federated', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('federation') == 'federated' }) }}">
+                    <a href="{{ front_options_url('federation', 'federated', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('federation') == 'federated' }) }}">
                         <i class="fa-solid fa-network-wired" aria-hidden="true"></i> &nbsp; {{ 'federated'|trans }}
                     </a>
                 </li>

--- a/templates/layout/_header_nav.html.twig
+++ b/templates/layout/_header_nav.html.twig
@@ -40,13 +40,13 @@
         <a href="
             {% if magazine is defined and magazine %}
                 {% if is_route_name_starts_with('front') %}
-                    {{ options_url('content', 'microblog', 'front_magazine', {'name': magazine.name,'p': null}) }}
+                    {{ options_url('content', 'microblog', 'front_magazine', {'name': magazine.name,'p': null,'type':null}) }}
                 {% else %}
                     {{ navbar_posts_url(magazine) }}
                 {% endif %}
             {% else %}
                 {% if is_route_name_starts_with('front') %}
-                    {{ options_url('content', 'microblog', 'front', {'p': null}) }}
+                    {{ options_url('content', 'microblog', 'front', {'p': null,'type':null}) }}
                 {% else %}
                     {{ navbar_posts_url(null) }}
                 {% endif %}

--- a/templates/layout/_header_nav.html.twig
+++ b/templates/layout/_header_nav.html.twig
@@ -10,6 +10,10 @@
     {% elseif criteria.getOption('content') == 'microblog' %}
         {% set activeLink = 'microblog' %}
     {% endif %}
+{% elseif entry is defined and entry %}
+    {% set activeLink = 'threads' %}
+{% elseif post is defined and post %}
+    {% set activeLink = 'microblog' %}
 {% endif %}
 
 {% if header_nav is empty %}

--- a/templates/post/_options.html.twig
+++ b/templates/post/_options.html.twig
@@ -11,31 +11,31 @@
             </button>
             <ul class="dropdown__menu">
                 <li>
-                    <a href="{{ options_url('sortBy', 'top', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('sortBy', 'top', null, {'p': null}) }}"
                     class="{{ html_classes({'active': criteria.getOption('sort') == 'top'}) }}">
                         {{ 'top'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('sortBy', 'hot', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('sortBy', 'hot', null, {'p': null}) }}"
                     class="{{ html_classes({'active': criteria.getOption('sort') == 'hot'}) }}">
                         {{ 'hot'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('sortBy', 'newest', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('sortBy', 'newest', null, {'p': null}) }}"
                     class="{{ html_classes({'active': criteria.getOption('sort') == 'newest'}) }}">
                         {{ 'newest'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('sortBy', 'active', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('sortBy', 'active', null, {'p': null}) }}"
                     class="{{ html_classes({'active': criteria.getOption('sort') == 'active'}) }}">
                         {{ 'active'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('sortBy', 'commented', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('sortBy', 'commented', null, {'p': null}) }}"
                     class="{{ html_classes({'active': criteria.getOption('sort') == 'commented'}) }}">
                         {{ 'commented'|trans }}
                     </a>
@@ -52,48 +52,48 @@
             </button>
             <ul class="dropdown__menu">
                 <li>
-                    <a href="{{ options_url('time', '∞', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('time', '∞', null, {'p': null}) }}"
                        class="{{ html_classes({'active': criteria.getOption('time') == 'all'}) }}">
                         {{ 'all_time'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('time', '3h', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('time', '3h', null, {'p': null}) }}"
                        class="{{ html_classes({'active': criteria.getOption('time') == '3h' }) }}">
                         {{ '3h'|trans }}
                     </a></li>
                 <li>
-                    <a href="{{ options_url('time', '6h', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('time', '6h', null, {'p': null}) }}"
                        class="{{ html_classes({'active': criteria.getOption('time') == '6h' }) }}">
                         {{ '6h'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('time', '12h', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('time', '12h', null, {'p': null}) }}"
                        class="{{ html_classes({'active': criteria.getOption('time') == '12h' }) }}">
                         {{ '12h'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('time', '1d', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('time', '1d', null, {'p': null}) }}"
                        class="{{ html_classes({'active': criteria.getOption('time') == '1d' }) }}">
                         {{ '1d'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('time', '1w', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('time', '1w', null, {'p': null}) }}"
                        class="{{ html_classes({'active': criteria.getOption('time') == '1w' }) }}">
                         {{ '1w'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('time', '1m', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('time', '1m', null, {'p': null}) }}"
                        class="{{ html_classes({'active': criteria.getOption('time') == '1m' }) }}">
                         {{ '1m'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('time', '1y', null, {'p': null}) }}"
+                    <a href="{{ front_options_url('time', '1y', null, {'p': null}) }}"
                        class="{{ html_classes({'active': criteria.getOption('time') == '1y' }) }}">
                         {{ '1y'|trans }}
                     </a>
@@ -126,27 +126,27 @@
                 </button>
                 <ul class="dropdown__menu">
                     <li>
-                        <a href="{{ options_url('type', 'all', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'all' }) }}">
+                        <a href="{{ front_options_url('type', null, null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'all' }) }}">
                             <i class="fa-solid fa-file" aria-hidden="true"></i> &nbsp; {{ 'all'|trans }}
                         </a>
                     </li>
                     <li>
-                        <a href="{{ options_url('type', 'links', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'links' }) }}">
+                        <a href="{{ front_options_url('type', 'links', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'links' }) }}">
                             <i class="fa-regular fa-file-code" aria-hidden="true"></i> &nbsp; {{ 'links'|trans }}
                         </a>
                     </li>
                     <li>
-                        <a href="{{ options_url('type', 'articles', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'threads' }) }}">
+                        <a href="{{ front_options_url('type', 'articles', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'threads' }) }}">
                             <i class="fa-regular fa-file-lines" aria-hidden="true"></i> &nbsp; {{ 'threads'|trans }}
                         </a>
                     </li>
                     <li>
-                        <a href="{{ options_url('type', 'photos', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'photos' }) }}">
+                        <a href="{{ front_options_url('type', 'photos', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'photos' }) }}">
                             <i class="fa-regular fa-file-image" aria-hidden="true"></i> &nbsp; {{ 'photos'|trans }}
                         </a>
                     </li>
                     <li>
-                        <a href="{{ options_url('type', 'videos', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'videos'}) }}">
+                        <a href="{{ front_options_url('type', 'videos', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('type') == 'videos'}) }}">
                             <i class="fa-regular fa-file-video" aria-hidden="true"></i> &nbsp; {{ 'videos'|trans }}
                         </a>
                     </li>
@@ -176,24 +176,24 @@
                 </button>
                 <ul class="dropdown__menu">
                     <li>
-                        <a href="{{ options_url('subscription', 'all', null, {'p': null}) }}" class="{{ html_classes({'active': not criteria.favourite and not criteria.moderated and not criteria.subscribed}) }}">
+                        <a href="{{ front_options_url('subscription', 'all', null, {'p': null}) }}" class="{{ html_classes({'active': not criteria.favourite and not criteria.moderated and not criteria.subscribed}) }}">
                             <i class="fa-solid fa-earth-americas" aria-hidden="true"></i> &nbsp; {{ 'all'|trans }}
                         </a>
                     </li>
                     {% if not is_route_name_contains('_magazine') %}
                         <li>
-                            <a href="{{ options_url('subscription', 'sub', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.subscribed }) }}">
+                            <a href="{{ front_options_url('subscription', 'sub', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.subscribed }) }}">
                                 <i class="fa-solid fa-folder-plus" aria-hidden="true"></i> &nbsp; {{ 'subscribed'|trans }}
                             </a>
                         </li>
                         <li>
-                            <a href="{{ options_url('subscription', 'mod', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.moderated }) }}">
+                            <a href="{{ front_options_url('subscription', 'mod', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.moderated }) }}">
                                 <i class="fa-solid fa-shield-halved" aria-hidden="true"></i> &nbsp;{{ 'moderated'|trans }}
                             </a>
                         </li>
                     {% endif %}
                     <li>
-                        <a href="{{ options_url('subscription', 'fav', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.favourite }) }}">
+                        <a href="{{ front_options_url('subscription', 'fav', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.favourite }) }}">
                             <i class="fa-solid fa-heart" aria-hidden="true"></i> &nbsp; {{ 'favourites'|trans }}
                         </a>
                     </li>
@@ -221,18 +221,18 @@
             </button>
             <ul class="dropdown__menu">
                 <li>
-                    <a href="{{ options_url('federation', 'all', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('federation') == 'all' }) }}">
+                    <a href="{{ front_options_url('federation', 'all', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('federation') == 'all' }) }}">
                         <i class="fa-solid fa-circle-nodes" aria-hidden="true"></i> &nbsp; {{ 'all'|trans }}
                     </a>
                 </li>
                 <li>
-                    <a href="{{ options_url('federation', 'local', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('federation') == 'local' }) }}">
+                    <a href="{{ front_options_url('federation', 'local', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('federation') == 'local' }) }}">
                         <i class="fa-solid fa-house-chimney" aria-hidden="true"></i> &nbsp; {{ 'local'|trans }}
                     </a>
                 </li>
                 {#
                 <li>
-                    <a href="{{ options_url('federation', 'federated', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('federation') == 'federated' }) }}">
+                    <a href="{{ front_options_url('federation', 'federated', null, {'p': null}) }}" class="{{ html_classes({'active': criteria.getOption('federation') == 'federated' }) }}">
                         <i class="fa-solid fa-network-wired" aria-hidden="true"></i> &nbsp; {{ 'federated'|trans }}
                     </a>
                 </li>


### PR DESCRIPTION
the new filter ui changes also introduces a couple more filtering parameters in the form of controller path params, for threads/entries listing it looks fine and relatively staightforward, but for microblog posts listing, what used to be a simple `/microblog` is now something like `/all/hot/∞/all/all/microblog`, which hinders the user experience on url readability and memorability compared to the previous scheme, for those who still care

this changes tries to adjust the path/routing of these front controller especially for the microblog part, to make it more simpler and could omit some default filter parameters if they aren't set, similar to the previous path scheme

note that this patch main focus is just the path routing, there's probably more to adjust/polish in front controller and related areas but those would likely be a separate follow up patch

---

some of the front path routing that I have in mind, based on on previous scheme:
- `/{subscription}/{content}/{sortBy}/{time}/{type}/{federation}` -- `/sub/microblog/newest/1d`
- `/{subscription}/{sortBy}/{time}/{type}/{federation}` -- `/mod/commented/1w` `(*)`
- `/{content}/{sortBy}/{time}/{type}/{federation}` -- `/microblog/newest`
- `/{sortBy}/{time}/{type}/{federation}` -- `/top/6h` `(*)`
- `/m/{magazineName}/{content}/{sortBy}/{time}/{type}/{federation}` -- `/m/playground/microblog/active`
- `/m/{magazineName}/{sortBy}/{time}/{type}/{federation}` -- `/m/random/newest` `(*)`

path components `sortBy` and after shouldn't showed up if using default filter values

paths marked with `(*)` could be later used for combined views default/short entry point when the time comes? right now they should be alias for when `content` param is `threads` i.e. threads/entries front view

`type` and `federation` may be able to be pulled out into query params, esp. `type` where it currently only make sense in the context of threads listing, as we don't do such categorization for microblog posts