### PR TITLE
Add option to hide related panels

### DIFF
--- a/src/Controller/User/ThemeSettingsController.php
+++ b/src/Controller/User/ThemeSettingsController.php
@@ -33,6 +33,10 @@ class ThemeSettingsController extends AbstractController
     public const KBIN_GENERAL_SIDEBAR_POSITION = 'kbin_general_sidebar_position';
     public const KBIN_GENERAL_DYNAMIC_LISTS = 'kbin_general_dynamic_lists';
     public const KBIN_GENERAL_FILTER_LABELS = 'kbin_general_filter_labels';
+    public const MBIN_GENERAL_SHOW_RELATED_POSTS = 'mbin_general_show_related_posts';
+    public const MBIN_GENERAL_SHOW_RELATED_ENTRIES = 'mbin_general_show_related_entries';
+    public const MBIN_GENERAL_SHOW_RELATED_MAGAZINES = 'mbin_general_show_related_magazines';
+    public const MBIN_GENERAL_SHOW_ACTIVE_USERS = 'mbin_general_show_active_users';
     public const KBIN_COMMENTS_SHOW_USER_AVATAR = 'kbin_comments_show_user_avatar';
     public const KBIN_COMMENTS_REPLY_POSITION = 'kbin_comments_reply_position';
     public const KBIN_SUBSCRIPTIONS_SHOW = 'kbin_subscriptions_show';
@@ -100,6 +104,10 @@ class ThemeSettingsController extends AbstractController
         self::KBIN_SUBSCRIPTIONS_SHOW_MAGAZINE_ICON,
         self::MBIN_MODERATION_LOG_SHOW_USER_AVATARS,
         self::MBIN_MODERATION_LOG_SHOW_MAGAZINE_ICONS,
+        self::MBIN_GENERAL_SHOW_RELATED_POSTS,
+        self::MBIN_GENERAL_SHOW_RELATED_ENTRIES,
+        self::MBIN_GENERAL_SHOW_RELATED_MAGAZINES,
+        self::MBIN_GENERAL_SHOW_ACTIVE_USERS,
     ];
 
     public const VALUES = [

--- a/templates/layout/_options_appearance.html.twig
+++ b/templates/layout/_options_appearance.html.twig
@@ -16,6 +16,10 @@
         {{ component('settings_row_switch', {label: 'infinite_scroll'|trans, help: 'infinite_scroll_help'|trans ,  settingsKey: 'KBIN_GENERAL_INFINITE_SCROLL'}) }}
         {{ component('settings_row_switch', {label: 'sticky_navbar'|trans, help: 'sticky_navbar_help'|trans,  settingsKey: 'KBIN_GENERAL_FIXED_NAVBAR'}) }}
         {{ component('settings_row_switch', {label: 'show_top_bar'|trans, settingsKey: 'KBIN_GENERAL_TOPBAR'}) }}
+        {{ component('settings_row_switch', {label: 'show_related_magazines'|trans, settingsKey: 'MBIN_GENERAL_SHOW_RELATED_MAGAZINES', defaultValue: 'true'}) }}
+        {{ component('settings_row_switch', {label: 'show_related_entries'|trans, settingsKey: 'MBIN_GENERAL_SHOW_RELATED_ENTRIES', defaultValue: 'true'}) }}
+        {{ component('settings_row_switch', {label: 'show_related_posts'|trans, settingsKey: 'MBIN_GENERAL_SHOW_RELATED_POSTS', defaultValue: 'true'}) }}
+        {{ component('settings_row_switch', {label: 'show_active_users'|trans, settingsKey: 'MBIN_GENERAL_SHOW_ACTIVE_USERS', defaultValue: 'true'}) }}
     </div>
     {% if app.user is defined and app.user is not same as null %}
         <strong>{{ 'subscriptions'|trans }}</strong>

--- a/templates/layout/_sidebar.html.twig
+++ b/templates/layout/_sidebar.html.twig
@@ -63,6 +63,12 @@
     {% endif %}
 </div>
 
+{% set show_related_magazines = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::MBIN_GENERAL_SHOW_RELATED_MAGAZINES')) %}
+{% set show_related_entries = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::MBIN_GENERAL_SHOW_RELATED_ENTRIES')) %}
+{% set show_related_posts = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::MBIN_GENERAL_SHOW_RELATED_POSTS')) %}
+{% set show_active_users = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::MBIN_GENERAL_SHOW_ACTIVE_USERS')) %}
+{% set V_FALSE = constant('App\\Controller\\User\\ThemeSettingsController::FALSE') %}
+
 {% if sidebar_top is empty %}
 {% else %}
     {{ sidebar_top|raw }}
@@ -91,12 +97,18 @@
 {% if tag is defined and tag %}
     {% include 'tag/_panel.html.twig' %}
 {% endif %}
-{{ component('related_magazines', {magazine: magazine is defined and magazine ? magazine.name : null, tag: tag is defined and tag ? tag : null}) }}
-{% if not is_route_name_contains('people') %}
+{% if show_related_magazines is not same as V_FALSE %}
+    {{ component('related_magazines', {magazine: magazine is defined and magazine ? magazine.name : null, tag: tag is defined and tag ? tag : null}) }}
+{% endif %}
+{% if not is_route_name_contains('people') and show_active_users is not same as V_FALSE %}
     {{ component('active_users', {magazine: magazine is defined and magazine ? magazine : null}) }}
 {% endif %}
-{{ component('related_posts', {magazine: magazine is defined and magazine ? magazine.name : null, tag: tag is defined and tag ? tag : null}) }}
-{{ component('related_entries', {magazine: magazine is defined and magazine ? magazine.name : null, tag: tag is defined and tag ? tag : null}) }}
+{% if show_related_posts is not same as V_FALSE %}
+    {{ component('related_posts', {magazine: magazine is defined and magazine ? magazine.name : null, tag: tag is defined and tag ? tag : null}) }}
+{% endif%}
+{% if show_related_entries is not same as V_FALSE %}
+    {{ component('related_entries', {magazine: magazine is defined and magazine ? magazine.name : null, tag: tag is defined and tag ? tag : null}) }}
+{% endif%}
 <section class="about section">
     <h3>{{ kbin_domain() }}</h3>
     <div class="container">

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -836,3 +836,7 @@ last_updated: Last updated
 and: and
 direct_message: Direct message
 manually_approves_followers: Manually approves followers
+show_related_magazines: Show random magazines
+show_related_entries: Show random threads
+show_related_posts: Show random posts
+show_active_users: Show active users


### PR DESCRIPTION
Add theme settings for turning off these panels:
- related magazines
- related entries
- related posts
- active users

![grafik](https://github.com/user-attachments/assets/21aaac57-e405-4c7e-bf2a-415557e4ba0a)

Closes #914 