### PR TITLE
Cleanup deprecation warnings in Symfony profiler pre 1.6.1 release

### DIFF
--- a/config/packages/liip_imagine.yaml
+++ b/config/packages/liip_imagine.yaml
@@ -19,7 +19,7 @@ liip_imagine:
     data_loader: kbin.liip_loader
     default_image: null
     twig:
-        mode: legacy
+        mode: lazy
     default_filter_set_settings:
         quality: 90
 

--- a/src/Provider/Authentik.php
+++ b/src/Provider/Authentik.php
@@ -23,37 +23,37 @@ class Authentik extends AbstractProvider
         parent::__construct($options, $collaborators);
     }
 
-    protected function getBaseUrl()
+    protected function getBaseUrl(): string
     {
         return rtrim($this->baseUrl, '/').'/';
     }
 
-    protected function getAuthorizationHeaders($token = null)
+    protected function getAuthorizationHeaders($token = null): array
     {
         return ['Authorization' => 'Bearer '.$token];
     }
 
-    public function getBaseAuthorizationUrl()
+    public function getBaseAuthorizationUrl(): string
     {
         return $this->getBaseUrl().'application/o/authorize/';
     }
 
-    public function getBaseAccessTokenUrl(array $params)
+    public function getBaseAccessTokenUrl(array $params): string
     {
         return $this->getBaseUrl().'application/o/token/';
     }
 
-    public function getResourceOwnerDetailsUrl(AccessToken $token)
+    public function getResourceOwnerDetailsUrl(AccessToken $token): string
     {
         return $this->getBaseUrl().'application/o/userinfo/';
     }
 
-    protected function getDefaultScopes()
+    protected function getDefaultScopes(): array
     {
         return ['openid', 'profile', 'email'];
     }
 
-    protected function checkResponse(ResponseInterface $response, $data)
+    protected function checkResponse(ResponseInterface $response, $data): void
     {
         if (!empty($data['error'])) {
             $error = htmlentities($data['error'], ENT_QUOTES, 'UTF-8');
@@ -62,12 +62,12 @@ class Authentik extends AbstractProvider
         }
     }
 
-    protected function createResourceOwner(array $response, AccessToken $token)
+    protected function createResourceOwner(array $response, AccessToken $token): AuthentikResourceOwner
     {
         return new AuthentikResourceOwner($response);
     }
 
-    protected function getScopeSeparator()
+    protected function getScopeSeparator(): string
     {
         return ' ';
     }

--- a/src/Provider/AuthentikResourceOwner.php
+++ b/src/Provider/AuthentikResourceOwner.php
@@ -15,42 +15,42 @@ class AuthentikResourceOwner implements ResourceOwnerInterface
         $this->response = $response;
     }
 
-    public function getId()
+    public function getId(): mixed
     {
         return $this->getResponseValue('sub');
     }
 
-    public function getEmail()
+    public function getEmail(): mixed
     {
         return $this->getResponseValue('email');
     }
 
-    public function getFamilyName()
+    public function getFamilyName(): mixed
     {
         return $this->getResponseValue('family_name');
     }
 
-    public function getGivenName()
+    public function getGivenName(): mixed
     {
         return $this->getResponseValue('given_name');
     }
 
-    public function getPreferredUsername()
+    public function getPreferredUsername(): mixed
     {
         return $this->getResponseValue('preferred_username');
     }
 
-    public function getPictureUrl()
+    public function getPictureUrl(): mixed
     {
         return $this->getResponseValue('picture');
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         return $this->response;
     }
 
-    protected function getResponseValue($key)
+    protected function getResponseValue($key): mixed
     {
         $keys = explode('.', $key);
         $value = $this->response;

--- a/src/Provider/SimpleLogin.php
+++ b/src/Provider/SimpleLogin.php
@@ -21,37 +21,37 @@ class SimpleLogin extends AbstractProvider
         parent::__construct($options, $collaborators);
     }
 
-    protected function getBaseUrl()
+    protected function getBaseUrl(): string
     {
         return rtrim($this->baseUrl, '/').'/';
     }
 
-    protected function getAuthorizationHeaders($token = null)
+    protected function getAuthorizationHeaders($token = null): array
     {
         return ['Authorization' => 'Bearer '.$token];
     }
 
-    public function getBaseAuthorizationUrl()
+    public function getBaseAuthorizationUrl(): string
     {
         return $this->getBaseUrl().'oauth2/authorize';
     }
 
-    public function getBaseAccessTokenUrl(array $params)
+    public function getBaseAccessTokenUrl(array $params): string
     {
         return $this->getBaseUrl().'oauth2/token';
     }
 
-    public function getResourceOwnerDetailsUrl(AccessToken $token)
+    public function getResourceOwnerDetailsUrl(AccessToken $token): string
     {
         return $this->getBaseUrl().'oauth2/userinfo';
     }
 
-    protected function getDefaultScopes()
+    protected function getDefaultScopes(): array
     {
         return ['openid', 'profile', 'email'];
     }
 
-    protected function checkResponse(ResponseInterface $response, $data)
+    protected function checkResponse(ResponseInterface $response, $data): void
     {
         if (!empty($data['error'])) {
             $error = htmlentities($data['error'], ENT_QUOTES, 'UTF-8');
@@ -60,12 +60,12 @@ class SimpleLogin extends AbstractProvider
         }
     }
 
