### PR TITLE
Update contrib workflow with new version and permissions

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -8,8 +8,11 @@ jobs:
   contrib-readme:
     runs-on: ubuntu-latest
     name: Update contrib in README
+    permissions:
+          contents: write
+          pull-requests: write
     steps:
       - name: Contribute List
-        uses: akhilmhdh/contributors-readme-action@v2.3.9
+        uses: akhilmhdh/contributors-readme-action@v2.3.10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update to new version and potentially address https://github.com/akhilmhdh/contributors-readme-action/issues/63#issuecomment-2093429839... action workflow/other checks don't seem to run automatically anymore until a commit is added to the branch it creates, which was not the case before as something else seems to have changed...