### PR TITLE
Bump to newer version that also fixes npm install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,7 +65,7 @@ RUN composer run-script --no-dev post-install-cmd && \
 
 ####################
 
-FROM node:22.4-alpine3.19 as builder-nodejs
+FROM node:22.5.1-alpine3.20 as builder-nodejs
 
 # Set NodeJS as production by default
 ARG NODE_ENV=production


### PR DESCRIPTION
Dump Nodejs version to 22.5.1, which also still should work (and contain the fix)...