-    protected function createResourceOwner(array $response, AccessToken $token)
+    protected function createResourceOwner(array $response, AccessToken $token): SimpleLoginResourceOwner
     {
         return new SimpleLoginResourceOwner($response);
     }
 
-    protected function getScopeSeparator()
+    protected function getScopeSeparator(): string
     {
         return ' ';
     }

--- a/src/Provider/SimpleLoginResourceOwner.php
+++ b/src/Provider/SimpleLoginResourceOwner.php
@@ -15,32 +15,32 @@ class SimpleLoginResourceOwner implements ResourceOwnerInterface
         $this->response = $response;
     }
 
-    public function getId()
+    public function getId(): mixed
     {
         return $this->getResponseValue('sub');
     }
 
-    public function getName()
+    public function getName(): mixed
     {
         return $this->getResponseValue('name');
     }
 
-    public function getEmail()
+    public function getEmail(): mixed
     {
         return $this->getResponseValue('email');
     }
 
-    public function getPictureUrl()
+    public function getPictureUrl(): mixed
     {
         return $this->getResponseValue('avatar_url');
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         return $this->response;
     }
 
-    protected function getResponseValue($key)
+    protected function getResponseValue($key): mixed
     {
         $keys = explode('.', $key);
         $value = $this->response;

--- a/src/Provider/Zitadel.php
+++ b/src/Provider/Zitadel.php
@@ -23,37 +23,37 @@ class Zitadel extends AbstractProvider
         parent::__construct($options, $collaborators);
     }
 
-    protected function getBaseUrl()
+    protected function getBaseUrl(): string
     {
         return rtrim($this->baseUrl, '/').'/';
     }
 
-    protected function getAuthorizationHeaders($token = null)
+    protected function getAuthorizationHeaders($token = null): array
     {
         return ['Authorization' => 'Bearer '.$token];
     }
 
-    public function getBaseAuthorizationUrl()
+    public function getBaseAuthorizationUrl(): string
     {
         return $this->getBaseUrl().'oauth/v2/authorize';
     }
 
-    public function getBaseAccessTokenUrl(array $params)
+    public function getBaseAccessTokenUrl(array $params): string
     {
         return $this->getBaseUrl().'oauth/v2/token';
     }
 
-    public function getResourceOwnerDetailsUrl(AccessToken $token)
+    public function getResourceOwnerDetailsUrl(AccessToken $token): string
     {
         return $this->getBaseUrl().'oidc/v1/userinfo';
     }
 
-    protected function getDefaultScopes()
+    protected function getDefaultScopes(): array
     {
         return ['openid', 'profile', 'email'];
     }
 
-    protected function checkResponse(ResponseInterface $response, $data)
+    protected function checkResponse(ResponseInterface $response, $data): void
     {
         if (!empty($data['error'])) {
             $error = htmlentities($data['error'], ENT_QUOTES, 'UTF-8');
@@ -62,12 +62,12 @@ class Zitadel extends AbstractProvider
         }
     }
 
-    protected function createResourceOwner(array $response, AccessToken $token)
+    protected function createResourceOwner(array $response, AccessToken $token): ZitadelResourceOwner
     {
         return new ZitadelResourceOwner($response);
     }
 
-    protected function getScopeSeparator()
+    protected function getScopeSeparator(): string
     {
         return ' ';
     }

--- a/src/Provider/ZitadelResourceOwner.php
+++ b/src/Provider/ZitadelResourceOwner.php
@@ -15,42 +15,42 @@ class ZitadelResourceOwner implements ResourceOwnerInterface
         $this->response = $response;
     }
 
-    public function getId()
+    public function getId(): mixed
     {
         return $this->getResponseValue('sub');
     }
 
-    public function getEmail()
+    public function getEmail(): mixed
     {
         return $this->getResponseValue('email');
     }
 
-    public function getFamilyName()
+    public function getFamilyName(): mixed
     {
         return $this->getResponseValue('family_name');
     }
 
-    public function getGivenName()
+    public function getGivenName(): mixed
     {
         return $this->getResponseValue('given_name');
     }
 
-    public function getPreferredUsername()
+    public function getPreferredUsername(): mixed
     {
         return $this->getResponseValue('preferred_username');
     }
 
-    public function getPictureUrl()
+    public function getPictureUrl(): mixed
     {
         return $this->getResponseValue('picture');
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         return $this->response;
     }
 
-    protected function getResponseValue($key)
+    protected function getResponseValue($key): mixed
     {
         $keys = explode('.', $key);
         $value = $this->response;


### PR DESCRIPTION
**Before:**

several (aka all...) generic/custom SSO methods are missing an explicit return type

![image](https://github.com/MbinOrg/mbin/assets/35878315/99c14681-9758-4c4b-9a83-6f87bcd98df6)

and liip twig mode config

![image](https://github.com/MbinOrg/mbin/assets/35878315/789e0ba4-46fe-480b-bb2a-c53a4462df3f)

**After:**

![image](https://github.com/MbinOrg/mbin/assets/35878315/344af6e3-7f3f-443b-95a2-9df3e96e2e95)

The few remaining are from packages we use and need further investigation, but it's good practice to knock these down before any upgrades to the Symfony version.