### PR TITLE
Add Filipino language selector to sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Following languages are currently supported/translated:
 - Dutch
 - English
 - Esperanto
+- Filipino
 - French
 - German
 - Greek

--- a/templates/layout/_sidebar.html.twig
+++ b/templates/layout/_sidebar.html.twig
@@ -148,7 +148,7 @@
             {% set current = app.request.cookies.get('kbin_lang') ?? header_accept_language ?? kbin_default_lang() %}
             <li>
                 <select data-action="kbin#changeLang">
-                    {% for code in ['bg', 'da', 'de', 'el', 'en', 'eo', 'es', 'fr', 'it', 'ja', 'nl', 'pl', 'pt', 'pt_BR', 'ru', 'tr', 'uk', 'zh_TW'] %}
+                    {% for code in ['bg', 'da', 'de', 'el', 'en', 'eo', 'es', 'fil', 'fr', 'it', 'ja', 'nl', 'pl', 'pt', 'pt_BR', 'ru', 'tr', 'uk', 'zh_TW'] %}
                         <option value="{{ code }}" {{ code is same as current ? 'selected' : '' }}>{{ code|language_name(code) }}</option>
                     {% endfor %}
                 </select>


### PR DESCRIPTION
Note that `timeago.js` does not support Filipino (fil):

https://github.com/hustcc/timeago.js/tree/master/src/lang