### PR TITLE
Improve modlog

### DIFF
--- a/src/Controller/User/ThemeSettingsController.php
+++ b/src/Controller/User/ThemeSettingsController.php
@@ -41,6 +41,8 @@ class ThemeSettingsController extends AbstractController
     public const KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE = 'kbin_subscriptions_sidebars_same_side';
     public const KBIN_SUBSCRIPTIONS_LARGE_PANEL = 'kbin_subscriptions_large_panel';
     public const KBIN_SUBSCRIPTIONS_SHOW_MAGAZINE_ICON = 'kbin_subscriptions_show_magazine_icon';
+    public const MBIN_MODERATION_LOG_SHOW_USER_AVATARS = 'mbin_moderation_log_show_user_avatars';
+    public const MBIN_MODERATION_LOG_SHOW_MAGAZINE_ICONS = 'mbin_moderation_log_show_magazine_icons';
 
     public const CLASSIC = 'classic';
     public const CHAT = 'chat';
@@ -96,6 +98,8 @@ class ThemeSettingsController extends AbstractController
         self::KBIN_SUBSCRIPTIONS_SIDEBARS_SAME_SIDE,
         self::KBIN_SUBSCRIPTIONS_LARGE_PANEL,
         self::KBIN_SUBSCRIPTIONS_SHOW_MAGAZINE_ICON,
