### PR TITLE
Make outbox message handlers use the `DeliverManager`

### DIFF
--- a/src/MessageHandler/ActivityPub/Outbox/AddHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/AddHandler.php
@@ -6,13 +6,11 @@ namespace App\MessageHandler\ActivityPub\Outbox;
 
 use App\Factory\ActivityPub\AddRemoveFactory;
 use App\Message\ActivityPub\Outbox\AddMessage;
-use App\Message\ActivityPub\Outbox\DeliverMessage;
 use App\Repository\MagazineRepository;
 use App\Repository\UserRepository;
+use App\Service\DeliverManager;
 use App\Service\SettingsManager;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
-use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsMessageHandler]
 class AddHandler
@@ -20,10 +18,9 @@ class AddHandler
     public function __construct(
         private readonly UserRepository $userRepository,
         private readonly MagazineRepository $magazineRepository,
-        private readonly LoggerInterface $logger,
         private readonly SettingsManager $settingsManager,
-        private readonly MessageBusInterface $bus,
         private readonly AddRemoveFactory $factory,
+        private readonly DeliverManager $deliverManager,
     ) {
     }
 
@@ -43,10 +40,6 @@ class AddHandler
         }
 
         $activity = $this->factory->buildAdd($actor, $added, $magazine);
-        foreach ($audience as $inboxUrl) {
-            if (!$this->settingsManager->isBannedInstance($inboxUrl)) {
-                $this->bus->dispatch(new DeliverMessage($inboxUrl, $activity));
-            }
-        }
+        $this->deliverManager->deliver($audience, $activity);
     }
 }

--- a/src/MessageHandler/ActivityPub/Outbox/CreateHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/CreateHandler.php
@@ -5,26 +5,25 @@ declare(strict_types=1);
 namespace App\MessageHandler\ActivityPub\Outbox;
 
 use App\Message\ActivityPub\Outbox\CreateMessage;
-use App\Message\ActivityPub\Outbox\DeliverMessage;
 use App\Repository\MagazineRepository;
 use App\Repository\UserRepository;
 use App\Service\ActivityPub\Wrapper\CreateWrapper;
 use App\Service\ActivityPubManager;
+use App\Service\DeliverManager;
 use App\Service\SettingsManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
-use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsMessageHandler]
 class CreateHandler
 {
     public function __construct(
-        private readonly MessageBusInterface $bus,
         private readonly UserRepository $userRepository,
         private readonly MagazineRepository $magazineRepository,
         private readonly CreateWrapper $createWrapper,
         private readonly EntityManagerInterface $entityManager,
         private readonly ActivityPubManager $activityPubManager,
+        private readonly DeliverManager $deliverManager,
         private readonly SettingsManager $settingsManager
     ) {
     }
@@ -39,28 +38,11 @@ class CreateHandler
 
         $activity = $this->createWrapper->build($entity);
 
-        $this->deliver(array_filter($this->userRepository->findAudience($entity->user)), $activity);
-        $this->deliver(
-            array_filter($this->activityPubManager->createInboxesFromCC($activity, $entity->user)),
-            $activity
-        );
-        $this->deliver(array_filter($this->magazineRepository->findAudience($entity->magazine)), $activity);
-    }
-
-    private function deliver(array $followers, array $activity): void
-    {
-        foreach ($followers as $follower) {
-            if (!$follower) {
-                continue;
-            }
-
-            $inboxUrl = \is_string($follower) ? $follower : $follower->apInboxUrl;
-
-            if ($this->settingsManager->isBannedInstance($inboxUrl)) {
-                continue;
-            }
-
-            $this->bus->dispatch(new DeliverMessage($follower, $activity));
-        }
+        $inboxes = array_filter(array_unique(array_merge(
+            $this->userRepository->findAudience($entity->user),
+            $this->activityPubManager->createInboxesFromCC($activity, $entity->user),
+            $this->magazineRepository->findAudience($entity->magazine)
+        )));
+        $this->deliverManager->deliver($inboxes, $activity);
     }
 }

--- a/src/MessageHandler/ActivityPub/Outbox/DeleteHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/DeleteHandler.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace App\MessageHandler\ActivityPub\Outbox;
 
 use App\Message\ActivityPub\Outbox\DeleteMessage;
-use App\Message\ActivityPub\Outbox\DeliverMessage;
 use App\Repository\MagazineRepository;
 use App\Repository\UserRepository;
 use App\Service\ActivityPubManager;
+use App\Service\DeliverManager;
 use App\Service\SettingsManager;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
-use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsMessageHandler]
 class DeleteHandler
@@ -19,9 +18,9 @@ class DeleteHandler
     public function __construct(
         private readonly UserRepository $userRepository,
         private readonly MagazineRepository $magazineRepository,
-        private readonly MessageBusInterface $bus,
         private readonly ActivityPubManager $activityPubManager,
         private readonly SettingsManager $settingsManager,
+        private readonly DeliverManager $deliverManager,
     ) {
     }
 
