### PR TITLE
Add send direct message button to profile

### DIFF
--- a/templates/components/user_actions.html.twig
+++ b/templates/components/user_actions.html.twig
@@ -36,9 +36,9 @@
             </button>
             <input type="hidden" name="token" value="{{ csrf_token('block') }}">
         </form>
-        <a href="{{ path('messages_create', {username: user.username}) }}" title="{{ 'send_message'|trans }}" aria-label="{{ 'send_message'|trans }}">
+        <a href="{{ path('messages_create', {username: user.username}) }}" title="{{ 'private_message'|trans }}" aria-label="{{ 'private_message'|trans }}">
             <button class="btn btn__secondary">
-                <i class="fa-solid fa-envelope" aria-hidden="true"></i> <span>{{ 'send_message'|trans }}</span>
+                <i class="fa-solid fa-envelope" aria-hidden="true"></i> <span>{{ 'private_message'|trans }}</span>
             </button>
         </a>
     {% elseif app.user is same as user and is_route_name_starts_with('user') and not is_route_name_contains('settings') %}

--- a/templates/components/user_actions.html.twig
+++ b/templates/components/user_actions.html.twig
@@ -36,9 +36,9 @@
             </button>
             <input type="hidden" name="token" value="{{ csrf_token('block') }}">
         </form>
-        <a href="{{ path('messages_create', {username: user.username}) }}" title="{{ 'private_message'|trans }}" aria-label="{{ 'private_message'|trans }}">
+        <a href="{{ path('messages_create', {username: user.username}) }}" title="{{ 'direct_message'|trans }}" aria-label="{{ 'direct_message'|trans }}">
             <button class="btn btn__secondary">
-                <i class="fa-solid fa-envelope" aria-hidden="true"></i> <span>{{ 'private_message'|trans }}</span>
+                <i class="fa-solid fa-envelope" aria-hidden="true"></i> <span class="hide-on-mobile">{{ 'direct_message'|trans }}</span>
             </button>
         </a>
     {% elseif app.user is same as user and is_route_name_starts_with('user') and not is_route_name_contains('settings') %}

--- a/templates/components/user_actions.html.twig
+++ b/templates/components/user_actions.html.twig
@@ -36,7 +36,7 @@
             </button>
             <input type="hidden" name="token" value="{{ csrf_token('block') }}">
         </form>
-        <a href="{{ path('user_message', {username: user.username}) }}" title="{{ 'send_message'|trans }}" aria-label="{{ 'send_message'|trans }}">
+        <a href="{{ path('messages_create', {username: user.username}) }}" title="{{ 'send_message'|trans }}" aria-label="{{ 'send_message'|trans }}">
             <button class="btn btn__secondary">{{ 'send_message'|trans }}</button>
         </a>
     {% elseif app.user is same as user and is_route_name_starts_with('user') and not is_route_name_contains('settings') %}

--- a/templates/components/user_actions.html.twig
+++ b/templates/components/user_actions.html.twig
@@ -36,6 +36,9 @@
             </button>
             <input type="hidden" name="token" value="{{ csrf_token('block') }}">
         </form>
+        <a href="{{ path('user_message', {username: user.username}) }}" title="{{ 'send_message'|trans }}" aria-label="{{ 'send_message'|trans }}">
+            <button class="btn btn__secondary">{{ 'send_message'|trans }}</button>
+        </a>
     {% elseif app.user is same as user and is_route_name_starts_with('user') and not is_route_name_contains('settings') %}
         <a href="{{ path('user_settings_profile') }}" title="{{ 'edit_my_profile'|trans }}" aria-label="{{ 'edit_my_profile'|trans }}">
             <button class="btn btn__secondary">{{ 'edit_my_profile'|trans }}</button>

--- a/templates/components/user_actions.html.twig
+++ b/templates/components/user_actions.html.twig
@@ -37,7 +37,9 @@
             <input type="hidden" name="token" value="{{ csrf_token('block') }}">
         </form>
         <a href="{{ path('messages_create', {username: user.username}) }}" title="{{ 'send_message'|trans }}" aria-label="{{ 'send_message'|trans }}">
-            <button class="btn btn__secondary">{{ 'send_message'|trans }}</button>
+            <button class="btn btn__secondary">
+                <i class="fa-solid fa-envelope" aria-hidden="true"></i> <span>{{ 'send_message'|trans }}</span>
+            </button>
         </a>
     {% elseif app.user is same as user and is_route_name_starts_with('user') and not is_route_name_contains('settings') %}
         <a href="{{ path('user_settings_profile') }}" title="{{ 'edit_my_profile'|trans }}" aria-label="{{ 'edit_my_profile'|trans }}">

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -87,8 +87,7 @@ from: from
 username: Username
 email: Email
 repeat_password: Repeat password
-agree_terms:
-  Consent to %terms_link_start%Terms and Conditions%terms_link_end% and
+agree_terms: Consent to %terms_link_start%Terms and Conditions%terms_link_end% and
   %policy_link_start%Privacy Policy%policy_link_end%
 terms: Terms of service
 privacy_policy: Privacy policy
@@ -109,8 +108,7 @@ change_theme: Change theme
 useful: Useful
 help: Help
 check_email: Check your email
-reset_check_email_desc:
-  If there is already an account associated with your email
+reset_check_email_desc: If there is already an account associated with your email
   address, you should receive an email shortly containing a link that you can use
   to reset your password. This link will expire in %expire%.
 reset_check_email_desc2: If you don't receive an email please check your spam folder.
@@ -209,8 +207,7 @@ notify_on_new_entry_reply: Any level comments in threads I authored
 notify_on_new_entry_comment_reply: Replies to my comments in any threads
 notify_on_new_post_reply: Any level replies to posts I authored
 notify_on_new_post_comment_reply: Replies to my comments on any posts
-notify_on_new_entry:
-  New threads (links or articles) in any magazine to which I'm
+notify_on_new_entry: New threads (links or articles) in any magazine to which I'm
   subscribed
 notify_on_new_posts: New posts in any magazine to which I'm subscribed
 save: Save
@@ -255,18 +252,15 @@ he_banned: ban
 he_unbanned: unban
 read_all: Read all
 show_all: Show all
-flash_register_success:
-  Welcome aboard! Your account is now registered. One last step
+flash_register_success: Welcome aboard! Your account is now registered. One last step
   - check your inbox for an activation link that will bring your account to life.
-flash_thread_new_success:
-  The thread has been created successfully and is now visible
+flash_thread_new_success: The thread has been created successfully and is now visible
   to other users.
 flash_thread_edit_success: The thread has been successfully edited.
 flash_thread_delete_success: The thread has been successfully deleted.
 flash_thread_pin_success: The thread has been successfully pinned.
 flash_thread_unpin_success: The thread has been successfully unpinned.
-flash_magazine_new_success:
-  The magazine has been created successfully. You can now
+flash_magazine_new_success: The magazine has been created successfully. You can now
   add new content or explore the magazine's administration panel.
 flash_magazine_edit_success: The magazine has been successfully edited.
 flash_mark_as_adult_success: The post has been successfully marked as NSFW.
@@ -274,11 +268,9 @@ flash_unmark_as_adult_success: The post has been successfully unmarked as NSFW.
 too_many_requests: Limit exceeded, please try again later.
 set_magazines_bar: Magazines bar
 set_magazines_bar_desc: add the magazine names after the comma
-set_magazines_bar_empty_desc:
-  if the field is empty, active magazines are displayed
+set_magazines_bar_empty_desc: if the field is empty, active magazines are displayed
   on the bar.
-mod_log_alert:
-  WARNING - The Modlog may contain unpleasant or distressing content
+mod_log_alert: WARNING - The Modlog may contain unpleasant or distressing content
   that has been removed by moderators. Please exercise caution.
 added_new_thread: Added a new thread
 edited_thread: Edited a thread
@@ -322,12 +314,10 @@ approve: Approve
 ban: Ban
 unban: Unban
 ban_hashtag_btn: Ban Hashtag
