### PR TITLE
Reapply "Bump to newer version that also fixes npm install (#930)"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,7 +65,7 @@ RUN composer run-script --no-dev post-install-cmd && \
 
 ####################
 
-FROM node:22.4-alpine3.19 as builder-nodejs
+FROM node:22.5.1-alpine3.20 as builder-nodejs
 
 # Set NodeJS as production by default
 ARG NODE_ENV=production


### PR DESCRIPTION
Let's try again with the latest 22.5.1. Again, I was too soon yesterday.

This reverts commit e87f99e7f41fc7608c57ef6cd6fac7c819bb51ac.