### PR TITLE
Include content of audience tag in the receivers

### DIFF
--- a/src/Service/ActivityPub/Note.php
+++ b/src/Service/ActivityPub/Note.php
@@ -187,7 +187,7 @@ class Note
     private function createPost(array $object): Post
     {
         $dto = new PostDto();
-        $dto->magazine = $this->activityPubManager->findOrCreateMagazineByToAndCC($object);
+        $dto->magazine = $this->activityPubManager->findOrCreateMagazineByToCCAndAudience($object);
         $dto->apId = $object['id'];
 
         $actor = $this->activityPubManager->findActorOrCreate($object['attributedTo']);

--- a/src/Service/ActivityPub/Page.php
+++ b/src/Service/ActivityPub/Page.php
@@ -65,7 +65,7 @@ class Page
                 $object['cc'] = [$object['cc']];
             }
 
-            $magazine = $this->activityPubManager->findOrCreateMagazineByToAndCC($object);
+            $magazine = $this->activityPubManager->findOrCreateMagazineByToCCAndAudience($object);
             $dto = new EntryDto();
             $dto->magazine = $magazine;
             $dto->title = $object['name'];

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -683,7 +683,7 @@ class ActivityPubManager
         return null;
     }
 
-    public function findOrCreateMagazineByToAndCC(array $object): Magazine|null
+    public function findOrCreateMagazineByToCCAndAudience(array $object): Magazine|null
     {
         $potentialGroups = self::getReceivers($object);
         $magazine = $this->magazineRepository->findByApGroupProfileId($potentialGroups);
@@ -711,8 +711,14 @@ class ActivityPubManager
     public static function getReceivers(array $object): array
     {
         $res = [];
+        if (isset($object['audience']) and \is_array($object['audience'])) {
+            $res = array_merge($res, $object['audience']);
+        } elseif (isset($object['audience']) and \is_string($object['audience'])) {
+            $res[] = $object['audience'];
+        }
+
         if (isset($object['to']) and \is_array($object['to'])) {
-            $res = $object['to'];
+            $res = array_merge($res, $object['to']);
         } elseif (isset($object['to']) and \is_string($object['to'])) {
             $res[] = $object['to'];
         }
@@ -724,6 +730,12 @@ class ActivityPubManager
         }
 
         if (isset($object['object']) and \is_array($object['object'])) {
+            if (isset($object['object']['audience']) and \is_array($object['object']['audience'])) {
+                $res = array_merge($res, $object['object']['audience']);
+            } elseif (isset($object['object']['audience']) and \is_string($object['object']['audience'])) {
+                $res[] = $object['object']['audience'];
+            }
+
             if (isset($object['object']['to']) and \is_array($object['object']['to'])) {
                 $res = array_merge($res, $object['object']['to']);
             } elseif (isset($object['object']['to']) and \is_string($object['object']['to'])) {


### PR DESCRIPTION
This PR improves fediverse compatibility. The content of the `audience` field of incoming objects is now also included in the receivers, so in the array that is used to find the magazine of incoming posts. NodeBB for example only uses the `audience` field