### PR TITLE
use github format admonitions in docs

### DIFF
--- a/docs/02-admin/01-installation/bare_metal.md
+++ b/docs/02-admin/01-installation/bare_metal.md
@@ -3,20 +3,14 @@
 Below is a step-by-step guide of the process for creating your own Mbin instance from the moment a new VPS/VM is created or directly on bare-metal.  
 This is a preliminary outline that will help you launch an instance for your own needs.
 
-:::note
-
-Mbin is still in development.
-
-:::
+> [!NOTE]
+> Mbin is still in development.
 
 This guide is aimed for Debian / Ubuntu distribution servers, but it could run on any modern Linux distro. This guide will however uses the `apt` commands.
 
-:::note
-
-In this document a few services that are specific to the bare metal installation are configured.
-You do need to follow the configuration guide as well. It describes the configuration of services shared between bare metal and docker.
-
-:::
+> [!NOTE]
+> In this document a few services that are specific to the bare metal installation are configured.
+> You do need to follow the configuration guide as well. It describes the configuration of services shared between bare metal and docker.
 
 ## Minimum hardware requirements
 
@@ -72,11 +66,8 @@ If you have a firewall installed (or you're behind a NAT), be sure to open port 
 
 1. Prepare & download keyring:
 
-:::note
-
-This assumes you already installed all the prerequisites packages from the "System prerequisites" chapter.
-
-:::
+> [!NOTE]
+> This assumes you already installed all the prerequisites packages from the "System prerequisites" chapter.
 
 ```bash
 sudo mkdir -p /etc/apt/keyrings
@@ -115,7 +106,7 @@ sudo chown mbin:www-data /var/www/mbin
 
 ## Generate Secrets
 
-> **Note**
+> [!NOTE]
 > This will generate several valid tokens for the Mbin setup, you will need quite a few.
 
 ```bash
@@ -169,7 +160,7 @@ nano .env
 
 Make sure you have substituted all the passwords and configured the basic services in `.env` file.
 
-> **Note**
+> [!NOTE]
 > The snippet below are to variables inside the .env file. Using the keys generated in the section above "Generating Secrets" fill in the values. You should fully review this file to ensure everything is configured correctly.
 
 ```ini
@@ -305,13 +296,10 @@ composer clear-cache
 
 If you run production already then _skip the steps below_.
 
-:::danger
-
-When running in development mode your instance will make _sensitive information_ available,
-such as database credentials, via the debug toolbar and/or stack traces.
-**DO NOT** expose your development instance to the Internet or you will have a bad time.
-
-:::
+> [!CAUTION]
+> When running in development mode your instance will make _sensitive information_ available,
+> such as database credentials, via the debug toolbar and/or stack traces.
+> **DO NOT** expose your development instance to the Internet or you will have a bad time.
 
 ```bash
 composer install
@@ -420,22 +408,15 @@ php bin/console doctrine:database:create
 php bin/console doctrine:migrations:migrate
 ```
 
-:::tip
-
-Check out [PostgreSQL tuning](../99-tuning/postgresql.md), you should not run the default PostgreSQL configuration in production.
-
-:::
-
+> [!TIP]
+> Check out [PostgreSQL tuning](../99-tuning/postgresql.md), you should not run the default PostgreSQL configuration in production.
 
 ## Install RabbitMQ
 
 [RabbitMQ Install](https://www.rabbitmq.com/install-debian.html#apt-quick-start-cloudsmith)
 
-:::note
-
-This assumes you already installed all the prerequisites packages from the "System prerequisites" chapter.
-
-:::
+> [!NOTE]
+> This assumes you already installed all the prerequisites packages from the "System prerequisites" chapter.
 
 ```bash
 ## Team RabbitMQ's main signing key
@@ -567,12 +548,10 @@ Save and close the file. Restart supervisor jobs:
 ```bash
 sudo supervisorctl reread && sudo supervisorctl update && sudo supervisorctl start all
 ```
-:::tip
 
-If you wish to restart your supervisor jobs in the future, use:
-
-:::
-
-```bash
-sudo supervisorctl restart all
-```
+> [!TIP]
+> If you wish to restart your supervisor jobs in the future, use:
+>
+> ```bash
+> sudo supervisorctl restart all
+> ```

--- a/docs/02-admin/01-installation/docker.md
+++ b/docs/02-admin/01-installation/docker.md
@@ -1,10 +1,7 @@
 # Docker Installation
 
-:::note
-
-Mbin is still in development.
-
-:::
+> [!NOTE]
+> Mbin is still in development.
 
 ## System Requirements
 
@@ -45,7 +42,7 @@ cd mbin
 
 ### Docker image preparation
 
-> **Note**
+> [!NOTE]
 > If you're using a version of Docker Engine earlier than 23.0, run `export DOCKER_BUILDKIT=1`, prior to building the image. This does not apply to users running Docker Desktop. More info can be found [here](https://docs.docker.com/build/buildkit/#getting-started)
 
 1. First go to the _docker directory_:
@@ -106,7 +103,7 @@ sudo chown $USER:$USER storage/media storage/caddy_config storage/caddy_data sto
 4. Update `APP_SECRET` in `.env`, generate a new one via: `node -e  "console.log(require('crypto').randomBytes(16).toString('hex'))"`
 5. _Optionally_: Use a newer PostgreSQL version (current fallback is v13). Update/set the `POSTGRES_VERSION` variable in your `.env` and `compose.override.yml` under `db`.
 
-> **Note**
+> [!NOTE]
 > Ensure the `HTTPS` environmental variable is set to `TRUE` in `compose.override.yml` for the `php`, `messenger`, and `messenger_ap` containers **if your environment is using a valid certificate behind a reverse proxy**. This is likely true for most production environments and is required for proper federation, that is, this will ensure the webfinger responses include `https:` in the URLs generated.
 
 ### Configure OAuth2 keys
@@ -160,11 +157,8 @@ You can also access RabbitMQ management UI via [http://localhost:15672](http://l
 
 Add any auxiliary container as you want. For example, add a Nginx container as reverse proxy to provide HTTPS encryption.
 
-:::note
-
-If you are building the docker images yourself, you might get merge conflicts when changing the `compose.yml`
-
-:::
+> [!NOTE]
+> If you are building the docker images yourself, you might get merge conflicts when changing the `compose.yml`
 
 ### Uploaded media files
 

--- a/docs/02-admin/02-configuration/lets_encrypt.md
+++ b/docs/02-admin/02-configuration/lets_encrypt.md
@@ -1,10 +1,7 @@
 # Let's Encrypt (TLS)
 
-:::note
-
-The Certbot authors recommend installing through snap as some distros' versions from APT tend to fall out-of-date; see https://eff-certbot.readthedocs.io/en/latest/install.html#snap-recommended for more.
-
-:::
+> [!TIP]
+> The Certbot authors recommend installing through snap as some distros' versions from APT tend to fall out-of-date; see https://eff-certbot.readthedocs.io/en/latest/install.html#snap-recommended for more.
 
 Install Snapd:
 

--- a/docs/02-admin/02-configuration/mbin_config_files.md
+++ b/docs/02-admin/02-configuration/mbin_config_files.md
@@ -14,8 +14,5 @@ And now change: `redirect_response_code: 302` to: `redirect_response_code: 301`.
 
 ---
 
-:::tip
-
-There are also other configuration files, eg. `config/packages/monolog.yaml` where you can change logging settings if you wish, but this is not required (these defaults are fine for production).
-
-:::
+> [!TIP]
+> There are also other configuration files, eg. `config/packages/monolog.yaml` where you can change logging settings if you wish, but this is not required (these defaults are fine for production).

--- a/docs/02-admin/02-configuration/nginx.md
+++ b/docs/02-admin/02-configuration/nginx.md
@@ -195,11 +195,8 @@ server {
 }
 ```
 
-:::warning
-
-If also want to also configure your `www.domain.tld` subdomain; our advise is to use a HTTP 301 redirect from the `www` subdomain towards the root domain. Do _NOT_ try to setup a double instance (you want to _avoid_ that ActivityPub will see `www` as a separate instance). See Nginx example below
-
-:::
+> [!WARNING]
+> If also want to also configure your `www.domain.tld` subdomain; our advise is to use a HTTP 301 redirect from the `www` subdomain towards the root domain. Do _NOT_ try to setup a double instance (you want to _avoid_ that ActivityPub will see `www` as a separate instance). See Nginx example below
 
 ```nginx
 # Example of a 301 redirect response for the www subdomain

--- a/docs/02-admin/03-optional-features/mercure.md
+++ b/docs/02-admin/03-optional-features/mercure.md
@@ -21,11 +21,8 @@ sudo chown -R mbin:www-data metal/caddy
 
 [Caddyfile Global Options](https://caddyserver.com/docs/caddyfile/options)
 
-:::note
-
-Caddyfiles: The one provided should work for most people, edit as needed via the previous link. Combination of mercure.conf and Caddyfile
-
-:::
+> [!NOTE]
+> Caddyfiles: The one provided should work for most people, edit as needed via the previous link. Combination of mercure.conf and Caddyfile
 
 Add new `Caddyfile` file:
 

--- a/docs/02-admin/04-running-mbin/first_setup.md
+++ b/docs/02-admin/04-running-mbin/first_setup.md
@@ -1,11 +1,8 @@
 # Mbin first setup
 
-:::tip
-
-If you are running docker, then you have to be in the `docker` folder and prefix the following commands with 
-`docker compose exec php`.
-
-:::
+> [!TIP]
+> If you are running docker, then you have to be in the `docker` folder and prefix the following commands with
+> `docker compose exec php`.
 
 Create new admin user (without email verification), please change the `username`, `email` and `password` below:
 

--- a/docs/02-admin/99-tuning/postgresql.md
+++ b/docs/02-admin/99-tuning/postgresql.md
@@ -60,9 +60,5 @@ effective_cache_size = 25GB
 
 For a reference you can check out [PGTune](https://pgtune.leopard.in.ua/)
 
-:::note
-
-We try to set `huge_pages` to: `on` in PostgreSQL, in order to make this works you need to [enable huge pages under Linux (click here)](https://www.enterprisedb.com/blog/tuning-debian-ubuntu-postgresql) as well! Please follow that guide. and play around with your kernel configurations.
-
-:::
-
+> [!NOTE]
+> We try to set `huge_pages` to: `on` in PostgreSQL, in order to make this works you need to [enable huge pages under Linux (click here)](https://www.enterprisedb.com/blog/tuning-debian-ubuntu-postgresql) as well! Please follow that guide. and play around with your kernel configurations.

--- a/docs/02-admin/FAQ.md
+++ b/docs/02-admin/FAQ.md
@@ -218,11 +218,8 @@ To fix the problem:
 
 If you believe you have a queued message that is infinitely looping / stuck, you can discard it by setting the `Get messages` `Ack mode` in RabbitMQ to `Reject requeue false` with a `Messages` setting of `1` and clicking `Get message(s)`.
 
-:::warning
-
-This will permanently discard the payload
-
-:::
+> [!WARNING]
+> This will permanently discard the payload
 
 ![Rabbit discard payload](../images/rabbit_reject_requeue_false.png)
 

--- a/docs/03-3rd_party_developer/oauth2_guide.md
+++ b/docs/03-3rd_party_developer/oauth2_guide.md
@@ -23,7 +23,7 @@ For all the API endpoints go to the swagger documentation page, which is: `https
 
 ## Obtaining OAuth2 credentials from a new server
 
-> [!Note]
+> [!NOTE]
 > Some of these structures contain comments that need to be removed before making the API calls. Copy/paste with care.
 
 1. Create a private OAuth2 client (for use in secure environments that you control)


### PR DESCRIPTION
change the admonitions in docs from docusaurus format to github format, so it'll show up properly when reading docs from github interface

combined with [remark-github-admonitions-to-directives][plugin] plugin on docusaurus side, this will make admonitions being rendered on both docusaurus site and the docs source file on github interface, rather than having to pick one or the other

also fix up a few older admonitions to use the new format along the way

[plugin]: https://github.com/incentro-dc/remark-github-admonitions-to-directives