### PR TITLE
limit magazine list column width to first column

### DIFF
--- a/assets/styles/components/_magazine.scss
+++ b/assets/styles/components/_magazine.scss
@@ -240,8 +240,8 @@ td {
     display: block;
   }
 
-  td {
-    max-width: 200px;
+  td:first-of-type {
+    max-width: 220px;
   }
 }
 


### PR DESCRIPTION
@nobodyatroot noticed that https://github.com/MbinOrg/mbin/pull/699 made it look a bit bad for mags you were subscribed to with large subscriber numbers. the intent was really to limit the column size on magazine names and not the other columns, so this restricts it to just the first column

|before|after|
|-|-|
|![image](https://github.com/MbinOrg/mbin/assets/146029455/64db9eff-4d97-4fb3-956b-39288fee2acd)|![image](https://github.com/MbinOrg/mbin/assets/146029455/fdc3c157-8da6-46a3-a782-afef79e60981)|

No matter what it's possible for the actions to go multi line though, even before that was true with the ultimate narrowest settings (fixed - sub bar separate)