### PR TITLE
New/cake day

### DIFF
--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -337,7 +337,8 @@ class ActivityPubManager
                     if ($createdAt < $now) {
                         $user->createdAt = $createdAt;
                     }
-                } catch (\Exception) {}
+                } catch (\Exception) {
+                }
             }
 
             // Only update about when summary is set
@@ -480,7 +481,8 @@ class ActivityPubManager
                     if ($createdAt < $now) {
                         $magazine->createdAt = $createdAt;
                     }
-                } catch (\Exception) {}
+                } catch (\Exception) {
+                }
             }
 
             $magazine->apInboxUrl = $actor['endpoints']['sharedInbox'] ?? $actor['inbox'];

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -330,6 +330,16 @@ class ActivityPubManager
             $user->apTimeoutAt = null;
             $user->apFetchedAt = new \DateTime();
 
+            if (isset($actor['published'])) {
+                try {
+                    $createdAt = new \DateTimeImmutable($actor['published']);
+                    $now = new \DateTimeImmutable();
+                    if ($createdAt < $now) {
+                        $user->createdAt = $createdAt;
+                    }
+                } catch (\Exception) {}
+            }
+
             // Only update about when summary is set
             if (isset($actor['summary'])) {
                 $converter = new HtmlConverter(['strip_tags' => true]);

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -473,6 +473,16 @@ class ActivityPubManager
                 $magazine->title = $actor['preferredUsername'];
             }
 
+            if (isset($actor['published'])) {
+                try {
+                    $createdAt = new \DateTimeImmutable($actor['published']);
+                    $now = new \DateTimeImmutable();
+                    if ($createdAt < $now) {
+                        $magazine->createdAt = $createdAt;
+                    }
+                } catch (\Exception) {}
+            }
+
             $magazine->apInboxUrl = $actor['endpoints']['sharedInbox'] ?? $actor['inbox'];
             $magazine->apDomain = parse_url($actor['id'], PHP_URL_HOST);
             $magazine->apFollowersUrl = $actor['followers'] ?? null;

--- a/src/Service/SettingsManager.php
+++ b/src/Service/SettingsManager.php
@@ -9,6 +9,7 @@ use App\Entity\Settings;
 use App\Repository\SettingsRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use JetBrains\PhpStorm\Pure;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class SettingsManager
 {
@@ -17,6 +18,7 @@ class SettingsManager
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly SettingsRepository $repository,
+        private readonly RequestStack $requestStack,
         private readonly string $kbinDomain,
         private readonly string $kbinTitle,
         private readonly string $kbinMetaTitle,
@@ -152,5 +154,12 @@ class SettingsManager
     public static function getValue(string $name): string
     {
         return self::$dto->{$name};
+    }
+
+    public function getLocale(): string
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        return $request->cookies->get('kbin_lang') ?? $request->getLocale() ?? $this->get('KBIN_DEFAULT_LANG');
     }
 }

--- a/src/Twig/Extension/SettingsExtension.php
+++ b/src/Twig/Extension/SettingsExtension.php
@@ -31,6 +31,7 @@ final class SettingsExtension extends AbstractExtension
             new TwigFunction('mbin_restrict_magazine_creation', [SettingsExtensionRuntime::class, 'mbinRestrictMagazineCreation']),
             new TwigFunction('mbin_private_instance', [SettingsExtensionRuntime::class, 'mbinPrivateInstance']),
             new TwigFunction('mbin_sso_show_first', [SettingsExtensionRuntime::class, 'mbinSsoShowFirst']),
+            new TwigFunction('mbin_lang', [SettingsExtensionRuntime::class, 'mbinLang']),
         ];
     }
 }

--- a/src/Twig/Runtime/SettingsExtensionRuntime.php
+++ b/src/Twig/Runtime/SettingsExtensionRuntime.php
@@ -118,4 +118,9 @@ class SettingsExtensionRuntime implements RuntimeExtensionInterface
     {
         return $this->settings->get('MBIN_SSO_SHOW_FIRST');
     }
+
+    public function mbinLang(): string
+    {
+        return $this->settings->getLocale();
+    }
 }

--- a/templates/user/_info.html.twig
+++ b/templates/user/_info.html.twig
@@ -19,15 +19,19 @@
     {% endif %}
     <ul class="info">
         <li>{{ 'joined'|trans }}: {{ component('date', {date: user.createdAt}) }}</li>
+        <li>{{ 'cake_day'|trans }}: <span><i class="fa-solid fa-cake" style="margin-right: .5em"></i>{{ user.createdAt|format_date('short', '', null, 'gregorian', mbin_lang()) }}</span></li>
         {%- set TYPE_ENTRY = constant('App\\Repository\\ReputationRepository::TYPE_ENTRY') -%}
         <li><a href="{{ path('user_reputation', {username: user.username, reputationType: TYPE_ENTRY}) }}" class="stretched-link">{{ 'reputation_points'|trans }}:</a> {{ get_reputation_total(user) }}</li>
         <li><a href="{{ path('user_moderated', {username: user.username}) }}"
                class="stretched-link">{{ 'moderated'|trans }}:</a> {{ count_user_moderated(user) }}
         </li>
         {% if app.user is not same as user %}
-            <li><a href="{{ path('messages_create', {username: user.username}) }}"
-                   class="stretched-link">{{ 'send_message'|trans }}</a> <i
-                        class="fa-solid fa-envelope" aria-hidden="true"></i></li>
+            <li>
+                <a href="{{ path('messages_create', {username: user.username}) }}" class="stretched-link">
+                    {{ 'send_message'|trans }}
+                </a>
+                <i class="fa-solid fa-envelope" aria-hidden="true"></i>
+            </li>
         {% endif %}
     </ul>
 </section>

--- a/templates/user/_user_popover.html.twig
+++ b/templates/user/_user_popover.html.twig
@@ -22,6 +22,10 @@
             <ul>
                 <li>{{ 'joined'|trans }}: {{ component('date', {date: user.createdAt}) }}</li>
                 <li>
+                    <i class="fa-solid fa-cake" style="margin-right: .5em;"></i>
+                    <span>{{ user.createdAt|format_date('short', '', null, 'gregorian', mbin_lang()) }}</span>
+                </li>
+                <li>
                     {%- set TYPE_ENTRY = constant('App\\Repository\\ReputationRepository::TYPE_ENTRY') -%}
                     <a href="{{ path('user_reputation', {username: user.username, reputationType: TYPE_ENTRY}) }}">
                         {{ 'reputation_points'|trans }}: {{ get_reputation_total(user) }}

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -824,5 +824,6 @@ related_entry: Related
 restrict_magazine_creation: Restrict local magazine creation to admins and global mods
 sso_show_first: Show SSO first on login and registration pages
 continue_with: Continue with
+cake_day: Cake day
 magazine_log_mod_added: has added a moderator
 magazine_log_mod_removed: has removed a moderator


### PR DESCRIPTION
- add the cake day to a users profile page, as well as the user popover
- set the `createdAt` field to a user's `published` field when updating them. We already expose that field
- set the `createdAt` field to a magazine's `published` field when updating them. We already expose that field

User Profile Page:
![grafik](https://github.com/MbinOrg/mbin/assets/25664458/e860128f-104e-4cb2-96c3-17e5554f6109)

User Popover:
![grafik](https://github.com/MbinOrg/mbin/assets/25664458/f22fc932-2c28-481e-a0b4-eccfd7697ba6)

The date display is localized