### PR TITLE
Fix 2fa redirect not being triggered on login

### DIFF
--- a/src/Security/Voter/PrivateInstanceVoter.php
+++ b/src/Security/Voter/PrivateInstanceVoter.php
@@ -6,6 +6,7 @@ namespace App\Security\Voter;
 
 use App\Entity\User;
 use App\Service\SettingsManager;
+use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
@@ -22,6 +23,10 @@ class PrivateInstanceVoter extends Voter
 
     protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token): bool
     {
+        if ($token instanceof TwoFactorTokenInterface) {
+            return false;
+        }
+
         if ($this->settingsManager->get('MBIN_PRIVATE_INSTANCE')) {
             $user = $token->getUser();
 


### PR DESCRIPTION
The private instance voter was missing logic to detect if the user was currently awaiting 2fa validation

symptom: users were logged in without seeing the 2fa prompt

following instructions from https://github.com/scheb/2fa/issues/23 added a token check to private instance voter to wait for user to get out of 2fa validation