### PR TITLE
Remove link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mbin
 
-Mbin is a fork of [/kbin](https://codeberg.org/Kbin/kbin-core), community-focused. Feel free to discuss on [Matrix](https://matrix.to/#/#mbin:melroy.org) and to create Pull Requests.
+Mbin is a fork of /kbin, community-focused. Feel free to discuss on [Matrix](https://matrix.to/#/#mbin:melroy.org) and to create Pull Requests.
 
 > [!Important]
 > Mbin is focused on what the community wants, pull requests can be merged by any repo maintainer (with merge rights in GitHub). Discussions take place on [Matrix](https://matrix.to/#/#mbin:melroy.org) then _consensus_ has to be reached by the community. If approved by the community, only one approval on the PR is required by one of the Mbin maintainers. It's built entirely on trust.


### PR DESCRIPTION
/kbin is not actively developed anymore, no need to link back to kbin.