-ban_hashtag_description:
-  Banning a hashtag will stop posts with this hashtag from being created,
+ban_hashtag_description: Banning a hashtag will stop posts with this hashtag from being created,
   as well as hiding existing posts with this hashtag.
 unban_hashtag_btn: Unban Hashtag
-unban_hashtag_description:
-  Unbanning a hashtag will allow creating posts with this hashtag again.
+unban_hashtag_description: Unbanning a hashtag will allow creating posts with this hashtag again.
   Existing posts with this hashtag are no longer hidden.
 filters: Filters
 approved: Approved
@@ -394,23 +384,20 @@ ban_account: Ban account
 unban_account: Unban account
 related_magazines: Related magazines
 random_magazines: Random magazines
-magazine_panel_tags_info:
-  Provide only if you want content from the fediverse to be
+magazine_panel_tags_info: Provide only if you want content from the fediverse to be
   included in this magazine based on tags
 sidebar: Sidebar
 auto_preview: Auto media preview
 dynamic_lists: Dynamic lists
 banned_instances: Banned instances
 kbin_intro_title: Explore the Fediverse
-kbin_intro_desc:
-  is a decentralized platform for content aggregation and microblogging
+kbin_intro_desc: is a decentralized platform for content aggregation and microblogging
   that operates within the Fediverse network.
 kbin_promo_title: Create your own instance
 kbin_promo_desc: '%link_start%Clone repo%link_end% and develop fediverse'
 captcha_enabled: Captcha enabled
 header_logo: Header logo
-browsing_one_thread:
-  You are only browsing one thread in the discussion! All comments
+browsing_one_thread: You are only browsing one thread in the discussion! All comments
   are available on the post page.
 return: Return
 boost: Boost
@@ -418,8 +405,7 @@ mercure_enabled: Mercure enabled
 report_issue: Report issue
 tokyo_night: Tokyo Night
 preferred_languages: Filter languages of threads and posts
-infinite_scroll_help:
-  Automatically load more content when you reach the bottom of
+infinite_scroll_help: Automatically load more content when you reach the bottom of
   the page.
 sticky_navbar_help: The navbar will stick to the top of the page when you scroll down.
 auto_preview_help: Automatically expand media previews.
@@ -434,8 +420,7 @@ local_and_federated: Local and federated
 filter.fields.only_names: Only names
 filter.fields.names_and_descriptions: Names and descriptions
 kbin_bot: Mbin Agent
-bot_body_content:
-  "Welcome to the Mbin Agent! This agent plays a crucial role in enabling
+bot_body_content: "Welcome to the Mbin Agent! This agent plays a crucial role in enabling
   ActivityPub functionality within Mbin. It ensures that Mbin can communicate and
   federate with other instances in the fediverse.\n\nActivityPub is an open standard
   protocol that allows decentralized social networking platforms to communicate and
@@ -445,8 +430,7 @@ bot_body_content:
   users, and engage in social interactions such as liking, sharing, and commenting
   on threads or posts."
 password_confirm_header: Confirm your password change request.
-your_account_is_not_active:
-  Your account has not been activated. Please check your
+your_account_is_not_active: Your account has not been activated. Please check your
   email for account activation instructions or <a href="%link_target%">request a new
   account activation email.</a>
 your_account_has_been_banned: Your account has been banned
@@ -465,19 +449,16 @@ federation_page_enabled: Federation page enabled
 federation_page_allowed_description: Known instances we federate with
 federation_page_disallowed_description: Instances we do not federate with
 federated_search_only_loggedin: Federated search limited if not logged in
-sidebar_sections_local_only:
-  Restrict "Random X" and "Active People" sections to local
+sidebar_sections_local_only: Restrict "Random X" and "Active People" sections to local
   only
 account_deletion_title: Account deletion
-account_deletion_description:
-  Your account will be deleted in 30 days unless you choose to delete the account immediately.
+account_deletion_description: Your account will be deleted in 30 days unless you choose to delete the account immediately.
   The account cannot be restored once deleted.
 account_deletion_button: Delete Account
 account_deletion_immediate: Delete immediately
 more_from_domain: More from domain
 errors.server500.title: 500 Internal Server Error
-errors.server500.description:
-  Sorry, something went wrong on our end. If you continue
+errors.server500.description: Sorry, something went wrong on our end. If you continue
   to see this error, try contacting the instance owner. If this instance is not working
   at all, check out %link_start%other Mbin instances%link_end% in the meanwhile until
   the problem is resolved.
@@ -485,36 +466,30 @@ errors.server429.title: 429 Too Many Requests
 errors.server404.title: 404 Not found
 errors.server403.title: 403 Forbidden
 email_confirm_button_text: Confirm your password change request
-email_confirm_link_help:
-  Alternatively you can copy and paste the following into your
+email_confirm_link_help: Alternatively you can copy and paste the following into your
   browser
 email.delete.title: User account deletion request
 email.delete.description: The following user has requested that their account be deleted
 resend_account_activation_email_question: Inactive account?
 resend_account_activation_email: Re-send account activation email
-resend_account_activation_email_error:
-  There was an issue submitting this request.
+resend_account_activation_email_error: There was an issue submitting this request.
   There may be no account associated with that email or perhaps it is already activated.
-resend_account_activation_email_success:
-  If an account associated with that email
+resend_account_activation_email_success: If an account associated with that email
   exists, we will send out a new activation email.
-resend_account_activation_email_description:
-  Enter the email address associated with
+resend_account_activation_email_description: Enter the email address associated with
   your account. We will send out another activation email for you.
 custom_css: Custom CSS
 ignore_magazines_custom_css: Ignore magazines custom CSS
 oauth.consent.title: OAuth2 Consent Form
 oauth.consent.grant_permissions: Grant Permissions
-oauth.consent.app_requesting_permissions:
-  would like to perform the following actions
+oauth.consent.app_requesting_permissions: would like to perform the following actions
   on your behalf
 oauth.consent.app_has_permissions: can already perform the following actions
 oauth.consent.to_allow_access: To allow this access, click the 'Allow' button below
 oauth.consent.allow: Allow
 oauth.consent.deny: Deny
 oauth.client_identifier.invalid: Invalid OAuth Client ID!
-oauth.client_not_granted_message_read_permission:
-  This app has not received permission
+oauth.client_not_granted_message_read_permission: This app has not received permission
   to read your messages.
 restrict_oauth_clients: Restrict OAuth2 Client creation to Admins
 private_instance: Force users to login before they can access any content
@@ -524,30 +499,23 @@ oauth2.grant.moderate.magazine.ban.delete: Unban users in your moderated magazin
 oauth2.grant.moderate.magazine.list: Read a list of your moderated magazines.
 oauth2.grant.moderate.magazine.reports.all: Manage reports in your moderated magazines.
 oauth2.grant.moderate.magazine.reports.read: Read reports in your moderated magazines.
-oauth2.grant.moderate.magazine.reports.action:
-  Accept or reject reports in your moderated
+oauth2.grant.moderate.magazine.reports.action: Accept or reject reports in your moderated
   magazines.
-oauth2.grant.moderate.magazine.trash.read:
-  View trashed content in your moderated
+oauth2.grant.moderate.magazine.trash.read: View trashed content in your moderated
   magazines.
 oauth2.grant.moderate.magazine_admin.all: Create, edit, or delete your owned magazines.
 oauth2.grant.moderate.magazine_admin.create: Create new magazines.
 oauth2.grant.moderate.magazine_admin.delete: Delete any of your owned magazines.
-oauth2.grant.moderate.magazine_admin.update:
-  Edit any of your owned magazines' rules,
+oauth2.grant.moderate.magazine_admin.update: Edit any of your owned magazines' rules,
   description, NSFW status, or icon.
-oauth2.grant.moderate.magazine_admin.edit_theme:
-  Edit the custom CSS of any of your
+oauth2.grant.moderate.magazine_admin.edit_theme: Edit the custom CSS of any of your
   owned magazines.
-oauth2.grant.moderate.magazine_admin.moderators:
-  Add or remove moderators of any of
+oauth2.grant.moderate.magazine_admin.moderators: Add or remove moderators of any of
   your owned magazines.
