### PR TITLE
Improve post-upgrade environment detection

### DIFF
--- a/bin/post-upgrade
+++ b/bin/post-upgrade
@@ -5,9 +5,28 @@ BIN_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 printf 'Do you want to proceed with the upgrade? (y/N)? '
 read -r answer
 if [ "$answer" != "${answer#[Yy]}" ]; then
-    # Retrieve prod or dev
-    ENV=$(php "${BIN_DIR}"/console about | grep -i Environment | awk '{print $NF}')
-    if [[ "$ENV" == "prod" ]]; then
+    # Retrieve prod or dev from .env.local.php file
+    ENV=grep -oP "'APP_ENV' => '\K[^']+" .env.local.php
+    if [[ "$ENV" == "dev" ]]; then
+        # Development
+        echo -e "INFO: Environment detected: Development\n"
+
+        cd "$BIN_DIR/.."
+        echo "INFO: Install/update PHP packages"
+        composer install
+        echo "INFO: Dump env file"
+        composer dump-env dev
+        echo "INFO: Clear application cache"
+        APP_ENV=dev APP_DEBUG=1 php "${BIN_DIR}"/console cache:clear -n
+        echo "INFO: Perform database migration"
+        APP_ENV=dev php "${BIN_DIR}"/console doctrine:migrations:migrate -n
+        echo "INFO: Clear composer cache"
+        composer clear-cache
+        echo "INFO: Install/update JS packages"
+        NODE_ENV=development npm ci
+        echo "INFO: Build frontend (development)"
+        NODE_ENV=development npm run dev
+    else
         # Production
         echo -e "INFO: Environment detected: Production\n"
 
@@ -27,25 +46,6 @@ if [ "$answer" != "${answer#[Yy]}" ]; then
         npm ci --include=dev
         echo "INFO: Build frontend (production)"
         NODE_ENV=production npm run build
-    else
-        # Development
-        echo -e "INFO: Environment detected: Development\n"
-
-        cd "$BIN_DIR/.."
-        echo "INFO: Install/update PHP packages"
-        composer install
-        echo "INFO: Dump env file"
-        composer dump-env dev
-        echo "INFO: Clear application cache"
-        APP_ENV=dev APP_DEBUG=1 php "${BIN_DIR}"/console cache:clear -n
-        echo "INFO: Perform database migration"
-        APP_ENV=dev php "${BIN_DIR}"/console doctrine:migrations:migrate -n
-        echo "INFO: Clear composer cache"
-        composer clear-cache
-        echo "INFO: Install/update JS packages"
-        NODE_ENV=development npm ci
-        echo "INFO: Build frontend (development)"
-        NODE_ENV=development npm run dev
     fi
 
     echo -e "INFO: Upgrade successfully completed!\n"


### PR DESCRIPTION
Improve post-upgrade prod/dev detection using `grep -oP`, since the `bin/console about` output could often fail to various reason like missing packages. Causing unstable behavior.

For example:  (`Uncaught Error: Class "Symfony\Bundle\MakerBundle\MakerBundle" not found`) or when a package is removed upstream (`PHP Fatal error:  Uncaught Error: Class "Omines\AntiSpamBundle\AntiSpamBundle" not found in /var/www/kbin.melroy.org/html/vendor/symfony/framework-bundle/Kernel/MicroKernelTrait.php:136
Stack trace:`).

I also switch to "prod" by default in the else statement.