### PR TITLE
move top pagination panel outside of section

### DIFF
--- a/templates/admin/users.html.twig
+++ b/templates/admin/users.html.twig
@@ -14,6 +14,9 @@
 
 {% block body %}
     {% include 'admin/_options.html.twig' %}
+    {% if(users.haveToPaginate is defined and users.haveToPaginate) %}
+        {{ pagerfanta(users, null, {'pageParameter':'[p]'}) }}
+    {% endif %}
     <div class="section" id="content">
         <div class="flex" data-controller="selection">
             <label class="select">
@@ -23,9 +26,6 @@
                 </select>
             </label>
         </div>
-        {% if(users.haveToPaginate is defined and users.haveToPaginate) %}
-            {{ pagerfanta(users, null, {'pageParameter':'[p]'}) }}
-        {% endif %}
         <table>
             <thead>
             <tr>


### PR DESCRIPTION
to align with pagination style of bottom panel

based on feedback from @asdfzdfj, keep the styling of pagination panels consistent on the page

|before|after|
|-|-|
|![image](https://github.com/MbinOrg/mbin/assets/146029455/3d2bf097-7519-4d8a-8907-b4fab919d723)|![image](https://github.com/MbinOrg/mbin/assets/146029455/da072cd6-90b4-48d8-b963-40e1325808e7)|