### PR TITLE
disable trim trailing space on markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,6 +30,9 @@ indent_style = space
 indent_size = 4
 quote_type = single
 
+[*.md]
+trim_trailing_whitespace = false
+
 [translations/*.yaml]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
adjust .editorconfig to disable auto disable trimming trailing space on markdown (`*.md`) files

in markdown you could insert a line break by adding 2 or more trailing spaces and then a new line,
but the recently adjusted .editorconfig is set to always trim trailing whitespaces a tthe end of the line which interferes with this markdown syntax