### PR TITLE
upgrade `Image::$sourceUrl` field to text for long links

### DIFF
--- a/migrations/Version20240409072525.php
+++ b/migrations/Version20240409072525.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240409072525 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'upgrade Image::$sourceUrl to text to support longer links';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE image ALTER source_url TYPE TEXT');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE image ALTER source_url TYPE VARCHAR(255)');
+    }
+}

--- a/src/Entity/Image.php
+++ b/src/Entity/Image.php
@@ -37,7 +37,7 @@ class Image
     public ?string $blurhash = null;
     #[Column(type: 'text', nullable: true)]
     public ?string $altText = null;
-    #[Column(type: 'string', nullable: true)]
+    #[Column(type: 'text', nullable: true)]
     public ?string $sourceUrl = null;
     #[Id]
     #[GeneratedValue]


### PR DESCRIPTION
upgrade `Image::$sourceUrl` field in the db to text type to support storing longer image links

if the image origin link is too long to fit in `varchar(255)` it'll fail when persisting the image entity, which could cause problem in other place e.g. failed to attach cover image/thumbnail to an entry

this should help with #692 and potential regression from #650, but I doubt this is the only one (though it'd be good if it is)