### PR TITLE
Add new exception to provide descriptive error (returned false) from `openssl_pkey_get_public` in signature validator

### DIFF
--- a/src/Exception/InvalidUserPublicKeyException.php
+++ b/src/Exception/InvalidUserPublicKeyException.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 namespace App\Exception;
 
-final class InvalidUserPublicKeyException extends \Exception
+class InvalidUserPublicKeyException extends \Exception
 {
+    /**
+     * @param string $apProfileId the url from which the activity was received
+     */
+    public function __construct(public string $apProfileId, int $code = 0, \Throwable $previous = null)
+    {
+        $message = "Unable to extract public key for '$apProfileId'.";
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/src/Exception/InvalidUserPublicKeyException.php
+++ b/src/Exception/InvalidUserPublicKeyException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+final class InvalidUserPublicKeyException extends \Exception
+{
+}

--- a/src/Exception/InvalidUserPublicKeyException.php
+++ b/src/Exception/InvalidUserPublicKeyException.php
@@ -7,7 +7,7 @@ namespace App\Exception;
 class InvalidUserPublicKeyException extends \Exception
 {
     /**
-     * @param string $apProfileId the url from which the activity was received
+     * @param string $apProfileId the url of the user where the key cannot be extracted, is malformed, or does not exist
      */
     public function __construct(public string $apProfileId, int $code = 0, \Throwable $previous = null)
     {

--- a/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
@@ -56,7 +56,7 @@ readonly class ActivityHandler
 
                 return;
             } catch (InvalidUserPublicKeyException $exception) {
-                $this->logger->warning("Unable to extract public key for '{user}'.", ['user' => $exception]);
+                $this->logger->warning("Unable to extract public key for '{user}'.", ['user' => $exception->apProfileId]);
 
                 return;
             }

--- a/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
@@ -56,7 +56,7 @@ readonly class ActivityHandler
 
                 return;
             } catch (InvalidUserPublicKeyException $exception) {
-                $this->logger->info("Unable to extract public key for '{user}'.", ['user' => $exception]);
+                $this->logger->warning("Unable to extract public key for '{user}'.", ['user' => $exception]);
 
                 return;
             }

--- a/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
@@ -7,6 +7,7 @@ namespace App\MessageHandler\ActivityPub\Inbox;
 use App\Entity\Magazine;
 use App\Entity\User;
 use App\Exception\InboxForwardingException;
+use App\Exception\InvalidUserPublicKeyException;
 use App\Message\ActivityPub\Inbox\ActivityMessage;
 use App\Message\ActivityPub\Inbox\AddMessage;
 use App\Message\ActivityPub\Inbox\AnnounceMessage;
@@ -52,6 +53,10 @@ readonly class ActivityHandler
                 $this->logger->info("The message was forwarded by {receivedFrom}. Dispatching a new activity message '{origin}'", ['receivedFrom' => $exception->receivedFrom, 'origin' => $exception->realOrigin]);
                 $body = $this->apHttpClient->getActivityObject($exception->realOrigin, false);
                 $this->bus->dispatch(new ActivityMessage($body));
+
+                return;
+            } catch (InvalidUserPublicKeyException $exception) {
+                $this->logger->info("Unable to extract public key for '{user}'.", ['user' => $exception]);
 
                 return;
             }

--- a/src/Service/ActivityPub/SignatureValidator.php
+++ b/src/Service/ActivityPub/SignatureValidator.php
@@ -113,7 +113,16 @@ readonly class SignatureValidator
 
         $user = $this->activityPubManager->findActorOrCreate($actorUrl);
         if (!empty($user)) {
-            $pkey = openssl_pkey_get_public($this->client->getActorObject($user->apProfileId)['publicKey']['publicKeyPem']);
+            try {
+                $userPkey = $this->client->getActorObject($user->apProfileId)['publicKey']['publicKeyPem'];
+            } catch (\Exception $e) {
+            }
+
+            if (!$userPkey) {
+                throw new InvalidUserPublicKeyException($user->apProfileId);
+            }
+
+            $pkey = openssl_pkey_get_public($userPkey);
 
             if (false === $pkey) {
                 throw new InvalidUserPublicKeyException($user->apProfileId);

--- a/src/Service/ActivityPub/SignatureValidator.php
+++ b/src/Service/ActivityPub/SignatureValidator.php
@@ -33,7 +33,7 @@ readonly class SignatureValidator
      * @param string $body    The body of the incoming request
      *
      * @throws InvalidApSignatureException   The HTTP request was not signed appropriately
-     * @throws InvalidUserPublicKeyException The public key of the specific user is invalid or null
+     * @throws InvalidUserPublicKeyException The public key of the specified user is invalid or null
      * @throws InboxForwardingException
      */
     public function validate(array $request, array $headers, string $body): void

--- a/src/Service/ActivityPub/SignatureValidator.php
+++ b/src/Service/ActivityPub/SignatureValidator.php
@@ -116,7 +116,7 @@ readonly class SignatureValidator
             $pkey = openssl_pkey_get_public($this->client->getActorObject($user->apProfileId)['publicKey']['publicKeyPem']);
 
             if (false === $pkey) {
-                throw new InvalidUserPublicKeyException("Unable to extract public key for user: '$user->apProfileId'");
+                throw new InvalidUserPublicKeyException($user->apProfileId);
             }
 
             $this->verifySignature($pkey, $signature, $headers, $request['uri'], $body);

--- a/src/Service/ActivityPub/SignatureValidator.php
+++ b/src/Service/ActivityPub/SignatureValidator.php
@@ -112,6 +112,11 @@ readonly class SignatureValidator
         $user = $this->activityPubManager->findActorOrCreate($actorUrl);
         if (!empty($user)) {
             $pkey = openssl_pkey_get_public($this->client->getActorObject($user->apProfileId)['publicKey']['publicKeyPem']);
+
+            if (false === $pkey) {
+                throw new InvalidApSignatureException("Unable to extract public key for user: '$user->apProfileId'");
+            }
+
             $this->verifySignature($pkey, $signature, $headers, $request['uri'], $body);
         }
     }

--- a/src/Service/ActivityPub/SignatureValidator.php
+++ b/src/Service/ActivityPub/SignatureValidator.php
@@ -118,10 +118,6 @@ readonly class SignatureValidator
             } catch (\Exception $e) {
             }
 
-            if (!$userPkey) {
-                throw new InvalidUserPublicKeyException($user->apProfileId);
-            }
-
             $pkey = openssl_pkey_get_public($userPkey);
 
             if (false === $pkey) {

--- a/src/Service/ActivityPub/SignatureValidator.php
+++ b/src/Service/ActivityPub/SignatureValidator.php
@@ -6,6 +6,7 @@ namespace App\Service\ActivityPub;
 
 use App\Exception\InboxForwardingException;
 use App\Exception\InvalidApSignatureException;
+use App\Exception\InvalidUserPublicKeyException;
 use App\Message\ActivityPub\Inbox\ActivityMessage;
 use App\Service\ActivityPubManager;
 use Psr\Log\LoggerInterface;
@@ -31,7 +32,8 @@ readonly class SignatureValidator
      * @param array  $headers Headers attached to the incoming request
      * @param string $body    The body of the incoming request
      *
-     * @throws InvalidApSignatureException The HTTP request was not signed appropriately
+     * @throws InvalidApSignatureException   The HTTP request was not signed appropriately
+     * @throws InvalidUserPublicKeyException The public key of the specific user is invalid or null
      * @throws InboxForwardingException
      */
     public function validate(array $request, array $headers, string $body): void
@@ -114,7 +116,7 @@ readonly class SignatureValidator
             $pkey = openssl_pkey_get_public($this->client->getActorObject($user->apProfileId)['publicKey']['publicKeyPem']);
 
             if (false === $pkey) {
-                throw new InvalidApSignatureException("Unable to extract public key for user: '$user->apProfileId'");
+                throw new InvalidUserPublicKeyException("Unable to extract public key for user: '$user->apProfileId'");
             }
 
             $this->verifySignature($pkey, $signature, $headers, $request['uri'], $body);

--- a/src/Service/ActivityPub/SignatureValidator.php
+++ b/src/Service/ActivityPub/SignatureValidator.php
@@ -113,12 +113,7 @@ readonly class SignatureValidator
 
         $user = $this->activityPubManager->findActorOrCreate($actorUrl);
         if (!empty($user)) {
-            try {
-                $userPkey = $this->client->getActorObject($user->apProfileId)['publicKey']['publicKeyPem'];
-            } catch (\Exception $e) {
-            }
-
-            $pkey = openssl_pkey_get_public($userPkey);
+            $pkey = openssl_pkey_get_public($this->client->getActorObject($user->apProfileId)['publicKey']['publicKeyPem']);
 
             if (false === $pkey) {
                 throw new InvalidUserPublicKeyException($user->apProfileId);


### PR DESCRIPTION
Provide more insight into this error thrown in messenger logs and properly handle exception.

Before:
```
00:56:32 WARNING   [php] Warning: Trying to access array offset on value of type null ["exception" => ErrorException { …}]
00:56:32 WARNING   [php] Warning: Trying to access array offset on value of type null ["exception" => ErrorException { …}]
00:56:32 WARNING   [messenger] Error thrown while handling message App\Message\ActivityPub\Inbox\ActivityMessage. Sending for retry #1 using 300000 ms delay. Error: "Handling "App\Message\ActivityPub\Inbox\ActivityMessage" failed: App\Service\ActivityPub\SignatureValidator::verifySignature(): Argument #1 ($pkey) must be of type OpenSSLAsymmetricKey, bool given, called in /var/www/kbin/src/Service/ActivityPub/SignatureValidator.php on line 115" ["class" => "App\Message\ActivityPub\Inbox\ActivityMessage","retryCount" => 1,"delay" => 300000,"error" => "Handling "App\Message\ActivityPub\Inbox\ActivityMessage" failed: App\Service\ActivityPub\SignatureValidator::verifySignature(): Argument #1 ($pkey) must be of type OpenSSLAsymmetricKey, bool given, called in /var/www/kbin/src/Service/ActivityPub/SignatureValidator.php on line 115","exception" => Symfony\Component\Messenger\Exception\HandlerFailedException { …}]
```

After:
```
02:33:20 WARNING   [php] Warning: Undefined array key "publicKey" ["exception" => ErrorException { …}]
02:33:20 WARNING   [php] Warning: Trying to access array offset on value of type null ["exception" => ErrorException { …}]
02:33:20 WARNING   [app] Unable to extract public key for 'https://mastodon.social/users/edisonparadaweb'. ["user" => "https://mastodon.social/users/edisonparadaweb"]
```

In this case, https://mastodon.social/users/edisonparadaweb doesn't exist anymore.