### PR TITLE
add aria attributes to cake day elements

### DIFF
--- a/assets/styles/components/_popover.scss
+++ b/assets/styles/components/_popover.scss
@@ -63,6 +63,14 @@
       font-size: .9rem;
       list-style: none;
       padding: 0;
+
+      li {
+        div {
+          i {
+            padding-right: .5rem;
+          }
+        }
+      }
     }
 
     .user__actions {

--- a/assets/styles/components/_sidebar.scss
+++ b/assets/styles/components/_sidebar.scss
@@ -176,6 +176,11 @@
         padding: 0;
       }
 
+      div {
+        i {
+          padding-right: .5rem;
+        }
+      }
     }
   }
 

--- a/templates/user/_info.html.twig
+++ b/templates/user/_info.html.twig
@@ -19,7 +19,7 @@
     {% endif %}
     <ul class="info">
         <li>{{ 'joined'|trans }}: {{ component('date', {date: user.createdAt}) }}</li>
-        <li>{{ 'cake_day'|trans }}: <span><i class="fa-solid fa-cake" style="margin-right: .5em"></i>{{ user.createdAt|format_date('short', '', null, 'gregorian', mbin_lang()) }}</span></li>
+        <li>{{ 'cake_day'|trans }}: <div><i class="fa-solid fa-cake" aria-hidden="true"></i> <span>{{ user.createdAt|format_date('short', '', null, 'gregorian', mbin_lang()) }}</span></div></li>
         {% if app.user is defined and app.user is not null and app.user.admin() and user.apId is not null %}
             <li>
                 {{ 'last_updated'|trans }}: {{ component('date', {date: user.apFetchedAt}) }}

--- a/templates/user/_user_popover.html.twig
+++ b/templates/user/_user_popover.html.twig
@@ -22,8 +22,10 @@
             <ul>
                 <li>{{ 'joined'|trans }}: {{ component('date', {date: user.createdAt}) }}</li>
                 <li>
-                    <i class="fa-solid fa-cake" style="margin-right: .5em;"></i>
-                    <span>{{ user.createdAt|format_date('short', '', null, 'gregorian', mbin_lang()) }}</span>
+                    <div title="{{ 'cake_day'|trans }}" aria-label="{{ 'cake_day'|trans }}">
+                        <i class="fa-solid fa-cake" aria-hidden="true"></i>
+                        <span>{{ user.createdAt|format_date('short', '', null, 'gregorian', mbin_lang()) }}</span>
+                    </div>
                 </li>
                 <li>
                     {%- set TYPE_ENTRY = constant('App\\Repository\\ReputationRepository::TYPE_ENTRY') -%}


### PR DESCRIPTION
adds `aria-hidden` and `aria-label` attributes to the new cake day locations

- cake icon on user page sidebar is decorative, as the label is already in the row, so gains `aria-hidden=true`
- cake icon on user popover is meant to denote that's is the user's cake day, so gains an `aria-label=Cake day` element surrounding it
- switched the padding to match how it is for other divs icons (if you compare with say follower count). we seem to use `padding right .5rem` on `div i` and then `margin-left .5rem` on `btn span`s (like the icons in the purge buttons)...  I wonder if we should unite these, or it doesn't really matter

| before | after |
|-|-|
|![image](https://github.com/MbinOrg/mbin/assets/146029455/a80cec6f-d2ba-4b9b-bf92-291d763e6d54)|![image](https://github.com/MbinOrg/mbin/assets/146029455/ddc967c1-096c-44c7-a697-b75635342a9d)|
|![image](https://github.com/MbinOrg/mbin/assets/146029455/9c796e49-8fe5-4546-b990-a69c84129128)|![image](https://github.com/MbinOrg/mbin/assets/146029455/f9504e5d-d23b-4095-830d-5a9a0fa405d0)|