### PR TITLE
expose the `apFetchedAt` field of users and magazines for admins

### DIFF
--- a/templates/components/magazine_box.html.twig
+++ b/templates/components/magazine_box.html.twig
@@ -42,6 +42,11 @@
             <li>{{ 'created_at'|trans }}:
                 {{ component('date', {date: computed.magazine.createdAt}) }}
             </li>
+            {% if app.user is defined and app.user is not null and app.user.admin() and computed.magazine.apId is not null %}
+                <li>
+                    {{ 'last_updated'|trans }}: {{ component('date', {date: computed.magazine.apFetchedAt}) }}
+                </li>
+            {% endif %}
             <li>{{ 'subscribers'|trans }}: <span>{{ computed.magazine.subscriptionsCount }}</span></li>
         </ul>
     {% endif %}

--- a/templates/user/_info.html.twig
+++ b/templates/user/_info.html.twig
@@ -19,6 +19,11 @@
     {% endif %}
     <ul class="info">
         <li>{{ 'joined'|trans }}: {{ component('date', {date: user.createdAt}) }}</li>
+        {% if app.user is defined and app.user is not null and app.user.admin() and user.apId is not null %}
+            <li>
+                {{ 'last_updated'|trans }}: {{ component('date', {date: user.apFetchedAt}) }}
+            </li>
+        {% endif %}
         {%- set TYPE_ENTRY = constant('App\\Repository\\ReputationRepository::TYPE_ENTRY') -%}
         <li><a href="{{ path('user_reputation', {username: user.username, reputationType: TYPE_ENTRY}) }}" class="stretched-link">{{ 'reputation_points'|trans }}:</a> {{ get_reputation_total(user) }}</li>
         <li><a href="{{ path('user_moderated', {username: user.username}) }}"

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -826,3 +826,4 @@ sso_show_first: Show SSO first on login and registration pages
 continue_with: Continue with
 magazine_log_mod_added: has added a moderator
 magazine_log_mod_removed: has removed a moderator
+last_updated: Last updated


### PR DESCRIPTION
user info box (on profile page):
![grafik](https://github.com/MbinOrg/mbin/assets/25664458/6e21499f-f48e-4484-bd96-0fb103e2e349)

magazine info box:
![grafik](https://github.com/MbinOrg/mbin/assets/25664458/014f5c8c-720c-41d8-b7e5-ab372d9e98a9)
