### PR TITLE
Fix/entry wrong type

### DIFF
--- a/migrations/Version20240701113000.php
+++ b/migrations/Version20240701113000.php
@@ -18,7 +18,7 @@ class Version20240701113000 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $type = Entry::ENTRY_TYPE_IMAGE;
-        $this->addSql("UPDATE entry SET type = '$type' WHERE image_id IS NOT NULL AND url IS NULL");
+        $this->addSql("UPDATE entry SET type = '$type', has_embed = true WHERE image_id IS NOT NULL AND url IS NULL");
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version20240701113000.php
+++ b/migrations/Version20240701113000.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Entity\Entry;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20240701113000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'fix the type of posts without a url, but with an image';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $type = Entry::ENTRY_TYPE_IMAGE;
+        $this->addSql("UPDATE entry SET type = '$type' WHERE image_id IS NOT NULL AND url IS NULL");
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Service/ActivityPub/Page.php
+++ b/src/Service/ActivityPub/Page.php
@@ -100,6 +100,10 @@ class Page
             $dto->apDislikeCount = $this->activityPubManager->extractRemoteDislikeCount($object);
             $dto->apShareCount = $this->activityPubManager->extractRemoteShareCount($object);
 
+            if (null !== $dto->image && null === $dto->url) {
+                $dto->type = Entry::ENTRY_TYPE_IMAGE;
+            }
+
             $this->logger->debug('creating page');
 
             return $this->entryManager->create($dto, $actor, false);

--- a/src/Service/ActivityPub/Page.php
+++ b/src/Service/ActivityPub/Page.php
@@ -100,10 +100,6 @@ class Page
             $dto->apDislikeCount = $this->activityPubManager->extractRemoteDislikeCount($object);
             $dto->apShareCount = $this->activityPubManager->extractRemoteShareCount($object);
 
-            if (null !== $dto->image && null === $dto->url) {
-                $dto->type = Entry::ENTRY_TYPE_IMAGE;
-            }
-
             $this->logger->debug('creating page');
 
             return $this->entryManager->create($dto, $actor, false);

--- a/src/Service/EntryManager.php
+++ b/src/Service/EntryManager.php
@@ -134,7 +134,7 @@ class EntryManager implements ContentManagerInterface
             $isImageUrl = ImageManager::isImageUrl($dto->url);
         }
 
-        if (($dto->image && !$dto->body) || $isImageUrl) {
+        if (($dto->image && !$dto->url) || $isImageUrl) {
             $entry->type = Entry::ENTRY_TYPE_IMAGE;
             $entry->hasEmbed = true;
 


### PR DESCRIPTION
Entries with an image, but with no URL would not have a preview as soon as the body was not empty. That does not make any sense, so I fixed it with this PR

The migration fixes the types already in the DB and new ones should be created correctly.

One example post where it didn't work and works now: https://feddit.org/post/337293
Not working: https://kbin.run/m/ich_iel@feddit.org/t/525694/Ich-iel
working: https://gehirneimer.de/m/ich_iel@feddit.org/t/252880/Ich-iel