### PR TITLE
Fix PrivacyPortal SSO

### DIFF
--- a/src/Security/PrivacyPortalAuthenticator.php
+++ b/src/Security/PrivacyPortalAuthenticator.php
@@ -6,6 +6,9 @@ namespace App\Security;
 
 use App\DTO\UserDto;
 use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Service\IpResolver;
+use App\Service\SettingsManager;
 use App\Service\UserManager;
 use App\Utils\Slugger;
 use Doctrine\ORM\EntityManagerInterface;
@@ -18,6 +21,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
@@ -29,6 +33,9 @@ class PrivacyPortalAuthenticator extends OAuth2Authenticator
         private readonly RouterInterface $router,
         private readonly EntityManagerInterface $entityManager,
         private readonly UserManager $userManager,
+        private readonly SettingsManager $settingsManager,
+        private readonly UserRepository $userRepository,
+        private readonly IpResolver $ipResolver,
         private readonly Slugger $slugger
     ) {
     }
@@ -73,7 +80,7 @@ class PrivacyPortalAuthenticator extends OAuth2Authenticator
                     throw new CustomUserMessageAuthenticationException('MBIN_SSO_REGISTRATIONS_ENABLED');
                 }
 
-                $username = $slugger->slug($privacyPortalUser->getNickname());
+                $username = $slugger->slug($privacyPortalUser->getName());
 
                 if ($this->userRepository->count(['username' => $username]) > 0) {
                     $username .= rand(1, 9999);


### PR DESCRIPTION
Fix missing class variables and a wrong method call (all according to the provided typing) in the `PrivacyPortalAuthenticator`