+        self::MBIN_MODERATION_LOG_SHOW_USER_AVATARS,
+        self::MBIN_MODERATION_LOG_SHOW_MAGAZINE_ICONS,
     ];
 
     public const VALUES = [

--- a/templates/layout/_options_appearance.html.twig
+++ b/templates/layout/_options_appearance.html.twig
@@ -51,4 +51,9 @@
         {{ component('settings_row_enum', {label: 'comment_reply_position'|trans, help: 'comment_reply_position_help'|trans, settingsKey: 'KBIN_COMMENTS_REPLY_POSITION', values: [ {name: 'position_top'|trans , value: 'TOP'}, {name: 'position_bottom'|trans , value: 'BOTTOM' } ], defaultValue: 'TOP' } ) }}
         {{ component('settings_row_switch', {label: 'show_avatars_on_comments'|trans, help: 'show_avatars_on_comments_help'|trans, settingsKey: 'KBIN_COMMENTS_SHOW_USER_AVATAR', defaultValue: true}) }}
     </div>
+    <strong>{{ 'mod_log'|trans }}</strong>
+    <div class="settings-section">
+        {{ component('settings_row_switch', {label: 'show_users_avatars'|trans, settingsKey: 'MBIN_MODERATION_LOG_SHOW_USER_AVATARS', defaultValue: false}) }}
+        {{ component('settings_row_switch', {label: 'show_magazines_icons'|trans, settingsKey: 'MBIN_MODERATION_LOG_SHOW_MAGAZINE_ICONS', defaultValue: false}) }}
+    </div>
 </div>

--- a/templates/modlog/_blocks.html.twig
+++ b/templates/modlog/_blocks.html.twig
@@ -1,46 +1,46 @@
 {% block log_entry_deleted %}
-    {{ component('user_inline', {user: log.user}) }} {{ 'removed_thread_by'|trans|lower }} {{ component('user_inline', {user: log.entry.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.entry.magazine, showAvatar: true }) }}{% endif %} -
+    {{ component('user_inline', {user: log.user, showAvatar: showAvatars}) }} {{ 'removed_thread_by'|trans|lower }} {{ component('user_inline', {user: log.entry.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.entry.magazine, showAvatar: showIcons }) }}{% endif %} -
     <a href="{{ entry_url(log.entry) }}">{{ log.entry.shortTitle(300) }}</a>
 {% endblock %}
 
 {% block log_entry_restored %}
-    {{ component('user_inline', {user: log.user}) }} {{ 'restored_thread_by'|trans|lower }} {{ component('user_inline', {user: log.entry.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.entry.magazine, showAvatar: true }) }}{% endif %} -
+    {{ component('user_inline', {user: log.user, showAvatar: showAvatars}) }} {{ 'restored_thread_by'|trans|lower }} {{ component('user_inline', {user: log.entry.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.entry.magazine, showAvatar: showIcons }) }}{% endif %} -
     <a href="{{ entry_url(log.entry) }}">{{ log.entry.shortTitle(300) }}</a>
 {% endblock %}
 
 {% block log_entry_comment_deleted %}
-    {{ component('user_inline', {user: log.user}) }} {{ 'removed_comment_by'|trans|lower }} {{ component('user_inline', {user: log.comment.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.comment.magazine, showAvatar: true }) }}{% endif %} -
+    {{ component('user_inline', {user: log.user, showAvatar: showAvatars}) }} {{ 'removed_comment_by'|trans|lower }} {{ component('user_inline', {user: log.comment.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.comment.magazine, showAvatar: showIcons }) }}{% endif %} -
     <a href="{{ entry_comment_view_url(log.comment) }}#{{ get_url_fragment(log.comment) }}">{{ log.comment.shortTitle(300) }}</a>
 {% endblock %}
 
 {% block log_entry_comment_restored %}
-    {{ component('user_inline', {user: log.user}) }} {{ 'restored_comment_by'|trans|lower }} {{ component('user_inline', {user: log.comment.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.comment.magazine, showAvatar: true }) }}{% endif %} -
+    {{ component('user_inline', {user: log.user, showAvatar: showAvatars}) }} {{ 'restored_comment_by'|trans|lower }} {{ component('user_inline', {user: log.comment.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.comment.magazine, showAvatar: showIcons }) }}{% endif %} -
     <a href="{{ entry_comment_view_url(log.comment) }}#{{ get_url_fragment(log.comment) }}">{{ log.comment.shortTitle(300) }}</a>
 {% endblock %}
 
 {% block log_post_deleted %}
-    {{ component('user_inline', {user: log.user}) }} {{ 'removed_post_by'|trans|lower }} {{ component('user_inline', {user: log.post.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.post.magazine, showAvatar: true }) }}{% endif %} -
+    {{ component('user_inline', {user: log.user, showAvatar: showAvatars}) }} {{ 'removed_post_by'|trans|lower }} {{ component('user_inline', {user: log.post.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.post.magazine, showAvatar: showIcons }) }}{% endif %} -
     <a href="{{ post_url(log.post) }}">{{ log.post.shortTitle(300) }}</a>
 {% endblock %}
 
 {% block log_post_restored %}
-    {{ component('user_inline', {user: log.user}) }} {{ 'restored_post_by'|trans|lower }} {{ component('user_inline', {user: log.post.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.post.magazine, showAvatar: true }) }}{% endif %} -
+    {{ component('user_inline', {user: log.user, showAvatar: showAvatars}) }} {{ 'restored_post_by'|trans|lower }} {{ component('user_inline', {user: log.post.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.post.magazine, showAvatar: showIcons }) }}{% endif %} -
     <a href="{{ post_url(log.post) }}">{{ log.post.shortTitle(300) }}</a>
 {% endblock %}
 
 {% block log_post_comment_deleted %}
-    {{ component('user_inline', {user: log.user}) }} {{ 'removed_comment_by'|trans|lower }} {{ component('user_inline', {user: log.comment.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.comment.magazine, showAvatar: true }) }}{% endif %} -
+    {{ component('user_inline', {user: log.user, showAvatar: showAvatars}) }} {{ 'removed_comment_by'|trans|lower }} {{ component('user_inline', {user: log.comment.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.comment.magazine, showAvatar: showIcons }) }}{% endif %} -
     <a href="{{ post_url(log.comment.post) }}#{{ get_url_fragment(log.comment) }}">{{ log.comment.shortTitle(300) }}</a>
 {% endblock %}
 
 {% block log_post_comment_restored %}
-    {{ component('user_inline', {user: log.user}) }} {{ 'restored_comment_by'|trans|lower }} {{ component('user_inline', {user: log.comment.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.comment.magazine, showAvatar: true }) }}{% endif %} -
+    {{ component('user_inline', {user: log.user, showAvatar: showAvatars}) }} {{ 'restored_comment_by'|trans|lower }} {{ component('user_inline', {user: log.comment.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.comment.magazine, showAvatar: showIcons }) }}{% endif %} -
     <a href="{{ post_url(log.comment.post) }}#{{ get_url_fragment(log.comment) }}">{{ log.comment.shortTitle(300) }}</a>
 {% endblock %}
 
 {% block log_ban %}
-    {{ component('user_inline', {user: log.user}) }} {% if log.meta is same as 'ban' %}{{ 'he_banned'|trans|lower }}{% else %}{{ 'he_unbanned'|trans|lower }}{% endif %} {{ component('user_inline', {user: log.ban.user}) }}
-    {% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.ban.magazine, showAvatar: true }) }}{% endif %}{% if log.ban.reason %} - {{ log.ban.reason }}{% endif %}
+    {{ component('user_inline', {user: log.user, showAvatar: showAvatars}) }} {% if log.meta is same as 'ban' %}{{ 'he_banned'|trans|lower }}{% else %}{{ 'he_unbanned'|trans|lower }}{% endif %} {{ component('user_inline', {user: log.ban.user}) }}
+    {% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.ban.magazine, showAvatar: showIcons }) }}{% endif %}{% if log.ban.reason %} - {{ log.ban.reason }}{% endif %}
 {% endblock %}
 
 {% block log_moderator_add %}
