### PR TITLE
fix visibility info no longer being shown

### DIFF
--- a/src/Controller/Entry/EntryFrontController.php
+++ b/src/Controller/Entry/EntryFrontController.php
@@ -51,7 +51,7 @@ class EntryFrontController extends AbstractController
         $templatePath = ('threads' === $content) ? 'entry/' : 'post/';
         $dataKey = ('threads' === $content) ? 'entries' : 'posts';
 
-        return $this->renderResponse($request, $content, $criteria, [$dataKey => $entities], $templatePath);
+        return $this->renderResponse($request, $content, $criteria, [$dataKey => $entities], $templatePath, $user);
     }
 
     // $name is magazine name, for compatibility
@@ -120,7 +120,7 @@ class EntryFrontController extends AbstractController
         $templatePath = ('threads' === $content) ? 'entry/' : 'post/';
         $dataKey = ('threads' === $content) ? 'entries' : 'posts';
 
-        return $this->renderResponse($request, $content, $criteria, [$dataKey => $entities, 'magazine' => $magazine], $templatePath);
+        return $this->renderResponse($request, $content, $criteria, [$dataKey => $entities, 'magazine' => $magazine], $templatePath, $user);
     }
 
     private function createCriteria(string $content, Request $request)
@@ -162,7 +162,7 @@ class EntryFrontController extends AbstractController
         }
     }
 
-    private function renderResponse(Request $request, $content, $criteria, $data, $templatePath)
+    private function renderResponse(Request $request, $content, $criteria, $data, $templatePath, ?User $user)
     {
         $baseData = ['criteria' => $criteria] + $data;
         if ('microblog' === $content) {
@@ -171,6 +171,7 @@ class EntryFrontController extends AbstractController
                 $dto->magazine = $data['magazine'];
             }
             $baseData['form'] = $this->createForm(PostType::class)->setData($dto)->createView();
+            $baseData['user'] = $user;
         }
 
         if ($request->isXmlHttpRequest()) {

--- a/templates/post/front.html.twig
+++ b/templates/post/front.html.twig
@@ -55,7 +55,7 @@
     {% endif %}
     {% include 'post/_options.html.twig' %}
     {% include 'layout/_flash.html.twig' %}
-    {% if app.user is defined and app.user %}
+    {% if user is defined and user %}
         {% include('user/_visibility_info.html.twig') %}
     {% endif %}
     {% if magazine is defined and magazine %}

--- a/templates/user/_visibility_info.html.twig
+++ b/templates/user/_visibility_info.html.twig
@@ -1,4 +1,4 @@
-{% if app.user is defined and app.user and app.user.visibility is same as 'trashed' %}
+{% if user is defined and user and user.visibility is same as 'trashed' %}
     <div class="alert alert__danger">
         <p>{{ 'account_is_suspended'|trans }}</p>
     </div>


### PR DESCRIPTION
for viewing other users

---

I messed up with #674, only checks for the logged in user can be replaced `user` with `app.user`, visibility info shows for either the logged in user or when viewing other users

The result was a suspended user would still see they were suspended, but when viewing other accounts that are suspended you would no longer see it

this reverts the change so that visibility info is based off the passed in user and adds `$user` to the microblog template so it can be shown in place of the new post form.