### PR TITLE
add missing sensitivity field for entry comment AP Note

### DIFF
--- a/src/Factory/ActivityPub/EntryCommentNoteFactory.php
+++ b/src/Factory/ActivityPub/EntryCommentNoteFactory.php
@@ -51,15 +51,19 @@ class EntryCommentNoteFactory
         }
 
         $note = array_merge($note ?? [], [
-            'type' => 'Note',
             'id' => $this->getActivityPubId($comment),
+            'type' => 'Note',
             'attributedTo' => $this->activityPubManager->getActorProfileId($comment->user),
             'inReplyTo' => $this->getReplyTo($comment),
             'to' => [
                 ActivityPubActivityInterface::PUBLIC_URL,
             ],
             'cc' => $cc,
-            'content' => $this->markdownConverter->convertToHtml($comment->body, [MarkdownConverter::RENDER_TARGET => RenderTarget::ActivityPub]),
+            'sensitive' => $comment->entry->isAdult(),
+            'content' => $this->markdownConverter->convertToHtml(
+                $comment->body,
+                [MarkdownConverter::RENDER_TARGET => RenderTarget::ActivityPub]
+            ),
             'mediaType' => 'text/html',
             'source' => $comment->body ? [
                 'content' => $comment->body,


### PR DESCRIPTION
add `sensitive` field for AP representation of an entry comment, using sensitive/isAdult value from the main entry,
like in post comment

https://github.com/MbinOrg/mbin/blob/cd1257499c71fd59575d6dfa4fd344d08be4f25b/src/Factory/ActivityPub/PostCommentNoteFactory.php#L57-L66

apparently this field is missing for entry comments