### PR TITLE
Do not auto-close issues because of stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,5 +18,5 @@ jobs:
           exempt-issue-labels: "high priority"
           days-before-issue-stale: 50
           days-before-pr-stale: 40
-          days-before-issue-close: 6
+          days-before-issue-close: -1
           days-before-pr-close: -1


### PR DESCRIPTION
People in the dev community do not want to auto-close the stale issues.

I do not agree (since I don't like ending up with 10k issues), but... here is the PR anyway. 
If more people approving this PR then rejecting, then it will be merged.