### PR TITLE
Fix infinite scrolling of results on search page

### DIFF
--- a/templates/search/_list.html.twig
+++ b/templates/search/_list.html.twig
@@ -1,0 +1,7 @@
+<div data-controller="subject-list">
+    {% if objects|length %}
+        {% include 'layout/_subject_list.html.twig' with {results: [object], entryCommentAttributes: {showMagazineName: true, showEntryTitle: true}, postCommentAttributes: {withPost: false}} %}
+    {% elseif q %}
+        {% include 'layout/_subject_list.html.twig' with {entryCommentAttributes: {showMagazineName: true, showEntryTitle: true}, postCommentAttributes: {withPost: false}} %}
+    {% endif %}
+</div>

--- a/templates/search/front.html.twig
+++ b/templates/search/front.html.twig
@@ -40,11 +40,11 @@
                 {% elseif object.type is defined and object.type is same as 'magazine' %}
                     {{ component('magazine_box', {magazine: object.object, stretchedLink: false}) }}
                 {% else %}
-                    {% include 'layout/_subject_list.html.twig' with {results: [object], entryCommentAttributes: {showMagazineName: true, showEntryTitle: true}, postCommentAttributes: {withPost: false}} %}
+                    {% include 'search/_list.html.twig' %}
                 {% endif %}
             {% endfor %}
         {% elseif q %}
-            {% include 'layout/_subject_list.html.twig' with {entryCommentAttributes: {showMagazineName: true, showEntryTitle: true}, postCommentAttributes: {withPost: false}} %}
+            {% include 'search/_list.html.twig' %}
         {% endif %}
     </div>
 {% endblock %}


### PR DESCRIPTION
infinite scrolling on the search page currently does not work, throwing the javascript exception of invalid json and showing the paginator instead. this updates the controller to handle xml requests

(this might sound familiar, it also isn't working by the same mechanic on user pages so expect that some time in the future)

based on [similar work](https://github.com/MbinOrg/mbin/pull/654/commits/e8fb274ac83dc875f92f4e7c6054b29130fe6be9) Benti did to get infinite scrolling working on tag pages