### PR TITLE
Fix entries with not showing preview icon

### DIFF
--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -148,8 +148,8 @@
                                 </span>
                             </li>
                         {% endif %}
-                        {% if entry.hasEmbed %}
-                            {% set preview_url = entry.type is same as 'image' and entry.image ? uploaded_asset(entry.image) : entry.url %}
+                        {% if entry.hasEmbed or entry.image %}
+                            {% set preview_url = (entry.type is same as 'image' or entry.url is same as null) and entry.image ? uploaded_asset(entry.image) : entry.url %}
                             <li>
                                 <button class="show-preview"
                                         data-action="preview#show"


### PR DESCRIPTION
- when an entry is of type article and does not point to a url, but has an image attached to it, the preview should show the image, right now there is just no preview icon in this case

| before | after |
| ------ | ----- |
| ![grafik](https://github.com/MbinOrg/mbin/assets/25664458/92e485a2-2bcc-4b7e-bb3b-a2e1817fbd67) | ![grafik](https://github.com/MbinOrg/mbin/assets/25664458/17cfa01e-9baf-4b8d-bba4-1152f33091c4) ![grafik](https://github.com/MbinOrg/mbin/assets/25664458/29843dde-d9c9-44b1-a3aa-0193f66e704d)
 |

