### PR TITLE
Emphasize creating `random` magazine in first time install docs

### DIFF
--- a/docs/02-admin/04-running-mbin/first_setup.md
+++ b/docs/02-admin/04-running-mbin/first_setup.md
@@ -15,7 +15,10 @@ php bin/console mbin:user:admin <username>
 php bin/console mbin:ap:keys:update
 ```
 
-Next, log in and create a magazine named "random" to which unclassified content from the fediverse will flow.
+Next, log in and create a magazine named `random` to which unclassified content from the fediverse will flow.
+
+> [!IMPORTANT]
+> Creating a `random` magazine is a requirement to getting microblog posts that don't fall under an existing magazine.
 
 ### Manual user activation
 


### PR DESCRIPTION
add a note that random mag is currently needed to get uncategorized posts. microblog posts that come in but don't find either a magazine with an associated tag or the fallback `random` mag will be turned away, as there is no equivalent user timeline as things like mastodon have.