### PR TITLE
Add null check to magazine description/rules before getting passed to markdown converter

### DIFF
--- a/src/Factory/ActivityPub/GroupFactory.php
+++ b/src/Factory/ActivityPub/GroupFactory.php
@@ -62,10 +62,10 @@ class GroupFactory
                 'publicKeyPem' => $magazine->publicKey,
             ],
             'summary' => $summary,
-            'source' => $markdownSummary ? [
+            'source' => [
                 'content' => $markdownSummary,
                 'mediaType' => 'text/markdown',
-            ] : null,
+            ],
             'sensitive' => $magazine->isAdult,
             'attributedTo' => $this->urlGenerator->generate(
                 'ap_magazine_moderators',

--- a/src/Factory/ActivityPub/GroupFactory.php
+++ b/src/Factory/ActivityPub/GroupFactory.php
@@ -23,16 +23,16 @@ class GroupFactory
 
     public function create(Magazine $magazine): array
     {
-        $markdownSummary = $magazine->description;
+        $markdownSummary = $magazine->description ?? '';
 
         if (!empty($magazine->rules)) {
-            $markdownSummary .= "\r\n\r\n### Rules\r\n\r\n".$magazine->rules;
+            $markdownSummary .= (!empty($markdownSummary) ? "\r\n\r\n" : '')."### Rules\r\n\r\n".$magazine->rules;
         }
 
-        $summary = $this->markdownConverter->convertToHtml(
+        $summary = !empty($markdownSummary) ? $this->markdownConverter->convertToHtml(
             $markdownSummary,
             [MarkdownConverter::RENDER_TARGET => RenderTarget::ActivityPub],
-        );
+        ) : '';
 
         $group = [
             'type' => 'Group',


### PR DESCRIPTION
Add null check to magazines without description and/or rules, fixes 500s observed in prod log:

```
{"message":"Uncaught PHP Exception TypeError: \"App\\Markdown\\MarkdownConverter::convertToHtml(): Argument #1 ($markdown) must be of type string, null given, called in /var/www/kbin/src/Factory/ActivityPub/GroupFactory.php on line 32\" at MarkdownConverter.php line 18","context":{"exception":{"class":"TypeError","message":"App\\Markdown\\MarkdownConverter::convertToHtml(): Argument #1 ($markdown) must be of type string, null given, called in /var/www/kbin/src/Factory/ActivityPub/GroupFactory.php on line 32","code":0,"file":"/var/www/kbin/src/Markdown/MarkdownConverter.php:18"}},"level":500,"level_name":"CRITICAL","channel":"request","datetime":"2024-04-30T22:37:08.608342+00:00","extra":{}}
{"message":"Uncaught PHP Exception TypeError: \"App\\Markdown\\MarkdownConverter::convertToHtml(): Argument #1 ($markdown) must be of type string, null given, called in /var/www/kbin/src/Factory/ActivityPub/GroupFactory.php on line 32\" at MarkdownConverter.php line 18","context":{"exception":{"class":"TypeError","message":"App\\Markdown\\MarkdownConverter::convertToHtml(): Argument #1 ($markdown) must be of type string, null given, called in /var/www/kbin/src/Factory/ActivityPub/GroupFactory.php on line 32","code":0,"file":"/var/www/kbin/src/Markdown/MarkdownConverter.php:18"}},"level":500,"level_name":"CRITICAL","channel":"request","datetime":"2024-04-30T22:37:09.785512+00:00","extra":{}}
{"message":"Uncaught PHP Exception TypeError: \"App\\Markdown\\MarkdownConverter::convertToHtml(): Argument #1 ($markdown) must be of type string, null given, called in /var/www/kbin/src/Factory/ActivityPub/GroupFactory.php on line 32\" at MarkdownConverter.php line 18","context":{"exception":{"class":"TypeError","message":"App\\Markdown\\MarkdownConverter::convertToHtml(): Argument #1 ($markdown) must be of type string, null given, called in /var/www/kbin/src/Factory/ActivityPub/GroupFactory.php on line 32","code":0,"file":"/var/www/kbin/src/Markdown/MarkdownConverter.php:18"}},"level":500,"level_name":"CRITICAL","channel":"request","datetime":"2024-04-30T22:37:10.210939+00:00","extra":{}}
{"message":"Uncaught PHP Exception TypeError: \"App\\Markdown\\MarkdownConverter::convertToHtml(): Argument #1 ($markdown) must be of type string, null given, called in /var/www/kbin/src/Factory/ActivityPub/GroupFactory.php on line 32\" at MarkdownConverter.php line 18","context":{"exception":{"class":"TypeError","message":"App\\Markdown\\MarkdownConverter::convertToHtml(): Argument #1 ($markdown) must be of type string, null given, called in /var/www/kbin/src/Factory/ActivityPub/GroupFactory.php on line 32","code":0,"file":"/var/www/kbin/src/Markdown/MarkdownConverter.php:18"}},"level":500,"level_name":"CRITICAL","channel":"request","datetime":"2024-04-30T22:37:11.171807+00:00","extra":{}}
