### PR TITLE
Also block DataForSeoBot user-agent

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -42,6 +42,9 @@ Disallow: /
 User-agent: SemrushBot
 Disallow: /
 
+User-agent: DataForSeoBot
+Disallow: /
+
 # Rest of indexing robots
 User-agent: *
 Request-rate: 1/1s


### PR DESCRIPTION
- Extend robots.txt with DataForSeoBot, which is yet another annoying SEO marking bot