### PR TITLE
post-upgrade detect env by reading `.env.local.php` directly

### DIFF
--- a/bin/post-upgrade
+++ b/bin/post-upgrade
@@ -6,7 +6,7 @@ printf 'Do you want to proceed with the upgrade? (y/N)? '
 read -r answer
 if [ "$answer" != "${answer#[Yy]}" ]; then
     # Retrieve prod or dev from .env.local.php file
-    ENV=$(grep -oP "'APP_ENV' => '\K[^']+" "$BIN_DIR/../.env.local.php")
+    ENV=$(php -r "\$env = require '$BIN_DIR/../.env.local.php'; echo \$env['APP_ENV'];")
     if [[ "$ENV" == "dev" ]]; then
         # Development
         echo -e "INFO: Environment detected: Development\n"


### PR DESCRIPTION
changed env detection in bin/post-upgrade script by just sourcing the `.env.local.php` file in php and print out the `APP_ENV` directly

there exists some grep out there that doesn't understand `-P` flag, and it would make post-install script unusable in those cases but anyone who's using this script (and mbin) in the first place should have php cli readily available