-oauth2.grant.moderate.magazine_admin.badges:
-  Create or remove badges from your owned
+oauth2.grant.moderate.magazine_admin.badges: Create or remove badges from your owned
   magazines.
 oauth2.grant.moderate.magazine_admin.tags: Create or remove tags from your owned magazines.
-oauth2.grant.moderate.magazine_admin.stats:
-  View the content, vote, and view stats
+oauth2.grant.moderate.magazine_admin.stats: View the content, vote, and view stats
   of your owned magazines.
 oauth2.grant.admin.all: Perform any administrative action on your instance.
 oauth2.grant.admin.entry.purge: Completely delete any thread from your instance.
@@ -556,64 +524,51 @@ oauth2.grant.write.general: Create or edit any of your threads, posts, or commen
 oauth2.grant.delete.general: Delete any of your threads, posts, or comments.
 oauth2.grant.report.general: Report threads, posts, or comments.
 oauth2.grant.vote.general: Upvote, downvote, or boost threads, posts, or comments.
-oauth2.grant.subscribe.general:
-  Subscribe or follow any magazine, domain, or user,
+oauth2.grant.subscribe.general: Subscribe or follow any magazine, domain, or user,
   and view the magazines, domains, and users you subscribe to.
-oauth2.grant.block.general:
-  Block or unblock any magazine, domain, or user, and view
+oauth2.grant.block.general: Block or unblock any magazine, domain, or user, and view
   the magazines, domains, and users you have blocked.
-oauth2.grant.domain.all:
-  Subscribe to or block domains, and view the domains you subscribe
+oauth2.grant.domain.all: Subscribe to or block domains, and view the domains you subscribe
   to or block.
-oauth2.grant.domain.subscribe:
-  Subscribe or unsubscribe to domains and view the domains
+oauth2.grant.domain.subscribe: Subscribe or unsubscribe to domains and view the domains
   you subscribe to.
-oauth2.grant.domain.block:
-  Block or unblock domains and view the domains you have
+oauth2.grant.domain.block: Block or unblock domains and view the domains you have
   blocked.
-oauth2.grant.entry.all:
-  Create, edit, or delete your threads, and vote, boost, or
+oauth2.grant.entry.all: Create, edit, or delete your threads, and vote, boost, or
   report any thread.
 oauth2.grant.entry.create: Create new threads.
 oauth2.grant.entry.edit: Edit your existing threads.
 oauth2.grant.entry.delete: Delete your existing threads.
 oauth2.grant.entry.vote: Upvote, boost, or downvote any thread.
 oauth2.grant.entry.report: Report any thread.
-oauth2.grant.entry_comment.all:
-  Create, edit, or delete your comments in threads,
+oauth2.grant.entry_comment.all: Create, edit, or delete your comments in threads,
   and vote, boost, or report any comment in a thread.
 oauth2.grant.entry_comment.create: Create new comments in threads.
 oauth2.grant.entry_comment.edit: Edit your existing comments in threads.
 oauth2.grant.entry_comment.delete: Delete your existing comments in threads.
 oauth2.grant.entry_comment.vote: Upvote, boost, or downvote any comment in a thread.
 oauth2.grant.entry_comment.report: Report any comment in a thread.
-oauth2.grant.magazine.all:
-  Subscribe to or block magazines, and view the magazines
+oauth2.grant.magazine.all: Subscribe to or block magazines, and view the magazines
   you subscribe to or block.
-oauth2.grant.magazine.subscribe:
-  Subscribe or unsubscribe to magazines and view the
+oauth2.grant.magazine.subscribe: Subscribe or unsubscribe to magazines and view the
   magazines you subscribe to.
-oauth2.grant.magazine.block:
-  Block or unblock magazines and view the magazines you
+oauth2.grant.magazine.block: Block or unblock magazines and view the magazines you
   have blocked.
-oauth2.grant.post.all:
-  Create, edit, or delete your microblogs, and vote, boost, or
+oauth2.grant.post.all: Create, edit, or delete your microblogs, and vote, boost, or
   report any microblog.
 oauth2.grant.post.create: Create new posts.
 oauth2.grant.post.edit: Edit your existing posts.
 oauth2.grant.post.delete: Delete your existing posts.
 oauth2.grant.post.vote: Upvote, boost, or downvote any post.
 oauth2.grant.post.report: Report any post.
-oauth2.grant.post_comment.all:
-  Create, edit, or delete your comments on posts, and
+oauth2.grant.post_comment.all: Create, edit, or delete your comments on posts, and
   vote, boost, or report any comment on a post.
 oauth2.grant.post_comment.create: Create new comments on posts.
 oauth2.grant.post_comment.edit: Edit your existing comments on posts.
 oauth2.grant.post_comment.delete: Delete your existing comments on posts.
 oauth2.grant.post_comment.vote: Upvote, boost, or downvote any comment on a post.
 oauth2.grant.post_comment.report: Report any comment on a post.
-oauth2.grant.user.all:
-  Read and edit your profile, messages, or notifications; Read
+oauth2.grant.user.all: Read and edit your profile, messages, or notifications; Read
   and edit permissions you've granted other apps; follow or block other users; view
   lists of users you follow or block.
 oauth2.grant.user.profile.all: Read and edit your profile.
@@ -625,72 +580,54 @@ oauth2.grant.user.message.create: Send messages to other users.
 oauth2.grant.user.notification.all: Read and clear your notifications.
 oauth2.grant.user.notification.read: Read your notifications, including message notifications.
 oauth2.grant.user.notification.delete: Clear your notifications.
-oauth2.grant.user.oauth_clients.all:
-  Read and edit the permissions you have granted
+oauth2.grant.user.oauth_clients.all: Read and edit the permissions you have granted
   to other OAuth2 applications.
-oauth2.grant.user.oauth_clients.read:
-  Read the permissions you have granted to other
+oauth2.grant.user.oauth_clients.read: Read the permissions you have granted to other
   OAuth2 applications.
-oauth2.grant.user.oauth_clients.edit:
-  Edit the permissions you have granted to other
+oauth2.grant.user.oauth_clients.edit: Edit the permissions you have granted to other
   OAuth2 applications.
 oauth2.grant.user.follow: Follow or unfollow users, and read a list of users you follow.
 oauth2.grant.user.block: Block or unblock users, and read a list of users you block.
-oauth2.grant.moderate.all:
-  Perform any moderation action you have permission to perform
+oauth2.grant.moderate.all: Perform any moderation action you have permission to perform
   in your moderated magazines.
 oauth2.grant.moderate.entry.all: Moderate threads in your moderated magazines.
-oauth2.grant.moderate.entry.change_language:
-  Change the language of threads in your
+oauth2.grant.moderate.entry.change_language: Change the language of threads in your
   moderated magazines.
 oauth2.grant.moderate.entry.pin: Pin threads to the top of your moderated magazines.
 oauth2.grant.moderate.entry.set_adult: Mark threads as NSFW in your moderated magazines.
 oauth2.grant.moderate.entry.trash: Trash or restore threads in your moderated magazines.
-oauth2.grant.moderate.entry_comment.all:
-  Moderate comments in threads in your moderated
+oauth2.grant.moderate.entry_comment.all: Moderate comments in threads in your moderated
   magazines.
-oauth2.grant.moderate.entry_comment.change_language:
-  Change the language of comments
+oauth2.grant.moderate.entry_comment.change_language: Change the language of comments
   in threads in your moderated magazines.
-oauth2.grant.moderate.entry_comment.set_adult:
-  Mark comments in threads as NSFW in
+oauth2.grant.moderate.entry_comment.set_adult: Mark comments in threads as NSFW in
   your moderated magazines.
-oauth2.grant.moderate.entry_comment.trash:
-  Trash or restore comments in threads in
+oauth2.grant.moderate.entry_comment.trash: Trash or restore comments in threads in
   your moderated magazines.
 oauth2.grant.moderate.post.all: Moderate posts in your moderated magazines.
