### PR TITLE
set `doctrine.orm.controller_resolver.auto_mapping: true`

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -22,6 +22,8 @@ doctrine:
         validate_xml_mapping: true
         naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
         auto_mapping: true
+        controller_resolver:
+            auto_mapping: true
         mappings:
             App:
                 type: attribute


### PR DESCRIPTION
it looks like doctrine bundle is about to deprecate controller auto mapping stuff, and it's giving out deprecation notice about this

explicitly set `doctrine.orm.controller_resolver.auto_mapping: true` as suggested by deprecation notice to keep existing behavior and remove the notice

see https://github.com/doctrine/DoctrineBundle/pull/1762 for more info