### PR TITLE
Fix/actor 404 json error

### DIFF
--- a/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
@@ -83,6 +83,12 @@ readonly class ActivityHandler
             return;
         }
 
+        if (null === $user) {
+            $this->logger->warning('Could not find an actor discarding ActivityMessage {m}', ['m' => $message->payload]);
+
+            return;
+        }
+
         $this->handle($payload);
     }
 

--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -198,7 +198,7 @@ class ApHttpClient
 
                 if (404 === $response->getStatusCode()) {
                     // treat a 404 error the same as a tombstone, since we think there was an actor, but it isn't there anymore
-                    return $this->tombstoneFactory->create($apProfileId);
+                    return json_encode($this->tombstoneFactory->create($apProfileId));
                 }
 
                 // Return the content.


### PR DESCRIPTION
When getting an actor by calling `ApHttpClient->getActorObject` and the response code is 404 we returned a string array. The code using the returned value expected a json string -> now return a json string. Since the `ActivityHandler` can now get `null` as a return value it now discards messages from which it cannot find the actor

This fixes errors like:
```json
{
    "message": "Error thrown while handling message App\\Message\\ActivityPub\\Inbox\\ActivityMessage. Removing from transport after 7 retries. Error: \"Handling \"App\\Message\\ActivityPub\\Inbox\\ActivityMessage\" failed: json_decode(): Argument #1 ($json) must be of type string, array given\"",
    "context": {
        "class": "App\\Message\\ActivityPub\\Inbox\\ActivityMessage",
        "retryCount": 7,
        "error": "Handling \"App\\Message\\ActivityPub\\Inbox\\ActivityMessage\" failed: json_decode(): Argument #1 ($json) must be of type string, array given",
        "exception": {
            "class": "Symfony\\Component\\Messenger\\Exception\\HandlerFailedException",
            "message": "Handling \"App\\Message\\ActivityPub\\Inbox\\ActivityMessage\" failed: json_decode(): Argument #1 ($json) must be of type string, array given",
            "code": 0,
            "file": "/var/www/kbin/vendor/symfony/messenger/Middleware/HandleMessageMiddleware.php:124",
            "trace": [
                "/var/www/kbin/vendor/symfony/messenger/Middleware/SendMessageMiddleware.php:71",
                "/var/www/kbin/vendor/symfony/messenger/Middleware/FailedMessageProcessingMiddleware.php:34",
                "/var/www/kbin/vendor/symfony/messenger/Middleware/DispatchAfterCurrentBusMiddleware.php:68",
                "/var/www/kbin/vendor/symfony/messenger/Middleware/RejectRedeliveredMessageMiddleware.php:41",
                "/var/www/kbin/vendor/symfony/messenger/Middleware/AddBusNameStampMiddleware.php:37",
                "/var/www/kbin/vendor/symfony/messenger/MessageBus.php:70",
                "/var/www/kbin/vendor/symfony/messenger/RoutableMessageBus.php:54",
                "/var/www/kbin/vendor/symfony/messenger/Worker.php:161",
                "/var/www/kbin/vendor/symfony/messenger/Worker.php:108",
                "/var/www/kbin/vendor/symfony/messenger/Command/ConsumeMessagesCommand.php:235",
                "/var/www/kbin/vendor/symfony/console/Command/Command.php:279",
                "/var/www/kbin/vendor/symfony/console/Application.php:1049",
                "/var/www/kbin/vendor/symfony/framework-bundle/Console/Application.php:125",
                "/var/www/kbin/vendor/symfony/console/Application.php:318",
                "/var/www/kbin/vendor/symfony/framework-bundle/Console/Application.php:79",
                "/var/www/kbin/vendor/symfony/console/Application.php:169",
                "/var/www/kbin/vendor/symfony/runtime/Runner/Symfony/ConsoleApplicationRunner.php:49",
                "/var/www/kbin/vendor/autoload_runtime.php:29",
                "/var/www/kbin/bin/console:15"
            ],
            "previous": {
                "class": "TypeError",
                "message": "json_decode(): Argument #1 ($json) must be of type string, array given",
                "code": 0,
                "file": "/var/www/kbin/src/Service/ActivityPub/ApHttpClient.php:210",
                "trace": [
                    "/var/www/kbin/src/Service/ActivityPub/ApHttpClient.php:210",
                    "/var/www/kbin/src/Service/ActivityPubManager.php:179",
                    "/var/www/kbin/src/Service/ActivityPub/SignatureValidator.php:112",
                    "/var/www/kbin/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php:50",
                    "/var/www/kbin/vendor/symfony/messenger/Middleware/HandleMessageMiddleware.php:152",
                    "/var/www/kbin/vendor/symfony/messenger/Middleware/HandleMessageMiddleware.php:91",
                    "/var/www/kbin/vendor/symfony/messenger/Middleware/SendMessageMiddleware.php:71",
                    "/var/www/kbin/vendor/symfony/messenger/Middleware/FailedMessageProcessingMiddleware.php:34",
                    "/var/www/kbin/vendor/symfony/messenger/Middleware/DispatchAfterCurrentBusMiddleware.php:68",
                    "/var/www/kbin/vendor/symfony/messenger/Middleware/RejectRedeliveredMessageMiddleware.php:41",
                    "/var/www/kbin/vendor/symfony/messenger/Middleware/AddBusNameStampMiddleware.php:37",
                    "/var/www/kbin/vendor/symfony/messenger/MessageBus.php:70",
                    "/var/www/kbin/vendor/symfony/messenger/RoutableMessageBus.php:54",
                    "/var/www/kbin/vendor/symfony/messenger/Worker.php:161",
                    "/var/www/kbin/vendor/symfony/messenger/Worker.php:108",
                    "/var/www/kbin/vendor/symfony/messenger/Command/ConsumeMessagesCommand.php:235",
                    "/var/www/kbin/vendor/symfony/console/Command/Command.php:279",
                    "/var/www/kbin/vendor/symfony/console/Application.php:1049",
                    "/var/www/kbin/vendor/symfony/framework-bundle/Console/Application.php:125",
                    "/var/www/kbin/vendor/symfony/console/Application.php:318",
                    "/var/www/kbin/vendor/symfony/framework-bundle/Console/Application.php:79",
                    "/var/www/kbin/vendor/symfony/console/Application.php:169",
                    "/var/www/kbin/vendor/symfony/runtime/Runner/Symfony/ConsoleApplicationRunner.php:49",
                    "/var/www/kbin/vendor/autoload_runtime.php:29",
                    "/var/www/kbin/bin/console:15"
                ]
            }
        }
    },
    "level": 500,
    "level_name": "CRITICAL",
    "channel": "messenger",
    "datetime": "2024-06-28T10:26:54.032344+00:00",
    "extra": {}
}
```