-oauth2.grant.moderate.post.change_language:
-  Change the language of posts in your moderated
+oauth2.grant.moderate.post.change_language: Change the language of posts in your moderated
   magazines.
 oauth2.grant.moderate.post.set_adult: Mark posts as NSFW in your moderated magazines.
 oauth2.grant.moderate.post.trash: Trash or restore posts in your moderated magazines.
-oauth2.grant.moderate.post_comment.all:
-  Moderate comments on posts in your moderated
+oauth2.grant.moderate.post_comment.all: Moderate comments on posts in your moderated
   magazines.
-oauth2.grant.moderate.post_comment.change_language:
-  Change the language of comments
+oauth2.grant.moderate.post_comment.change_language: Change the language of comments
   on posts in your moderated magazines.
-oauth2.grant.moderate.post_comment.set_adult:
-  Mark comments on posts as NSFW in your
+oauth2.grant.moderate.post_comment.set_adult: Mark comments on posts as NSFW in your
   moderated magazines.
-oauth2.grant.moderate.post_comment.trash:
-  Trash or restore comments on posts in your
+oauth2.grant.moderate.post_comment.trash: Trash or restore comments on posts in your
   moderated magazines.
-oauth2.grant.moderate.magazine.all:
-  Manage bans, reports, and view trashed items in
+oauth2.grant.moderate.magazine.all: Manage bans, reports, and view trashed items in
   your moderated magazines.
 oauth2.grant.moderate.magazine.ban.all: Manage banned users in your moderated magazines.
 oauth2.grant.moderate.magazine.ban.read: View banned users in your moderated magazines.
 oauth2.grant.moderate.magazine.ban.create: Ban users in your moderated magazines.
-oauth2.grant.admin.entry_comment.purge:
-  Completely delete any comment in a thread
+oauth2.grant.admin.entry_comment.purge: Completely delete any comment in a thread
   from your instance.
 oauth2.grant.admin.post.purge: Completely delete any post from your instance.
-oauth2.grant.admin.post_comment.purge:
-  Completely delete any comment on a post from
+oauth2.grant.admin.post_comment.purge: Completely delete any comment on a post from
   your instance.
-oauth2.grant.admin.magazine.all:
-  Move threads between or completely delete magazines
+oauth2.grant.admin.magazine.all: Move threads between or completely delete magazines
   on your instance.
 oauth2.grant.admin.magazine.move_entry: Move threads between magazines on your instance.
 oauth2.grant.admin.magazine.purge: Completely delete magazines on your instance.
@@ -704,65 +641,51 @@ oauth2.grant.admin.instance.stats: View your instance's stats.
 oauth2.grant.admin.instance.settings.all: View or update settings on your instance.
 oauth2.grant.admin.instance.settings.read: View settings on your instance.
 oauth2.grant.admin.instance.settings.edit: Update settings on your instance.
-oauth2.grant.admin.instance.information.edit:
-  Update the About, FAQ, Contact, Terms
+oauth2.grant.admin.instance.information.edit: Update the About, FAQ, Contact, Terms
   of Service, and Privacy Policy pages on your instance.
 oauth2.grant.admin.federation.all: View and update currently defederated instances.
 oauth2.grant.admin.federation.read: View the list of defederated instances.
-oauth2.grant.admin.federation.update:
-  Add or remove instances to or from the list
+oauth2.grant.admin.federation.update: Add or remove instances to or from the list
   of defederated instances.
-oauth2.grant.admin.oauth_clients.all:
-  View or revoke OAuth2 clients that exist on
+oauth2.grant.admin.oauth_clients.all: View or revoke OAuth2 clients that exist on
   your instance.
-oauth2.grant.admin.oauth_clients.read:
-  View the OAuth2 clients that exist on your
+oauth2.grant.admin.oauth_clients.read: View the OAuth2 clients that exist on your
   instance, and their usage stats.
 oauth2.grant.admin.oauth_clients.revoke: Revoke access to OAuth2 clients on your instance.
 last_active: Last Active
 flash_post_pin_success: The post has been successfully pinned.
 flash_post_unpin_success: The post has been successfully unpinned.
-comment_reply_position_help:
-  Display the comment reply form either at the top or bottom
+comment_reply_position_help: Display the comment reply form either at the top or bottom
   of the page. When 'infinite scroll' is enabled the position will always appear at
   the top.
 show_avatars_on_comments: Show Comment Avatars
 single_settings: Single
 update_comment: Update comment
-show_avatars_on_comments_help:
-  Display/hide user avatars when viewing comments on
+show_avatars_on_comments_help: Display/hide user avatars when viewing comments on
   a single thread or post.
 comment_reply_position: Comment reply position
-magazine_theme_appearance_custom_css:
-  Custom CSS that will apply when viewing content
+magazine_theme_appearance_custom_css: Custom CSS that will apply when viewing content
   within your magazine.
-magazine_theme_appearance_icon:
-  Custom icon for the magazine. If none is selected,
+magazine_theme_appearance_icon: Custom icon for the magazine. If none is selected,
   the default icon will be used.
-magazine_theme_appearance_background_image:
-  Custom background image that will be applied
+magazine_theme_appearance_background_image: Custom background image that will be applied
   when viewing content within your magazine.
 moderation.report.approve_report_title: Approve Report
 moderation.report.reject_report_title: Reject Report
-moderation.report.ban_user_description:
-  Do you want to ban the user (%username%) who
+moderation.report.ban_user_description: Do you want to ban the user (%username%) who
   created this content from this magazine?
-moderation.report.approve_report_confirmation:
-  Are you sure that you want to approve
+moderation.report.approve_report_confirmation: Are you sure that you want to approve
   this report?
 subject_reported_exists: This content has already been reported.
 moderation.report.ban_user_title: Ban User
-moderation.report.reject_report_confirmation:
-  Are you sure that you want to reject
+moderation.report.reject_report_confirmation: Are you sure that you want to reject
   this report?
 oauth2.grant.moderate.post.pin: Pin posts to the top of your moderated magazines.
 delete_content: Delete content
 purge_content: Purge content
-delete_content_desc:
-  Delete the user's content while leaving the responses of other
+delete_content_desc: Delete the user's content while leaving the responses of other
   users in the created threads, posts and comments.
-purge_content_desc:
-  Completely purge the user's content, including deleting the responses
+purge_content_desc: Completely purge the user's content, including deleting the responses
   of other users in created threads, posts and comments.
 delete_account_desc: Delete the account, including the responses
   of other users in created threads, posts and comments.
@@ -781,34 +704,27 @@ two_factor_backup: Two-factor authentication backup codes
 2fa.enable: Setup two-factor authentication
 2fa.disable: Disable two-factor authentication
 2fa.backup: Your two-factor backup codes
-2fa.backup-create.help:
-  You can create new backup authentication codes; doing so will
+2fa.backup-create.help: You can create new backup authentication codes; doing so will
   invalidate existing codes.
 2fa.backup-create.label: Create new backup authentication codes
 2fa.remove: Remove 2FA
 2fa.add: Add to my account
 2fa.verify_authentication_code.label: Enter a two-factor code to verify setup
-2fa.qr_code_img.alt:
-  A QR code that allows the setup of two-factor authentication
+2fa.qr_code_img.alt: A QR code that allows the setup of two-factor authentication
   for your account
-2fa.qr_code_link.title:
-  Visiting this link may allow your platform to register this
+2fa.qr_code_link.title: Visiting this link may allow your platform to register this
   two-factor authentication
 2fa.user_active_tfa.title: User has active 2FA
-2fa.available_apps:
-  Use a two-factor authentication app such as %google_authenticator%,
+2fa.available_apps: Use a two-factor authentication app such as %google_authenticator%,
   %aegis% (Android) or %raivo% (iOS) to scan the QR-code.
-2fa.backup_codes.help:
-  You can use these codes when you don't have your two-factor
+2fa.backup_codes.help: You can use these codes when you don't have your two-factor
   authentication device or app. You will <strong>not be shown them again</strong>
   and will be able to use each of them <strong>only once</strong>.
-2fa.backup_codes.recommendation:
-  It is recommended that you keep a copy of them in
+2fa.backup_codes.recommendation: It is recommended that you keep a copy of them in
   a safe place.
 cancel: Cancel
 password_and_2fa: Password & 2FA
