### PR TITLE
Improve minor paths to avoid breakage of server

### DIFF
--- a/docs/02-admin/01-installation/bare_metal.md
+++ b/docs/02-admin/01-installation/bare_metal.md
@@ -122,6 +122,7 @@ git clone https://github.com/MbinOrg/mbin.git .
 ### Create & configure media directory
 
 ```bash
+cd /var/www/mbin
 mkdir public/media
 sudo chmod -R 775 public/media
 sudo chown -R mbin:www-data public/media

--- a/docs/02-admin/01-installation/bare_metal.md
+++ b/docs/02-admin/01-installation/bare_metal.md
@@ -98,6 +98,7 @@ sudo su - mbin
 
 ```bash
 sudo mkdir -p /var/www/mbin
+cd /var/www/mbin
 sudo chown mbin:www-data /var/www/mbin
 ```
 


### PR DESCRIPTION
I have already break my server twice by quickly copying and pasting commands without paying attention to mbin path.

Added some 'cd /var/www/mbin' commands to prevent accidental execute of commands to root directory which will break permissions causing critical server instability.