### PR TITLE
Update cache action to v4

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -37,14 +37,14 @@ jobs:
         run: |
           echo "hash=$(md5sum composer.lock)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: npm-cache # use this to check for `cache-hit` (`steps.npm-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.npm-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-npm-${{ steps.npm-lock-hash.outputs.hash }}
           restore-keys: ${{ runner.os }}-npm-
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-no-dev-${{ steps.composer-lock-hash.outputs.hash }}
@@ -77,7 +77,7 @@ jobs:
         run: |
           echo "hash=$(md5sum composer.lock)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ steps.composer-lock-hash.outputs.hash }}
@@ -120,7 +120,7 @@ jobs:
         run: |
           echo "hash=$(md5sum tools/composer.lock)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-tools-${{ steps.composer-lock-hash.outputs.hash }}


### PR DESCRIPTION
- Update cache action to latest version (v4)
- This action is also updated to Node.js 20, which would get rid of the Annotations/warning in the workflow runs. 

Like so:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3. For more  information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
