### PR TITLE
Revert "Fix entries with not showing preview icon"

### DIFF
--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -148,8 +148,8 @@
                                 </span>
                             </li>
                         {% endif %}
-                        {% if entry.hasEmbed or entry.image %}
-                            {% set preview_url = (entry.type is same as 'image' or entry.url is same as null) and entry.image ? uploaded_asset(entry.image) : entry.url %}
+                        {% if entry.hasEmbed %}
+                            {% set preview_url = entry.type is same as 'image' and entry.image ? uploaded_asset(entry.image) : entry.url %}
                             <li>
                                 <button class="show-preview"
                                         data-action="preview#show"


### PR DESCRIPTION
Reverts MbinOrg/mbin#847

It fixed the problem for posts which do have an attached image ([example](https://gehirneimer.de/m/ich_iel@feddit.de/t/247003/Ich-iel)), but no attached url, but fucked posts which had that does not point to a url ([example](https://gehirneimer.de/m/FloatingIsFun@fedia.io/t/246085/Duolingo-Hero-Image-by-Duolingo))

Discussed solution: fix it not at the rendering stage, but at the type guessing stage