@@ -49,9 +49,8 @@
     {% else %}
         {{ 'someone'|trans }}
     {% endif %}
-    {{ 'magazine_log_mod_added'|trans }}
-    {% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.magazine, showAvatar: true }) }}{% endif %}
-    : {{ component('user_inline', {user: log.user}) }}
+    {{ 'magazine_log_mod_added'|trans -}}
+    {% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.magazine, showAvatar: showIcons }) -}}{%- endif -%}: {{ component('user_inline', {user: log.user, showAvatar: showAvatars}) }}
 {% endblock %}
 
 {% block log_moderator_remove %}
@@ -60,7 +59,6 @@
     {% else %}
         {{ 'someone'|trans }}
     {% endif %}
-    {{ 'magazine_log_mod_removed'|trans }}
-    {% if showMagazine %} {{ 'from'|trans|lower }} {{ component('magazine_inline', {magazine: log.magazine, showAvatar: true }) }}{% endif %}
-    : {{ component('user_inline', {user: log.user}) }}
+    {{ 'magazine_log_mod_removed'|trans -}}
+    {% if showMagazine %} {{ 'from'|trans|lower }} {{ component('magazine_inline', {magazine: log.magazine, showAvatar: showIcons }) -}}{%- endif -%}: {{ component('user_inline', {user: log.user, showAvatar: showAvatars}) }}
 {% endblock %}

--- a/templates/modlog/_blocks.html.twig
+++ b/templates/modlog/_blocks.html.twig
@@ -1,58 +1,66 @@
 {% block log_entry_deleted %}
-    {{ component('user_inline', {user: log.user, showAvatar: false}) }} {{ 'removed_thread_by'|trans|lower }} {{ component('user_inline', {user: log.entry.user, showAvatar: false}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.entry.magazine, showIcon: false }) }}{% endif %} -
+    {{ component('user_inline', {user: log.user}) }} {{ 'removed_thread_by'|trans|lower }} {{ component('user_inline', {user: log.entry.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.entry.magazine, showAvatar: true }) }}{% endif %} -
     <a href="{{ entry_url(log.entry) }}">{{ log.entry.shortTitle(300) }}</a>
 {% endblock %}
 
 {% block log_entry_restored %}