-flash_account_settings_changed:
-  Your account settings have been successfully changed.
+flash_account_settings_changed: Your account settings have been successfully changed.
   You will need to login again.
 show_subscriptions: Show subscriptions
 subscription_sort: Sort
@@ -855,23 +771,20 @@ open_url_to_fediverse: Open original URL
 change_my_avatar: Change my avatar
 change_my_cover: Change my cover
 edit_my_profile: Edit my profile
-account_settings_changed:
-  Your account settings have been successfully changed. You
+account_settings_changed: Your account settings have been successfully changed. You
   will need to login again.
 magazine_deletion: Magazine deletion
 delete_magazine: Delete magazine
 restore_magazine: Restore magazine
 purge_magazine: Purge magazine
-magazine_is_deleted:
-  Magazine is deleted. You can <a href="%link_target%">restore</a>
+magazine_is_deleted: Magazine is deleted. You can <a href="%link_target%">restore</a>
   it within 30 days.
 suspend_account: Suspend account
 unsuspend_account: Unsuspend account
 account_suspended: The account has been suspended.
 account_unsuspended: The account has been unsuspended.
 deletion: Deletion
-user_suspend_desc:
-  Suspending your account hides your content on the instance, but
+user_suspend_desc: Suspending your account hides your content on the instance, but
   doesn't permanently remove it, and you can restore it at any time.
 account_banned: The account has been banned.
 account_unbanned: The account has been unbanned.

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -292,7 +292,7 @@ comment: Comment
 post: Post
 ban_expired: Ban expired
 purge: Purge
-send_message: Send private message
+send_message: Send direct message
 message: Message
 infinite_scroll: Infinite scrolling
 show_top_bar: Show top bar
@@ -832,4 +832,4 @@ magazine_log_mod_added: has added a moderator
 magazine_log_mod_removed: has removed a moderator
 last_updated: Last updated
 and: and
-private_message: Private message
+direct_message: Direct message

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -87,7 +87,8 @@ from: from
 username: Username
 email: Email
 repeat_password: Repeat password
-agree_terms: Consent to %terms_link_start%Terms and Conditions%terms_link_end% and
+agree_terms:
+  Consent to %terms_link_start%Terms and Conditions%terms_link_end% and
   %policy_link_start%Privacy Policy%policy_link_end%
 terms: Terms of service
 privacy_policy: Privacy policy
@@ -108,7 +109,8 @@ change_theme: Change theme
 useful: Useful
 help: Help
 check_email: Check your email
-reset_check_email_desc: If there is already an account associated with your email
+reset_check_email_desc:
+  If there is already an account associated with your email
   address, you should receive an email shortly containing a link that you can use
   to reset your password. This link will expire in %expire%.
 reset_check_email_desc2: If you don't receive an email please check your spam folder.
@@ -207,7 +209,8 @@ notify_on_new_entry_reply: Any level comments in threads I authored
 notify_on_new_entry_comment_reply: Replies to my comments in any threads
 notify_on_new_post_reply: Any level replies to posts I authored
 notify_on_new_post_comment_reply: Replies to my comments on any posts
-notify_on_new_entry: New threads (links or articles) in any magazine to which I'm
+notify_on_new_entry:
+  New threads (links or articles) in any magazine to which I'm
   subscribed
 notify_on_new_posts: New posts in any magazine to which I'm subscribed
 save: Save
@@ -252,15 +255,18 @@ he_banned: ban
 he_unbanned: unban
 read_all: Read all
 show_all: Show all
-flash_register_success: Welcome aboard! Your account is now registered. One last step
+flash_register_success:
+  Welcome aboard! Your account is now registered. One last step
   - check your inbox for an activation link that will bring your account to life.
-flash_thread_new_success: The thread has been created successfully and is now visible
+flash_thread_new_success:
+  The thread has been created successfully and is now visible
   to other users.
 flash_thread_edit_success: The thread has been successfully edited.
 flash_thread_delete_success: The thread has been successfully deleted.
 flash_thread_pin_success: The thread has been successfully pinned.
 flash_thread_unpin_success: The thread has been successfully unpinned.
-flash_magazine_new_success: The magazine has been created successfully. You can now
+flash_magazine_new_success:
+  The magazine has been created successfully. You can now
   add new content or explore the magazine's administration panel.
 flash_magazine_edit_success: The magazine has been successfully edited.
 flash_mark_as_adult_success: The post has been successfully marked as NSFW.
@@ -268,9 +274,11 @@ flash_unmark_as_adult_success: The post has been successfully unmarked as NSFW.
 too_many_requests: Limit exceeded, please try again later.
 set_magazines_bar: Magazines bar
 set_magazines_bar_desc: add the magazine names after the comma
-set_magazines_bar_empty_desc: if the field is empty, active magazines are displayed
+set_magazines_bar_empty_desc:
+  if the field is empty, active magazines are displayed
   on the bar.
-mod_log_alert: WARNING - The Modlog may contain unpleasant or distressing content
+mod_log_alert:
+  WARNING - The Modlog may contain unpleasant or distressing content
   that has been removed by moderators. Please exercise caution.
 added_new_thread: Added a new thread
 edited_thread: Edited a thread
@@ -292,7 +300,7 @@ comment: Comment
 post: Post
 ban_expired: Ban expired
 purge: Purge
-send_message: Send message
+send_message: Send private message
 message: Message
 infinite_scroll: Infinite scrolling
 show_top_bar: Show top bar
@@ -314,10 +322,12 @@ approve: Approve
 ban: Ban
 unban: Unban
 ban_hashtag_btn: Ban Hashtag
-ban_hashtag_description: Banning a hashtag will stop posts with this hashtag from being created,
+ban_hashtag_description:
+  Banning a hashtag will stop posts with this hashtag from being created,
   as well as hiding existing posts with this hashtag.
 unban_hashtag_btn: Unban Hashtag
-unban_hashtag_description: Unbanning a hashtag will allow creating posts with this hashtag again.
+unban_hashtag_description:
+  Unbanning a hashtag will allow creating posts with this hashtag again.
   Existing posts with this hashtag are no longer hidden.
 filters: Filters
 approved: Approved
@@ -384,20 +394,23 @@ ban_account: Ban account
 unban_account: Unban account
 related_magazines: Related magazines
 random_magazines: Random magazines
-magazine_panel_tags_info: Provide only if you want content from the fediverse to be
+magazine_panel_tags_info:
+  Provide only if you want content from the fediverse to be
   included in this magazine based on tags
 sidebar: Sidebar
 auto_preview: Auto media preview
 dynamic_lists: Dynamic lists
 banned_instances: Banned instances
 kbin_intro_title: Explore the Fediverse
-kbin_intro_desc: is a decentralized platform for content aggregation and microblogging
+kbin_intro_desc:
+  is a decentralized platform for content aggregation and microblogging
   that operates within the Fediverse network.
 kbin_promo_title: Create your own instance
 kbin_promo_desc: '%link_start%Clone repo%link_end% and develop fediverse'
 captcha_enabled: Captcha enabled
 header_logo: Header logo
-browsing_one_thread: You are only browsing one thread in the discussion! All comments
+browsing_one_thread:
+  You are only browsing one thread in the discussion! All comments
   are available on the post page.
 return: Return
 boost: Boost
@@ -405,7 +418,8 @@ mercure_enabled: Mercure enabled
 report_issue: Report issue
 tokyo_night: Tokyo Night
 preferred_languages: Filter languages of threads and posts
-infinite_scroll_help: Automatically load more content when you reach the bottom of
+infinite_scroll_help:
+  Automatically load more content when you reach the bottom of
   the page.
 sticky_navbar_help: The navbar will stick to the top of the page when you scroll down.
 auto_preview_help: Automatically expand media previews.
@@ -420,7 +434,8 @@ local_and_federated: Local and federated
 filter.fields.only_names: Only names
 filter.fields.names_and_descriptions: Names and descriptions
 kbin_bot: Mbin Agent
