### PR TITLE
update magazine ban and log table foreign keys

### DIFF
--- a/migrations/Version20240412010024.php
+++ b/migrations/Version20240412010024.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240412010024 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Fix on delete to cascade for magazine_ban and magazine_log tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE magazine_ban DROP CONSTRAINT FK_6A126CE5386B8E7');
+        $this->addSql('ALTER TABLE magazine_ban ADD CONSTRAINT FK_6A126CE5386B8E7 FOREIGN KEY (banned_by_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE magazine_log DROP CONSTRAINT FK_87D3D4C5A76ED395');
+        $this->addSql('ALTER TABLE magazine_log ADD CONSTRAINT FK_87D3D4C5A76ED395 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE magazine_log DROP CONSTRAINT fk_87d3d4c5a76ed395');
+        $this->addSql('ALTER TABLE magazine_log ADD CONSTRAINT fk_87d3d4c5a76ed395 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE magazine_ban DROP CONSTRAINT fk_6a126ce5386b8e7');
+        $this->addSql('ALTER TABLE magazine_ban ADD CONSTRAINT fk_6a126ce5386b8e7 FOREIGN KEY (banned_by_id) REFERENCES "user" (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+}

--- a/src/Entity/MagazineBan.php
+++ b/src/Entity/MagazineBan.php
@@ -27,7 +27,7 @@ class MagazineBan
     #[JoinColumn(nullable: false, onDelete: 'CASCADE')]
     public ?User $user;
     #[ManyToOne(targetEntity: User::class)]
-    #[JoinColumn(nullable: false, onDelete: 'SET NULL')]
+    #[JoinColumn(nullable: false, onDelete: 'CASCADE')]
     public ?User $bannedBy;
     #[Column(type: 'text', length: 2048, nullable: true)]
     public ?string $reason = null;

--- a/src/Entity/MagazineLog.php
+++ b/src/Entity/MagazineLog.php
@@ -41,7 +41,7 @@ abstract class MagazineLog
     #[JoinColumn(nullable: false, onDelete: 'CASCADE')]
     public Magazine $magazine;
     #[ManyToOne(targetEntity: User::class)]
-    #[JoinColumn(nullable: false, onDelete: 'SET NULL')]
+    #[JoinColumn(nullable: false, onDelete: 'CASCADE')]
     public User $user;
     #[Id]
     #[GeneratedValue]


### PR DESCRIPTION
to on delete cascade as set null errors with null value on not null column

verified that accounts in magazine_log could now be deleted

before:

made `user4` with a user_id of `29`. Banned other accounts and deleted other comments as them (this part might be why this happens less frequently, the user_id is actually the _moderator_ user id taking action, not the user id action was taken against. So this happens when a moderator deletes their own account.

```
# select * from magazine_log;
 id | magazine_id | user_id | entry_id | entry_comment_id | post_id | post_comment_id | ban_id |       created_at       |        log_type        | meta  
----+-------------+---------+----------+------------------+---------+-----------------+--------+------------------------+------------------------+-------
 24 |           1 |      29 |          |              740 |         |                 |        | 2024-04-12 01:17:00+00 | entry_comment_deleted  | 

# select is_deleted from public.user where username = 'user4';
 is_deleted 
------------
 f
```

```
CONTEXT:  SQL statement "UPDATE ONLY "public"."magazine_log" SET "user_id" = NULL WHERE $1 OPERATOR(pg_catalog.=) "user_id""" {"class":"App\\Message\\DeleteUserMessage","retryCount":1,"delay":300000,"error":"Handling \"App\\Message\\DeleteUserMessage\" failed: An exception occurred while executing a query: SQLSTATE[23502]: Not null violation: 7 ERROR:  null value in column \"user_id\" of relation \"magazine_log\" violates not-null constraint
CONTEXT:  SQL statement \"UPDATE ONLY \"public\".\"magazine_log\" SET \"user_id\" = NULL WHERE $1 OPERATOR(pg_catalog.=) \"user_id\"\"","exception":"[object] (Symfony\\Component\\Messenger\\Exception\\HandlerFailedException(code: 7): Handling \"App\\Message\\DeleteUserMessage\" failed: An exception occurred while executing a query: SQLSTATE[23502]: Not null violation: 7 ERROR:  null value in column \"user_id\" of relation \"magazine_log\" violates not-null constraint
[previous exception] [object] (Doctrine\\DBAL\\Exception\\NotNullConstraintViolationException(code: 7): An exception occurred while executing a query: SQLSTATE[23502]: Not null violation: 7 ERROR:  null value in column \"user_id\" of relation \"magazine_log\" violates not-null constraint
[previous exception] [object] (Doctrine\\DBAL\\Driver\\PDO\\Exception(code: 7): SQLSTATE[23502]: Not null violation: 7 ERROR:  null value in column \"user_id\" of relation \"magazine_log\" violates not-null constraint
[previous exception] [object] (PDOException(code: 23502): SQLSTATE[23502]: Not null violation: 7 ERROR:  null value in column \"user_id\" of relation \"magazine_log\" violates not-null constraint
```

I then migrated, and had to shut down messengers (alter table showed as blocked by messengers using the get blocked queries mentioned in #702 ) to get the migration to finish. It then took a bit, which made me concerned that it had failed, but after a few minutes with no action on my part


```
# select * from magazine_log;
 id | magazine_id | user_id | entry_id | entry_comment_id | post_id | post_comment_id | ban_id |       created_at       |        log_type        | meta  
----+-------------+---------+----------+------------------+---------+-----------------+--------+------------------------+------------------------+-------

# select is_deleted from public.user where username = 'user4';
 is_deleted 
------------
 t
```
