### PR TITLE
remove ratelimit on user create command for admins

### DIFF
--- a/src/Command/UserCommand.php
+++ b/src/Command/UserCommand.php
@@ -72,7 +72,7 @@ class UserCommand extends Command
         $dto = (new UserDto())->create($input->getArgument('username'), $input->getArgument('email'));
         $dto->plainPassword = $input->getArgument('password');
 
-        $user = $this->manager->create($dto, false);
+        $user = $this->manager->create($dto, false, false);
 
         if ($input->getOption('admin')) {
             $user->setOrRemoveAdminRole();


### PR DESCRIPTION
admins would get ratelimited when making multiple users quickly with 

```
{"message":"Error thrown while running command \"mbin:user:create user8 'user8@local' local\". Message: \"\"","context":{"exception":{"class":"Symfony\\Component\\HttpKernel\\Exception\\TooManyRequestsHttpException","message":"","code":0,"file":"/var/www/mbin/src/Service/UserManager.php:149"},"command":"mbin:user:create user8 'user8@local' local","message":""},"level":500,"level_name":"CRITICAL","channel":"console","datetime":"2024-04-30T23:34:24.250163+00:00","extra":{}}
23:34:24 CRITICAL  [console] Error thrown while running command "mbin:user:create user8 'user8@local' local". Message: "" ["exception" => Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException { …},"command" => "mbin:user:create user8 'user8@local' local","message" => ""]

In UserManager.php line 149:
                                                                         
  [Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException]  
                                                                         

mbin:user:create [-r|--remove] [--admin] [--moderator] [--] <username> <email> <password>
```

this passes the third arg to https://github.com/MbinOrg/mbin/blob/43bf5a95889352a18ac6c513ecb0087d655a1464/src/Service/UserManager.php#L144

which allows admins to bypass the ratelimit