-bot_body_content: "Welcome to the Mbin Agent! This agent plays a crucial role in enabling
+bot_body_content:
+  "Welcome to the Mbin Agent! This agent plays a crucial role in enabling
   ActivityPub functionality within Mbin. It ensures that Mbin can communicate and
   federate with other instances in the fediverse.\n\nActivityPub is an open standard
   protocol that allows decentralized social networking platforms to communicate and
@@ -430,7 +445,8 @@ bot_body_content: "Welcome to the Mbin Agent! This agent plays a crucial role in
   users, and engage in social interactions such as liking, sharing, and commenting
   on threads or posts."
 password_confirm_header: Confirm your password change request.
-your_account_is_not_active: Your account has not been activated. Please check your
+your_account_is_not_active:
+  Your account has not been activated. Please check your
   email for account activation instructions or <a href="%link_target%">request a new
   account activation email.</a>
 your_account_has_been_banned: Your account has been banned
@@ -449,16 +465,19 @@ federation_page_enabled: Federation page enabled
 federation_page_allowed_description: Known instances we federate with
 federation_page_disallowed_description: Instances we do not federate with
 federated_search_only_loggedin: Federated search limited if not logged in
-sidebar_sections_local_only: Restrict "Random X" and "Active People" sections to local
+sidebar_sections_local_only:
+  Restrict "Random X" and "Active People" sections to local
   only
 account_deletion_title: Account deletion
-account_deletion_description: Your account will be deleted in 30 days unless you choose to delete the account immediately.
+account_deletion_description:
+  Your account will be deleted in 30 days unless you choose to delete the account immediately.
   The account cannot be restored once deleted.
 account_deletion_button: Delete Account
 account_deletion_immediate: Delete immediately
 more_from_domain: More from domain
 errors.server500.title: 500 Internal Server Error
-errors.server500.description: Sorry, something went wrong on our end. If you continue
+errors.server500.description:
+  Sorry, something went wrong on our end. If you continue
   to see this error, try contacting the instance owner. If this instance is not working
   at all, check out %link_start%other Mbin instances%link_end% in the meanwhile until
   the problem is resolved.
@@ -466,30 +485,36 @@ errors.server429.title: 429 Too Many Requests
 errors.server404.title: 404 Not found
 errors.server403.title: 403 Forbidden
 email_confirm_button_text: Confirm your password change request
-email_confirm_link_help: Alternatively you can copy and paste the following into your
+email_confirm_link_help:
+  Alternatively you can copy and paste the following into your
   browser
 email.delete.title: User account deletion request
 email.delete.description: The following user has requested that their account be deleted
 resend_account_activation_email_question: Inactive account?
 resend_account_activation_email: Re-send account activation email
-resend_account_activation_email_error: There was an issue submitting this request.
+resend_account_activation_email_error:
+  There was an issue submitting this request.
   There may be no account associated with that email or perhaps it is already activated.
-resend_account_activation_email_success: If an account associated with that email
+resend_account_activation_email_success:
+  If an account associated with that email
   exists, we will send out a new activation email.
-resend_account_activation_email_description: Enter the email address associated with
+resend_account_activation_email_description:
+  Enter the email address associated with
   your account. We will send out another activation email for you.
 custom_css: Custom CSS
 ignore_magazines_custom_css: Ignore magazines custom CSS
 oauth.consent.title: OAuth2 Consent Form
 oauth.consent.grant_permissions: Grant Permissions
-oauth.consent.app_requesting_permissions: would like to perform the following actions
+oauth.consent.app_requesting_permissions:
+  would like to perform the following actions
   on your behalf
 oauth.consent.app_has_permissions: can already perform the following actions
 oauth.consent.to_allow_access: To allow this access, click the 'Allow' button below
 oauth.consent.allow: Allow
 oauth.consent.deny: Deny
 oauth.client_identifier.invalid: Invalid OAuth Client ID!
-oauth.client_not_granted_message_read_permission: This app has not received permission
+oauth.client_not_granted_message_read_permission:
+  This app has not received permission
   to read your messages.
 restrict_oauth_clients: Restrict OAuth2 Client creation to Admins
 private_instance: Force users to login before they can access any content
@@ -499,23 +524,30 @@ oauth2.grant.moderate.magazine.ban.delete: Unban users in your moderated magazin
 oauth2.grant.moderate.magazine.list: Read a list of your moderated magazines.
 oauth2.grant.moderate.magazine.reports.all: Manage reports in your moderated magazines.
 oauth2.grant.moderate.magazine.reports.read: Read reports in your moderated magazines.
-oauth2.grant.moderate.magazine.reports.action: Accept or reject reports in your moderated
+oauth2.grant.moderate.magazine.reports.action:
+  Accept or reject reports in your moderated
   magazines.
-oauth2.grant.moderate.magazine.trash.read: View trashed content in your moderated
+oauth2.grant.moderate.magazine.trash.read:
+  View trashed content in your moderated
   magazines.
 oauth2.grant.moderate.magazine_admin.all: Create, edit, or delete your owned magazines.
 oauth2.grant.moderate.magazine_admin.create: Create new magazines.
 oauth2.grant.moderate.magazine_admin.delete: Delete any of your owned magazines.
-oauth2.grant.moderate.magazine_admin.update: Edit any of your owned magazines' rules,
+oauth2.grant.moderate.magazine_admin.update:
+  Edit any of your owned magazines' rules,
   description, NSFW status, or icon.
-oauth2.grant.moderate.magazine_admin.edit_theme: Edit the custom CSS of any of your
+oauth2.grant.moderate.magazine_admin.edit_theme:
+  Edit the custom CSS of any of your
   owned magazines.
-oauth2.grant.moderate.magazine_admin.moderators: Add or remove moderators of any of
+oauth2.grant.moderate.magazine_admin.moderators:
+  Add or remove moderators of any of
   your owned magazines.
-oauth2.grant.moderate.magazine_admin.badges: Create or remove badges from your owned
+oauth2.grant.moderate.magazine_admin.badges:
+  Create or remove badges from your owned
   magazines.
 oauth2.grant.moderate.magazine_admin.tags: Create or remove tags from your owned magazines.
-oauth2.grant.moderate.magazine_admin.stats: View the content, vote, and view stats
+oauth2.grant.moderate.magazine_admin.stats:
+  View the content, vote, and view stats
   of your owned magazines.
 oauth2.grant.admin.all: Perform any administrative action on your instance.
 oauth2.grant.admin.entry.purge: Completely delete any thread from your instance.
@@ -524,51 +556,64 @@ oauth2.grant.write.general: Create or edit any of your threads, posts, or commen
 oauth2.grant.delete.general: Delete any of your threads, posts, or comments.
 oauth2.grant.report.general: Report threads, posts, or comments.
 oauth2.grant.vote.general: Upvote, downvote, or boost threads, posts, or comments.
-oauth2.grant.subscribe.general: Subscribe or follow any magazine, domain, or user,
+oauth2.grant.subscribe.general:
+  Subscribe or follow any magazine, domain, or user,
   and view the magazines, domains, and users you subscribe to.
-oauth2.grant.block.general: Block or unblock any magazine, domain, or user, and view
+oauth2.grant.block.general:
+  Block or unblock any magazine, domain, or user, and view
   the magazines, domains, and users you have blocked.
-oauth2.grant.domain.all: Subscribe to or block domains, and view the domains you subscribe
+oauth2.grant.domain.all:
+  Subscribe to or block domains, and view the domains you subscribe
   to or block.
-oauth2.grant.domain.subscribe: Subscribe or unsubscribe to domains and view the domains
+oauth2.grant.domain.subscribe:
+  Subscribe or unsubscribe to domains and view the domains
   you subscribe to.
-oauth2.grant.domain.block: Block or unblock domains and view the domains you have
+oauth2.grant.domain.block:
+  Block or unblock domains and view the domains you have
   blocked.
-oauth2.grant.entry.all: Create, edit, or delete your threads, and vote, boost, or
+oauth2.grant.entry.all:
+  Create, edit, or delete your threads, and vote, boost, or
   report any thread.
 oauth2.grant.entry.create: Create new threads.
 oauth2.grant.entry.edit: Edit your existing threads.
 oauth2.grant.entry.delete: Delete your existing threads.
 oauth2.grant.entry.vote: Upvote, boost, or downvote any thread.
 oauth2.grant.entry.report: Report any thread.
