### PR TITLE
Remove text from DM button, stops excessive text wrap on desktop view with three columns

### DIFF
--- a/templates/components/user_actions.html.twig
+++ b/templates/components/user_actions.html.twig
@@ -38,7 +38,7 @@
         </form>
         <a href="{{ path('messages_create', {username: user.username}) }}" title="{{ 'direct_message'|trans }}" aria-label="{{ 'direct_message'|trans }}">
             <button class="btn btn__secondary">
-                <i class="fa-solid fa-envelope" aria-hidden="true"></i> <span class="hide-on-mobile">{{ 'direct_message'|trans }}</span>
+                <i class="fa-solid fa-envelope" aria-hidden="true"></i>
             </button>
         </a>
     {% elseif app.user is same as user and is_route_name_starts_with('user') and not is_route_name_contains('settings') %}


### PR DESCRIPTION
PR removes the text from the DM button, stops the smooshed text wrapping on desktop view with 3 column view enabled:

Before:
![image](https://github.com/MbinOrg/mbin/assets/35878315/436a70cb-79d8-49c6-a3dc-4e33d97d7c4e)

![image](https://github.com/MbinOrg/mbin/assets/35878315/4f690feb-d9fa-4c82-9b15-4a7a0b6e3901)

After:
![image](https://github.com/MbinOrg/mbin/assets/35878315/ffd4063c-36bb-416d-aa67-e3bcc934ab08)

![image](https://github.com/MbinOrg/mbin/assets/35878315/3a3ee9eb-7dd1-4326-9d3a-59b8b5e30787)

The envelope icon should be enough to get the point across that this is to message the user... also consider we do the same thing already with the mobile view `<span class="hide-on-mobile">`. I've retained the hover over text fwiw, not that it matters much on mobile anyway.... but at least it will show the translation on desktop