-    {{ component('user_inline', {user: log.user, showAvatar: false}) }} {{ 'restored_thread_by'|trans|lower }} {{ component('user_inline', {user: log.entry.user, showAvatar: false}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.entry.magazine, showIcon: false }) }}{% endif %} -
+    {{ component('user_inline', {user: log.user}) }} {{ 'restored_thread_by'|trans|lower }} {{ component('user_inline', {user: log.entry.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.entry.magazine, showAvatar: true }) }}{% endif %} -
     <a href="{{ entry_url(log.entry) }}">{{ log.entry.shortTitle(300) }}</a>
 {% endblock %}
 
 {% block log_entry_comment_deleted %}
-    {{ component('user_inline', {user: log.user, showAvatar: false}) }} {{ 'removed_comment_by'|trans|lower }} {{ component('user_inline', {user: log.comment.user, showAvatar: false}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.comment.magazine, showIcon: false }) }}{% endif %} -
+    {{ component('user_inline', {user: log.user}) }} {{ 'removed_comment_by'|trans|lower }} {{ component('user_inline', {user: log.comment.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.comment.magazine, showAvatar: true }) }}{% endif %} -
     <a href="{{ entry_comment_view_url(log.comment) }}#{{ get_url_fragment(log.comment) }}">{{ log.comment.shortTitle(300) }}</a>
 {% endblock %}
 
 {% block log_entry_comment_restored %}
-    {{ component('user_inline', {user: log.user, showAvatar: false}) }} {{ 'restored_comment_by'|trans|lower }} {{ component('user_inline', {user: log.comment.user, showAvatar: false}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.comment.magazine, showIcon: false }) }}{% endif %} -
+    {{ component('user_inline', {user: log.user}) }} {{ 'restored_comment_by'|trans|lower }} {{ component('user_inline', {user: log.comment.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.comment.magazine, showAvatar: true }) }}{% endif %} -
     <a href="{{ entry_comment_view_url(log.comment) }}#{{ get_url_fragment(log.comment) }}">{{ log.comment.shortTitle(300) }}</a>
 {% endblock %}
 
 {% block log_post_deleted %}
-    {{ component('user_inline', {user: log.user, showAvatar: false}) }} {{ 'removed_post_by'|trans|lower }} {{ component('user_inline', {user: log.post.user, showAvatar: false}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.post.magazine, showIcon: false }) }}{% endif %} -
+    {{ component('user_inline', {user: log.user}) }} {{ 'removed_post_by'|trans|lower }} {{ component('user_inline', {user: log.post.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.post.magazine, showAvatar: true }) }}{% endif %} -
     <a href="{{ post_url(log.post) }}">{{ log.post.shortTitle(300) }}</a>
 {% endblock %}
 
 {% block log_post_restored %}
-    {{ component('user_inline', {user: log.user, showAvatar: false}) }} {{ 'restored_post_by'|trans|lower }} {{ component('user_inline', {user: log.post.user, showAvatar: false}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.post.magazine, showIcon: false }) }}{% endif %} -
+    {{ component('user_inline', {user: log.user}) }} {{ 'restored_post_by'|trans|lower }} {{ component('user_inline', {user: log.post.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.post.magazine, showAvatar: true }) }}{% endif %} -
     <a href="{{ post_url(log.post) }}">{{ log.post.shortTitle(300) }}</a>
 {% endblock %}
 
 {% block log_post_comment_deleted %}
-    {{ component('user_inline', {user: log.user, showAvatar: false}) }} {{ 'removed_comment_by'|trans|lower }} {{ component('user_inline', {user: log.comment.user, showAvatar: false}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.comment.magazine, showIcon: false }) }}{% endif %} -
+    {{ component('user_inline', {user: log.user}) }} {{ 'removed_comment_by'|trans|lower }} {{ component('user_inline', {user: log.comment.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.comment.magazine, showAvatar: true }) }}{% endif %} -
     <a href="{{ post_url(log.comment.post) }}#{{ get_url_fragment(log.comment) }}">{{ log.comment.shortTitle(300) }}</a>
 {% endblock %}
 
 {% block log_post_comment_restored %}
