### PR TITLE
switch magazine list to show magazine display names

### DIFF
--- a/assets/styles/components/_magazine.scss
+++ b/assets/styles/components/_magazine.scss
@@ -240,6 +240,9 @@ td {
     display: block;
   }
 
+  td {
+    max-width: 200px;
+  }
 }
 
 .magazine-list-mobile{

--- a/templates/magazine/_list.html.twig
+++ b/templates/magazine/_list.html.twig
@@ -63,7 +63,7 @@
                     <tbody>
                     {% for magazine in magazines %}
                         <tr>
-                            <td>{{ component('magazine_inline', { magazine: magazine, stretchedLink: true, showAvatar: true, fullName: true}) }}</td>
+                            <td>{{ component('magazine_inline', { magazine: magazine, stretchedLink: true, showAvatar: true}) }} {% if magazine.isAdult %}<small class="badge danger">18+</small>{% endif %}</td>
                             <td>{{ magazine.entryCount }}</td>
                             <td>{{ magazine.entryCommentCount }}</td>
                             <td>{{ magazine.postCount + magazine.postCommentCount }}</td>
@@ -96,7 +96,7 @@
                 {% for magazine in magazines %}
                         <div class="magazine">
                             <div class="magazine__top">
-                                <div class="magazine__inline">{{ component('magazine_inline', { magazine: magazine, stretchedLink: true, showAvatar: true, fullName: true}) }}</div>
+                                <div class="magazine__inline">{{ component('magazine_inline', { magazine: magazine, stretchedLink: true, showAvatar: true}) }} {% if magazine.isAdult %}<small class="badge danger">18+</small>{% endif %}</div>
                                 <div class="magazine__information">
                                     <span class="magazine__info"><span class="value">{{ magazine.entryCount }}</span><span class="label">{{ 'threads'|trans }}</span></span>
                                     <span class="magazine__info"><span class="value">{{ magazine.entryCommentCount }}</span><span class="label">{{ 'comments'|trans }}</span></span>


### PR DESCRIPTION
this simply changes the magazine table list view to display the magazine titles rather than addresses

|before|after|
|-|-|
|![image](https://github.com/MbinOrg/mbin/assets/146029455/cba33025-4e2b-4267-8145-6dde0a427791)|![image](https://github.com/MbinOrg/mbin/assets/146029455/e7a3ed63-7204-4ae6-9da5-f4c0c24e2445)|