### PR TITLE
add rel attribute when opening original urls

### DIFF
--- a/templates/entry/_menu.html.twig
+++ b/templates/entry/_menu.html.twig
@@ -23,6 +23,7 @@
     <li class="dropdown__separator"></li>
     <li>
       <a target="_blank"
+        rel="{{ get_rel(entry.apId ?? path('ap_entry', {magazine_name: entry.magazine.name, entry_id: entry.id})) }}"
         href="{{ entry.apId ?? path('ap_entry', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}">
         {{ 'open_url_to_fediverse'|trans }}
       </a>

--- a/templates/entry/comment/_menu.html.twig
+++ b/templates/entry/comment/_menu.html.twig
@@ -17,6 +17,7 @@
         <li class="dropdown__separator"></li>
         <li>
             <a target="_blank"
+                rel="{{ get_rel(comment.apId ?? path('ap_entry_comment', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id})) }}"
                 href="{{ comment.apId ?? path('ap_entry_comment', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id}) }}">
                 {{ 'open_url_to_fediverse'|trans }}
             </a>

--- a/templates/layout/_sidebar.html.twig
+++ b/templates/layout/_sidebar.html.twig
@@ -132,11 +132,11 @@
         </ul>
         <div class="about-seperator"></div>
         <ul class="about-mbin">
-            <li>Powered by <a href="https://github.com/MbinOrg/mbin" target="_blank" rel="no-referrer">Mbin</a></li>
+            <li>Powered by <a href="https://github.com/MbinOrg/mbin" target="_blank" rel="noopener noreferrer nofollow">Mbin</a></li>
             <li aria-hidden="true">&#9679;</li>
             <li>{{ mbin_current_version() }}</li>
             <li aria-hidden="true">&#9679;</li>
-            <li><a href="https://github.com/MbinOrg/mbin/issues" target="_blank" rel="no-referrer">{{ 'report_issue'|trans }}</a></li>
+            <li><a href="https://github.com/MbinOrg/mbin/issues" target="_blank" rel="noopener noreferrer nofollow">{{ 'report_issue'|trans }}</a></li>
         </ul>
         <ul class="about-options">
             {% set header_accept_language = app.request.headers.has('accept_language')

--- a/templates/post/_menu.html.twig
+++ b/templates/post/_menu.html.twig
@@ -17,6 +17,7 @@
         <li class="dropdown__separator"></li>
         <li>
             <a target="_blank"
+                rel="{{ get_rel(post.apId ?? path('ap_post', {magazine_name: post.magazine.name, post_id: post.id})) }}"
                 href="{{ post.apId ?? path('ap_post', {magazine_name: post.magazine.name, post_id: post.id}) }}">
                 {{ 'open_url_to_fediverse'|trans }}
             </a>

--- a/templates/post/comment/_menu.html.twig
+++ b/templates/post/comment/_menu.html.twig
@@ -17,6 +17,7 @@
         <li class="dropdown__separator"></li>
         <li>
             <a target="_blank"
+                rel="{{ get_rel(comment.apId ?? path('ap_post_comment', {magazine_name: comment.magazine.name, post_id: comment.post.id, comment_id: comment.id})) }}"
                 href="{{ comment.apId ?? path('ap_post_comment', {magazine_name: comment.magazine.name, post_id: comment.post.id, comment_id: comment.id}) }}">
                 {{ 'open_url_to_fediverse'|trans }}
             </a>


### PR DESCRIPTION
add rel attribute when opening original urls
update sidebar github links to include `noopener` and `nofollow`

noticed the "Open original URL" links will open external links with no `rel` attribute. This changes that so when it's a local original URL it will be `rel="follow"` (which isn't a [valid `rel` value](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel) but not going to touch `get_rel()` in this PR) and when it's an external link it will be `rel="nofollow noopener noreferrer"`