-oauth2.grant.entry_comment.all: Create, edit, or delete your comments in threads,
+oauth2.grant.entry_comment.all:
+  Create, edit, or delete your comments in threads,
   and vote, boost, or report any comment in a thread.
 oauth2.grant.entry_comment.create: Create new comments in threads.
 oauth2.grant.entry_comment.edit: Edit your existing comments in threads.
 oauth2.grant.entry_comment.delete: Delete your existing comments in threads.
 oauth2.grant.entry_comment.vote: Upvote, boost, or downvote any comment in a thread.
 oauth2.grant.entry_comment.report: Report any comment in a thread.
-oauth2.grant.magazine.all: Subscribe to or block magazines, and view the magazines
+oauth2.grant.magazine.all:
+  Subscribe to or block magazines, and view the magazines
   you subscribe to or block.
-oauth2.grant.magazine.subscribe: Subscribe or unsubscribe to magazines and view the
+oauth2.grant.magazine.subscribe:
+  Subscribe or unsubscribe to magazines and view the
   magazines you subscribe to.
-oauth2.grant.magazine.block: Block or unblock magazines and view the magazines you
+oauth2.grant.magazine.block:
+  Block or unblock magazines and view the magazines you
   have blocked.
-oauth2.grant.post.all: Create, edit, or delete your microblogs, and vote, boost, or
+oauth2.grant.post.all:
+  Create, edit, or delete your microblogs, and vote, boost, or
   report any microblog.
 oauth2.grant.post.create: Create new posts.
 oauth2.grant.post.edit: Edit your existing posts.
 oauth2.grant.post.delete: Delete your existing posts.
 oauth2.grant.post.vote: Upvote, boost, or downvote any post.
 oauth2.grant.post.report: Report any post.
-oauth2.grant.post_comment.all: Create, edit, or delete your comments on posts, and
+oauth2.grant.post_comment.all:
+  Create, edit, or delete your comments on posts, and
   vote, boost, or report any comment on a post.
 oauth2.grant.post_comment.create: Create new comments on posts.
 oauth2.grant.post_comment.edit: Edit your existing comments on posts.
 oauth2.grant.post_comment.delete: Delete your existing comments on posts.
 oauth2.grant.post_comment.vote: Upvote, boost, or downvote any comment on a post.
 oauth2.grant.post_comment.report: Report any comment on a post.
-oauth2.grant.user.all: Read and edit your profile, messages, or notifications; Read
+oauth2.grant.user.all:
+  Read and edit your profile, messages, or notifications; Read
   and edit permissions you've granted other apps; follow or block other users; view
   lists of users you follow or block.
 oauth2.grant.user.profile.all: Read and edit your profile.
@@ -580,54 +625,72 @@ oauth2.grant.user.message.create: Send messages to other users.
 oauth2.grant.user.notification.all: Read and clear your notifications.
 oauth2.grant.user.notification.read: Read your notifications, including message notifications.
 oauth2.grant.user.notification.delete: Clear your notifications.
-oauth2.grant.user.oauth_clients.all: Read and edit the permissions you have granted
+oauth2.grant.user.oauth_clients.all:
+  Read and edit the permissions you have granted
   to other OAuth2 applications.
-oauth2.grant.user.oauth_clients.read: Read the permissions you have granted to other
+oauth2.grant.user.oauth_clients.read:
+  Read the permissions you have granted to other
   OAuth2 applications.
-oauth2.grant.user.oauth_clients.edit: Edit the permissions you have granted to other
+oauth2.grant.user.oauth_clients.edit:
+  Edit the permissions you have granted to other
   OAuth2 applications.
 oauth2.grant.user.follow: Follow or unfollow users, and read a list of users you follow.
 oauth2.grant.user.block: Block or unblock users, and read a list of users you block.
-oauth2.grant.moderate.all: Perform any moderation action you have permission to perform
+oauth2.grant.moderate.all:
+  Perform any moderation action you have permission to perform
   in your moderated magazines.
 oauth2.grant.moderate.entry.all: Moderate threads in your moderated magazines.
-oauth2.grant.moderate.entry.change_language: Change the language of threads in your
+oauth2.grant.moderate.entry.change_language:
+  Change the language of threads in your
   moderated magazines.
 oauth2.grant.moderate.entry.pin: Pin threads to the top of your moderated magazines.
 oauth2.grant.moderate.entry.set_adult: Mark threads as NSFW in your moderated magazines.
 oauth2.grant.moderate.entry.trash: Trash or restore threads in your moderated magazines.
-oauth2.grant.moderate.entry_comment.all: Moderate comments in threads in your moderated
+oauth2.grant.moderate.entry_comment.all:
+  Moderate comments in threads in your moderated
   magazines.
-oauth2.grant.moderate.entry_comment.change_language: Change the language of comments
+oauth2.grant.moderate.entry_comment.change_language:
+  Change the language of comments
   in threads in your moderated magazines.
-oauth2.grant.moderate.entry_comment.set_adult: Mark comments in threads as NSFW in
+oauth2.grant.moderate.entry_comment.set_adult:
+  Mark comments in threads as NSFW in
   your moderated magazines.
-oauth2.grant.moderate.entry_comment.trash: Trash or restore comments in threads in
+oauth2.grant.moderate.entry_comment.trash:
+  Trash or restore comments in threads in
   your moderated magazines.
 oauth2.grant.moderate.post.all: Moderate posts in your moderated magazines.
-oauth2.grant.moderate.post.change_language: Change the language of posts in your moderated
+oauth2.grant.moderate.post.change_language:
+  Change the language of posts in your moderated
   magazines.
 oauth2.grant.moderate.post.set_adult: Mark posts as NSFW in your moderated magazines.
 oauth2.grant.moderate.post.trash: Trash or restore posts in your moderated magazines.
-oauth2.grant.moderate.post_comment.all: Moderate comments on posts in your moderated
+oauth2.grant.moderate.post_comment.all:
+  Moderate comments on posts in your moderated
   magazines.
-oauth2.grant.moderate.post_comment.change_language: Change the language of comments
+oauth2.grant.moderate.post_comment.change_language:
+  Change the language of comments
   on posts in your moderated magazines.
-oauth2.grant.moderate.post_comment.set_adult: Mark comments on posts as NSFW in your
+oauth2.grant.moderate.post_comment.set_adult:
+  Mark comments on posts as NSFW in your
   moderated magazines.
-oauth2.grant.moderate.post_comment.trash: Trash or restore comments on posts in your
+oauth2.grant.moderate.post_comment.trash:
+  Trash or restore comments on posts in your
   moderated magazines.
-oauth2.grant.moderate.magazine.all: Manage bans, reports, and view trashed items in
+oauth2.grant.moderate.magazine.all:
+  Manage bans, reports, and view trashed items in
   your moderated magazines.
 oauth2.grant.moderate.magazine.ban.all: Manage banned users in your moderated magazines.
 oauth2.grant.moderate.magazine.ban.read: View banned users in your moderated magazines.
 oauth2.grant.moderate.magazine.ban.create: Ban users in your moderated magazines.
-oauth2.grant.admin.entry_comment.purge: Completely delete any comment in a thread
+oauth2.grant.admin.entry_comment.purge:
+  Completely delete any comment in a thread
   from your instance.
 oauth2.grant.admin.post.purge: Completely delete any post from your instance.
-oauth2.grant.admin.post_comment.purge: Completely delete any comment on a post from
+oauth2.grant.admin.post_comment.purge:
+  Completely delete any comment on a post from
   your instance.
-oauth2.grant.admin.magazine.all: Move threads between or completely delete magazines
+oauth2.grant.admin.magazine.all:
+  Move threads between or completely delete magazines
   on your instance.
 oauth2.grant.admin.magazine.move_entry: Move threads between magazines on your instance.
 oauth2.grant.admin.magazine.purge: Completely delete magazines on your instance.
