### PR TITLE
Show users without magazine about hide deleted users

### DIFF
--- a/docs/04-contributing/linting.md
+++ b/docs/04-contributing/linting.md
@@ -11,3 +11,5 @@ Try to automatically fix linting errors:
 ```bash
 tools/vendor/bin/php-cs-fixer fix
 ```
+
+_Note:_ First time you run the linter, it might take a while. After a hot cache, linting will be faster.


### PR DESCRIPTION
- Show users on the magazine people listing page even when they do not have about or an avatar
- Refactor method name to reflect the actual behavior
- Also check for user `is_deleted` database column in queries
- Small lint doc notice added.