### PR TITLE
add rel to clipboard and github sidebar links

### DIFF
--- a/templates/entry/_menu.html.twig
+++ b/templates/entry/_menu.html.twig
@@ -30,6 +30,7 @@
     </li>
     <li>
       <a data-action="clipboard#copy"
+        rel="{{ get_rel(entry.apId ?? path('ap_entry', {magazine_name: entry.magazine.name, entry_id: entry.id})) }}"
         href="{{ entry.apId ?? path('ap_entry', {magazine_name: entry.magazine.name, entry_id: entry.id}) }}">
         {{ 'copy_url_to_fediverse'|trans }}
       </a>

--- a/templates/entry/comment/_menu.html.twig
+++ b/templates/entry/comment/_menu.html.twig
@@ -24,6 +24,7 @@
         </li>
         <li>
             <a data-action="clipboard#copy"
+                rel="{{ get_rel(comment.apId ?? path('ap_entry_comment', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id})) }}"
                 href="{{ comment.apId ?? path('ap_entry_comment', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id}) }}">
                 {{ 'copy_url_to_fediverse'|trans }}
             </a>

--- a/templates/layout/_sidebar.html.twig
+++ b/templates/layout/_sidebar.html.twig
@@ -158,7 +158,7 @@
     <div>
         <h4>{{ 'kbin_promo_title'|trans }}</h4>
         <p>{{ 'kbin_promo_desc'|trans({
-                '%link_start%': '<a href="https://github.com/MbinOrg/mbin" class="stretched-link">',
+                '%link_start%': '<a href="https://github.com/MbinOrg/mbin" target="_blank" rel="noopener noreferrer nofollow" class="stretched-link">',
                 '%link_end%': '</a>'
             })|raw }}</p>
     </div>

--- a/templates/post/_menu.html.twig
+++ b/templates/post/_menu.html.twig
@@ -24,6 +24,7 @@
         </li>
         <li>
             <a data-action="clipboard#copy"
+                rel="{{ get_rel(post.apId ?? path('ap_post', {magazine_name: post.magazine.name, post_id: post.id})) }}"
                 href="{{ post.apId ?? path('ap_post', {magazine_name: post.magazine.name, post_id: post.id}) }}">
                 {{ 'copy_url_to_fediverse'|trans }}
             </a>

--- a/templates/post/comment/_menu.html.twig
+++ b/templates/post/comment/_menu.html.twig
@@ -24,6 +24,7 @@
         </li>
         <li>
             <a data-action="clipboard#copy"
+                rel="{{ get_rel(comment.apId ?? path('ap_post_comment', {magazine_name: comment.magazine.name, post_id: comment.post.id, comment_id: comment.id})) }}"
                 href="{{ comment.apId ?? path('ap_post_comment', {magazine_name: comment.magazine.name, post_id: comment.post.id, comment_id: comment.id}) }}">
                 {{ 'copy_url_to_fediverse'|trans }}
             </a>


### PR DESCRIPTION
a couple more spots of adding the `rel` attribute of `noopener noreferrer nofollow` to remote links, specifically to the copy original url in menus. Normally this is a no-op that copies to clipboard but if the user uses their middle mouse button, or javascript is disabled, wanted to make sure it had those settings. Also to the clone repo component in the sidebar, which I realized I missed, was missing opening in a new window as well as `rel`