@@ -641,51 +704,65 @@ oauth2.grant.admin.instance.stats: View your instance's stats.
 oauth2.grant.admin.instance.settings.all: View or update settings on your instance.
 oauth2.grant.admin.instance.settings.read: View settings on your instance.
 oauth2.grant.admin.instance.settings.edit: Update settings on your instance.
-oauth2.grant.admin.instance.information.edit: Update the About, FAQ, Contact, Terms
+oauth2.grant.admin.instance.information.edit:
+  Update the About, FAQ, Contact, Terms
   of Service, and Privacy Policy pages on your instance.
 oauth2.grant.admin.federation.all: View and update currently defederated instances.
 oauth2.grant.admin.federation.read: View the list of defederated instances.
-oauth2.grant.admin.federation.update: Add or remove instances to or from the list
+oauth2.grant.admin.federation.update:
+  Add or remove instances to or from the list
   of defederated instances.
-oauth2.grant.admin.oauth_clients.all: View or revoke OAuth2 clients that exist on
+oauth2.grant.admin.oauth_clients.all:
+  View or revoke OAuth2 clients that exist on
   your instance.
-oauth2.grant.admin.oauth_clients.read: View the OAuth2 clients that exist on your
+oauth2.grant.admin.oauth_clients.read:
+  View the OAuth2 clients that exist on your
   instance, and their usage stats.
 oauth2.grant.admin.oauth_clients.revoke: Revoke access to OAuth2 clients on your instance.
 last_active: Last Active
 flash_post_pin_success: The post has been successfully pinned.
 flash_post_unpin_success: The post has been successfully unpinned.
-comment_reply_position_help: Display the comment reply form either at the top or bottom
+comment_reply_position_help:
+  Display the comment reply form either at the top or bottom
   of the page. When 'infinite scroll' is enabled the position will always appear at
   the top.
 show_avatars_on_comments: Show Comment Avatars
 single_settings: Single
 update_comment: Update comment
-show_avatars_on_comments_help: Display/hide user avatars when viewing comments on
+show_avatars_on_comments_help:
+  Display/hide user avatars when viewing comments on
   a single thread or post.
 comment_reply_position: Comment reply position
-magazine_theme_appearance_custom_css: Custom CSS that will apply when viewing content
+magazine_theme_appearance_custom_css:
+  Custom CSS that will apply when viewing content
   within your magazine.
-magazine_theme_appearance_icon: Custom icon for the magazine. If none is selected,
+magazine_theme_appearance_icon:
+  Custom icon for the magazine. If none is selected,
   the default icon will be used.
-magazine_theme_appearance_background_image: Custom background image that will be applied
+magazine_theme_appearance_background_image:
+  Custom background image that will be applied
   when viewing content within your magazine.
 moderation.report.approve_report_title: Approve Report
 moderation.report.reject_report_title: Reject Report
-moderation.report.ban_user_description: Do you want to ban the user (%username%) who
+moderation.report.ban_user_description:
+  Do you want to ban the user (%username%) who
   created this content from this magazine?
-moderation.report.approve_report_confirmation: Are you sure that you want to approve
+moderation.report.approve_report_confirmation:
+  Are you sure that you want to approve
   this report?
 subject_reported_exists: This content has already been reported.
 moderation.report.ban_user_title: Ban User
-moderation.report.reject_report_confirmation: Are you sure that you want to reject
+moderation.report.reject_report_confirmation:
+  Are you sure that you want to reject
   this report?
 oauth2.grant.moderate.post.pin: Pin posts to the top of your moderated magazines.
 delete_content: Delete content
 purge_content: Purge content
-delete_content_desc: Delete the user's content while leaving the responses of other
+delete_content_desc:
+  Delete the user's content while leaving the responses of other
   users in the created threads, posts and comments.
-purge_content_desc: Completely purge the user's content, including deleting the responses
+purge_content_desc:
+  Completely purge the user's content, including deleting the responses
   of other users in created threads, posts and comments.
 delete_account_desc: Delete the account, including the responses
   of other users in created threads, posts and comments.
@@ -704,27 +781,34 @@ two_factor_backup: Two-factor authentication backup codes
 2fa.enable: Setup two-factor authentication
 2fa.disable: Disable two-factor authentication
 2fa.backup: Your two-factor backup codes
-2fa.backup-create.help: You can create new backup authentication codes; doing so will
+2fa.backup-create.help:
+  You can create new backup authentication codes; doing so will
   invalidate existing codes.
 2fa.backup-create.label: Create new backup authentication codes
 2fa.remove: Remove 2FA
 2fa.add: Add to my account
 2fa.verify_authentication_code.label: Enter a two-factor code to verify setup
-2fa.qr_code_img.alt: A QR code that allows the setup of two-factor authentication
+2fa.qr_code_img.alt:
+  A QR code that allows the setup of two-factor authentication
   for your account
-2fa.qr_code_link.title: Visiting this link may allow your platform to register this
+2fa.qr_code_link.title:
+  Visiting this link may allow your platform to register this
   two-factor authentication
 2fa.user_active_tfa.title: User has active 2FA
-2fa.available_apps: Use a two-factor authentication app such as %google_authenticator%,
+2fa.available_apps:
+  Use a two-factor authentication app such as %google_authenticator%,
   %aegis% (Android) or %raivo% (iOS) to scan the QR-code.
-2fa.backup_codes.help: You can use these codes when you don't have your two-factor
+2fa.backup_codes.help:
+  You can use these codes when you don't have your two-factor
   authentication device or app. You will <strong>not be shown them again</strong>
   and will be able to use each of them <strong>only once</strong>.
-2fa.backup_codes.recommendation: It is recommended that you keep a copy of them in
+2fa.backup_codes.recommendation:
+  It is recommended that you keep a copy of them in
   a safe place.
 cancel: Cancel
 password_and_2fa: Password & 2FA
-flash_account_settings_changed: Your account settings have been successfully changed.
+flash_account_settings_changed:
+  Your account settings have been successfully changed.
   You will need to login again.
 show_subscriptions: Show subscriptions
 subscription_sort: Sort
@@ -771,20 +855,23 @@ open_url_to_fediverse: Open original URL
 change_my_avatar: Change my avatar
 change_my_cover: Change my cover
 edit_my_profile: Edit my profile
-account_settings_changed: Your account settings have been successfully changed. You
+account_settings_changed:
+  Your account settings have been successfully changed. You
   will need to login again.
 magazine_deletion: Magazine deletion
 delete_magazine: Delete magazine
 restore_magazine: Restore magazine
 purge_magazine: Purge magazine
-magazine_is_deleted: Magazine is deleted. You can <a href="%link_target%">restore</a>
+magazine_is_deleted:
+  Magazine is deleted. You can <a href="%link_target%">restore</a>
   it within 30 days.
 suspend_account: Suspend account
 unsuspend_account: Unsuspend account
 account_suspended: The account has been suspended.
 account_unsuspended: The account has been unsuspended.
 deletion: Deletion
-user_suspend_desc: Suspending your account hides your content on the instance, but
+user_suspend_desc:
+  Suspending your account hides your content on the instance, but
   doesn't permanently remove it, and you can restore it at any time.
 account_banned: The account has been banned.
 account_unbanned: The account has been unbanned.
@@ -832,3 +919,4 @@ magazine_log_mod_added: has added a moderator
 magazine_log_mod_removed: has removed a moderator
 last_updated: Last updated
 and: and
+private_message: Private message


### PR DESCRIPTION
Goal: Make the (now working) direct message feature better visible for the end-user, instead of looking in the info menu.

- Add an additional button to the profile, calling it "Direct message" since that covers the meaning much better
  - Button comes with an envelope icon and links to the same `<user>/message` path as the existing send message link.
- Rephrase existing "Send message" in _info.html.twig to "Send direct message" to keep it aligned. 


Example:

![image](https://github.com/MbinOrg/mbin/assets/628926/c8b9731d-a623-40a3-9524-0a12fa11c0b9)

Example mobile:

![image](https://github.com/MbinOrg/mbin/assets/628926/860304d7-219e-4ccb-a33e-82310de097ae)