-    {{ component('user_inline', {user: log.user, showAvatar: false}) }} {{ 'restored_comment_by'|trans|lower }} {{ component('user_inline', {user: log.comment.user, showAvatar: false}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.comment.magazine, showIcon: false }) }}{% endif %} -
+    {{ component('user_inline', {user: log.user}) }} {{ 'restored_comment_by'|trans|lower }} {{ component('user_inline', {user: log.comment.user}) }}{% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.comment.magazine, showAvatar: true }) }}{% endif %} -
     <a href="{{ post_url(log.comment.post) }}#{{ get_url_fragment(log.comment) }}">{{ log.comment.shortTitle(300) }}</a>
 {% endblock %}
 
 {% block log_ban %}
-    {{ component('user_inline', {user: log.user, showAvatar: false}) }} {% if log.meta is same as 'ban' %}{{ 'he_banned'|trans|lower }}{% else %}{{ 'he_unbanned'|trans|lower }}{% endif %} {{ component('user_inline', {user: log.ban.user, showAvatar: false}) }}
-    {% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.ban.magazine, showIcon: false }) }}{% endif %}{% if log.ban.reason %} - {{ log.ban.reason }}{% endif %}
+    {{ component('user_inline', {user: log.user}) }} {% if log.meta is same as 'ban' %}{{ 'he_banned'|trans|lower }}{% else %}{{ 'he_unbanned'|trans|lower }}{% endif %} {{ component('user_inline', {user: log.ban.user}) }}
+    {% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.ban.magazine, showAvatar: true }) }}{% endif %}{% if log.ban.reason %} - {{ log.ban.reason }}{% endif %}
 {% endblock %}
 
 {% block log_moderator_add %}
     {% if log.actingUser is not same as null %}
         {{ component('user_inline', {user: log.actingUser}) }}
+    {% else %}
+        {{ 'someone'|trans }}
     {% endif %}
-    {{ 'magazine_log_mod_added'|trans }}: {{ component('user_inline', {user: log.user}) }}
+    {{ 'magazine_log_mod_added'|trans }}
+    {% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.magazine, showAvatar: true }) }}{% endif %}
+    : {{ component('user_inline', {user: log.user}) }}
 {% endblock %}
 
 {% block log_moderator_remove %}
     {% if log.actingUser is not same as null %}
         {{ component('user_inline', {user: log.actingUser}) }}
+    {% else %}
+        {{ 'someone'|trans }}
     {% endif %}
-    {{ 'magazine_log_mod_removed'|trans }}: {{ component('user_inline', {user: log.user}) }}
+    {{ 'magazine_log_mod_removed'|trans }}
+    {% if showMagazine %} {{ 'from'|trans|lower }} {{ component('magazine_inline', {magazine: log.magazine, showAvatar: true }) }}{% endif %}
+    : {{ component('user_inline', {user: log.user}) }}
 {% endblock %}

--- a/templates/modlog/front.html.twig
+++ b/templates/modlog/front.html.twig
@@ -1,4 +1,9 @@
 {% extends 'base.html.twig' %}
