### PR TITLE
bump version to 1.5.3

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -17,7 +17,7 @@ framework:
     http_client:
         default_options:
             headers:
-                'User-Agent': 'Mbin/1.5.2 (+https://%kbin_domain%/agent)'
+                'User-Agent': 'Mbin/1.5.3 (+https://%kbin_domain%/agent)'
 
     #esi: true
     #fragments: true

--- a/src/Service/ProjectInfoService.php
+++ b/src/Service/ProjectInfoService.php
@@ -10,7 +10,7 @@ namespace App\Service;
 class ProjectInfoService
 {
     // If updating version, please also update http client UA in [/config/packages/framework.yaml]
-    private const VERSION = '1.5.2'; // TODO: Retrieve the version from git tags or getenv()?
+    private const VERSION = '1.5.3'; // TODO: Retrieve the version from git tags or getenv()?
     private const NAME = 'mbin';
     private const USER_AGENT = 'Mbin';
     private const REPOSITORY_URL = 'https://github.com/MbinOrg/mbin';


### PR DESCRIPTION
bumping version numbers to cherry pick into a 1.5.3 that will be off of 1.5.2 rather than main
the idea is everything went into main, was cherry picked into a release branch so main shouldn't have anything special done to it