### PR TITLE
Make 2fa input field required to submit form

### DIFF
--- a/templates/user/2fa.html.twig
+++ b/templates/user/2fa.html.twig
@@ -27,6 +27,7 @@
                            name="{{ authCodeParameterName }}"
                            autocomplete="one-time-code"
                            autofocus
+                           required
                            inputmode="numeric"
                            pattern="[0-9]*"/>
                 </div>


### PR DESCRIPTION
Simple change to make it so the 2fa code form when logging in must have a value to be submitted

before and after when submitting a form with no code specified

|before|after|
|-|-|
|![image](https://github.com/MbinOrg/mbin/assets/146029455/3162f720-6018-4461-baaa-ad50200aef86)|![image](https://github.com/MbinOrg/mbin/assets/146029455/619534aa-708d-4709-82ec-a82d46402f4c)|