+{% set V_TRUE = constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
+{% set MBIN_MODERATION_LOG_SHOW_USER_AVATARS = constant('App\\Controller\\User\\ThemeSettingsController::MBIN_MODERATION_LOG_SHOW_USER_AVATARS') %}
+{% set showAvatars = app.request.cookies.get(MBIN_MODERATION_LOG_SHOW_USER_AVATARS) is same as V_TRUE %}
+{% set MBIN_MODERATION_LOG_SHOW_MAGAZINE_ICONS = constant('App\\Controller\\User\\ThemeSettingsController::MBIN_MODERATION_LOG_SHOW_MAGAZINE_ICONS') %}
+{% set showIcons = app.request.cookies.get(MBIN_MODERATION_LOG_SHOW_MAGAZINE_ICONS) is same as V_TRUE %}
 {% use 'modlog/_blocks.html.twig' %}
 
 {%- block title -%}
@@ -28,6 +33,8 @@
                 {%- with {
                     log: log,
                     showMagazine: true,
+                    showAvatars: showAvatars,
+                    showIcons: showIcons,
                 } only -%}
                     {{ block(log.type) }}
                 {%- endwith -%}

--- a/templates/modlog/front.html.twig
+++ b/templates/modlog/front.html.twig
@@ -27,7 +27,7 @@
             <div>
                 {%- with {
                     log: log,
-                    showMagazine: false,
+                    showMagazine: true,
                 } only -%}
                     {{ block(log.type) }}
                 {%- endwith -%}

--- a/templates/modlog/magazine.html.twig
+++ b/templates/modlog/magazine.html.twig
@@ -1,11 +1,16 @@
 {% extends 'base.html.twig' %}
+{% set V_TRUE = constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
+{% set MBIN_MODERATION_LOG_SHOW_USER_AVATARS = constant('App\\Controller\\User\\ThemeSettingsController::MBIN_MODERATION_LOG_SHOW_USER_AVATARS') %}
+{% set showAvatars = app.request.cookies.get(MBIN_MODERATION_LOG_SHOW_USER_AVATARS) is same as V_TRUE %}
+{% set MBIN_MODERATION_LOG_SHOW_MAGAZINE_ICONS = constant('App\\Controller\\User\\ThemeSettingsController::MBIN_MODERATION_LOG_SHOW_MAGAZINE_ICONS') %}
+{% set showIcons = app.request.cookies.get(MBIN_MODERATION_LOG_SHOW_MAGAZINE_ICONS) is same as V_TRUE %}
 {% use 'modlog/_blocks.html.twig' %}
 
 {%- block title -%}
     {{- 'magazines'|trans }} - {{ parent() -}}
 {%- endblock -%}
 
-{% block mainClass %}page-magazines{% endblock %}
+{% block mainClass %}page-magazines page-modlog{% endblock %}
 
 {% block header_nav %}
 {% endblock %}
@@ -24,6 +29,8 @@
                 {%- with {
                     log: log,
                     showMagazine: false,
+                    showAvatars: showAvatars,
+                    showIcons: showIcons,
                 } only -%}
                     {{ block(log.type) }}
                 {%- endwith -%}

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -83,6 +83,7 @@ reset_password: Reset password
 show_more: Show more
 to: to
 in: in
+from: from
 username: Username
 email: Email
 repeat_password: Repeat password
@@ -824,5 +825,6 @@ related_entry: Related
 restrict_magazine_creation: Restrict local magazine creation to admins and global mods
 sso_show_first: Show SSO first on login and registration pages
 continue_with: Continue with
+someone: Someone
 magazine_log_mod_added: has added a moderator
 magazine_log_mod_removed: has removed a moderator


### PR DESCRIPTION
- show the magazine if the instance wide modlog is viewed
- add appearance settings to show avatars of users and icons of magazines in the modlog. They default to false
- improve moderator update messages when no `actingUser` is provided (happens when the changes were made by the update actor command/method

Instance wide modlog:
![grafik](https://github.com/MbinOrg/mbin/assets/25664458/01fd0fba-3b9c-4cfb-abb6-ed1e20f9bc2a)

Magazine modlog:
![grafik](https://github.com/MbinOrg/mbin/assets/25664458/61a9824d-8a36-421d-a9d0-c44ebe89c1b9)

New appearance settings:
![grafik](https://github.com/MbinOrg/mbin/assets/25664458/f73b0349-426d-4011-a4d1-45e3eaecd2ad)