### PR TITLE
refactor base template

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -1,8 +1,26 @@
+{%- set V_TRUE = constant('App\\Controller\\User\\ThemeSettingsController::TRUE') -%}
+{%- set V_FALSE = constant('App\\Controller\\User\\ThemeSettingsController::FALSE') -%}
+{%- set V_LEFT = constant('App\\Controller\\User\\ThemeSettingsController::LEFT') -%}
+{%- set V_RIGHT = constant('App\\Controller\\User\\ThemeSettingsController::RIGHT') -%}
+{%- set V_FIXED = constant('App\\Controller\\User\\ThemeSettingsController::FIXED') -%}
+{%- set V_LAST_ACTIVE = constant('App\\Controller\\User\\ThemeSettingsController::LAST_ACTIVE') -%}
+
+{%- set FONT_SIZE = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_FONT_SIZE'), '100') -%}
+{%- set THEME = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_THEME'), mbin_default_theme()) -%}
+{%- set PAGE_WIDTH = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH'), V_FIXED) -%}
+{%- set ROUNDED_EDGES = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_ROUNDED_EDGES'), V_TRUE) -%}
+{%- set TOPBAR = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_TOPBAR'), V_FALSE) -%}
+{%- set FIXED_NAVBAR = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_FIXED_NAVBAR'), V_FALSE) -%}
+{%- set SIDEBAR_POSITION = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION'), V_RIGHT) -%}
+{%- set COMPACT = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT'), V_FALSE) -%}
+
+{%- set SUBSCRIPTIONS_SHOW = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SHOW'), V_TRUE) -%}
+{%- set SUBSCRIPTIONS_SEPARATE = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR'), V_FALSE) -%}
+{%- set SUBSCRIPTIONS_SAME_SIDE = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE'), V_FALSE) -%}
+{%- set SUBSCRIPTIONS_SORT = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SORT'), V_LAST_ACTIVE) -%}
 <!DOCTYPE html>
 <html lang="{{ app.request.locale }}"
-      style="font-size: {{ app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_FONT_SIZE'))
-      ? app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_FONT_SIZE'))~'%'
-      : '100%' }}">
+      style="font-size: {{ FONT_SIZE~'%' }}">
 <head>
     <meta charset="UTF-8">
     <title>{%- block title -%}{{ kbin_meta_title() }}{%- endblock -%}</title>
@@ -39,15 +57,13 @@
         {% endif %}
     {% endblock %}
 </head>
-<body class="{{ html_classes(app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_THEME'))
-    ? 'theme--'~app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_THEME'))
-    : 'theme--'~mbin_default_theme(), {
-        'rounded-edges': app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_ROUNDED_EDGES')) == false or app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_ROUNDED_EDGES')) is same as 'true',
-        'topbar': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_TOPBAR')) is same as 'true',
-        'fixed-navbar': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_FIXED_NAVBAR')) is same as 'true',
-        'sidebar-left': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_SIDEBAR_POSITION')) is same as constant('App\\Controller\\User\\ThemeSettingsController::LEFT'),
-        'subs-show': app.user is defined and app.user is not same as null and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SHOW')) is not same as 'false' and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR')) is same as 'true',
-        'sidebars-same-side': app.user is defined and app.user is not same as null and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR')) is same as 'true' and app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE')) is same as 'true',
+<body class="{{ html_classes('theme--'~THEME, {
+        'rounded-edges': ROUNDED_EDGES is same as V_TRUE,
+        'topbar': TOPBAR is same as V_TRUE,
+        'fixed-navbar': FIXED_NAVBAR is same as V_TRUE,
+        'sidebar-left': SIDEBAR_POSITION is same as V_LEFT,
+        'subs-show': app.user is defined and app.user is not same as null and SUBSCRIPTIONS_SHOW is not same as V_FALSE and SUBSCRIPTIONS_SEPARATE is same as V_TRUE,
+        'sidebars-same-side': app.user is defined and app.user is not same as null and SUBSCRIPTIONS_SEPARATE is same as V_TRUE and SUBSCRIPTIONS_SAME_SIDE is same as V_TRUE,
     }) }}"
         data-controller="kbin notifications"
         data-notifications-user-value="{{ app.user ? app.user.id : null }}"
@@ -58,13 +74,10 @@
 {% include 'layout/_header.html.twig' with {header_nav: block('header_nav')} %}
 {{ component('announcement') }}
 <div id="middle" class="{%- block mainClass -%}page{%- endblock %}">
-    <div class="kbin-container
-      {{ html_classes(app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH'))
-        ? 'width--'~app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH'))
-        : 'width--fixed') }}">
+    <div class="kbin-container {{ html_classes('width--'~PAGE_WIDTH) }}">
         <main id="main"
               data-controller="lightbox timeago confirmation"
-              class="{{ html_classes({'view-compact': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_ENTRIES_COMPACT')) is same as 'true'}) }}">
+              class="{{ html_classes({'view-compact': COMPACT is same as V_TRUE}) }}">
             {% block body %}{% endblock %}
         </main>
         <aside id="sidebar">
@@ -72,10 +85,11 @@
                 {% include 'layout/_sidebar.html.twig' with {sidebar_top: block('sidebar_top'), header_nav: block('header_nav')} %}
             {% endblock %}
         </aside>
-        {% if app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SHOW')) is not same as constant('App\\Controller\\User\\ThemeSettingsController::FALSE') and
-            app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_IN_SEPARATE_SIDEBAR')) is same as constant('App\\Controller\\User\\ThemeSettingsController::TRUE') and
-            app.user is defined and app.user is not same as null %}
-            {{ component('sidebar_subscriptions', { openMagazine: magazine is defined ? magazine : null, user: app.user, sort: app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_SUBSCRIPTIONS_SORT'))}) }}
+        {% if app.user is defined and app.user is not same as null and
+            SUBSCRIPTIONS_SHOW is not same as V_FALSE and
+            SUBSCRIPTIONS_SEPARATE is same as V_TRUE
+        %}
+            {{ component('sidebar_subscriptions', { openMagazine: magazine is defined ? magazine : null, user: app.user, sort: SUBSCRIPTIONS_SORT }) }}
         {% endif %}
     </div>
 </div>


### PR DESCRIPTION
This simply refactors the base template to be like some other templates, where vars are defined at the top. there should be no changes to functionality

To go over the benefits to make sure they still make sense as obviously this one has way more vars than usual:
- the html is much cleaner (`app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_THEME'))
    ? 'theme--'~app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_THEME'))
    : 'theme--'~mbin_default_theme()` turns into `'theme--'~THEME`
- defaults are well defined instead of being a confusing "what checks for null and what ignores the check meaning it defaults false", you can see simply at the top the default for `SUBSCRIPTIONS_SORT` is `V_LAST_ACTIVE` and if we ever decide to change it it's easy and not throughout the entire file
- vars are reused, but not sure this actually matters to twig or not, but still nice
- checks are done against their actual values, for things like `V_RIGHT` and `V_LEFT`, that might've been true before, but for `is same as 'true'` we were relying on it always matching `ThemeSettingsController::TRUE`, which it likely will but at least it compares against the type source of truth