### PR TITLE
Add Brazilian Portuguese and Danish language selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Following languages are currently supported/translated:
 
 - Bulgarian
 - Chinese
+- Danish
 - Dutch
 - English
 - Esperanto

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Following languages are currently supported/translated:
 - Japanese
 - Polish
 - Portuguese
+- Portuguese (Brazil)
 - Russian
 - Spanish
 - Turkish

--- a/assets/controllers/timeago_controller.js
+++ b/assets/controllers/timeago_controller.js
@@ -3,6 +3,7 @@ import { Controller } from '@hotwired/stimulus';
 // eslint-disable-next-line -- grouping timeago imports here is more readable than properly sorting
 import * as timeago from 'timeago.js';
 import bg from 'timeago.js/lib/lang/bg';
+import da from 'timeago.js/lib/lang/da';
 import de from 'timeago.js/lib/lang/de';
 import el from 'timeago.js/lib/lang/el';
 import en from 'timeago.js/lib/lang/en_US';
@@ -28,7 +29,7 @@ export default class extends Controller {
         }
 
         const lang = document.documentElement.lang;
-        const languages = { bg, de, el, en, es, fr, it, ja, nl, pl, pt_BR, ru, tr, uk, zh_TW };
+        const languages = { bg, da, de, el, en, es, fr, it, ja, nl, pl, pt_BR, ru, tr, uk, zh_TW };
 
         if (languages[lang]) {
             timeago.register(lang, languages[lang]);

--- a/assets/controllers/timeago_controller.js
+++ b/assets/controllers/timeago_controller.js
@@ -12,7 +12,7 @@ import it from 'timeago.js/lib/lang/it';
 import ja from 'timeago.js/lib/lang/ja';
 import nl from 'timeago.js/lib/lang/nl';
 import pl from 'timeago.js/lib/lang/pl';
-import pt from 'timeago.js/lib/lang/pt_BR';
+import pt_BR from 'timeago.js/lib/lang/pt_BR';
 import ru from 'timeago.js/lib/lang/ru';
 import tr from 'timeago.js/lib/lang/tr';
 import uk from 'timeago.js/lib/lang/uk';
@@ -28,7 +28,7 @@ export default class extends Controller {
         }
 
         const lang = document.documentElement.lang;
-        const languages = { bg, de, el, en, es, fr, it, ja, nl, pl, pt, ru, tr, uk, zh_TW };
+        const languages = { bg, de, el, en, es, fr, it, ja, nl, pl, pt_BR, ru, tr, uk, zh_TW };
 
         if (languages[lang]) {
             timeago.register(lang, languages[lang]);

--- a/templates/layout/_sidebar.html.twig
+++ b/templates/layout/_sidebar.html.twig
@@ -148,7 +148,7 @@
             {% set current = app.request.cookies.get('kbin_lang') ?? header_accept_language ?? kbin_default_lang() %}
             <li>
                 <select data-action="kbin#changeLang">
-                    {% for code in ['bg', 'de', 'el', 'en', 'eo', 'es', 'fr', 'it', 'ja', 'nl', 'pl', 'pt', 'pt_BR', 'ru', 'tr', 'uk', 'zh_TW'] %}
+                    {% for code in ['bg', 'da', 'de', 'el', 'en', 'eo', 'es', 'fr', 'it', 'ja', 'nl', 'pl', 'pt', 'pt_BR', 'ru', 'tr', 'uk', 'zh_TW'] %}
                         <option value="{{ code }}" {{ code is same as current ? 'selected' : '' }}>{{ code|language_name(code) }}</option>
                     {% endfor %}
                 </select>

--- a/templates/layout/_sidebar.html.twig
+++ b/templates/layout/_sidebar.html.twig
@@ -148,7 +148,7 @@
             {% set current = app.request.cookies.get('kbin_lang') ?? header_accept_language ?? kbin_default_lang() %}
             <li>
                 <select data-action="kbin#changeLang">
-                    {% for code in ['bg', 'de', 'el', 'en', 'eo', 'es', 'fr', 'it', 'ja', 'nl', 'pl', 'pt', 'ru', 'tr', 'uk', 'zh_TW'] %}
+                    {% for code in ['bg', 'de', 'el', 'en', 'eo', 'es', 'fr', 'it', 'ja', 'nl', 'pl', 'pt', 'pt_BR', 'ru', 'tr', 'uk', 'zh_TW'] %}
                         <option value="{{ code }}" {{ code is same as current ? 'selected' : '' }}>{{ code|language_name(code) }}</option>
                     {% endfor %}
                 </select>


### PR DESCRIPTION
Add Brazilian Portuguese and Danish language selectors, also update `timeago_controller.js` to reflect proper `pt_BR` usage as they do not have `pt` only translation available: https://github.com/hustcc/timeago.js/tree/master/src/lang