### PR TITLE
Increase lifetime remember me cookie

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -11,7 +11,7 @@ framework:
         handler_id: '%env(REDIS_DNS)%'
         cookie_secure: auto
         cookie_samesite: lax
-        gc_maxlifetime: 604800 # Match the remember_me lifetime
+        gc_maxlifetime: 1814400 # Match the remember_me lifetime
         storage_factory_id: session.storage.factory.native
 
     http_client:

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -49,7 +49,7 @@ security:
             user_checker: App\Security\UserChecker
             remember_me:
                 secret: '%kernel.secret%'
-                lifetime: 604800
+                lifetime: 1814400
                 path: /
                 token_provider:
                     doctrine: true


### PR DESCRIPTION
- Increase lifetime for "remember me" cookie to 3 weeks (instead of only 1week).
- GC max lifetime with the same 3 weeks value