@@ -34,25 +33,11 @@ class DeleteHandler
         $user = $this->userRepository->find($message->userId);
         $magazine = $this->magazineRepository->find($message->magazineId);
 
-        $this->deliver(array_filter($this->userRepository->findAudience($user)), $message->payload);
-        $this->deliver(
-            array_filter($this->activityPubManager->createInboxesFromCC($message->payload, $user)),
-            $message->payload
-        );
-        $this->deliver(array_filter($this->magazineRepository->findAudience($magazine)), $message->payload);
-    }
-
-    private function deliver(array $followers, array $activity)
-    {
-        foreach ($followers as $follower) {
-            if (!$follower) {
-                continue;
-            }
-            if (\is_string($follower)) {
-                $this->bus->dispatch(new DeliverMessage($follower, $activity));
-                continue;
-            }
-            $this->bus->dispatch(new DeliverMessage($follower->apProfileId, $activity));
-        }
+        $inboxes = array_filter(array_unique(array_merge(
+            $this->userRepository->findAudience($user),
+            $this->activityPubManager->createInboxesFromCC($message->payload, $user),
+            $this->magazineRepository->findAudience($magazine)
+        )));
+        $this->deliverManager->deliver($inboxes, $message->payload);
     }
 }

--- a/src/MessageHandler/ActivityPub/Outbox/FollowHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/FollowHandler.php
@@ -11,6 +11,7 @@ use App\Service\ActivityPub\ApHttpClient;
 use App\Service\ActivityPub\Wrapper\FollowWrapper;
 use App\Service\ActivityPub\Wrapper\UndoWrapper;
 use App\Service\ActivityPubManager;
+use App\Service\DeliverManager;
 use App\Service\SettingsManager;
 use JetBrains\PhpStorm\ArrayShape;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -25,7 +26,8 @@ class FollowHandler
         private readonly FollowWrapper $followWrapper,
         private readonly UndoWrapper $undoWrapper,
         private readonly ApHttpClient $apHttpClient,
-        private readonly SettingsManager $settingsManager
+        private readonly SettingsManager $settingsManager,
+        private readonly DeliverManager $deliverManager,
     ) {
     }
 
@@ -60,6 +62,6 @@ class FollowHandler
 
         $inbox = $this->apHttpClient->getInboxUrl($followingProfileId);
 
-        $this->apHttpClient->post($inbox, $follower, $followObject);
+        $this->deliverManager->deliver([$inbox], $followObject);
     }
 }

--- a/src/MessageHandler/ActivityPub/Outbox/RemoveHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/RemoveHandler.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace App\MessageHandler\ActivityPub\Outbox;
 
 use App\Factory\ActivityPub\AddRemoveFactory;
-use App\Message\ActivityPub\Outbox\DeliverMessage;
 use App\Message\ActivityPub\Outbox\RemoveMessage;
 use App\Repository\MagazineRepository;
 use App\Repository\UserRepository;
+use App\Service\DeliverManager;
 use App\Service\SettingsManager;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
-use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsMessageHandler]
 class RemoveHandler
@@ -20,10 +18,9 @@ class RemoveHandler
     public function __construct(
         private readonly UserRepository $userRepository,
         private readonly MagazineRepository $magazineRepository,
-        private readonly LoggerInterface $logger,
         private readonly SettingsManager $settingsManager,
-        private readonly MessageBusInterface $bus,
         private readonly AddRemoveFactory $factory,
+        private readonly DeliverManager $deliverManager,
     ) {
     }
 
@@ -43,10 +40,6 @@ class RemoveHandler
         }
 
         $activity = $this->factory->buildRemove($actor, $removed, $magazine);
-        foreach ($audience as $inboxUrl) {
-            if (!$this->settingsManager->isBannedInstance($inboxUrl)) {
-                $this->bus->dispatch(new DeliverMessage($inboxUrl, $activity));
-            }
-        }
+        $this->deliverManager->deliver($audience, $activity);
     }
 }

--- a/src/Service/DeliverManager.php
+++ b/src/Service/DeliverManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Entity\Traits\ActivityPubActorTrait;
 use App\Message\ActivityPub\Outbox\DeliverMessage;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -15,14 +16,17 @@ readonly class DeliverManager
     ) {
     }
 
-    public function deliver(array $followers, array $activity): void
+    /**
+     * @param string[]|ActivityPubActorTrait[] $inboxes
+     */
+    public function deliver(array $inboxes, array $activity): void
     {
-        foreach ($followers as $follower) {
-            if (!$follower) {
+        foreach ($inboxes as $inbox) {
+            if (!$inbox) {
                 continue;
             }
 
-            $inboxUrl = \is_string($follower) ? $follower : $follower->apInboxUrl;
+            $inboxUrl = \is_string($inbox) ? $inbox : $inbox->apInboxUrl;
 
             if ($this->settingsManager->isBannedInstance($inboxUrl)) {
                 continue;


### PR DESCRIPTION
A lot of the outbox messengers did not use the `DeliverManager` and some even forgot to check for banned instances. This PR just moves the outbox message handlers to use that class for sending out `DeliverMessage`s