### PR TITLE
Exclude `node_modules` and `vendor` directories from PHP linter

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,6 +8,7 @@ $finder = (new PhpCsFixer\Finder())
         'var',
         'node_modules',
         'vendor',
+        'docker',
     ])
 ;
 

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 $finder = (new PhpCsFixer\Finder())
     ->in(__DIR__)
-    ->exclude('var')
+    ->exclude([
+        'var',
+        'node_modules',
+        'vendor',
+    ])
 ;
 
 return (new PhpCsFixer\Config())


### PR DESCRIPTION
I noticed our PHP linter was "fixing" files in the `node_modules` and potentially `vendor` directories, I've updated the linter config to exclude files from these directories.