### PR TITLE
Modify all SSO providers to redirect to the profile settings

### DIFF
--- a/src/Security/AuthentikAuthenticator.php
+++ b/src/Security/AuthentikAuthenticator.php
@@ -156,7 +156,7 @@ class AuthentikAuthenticator extends OAuth2Authenticator
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
-        $targetUrl = $this->router->generate('front');
+        $targetUrl = $this->router->generate('user_settings_profile');
 
         return new RedirectResponse($targetUrl);
     }

--- a/src/Security/AzureAuthenticator.php
+++ b/src/Security/AzureAuthenticator.php
@@ -119,7 +119,7 @@ class AzureAuthenticator extends OAuth2Authenticator
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
-        $targetUrl = $this->router->generate('front');
+        $targetUrl = $this->router->generate('user_settings_profile');
 
         return new RedirectResponse($targetUrl);
     }

--- a/src/Security/DiscordAuthenticator.php
+++ b/src/Security/DiscordAuthenticator.php
@@ -128,7 +128,7 @@ class DiscordAuthenticator extends OAuth2Authenticator
         TokenInterface $token,
         string $firewallName
     ): ?Response {
-        $targetUrl = $this->router->generate('front');
+        $targetUrl = $this->router->generate('user_settings_profile');
 
         return new RedirectResponse($targetUrl);
     }

--- a/src/Security/FacebookAuthenticator.php
+++ b/src/Security/FacebookAuthenticator.php
@@ -152,7 +152,7 @@ class FacebookAuthenticator extends OAuth2Authenticator
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
-        $targetUrl = $this->router->generate('front');
+        $targetUrl = $this->router->generate('user_settings_profile');
 
         return new RedirectResponse($targetUrl);
     }

--- a/src/Security/GithubAuthenticator.php
+++ b/src/Security/GithubAuthenticator.php
@@ -102,7 +102,7 @@ class GithubAuthenticator extends OAuth2Authenticator
         TokenInterface $token,
         string $firewallName
     ): ?Response {
-        $targetUrl = $this->router->generate('front');
+        $targetUrl = $this->router->generate('user_settings_profile');
 
         return new RedirectResponse($targetUrl);
     }

--- a/src/Security/GoogleAuthenticator.php
+++ b/src/Security/GoogleAuthenticator.php
@@ -158,7 +158,7 @@ class GoogleAuthenticator extends OAuth2Authenticator
         TokenInterface $token,
         string $firewallName
     ): ?Response {
-        $targetUrl = $this->router->generate('front');
+        $targetUrl = $this->router->generate('user_settings_profile');
 
         return new RedirectResponse($targetUrl);
     }

--- a/src/Security/KeycloakAuthenticator.php
+++ b/src/Security/KeycloakAuthenticator.php
@@ -119,7 +119,7 @@ class KeycloakAuthenticator extends OAuth2Authenticator
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
-        $targetUrl = $this->router->generate('front');
+        $targetUrl = $this->router->generate('user_settings_profile');
 
         return new RedirectResponse($targetUrl);
     }

--- a/src/Security/SimpleLoginAuthenticator.php
+++ b/src/Security/SimpleLoginAuthenticator.php
@@ -164,7 +164,7 @@ class SimpleLoginAuthenticator extends OAuth2Authenticator
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
-        $targetUrl = $this->router->generate('front');
+        $targetUrl = $this->router->generate('user_settings_profile');
 
         return new RedirectResponse($targetUrl);
     }

--- a/src/Security/ZitadelAuthenticator.php
+++ b/src/Security/ZitadelAuthenticator.php
@@ -157,7 +157,7 @@ class ZitadelAuthenticator extends OAuth2Authenticator
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
-        $targetUrl = $this->router->generate('front');
+        $targetUrl = $this->router->generate('user_settings_profile');
 
         return new RedirectResponse($targetUrl);
     }


### PR DESCRIPTION
Make all SSO providers redirect to the profile settings on successful authentication so a user can change the username if they want. When a user already exists a random number is appended to the username, for a user to be able to change their name they must not have interacted with anything and that is unlikely if we redirect them to the home page

Closes #890 