### PR TITLE
Remove kbin migration, code bases are far too diverged to be a safe recommendation anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Unique Features of Mbin for server owners & users alike:
 - Support of **all** ActivityPub Actor Types (including also "Service" account support; thus support for robot accounts)
 - **Up-to-date** PHP packages and **security/vulnerability** issues fixed
 - Support for `application/json` Accept request header on all ActivityPub end-points
-- Easy migration path from Kbin to Mbin (see "Migrating?" below)
 - Introducing a hosted documentation: [docs.joinmbin.org](https://docs.joinmbin.org)
 
 See also: [all merged PRs](https://github.com/MbinOrg/mbin/pulls?q=is%3Apr+is%3Amerged) or [our releases](https://github.com/MbinOrg/mbin/releases).
@@ -57,25 +56,6 @@ For developers:
 - [Contribution guidelines](CONTRIBUTING.md) - please read first, including before opening an issue!
 
 ## Getting Started
-
-### Migrating?
-
-If you want to migrate from Kbin to Mbin (on bare metal), just follow the easy steps below (default branch is `main`):
-
-```bash
-# How to your current setup folder
-cd /var/www/your-instance
-# Override the git remote
-git remote set-url origin https://github.com/MbinOrg/mbin.git
-# Fetch the latest changes and move to the main branch
-git fetch
-git checkout main
-
-# Execute post upgrade script after migration/update
-./bin/post-upgrade
-```
-
-Done!
 
 ### Requirements
 


### PR DESCRIPTION
I think it's far too risky to recommend migrating from kbin to mbin anymore as there's a high probability of data loss with how the DB schema/migrations have diverged... that is, unless someone wants to take on owning the migration path (_not it_).