### PR TITLE
use only `application/activity+json` for AP fetching

### DIFF
--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -316,7 +316,7 @@ class ApHttpClient
         unset($headers['(request-target)']);
         $headers['Signature'] = $signatureHeader;
         $headers['User-Agent'] = $this->projectInfo->getUserAgent().'/'.$this->projectInfo->getVersion().' (+https://'.$this->kbinDomain.'/agent)';
-        $headers['Accept'] = 'application/activity+json, application/ld+json';
+        $headers['Accept'] = 'application/activity+json';
         $headers['Content-Type'] = 'application/activity+json';
 
         return $headers;
@@ -340,7 +340,7 @@ class ApHttpClient
             $headers['Accept'] = 'application/jrd+json';
             $headers['Content-Type'] = 'application/jrd+json';
         } else {
-            $headers['Accept'] = 'application/activity+json, application/ld+json';
+            $headers['Accept'] = 'application/activity+json';
             $headers['Content-Type'] = 'application/activity+json';
         }
 


### PR DESCRIPTION
some softwares/instances doesn't handle multiple Accept header values too well, resulting in failed fetches e.g. the instance that piped link bot is on