### PR TITLE
connect mercure endpoint url to noti controller directly

### DIFF
--- a/assets/utils/event-source.js
+++ b/assets/utils/event-source.js
@@ -1,17 +1,16 @@
-export default function
-    subscribe(topics, cb) {
-    const mercureElem = document.getElementById("mercure-url");
-    if (mercureElem) {
-        const url = new URL(mercureElem.textContent.trim());
-
-        topics.forEach(topic => {
-            url.searchParams.append('topic', topic);
-        })
-
-        const eventSource = new EventSource(url);
-        eventSource.onmessage = e => cb(e);
-
-        return eventSource;
+export default function subscribe(endpoint, topics, cb) {
+    if (!endpoint) {
+        return null;
     }
-    return null;
+
+    const url = new URL(endpoint);
+
+    topics.forEach((topic) => {
+        url.searchParams.append('topic', topic);
+    });
+
+    const eventSource = new EventSource(url);
+    eventSource.onmessage = (e) => cb(e);
+
+    return eventSource;
 }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -51,10 +51,6 @@
 
     {% block javascripts %}
         {{ encore_entry_script_tags('app') }}
-        {% if kbin_mercure_enabled() %}
-        {#        <script type="application/json" id="mercure-url">{{ mercure()|raw }}</script> #}
-        <script type="application/json" id="mercure-url">{{- 'https://' ~ kbin_domain() ~ '/.well-known/mercure' }}</script>
-        {% endif %}
     {% endblock %}
 </head>
 <body class="{{ html_classes('theme--'~THEME, {
@@ -66,6 +62,7 @@
         'sidebars-same-side': app.user is defined and app.user is not same as null and SUBSCRIPTIONS_SEPARATE is same as V_TRUE and SUBSCRIPTIONS_SAME_SIDE is same as V_TRUE,
     }) }}"
         data-controller="kbin notifications"
+        data-notifications-endpoint-value="{{ kbin_mercure_enabled() ? 'https://'~kbin_domain()~'/.well-known/mercure' : null }}"
         data-notifications-user-value="{{ app.user ? app.user.id : null }}"
         data-notifications-magazine-value="{{ magazine is defined and magazine ? magazine.id : null }}"
         data-notifications-entry-id-value="{{ entry is defined and entry ? entry.id : null }}"


### PR DESCRIPTION
adjusted notification controller to take mercure endpoint url directly as controller values rather than templating the endpoint separately and then extracting them from dom nodes

if the endpoint isn't provided then it will not attempt to connect to mercure, effectively disabling them

also fix controller related js files according to eslint rules

overall functionality should remain the same