### PR TITLE
webfinger controller event pass request once

### DIFF
--- a/src/Controller/ActivityPub/WebFingerController.php
+++ b/src/Controller/ActivityPub/WebFingerController.php
@@ -18,7 +18,7 @@ class WebFingerController
 
     public function __invoke(Request $request): JsonResponse
     {
-        $event = new WebfingerResponseEvent(new JsonRd());
+        $event = new WebfingerResponseEvent(new JsonRd(), $request);
         $this->eventDispatcher->dispatch($event);
 
         if (!empty($event->jsonRd->getLinks())) {

--- a/src/Event/ActivityPub/WebfingerResponseEvent.php
+++ b/src/Event/ActivityPub/WebfingerResponseEvent.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace App\Event\ActivityPub;
 
 use App\ActivityPub\JsonRd;
+use Symfony\Component\HttpFoundation\Request;
 
 class WebfingerResponseEvent
 {
-    public function __construct(public JsonRd $jsonRd)
-    {
+    public function __construct(
+        public JsonRd $jsonRd,
+        public Request $request,
+    ) {
     }
 }

--- a/src/EventSubscriber/ActivityPub/GroupWebFingerProfileSubscriber.php
+++ b/src/EventSubscriber/ActivityPub/GroupWebFingerProfileSubscriber.php
@@ -11,13 +11,11 @@ use App\Repository\MagazineRepository;
 use App\Service\ActivityPub\Webfinger\WebFingerParameters;
 use JetBrains\PhpStorm\ArrayShape;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class GroupWebFingerProfileSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly RequestStack $requestStack,
         private readonly WebFingerParameters $webfingerParameters,
         private readonly MagazineRepository $magazineRepository,
         private readonly UrlGeneratorInterface $urlGenerator,
@@ -34,13 +32,13 @@ class GroupWebFingerProfileSubscriber implements EventSubscriberInterface
 
     public function buildResponse(WebfingerResponseEvent $event): void
     {
-        $request = $this->requestStack->getCurrentRequest();
-        $params = $this->webfingerParameters->getParams();
+        $params = $this->webfingerParameters->getParams($event->request);
         $jsonRd = $event->jsonRd;
 
-        if (isset($params[WebFingerParameters::ACCOUNT_KEY_NAME]) && $actor = $this->getActor(
-            $params[WebFingerParameters::ACCOUNT_KEY_NAME]
-        )) {
+        if (
+            isset($params[WebFingerParameters::ACCOUNT_KEY_NAME])
+            && $actor = $this->getActor($params[WebFingerParameters::ACCOUNT_KEY_NAME])
+        ) {
             $accountHref = $this->urlGenerator->generate(
                 'ap_magazine',
                 ['name' => $actor->name],

--- a/src/EventSubscriber/ActivityPub/UserWebFingerProfileSubscriber.php
+++ b/src/EventSubscriber/ActivityPub/UserWebFingerProfileSubscriber.php
@@ -13,14 +13,12 @@ use App\Service\SettingsManager;
 use JetBrains\PhpStorm\ArrayShape;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class UserWebFingerProfileSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly RequestStack $requestStack,
         private readonly WebFingerParameters $webfingerParameters,
         private readonly UserRepository $userRepository,
         private readonly UrlGeneratorInterface $urlGenerator,
@@ -40,8 +38,7 @@ class UserWebFingerProfileSubscriber implements EventSubscriberInterface
 
     public function buildResponse(WebfingerResponseEvent $event): void
     {
-        $request = $this->requestStack->getCurrentRequest();
-        $params = $this->webfingerParameters->getParams();
+        $params = $this->webfingerParameters->getParams($event->request);
         $jsonRd = $event->jsonRd;
 
         if (isset($params[WebFingerParameters::ACCOUNT_KEY_NAME])) {

--- a/src/EventSubscriber/ActivityPub/UserWebFingerSubscriber.php
+++ b/src/EventSubscriber/ActivityPub/UserWebFingerSubscriber.php
@@ -10,14 +10,12 @@ use App\Repository\UserRepository;
 use App\Service\ActivityPub\Webfinger\WebFingerParameters;
 use JetBrains\PhpStorm\ArrayShape;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class UserWebFingerSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly RequestStack $requestStack,
         private readonly WebFingerParameters $webfingerParameters,
         private readonly UserRepository $userRepository,
         private readonly UrlGeneratorInterface $urlGenerator
@@ -34,8 +32,8 @@ class UserWebFingerSubscriber implements EventSubscriberInterface
 
     public function buildResponse(WebfingerResponseEvent $event): void
     {
-        $request = $this->requestStack->getCurrentRequest();
-        $params = $this->webfingerParameters->getParams();
+        $request = $event->request;
+        $params = $this->webfingerParameters->getParams($request);
         $jsonRd = $event->jsonRd;
 
         $subject = $request->query->get('resource') ?: '';
@@ -43,9 +41,10 @@ class UserWebFingerSubscriber implements EventSubscriberInterface
             $jsonRd->setSubject($subject);
         }
 
-        if (isset($params[WebFingerParameters::ACCOUNT_KEY_NAME]) && $actor = $this->getActor(
-            $params[WebFingerParameters::ACCOUNT_KEY_NAME]
-        )) {
+        if (
+            isset($params[WebFingerParameters::ACCOUNT_KEY_NAME])
+            && $actor = $this->getActor($params[WebFingerParameters::ACCOUNT_KEY_NAME])
+        ) {
             $accountHref = $this->urlGenerator->generate(
                 'ap_user',
                 ['username' => $actor->getUserIdentifier()],

--- a/src/Service/ActivityPub/Webfinger/WebFingerParameters.php
+++ b/src/Service/ActivityPub/Webfinger/WebFingerParameters.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service\ActivityPub\Webfinger;
 
-use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Request;
 
 class WebFingerParameters
 {
@@ -12,15 +12,16 @@ class WebFingerParameters
     public const HOST_KEY_NAME = 'host';
     public const ACCOUNT_KEY_NAME = 'account';
 
-    public function __construct(private readonly RequestStack $requestStack)
+    public function __construct()
     {
     }
 
-    public function getParams(): array
+    /**
+     * @return array{acccount?: string, host?: string, rel?: array}
+     */
+    public function getParams(Request $request): array
     {
         $params = [];
-
-        $request = $this->requestStack->getCurrentRequest();
 
         if ($resource = $request->query->get('resource')) {
             $host = $request->server->get('HTTP_HOST'); // @todo


### PR DESCRIPTION
pass the webfinger request from controller to WebfingerResponseEvent and its handlers once rather than (implicitly) pulling the request from the stack, also adjusted WebFingerParameters the same way to have it parse the params out of the given request object

just to make it clearer what's the required input, rather than magically conjuring them out of thin air (not really) on use

---

perhaps could go one step further by parsing webfinger params then pass the parsed params on dispatch instead, or perhaps it should be done as pre/post event?