### PR TITLE
Wrap all messenger invokes in their own transaction

### DIFF
--- a/src/Exception/EntityNotFoundException.php
+++ b/src/Exception/EntityNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+class EntityNotFoundException extends \Exception
+{
+}

--- a/src/Message/Contracts/ActivityPubInboxInterface.php
+++ b/src/Message/Contracts/ActivityPubInboxInterface.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace App\Message\Contracts;
 
-interface ActivityPubInboxInterface
+interface ActivityPubInboxInterface extends MessageInterface
 {
 }

--- a/src/Message/Contracts/ActivityPubInboxReceiveInterface.php
+++ b/src/Message/Contracts/ActivityPubInboxReceiveInterface.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace App\Message\Contracts;
 
-interface ActivityPubInboxReceiveInterface
+interface ActivityPubInboxReceiveInterface extends MessageInterface
 {
 }

--- a/src/Message/Contracts/ActivityPubOutboxDeliverInterface.php
+++ b/src/Message/Contracts/ActivityPubOutboxDeliverInterface.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace App\Message\Contracts;
 
-interface ActivityPubOutboxDeliverInterface
+interface ActivityPubOutboxDeliverInterface extends MessageInterface
 {
 }

--- a/src/Message/Contracts/ActivityPubResolveInterface.php
+++ b/src/Message/Contracts/ActivityPubResolveInterface.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace App\Message\Contracts;
 
-interface ActivityPubResolveInterface
+interface ActivityPubResolveInterface extends MessageInterface
 {
 }

--- a/src/Message/Contracts/AsyncMessageInterface.php
+++ b/src/Message/Contracts/AsyncMessageInterface.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace App\Message\Contracts;
 
-interface AsyncMessageInterface
+interface AsyncMessageInterface extends MessageInterface
 {
 }

--- a/src/Message/Contracts/MessageInterface.php
+++ b/src/Message/Contracts/MessageInterface.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace App\Message\Contracts;
 
-interface ActivityPubOutboxInterface extends MessageInterface
+interface MessageInterface
 {
 }

--- a/src/Message/Contracts/SendConfirmationEmailInterface.php
+++ b/src/Message/Contracts/SendConfirmationEmailInterface.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace App\Message\Contracts;
 
-interface SendConfirmationEmailInterface
+interface SendConfirmationEmailInterface extends MessageInterface
 {
 }

--- a/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
@@ -44,6 +44,11 @@ readonly class ActivityHandler
 
     public function __invoke(ActivityMessage $message): void
     {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(ActivityMessage $message): void
+    {
         $payload = @json_decode($message->payload, true);
 
         if ($message->request && $message->headers) {

--- a/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
@@ -19,6 +19,8 @@ use App\Message\ActivityPub\Inbox\FollowMessage;
 use App\Message\ActivityPub\Inbox\LikeMessage;
 use App\Message\ActivityPub\Inbox\RemoveMessage;
 use App\Message\ActivityPub\Inbox\UpdateMessage;
+use App\Message\Contracts\MessageInterface;
+use App\MessageHandler\MbinMessageHandler;
 use App\Service\ActivityPub\ApHttpClient;
 use App\Service\ActivityPub\SignatureValidator;
 use App\Service\ActivityPubManager;
@@ -29,26 +31,30 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsMessageHandler]
-readonly class ActivityHandler
+class ActivityHandler extends MbinMessageHandler
 {
     public function __construct(
-        private EntityManagerInterface $entityManager,
-        private SignatureValidator $signatureValidator,
-        private SettingsManager $settingsManager,
-        private MessageBusInterface $bus,
-        private ActivityPubManager $manager,
-        private ApHttpClient $apHttpClient,
-        private LoggerInterface $logger
+        private readonly EntityManagerInterface $entityManager,
+        private readonly SignatureValidator $signatureValidator,
+        private readonly SettingsManager $settingsManager,
+        private readonly MessageBusInterface $bus,
+        private readonly ActivityPubManager $manager,
+        private readonly ApHttpClient $apHttpClient,
+        private readonly LoggerInterface $logger
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(ActivityMessage $message): void
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(ActivityMessage $message): void
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof ActivityMessage)) {
+            throw new \LogicException();
+        }
         $payload = @json_decode($message->payload, true);
 
         if ($message->request && $message->headers) {

--- a/src/MessageHandler/ActivityPub/Inbox/AnnounceHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/AnnounceHandler.php
@@ -30,6 +30,11 @@ class AnnounceHandler
 
     public function __invoke(AnnounceMessage $message): void
     {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(AnnounceMessage $message): void
+    {
         $chainDispatchCallback = function (array $object, ?string $adjustedUrl) use ($message) {
             if ($adjustedUrl) {
                 $this->logger->info('got an adjusted url: {url}, using that instead of {old}', ['url' => $adjustedUrl, 'old' => $message->payload['object']['id'] ?? $message->payload['object']]);

--- a/src/MessageHandler/ActivityPub/Inbox/CreateHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/CreateHandler.php
@@ -16,6 +16,7 @@ use App\Service\ActivityPub\Note;
 use App\Service\ActivityPub\Page;
 use App\Service\ActivityPubManager;
 use App\Service\MessageManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -27,6 +28,7 @@ class CreateHandler
     private bool $stickyIt;
 
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly Note $note,
         private readonly Page $page,
         private readonly MessageBusInterface $bus,
@@ -41,6 +43,14 @@ class CreateHandler
      * @throws \Exception
      */
     public function __invoke(CreateMessage $message): void
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function doWork(CreateMessage $message): void
     {
         $this->object = $message->payload;
         $this->stickyIt = $message->stickyIt;

--- a/src/MessageHandler/ActivityPub/Inbox/DeleteHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/DeleteHandler.php
@@ -40,6 +40,11 @@ class DeleteHandler
 
     public function __invoke(DeleteMessage $message): void
     {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(DeleteMessage $message): void
+    {
         $actor = $this->activityPubManager->findActorOrCreate($message->payload['actor']);
 
         $id = \is_array($message->payload['object']) ? $message->payload['object']['id'] : $message->payload['object'];

--- a/src/MessageHandler/ActivityPub/Inbox/DeleteHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/DeleteHandler.php
@@ -10,7 +10,9 @@ use App\Entity\Post;
 use App\Entity\PostComment;
 use App\Entity\User;
 use App\Message\ActivityPub\Inbox\DeleteMessage;
+use App\Message\Contracts\MessageInterface;
 use App\Message\DeleteUserMessage;
+use App\MessageHandler\MbinMessageHandler;
 use App\Repository\ApActivityRepository;
 use App\Repository\UserRepository;
 use App\Service\ActivityPubManager;
@@ -23,7 +25,7 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsMessageHandler]
-class DeleteHandler
+class DeleteHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly MessageBusInterface $bus,
@@ -36,15 +38,19 @@ class DeleteHandler
         private readonly PostManager $postManager,
         private readonly PostCommentManager $postCommentManager
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(DeleteMessage $message): void
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(DeleteMessage $message): void
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof DeleteMessage)) {
+            throw new \LogicException();
+        }
         $actor = $this->activityPubManager->findActorOrCreate($message->payload['actor']);
 
         $id = \is_array($message->payload['object']) ? $message->payload['object']['id'] : $message->payload['object'];

--- a/src/MessageHandler/ActivityPub/Inbox/RemoveHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/RemoveHandler.php
@@ -15,6 +15,7 @@ use App\Service\ActivityPubManager;
 use App\Service\EntryManager;
 use App\Service\MagazineManager;
 use App\Service\SettingsManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -22,6 +23,7 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 class RemoveHandler
 {
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly ApActivityRepository $apActivityRepository,
         private readonly ActivityPubManager $activityPubManager,
         private readonly MagazineRepository $magazineRepository,
@@ -34,6 +36,11 @@ class RemoveHandler
     }
 
     public function __invoke(RemoveMessage $message): void
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(RemoveMessage $message): void
     {
         $payload = $message->payload;
         $actor = $this->activityPubManager->findUserActorOrCreateOrThrow($payload['actor']);

--- a/src/MessageHandler/ActivityPub/Inbox/RemoveHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/RemoveHandler.php
@@ -8,6 +8,8 @@ use App\Entity\Entry;
 use App\Entity\Magazine;
 use App\Entity\User;
 use App\Message\ActivityPub\Inbox\RemoveMessage;
+use App\Message\Contracts\MessageInterface;
+use App\MessageHandler\MbinMessageHandler;
 use App\Repository\ApActivityRepository;
 use App\Repository\EntryRepository;
 use App\Repository\MagazineRepository;
@@ -20,7 +22,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
-class RemoveHandler
+class RemoveHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
@@ -33,15 +35,19 @@ class RemoveHandler
         private readonly EntryManager $entryManager,
         private readonly SettingsManager $settingsManager,
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(RemoveMessage $message): void
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(RemoveMessage $message): void
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof RemoveMessage)) {
+            throw new \LogicException();
+        }
         $payload = $message->payload;
         $actor = $this->activityPubManager->findUserActorOrCreateOrThrow($payload['actor']);
         $targetMag = $this->magazineRepository->getMagazineFromModeratorsUrl($payload['target']);

--- a/src/MessageHandler/ActivityPub/Inbox/UpdateHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/UpdateHandler.php
@@ -56,6 +56,11 @@ class UpdateHandler
 
     public function __invoke(UpdateMessage $message): void
     {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(UpdateMessage $message): void
+    {
         $this->payload = $message->payload;
 
         try {

--- a/src/MessageHandler/ActivityPub/Outbox/AddHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/AddHandler.php
@@ -10,12 +10,14 @@ use App\Repository\MagazineRepository;
 use App\Repository\UserRepository;
 use App\Service\DeliverManager;
 use App\Service\SettingsManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
 class AddHandler
 {
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly UserRepository $userRepository,
         private readonly MagazineRepository $magazineRepository,
         private readonly SettingsManager $settingsManager,
@@ -25,6 +27,11 @@ class AddHandler
     }
 
     public function __invoke(AddMessage $message): void
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(AddMessage $message): void
     {
         if (!$this->settingsManager->get('KBIN_FEDERATION_ENABLED')) {
             return;

--- a/src/MessageHandler/ActivityPub/Outbox/AnnounceHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/AnnounceHandler.php
@@ -43,6 +43,11 @@ class AnnounceHandler
 
     public function __invoke(AnnounceMessage $message): void
     {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(AnnounceMessage $message): void
+    {
         if (!$this->settingsManager->get('KBIN_FEDERATION_ENABLED')) {
             return;
         }

--- a/src/MessageHandler/ActivityPub/Outbox/AnnounceLikeHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/AnnounceLikeHandler.php
@@ -42,6 +42,11 @@ class AnnounceLikeHandler
 
     public function __invoke(AnnounceLikeMessage $message): void
     {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(AnnounceLikeMessage $message): void
+    {
         if (!$this->settingsManager->get('KBIN_FEDERATION_ENABLED')) {
             return;
         }

--- a/src/MessageHandler/ActivityPub/Outbox/CreateHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/CreateHandler.php
@@ -35,6 +35,11 @@ class CreateHandler
 
     public function __invoke(CreateMessage $message): void
     {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(CreateMessage $message): void
+    {
         if (!$this->settingsManager->get('KBIN_FEDERATION_ENABLED')) {
             return;
         }

--- a/src/MessageHandler/ActivityPub/Outbox/DeleteHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/DeleteHandler.php
@@ -10,12 +10,14 @@ use App\Repository\UserRepository;
 use App\Service\ActivityPubManager;
 use App\Service\DeliverManager;
 use App\Service\SettingsManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
 class DeleteHandler
 {
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly UserRepository $userRepository,
         private readonly MagazineRepository $magazineRepository,
         private readonly ActivityPubManager $activityPubManager,
@@ -25,6 +27,11 @@ class DeleteHandler
     }
 
     public function __invoke(DeleteMessage $message): void
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(DeleteMessage $message): void
     {
         if (!$this->settingsManager->get('KBIN_FEDERATION_ENABLED')) {
             return;

--- a/src/MessageHandler/ActivityPub/Outbox/GenericAnnounceHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/GenericAnnounceHandler.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\MessageHandler\ActivityPub\Outbox;
 
 use App\Message\ActivityPub\Outbox\GenericAnnounceMessage;
+use App\Message\Contracts\MessageInterface;
+use App\MessageHandler\MbinMessageHandler;
 use App\Repository\MagazineRepository;
 use App\Service\ActivityPub\Wrapper\AnnounceWrapper;
 use App\Service\DeliverManager;
@@ -14,27 +16,31 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 #[AsMessageHandler]
-readonly class GenericAnnounceHandler
+class GenericAnnounceHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
-        private SettingsManager $settingsManager,
-        private UrlGeneratorInterface $urlGenerator,
-        private MagazineRepository $magazineRepository,
-        private AnnounceWrapper $announceWrapper,
-        private DeliverManager $deliverManager,
+        private readonly SettingsManager $settingsManager,
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly MagazineRepository $magazineRepository,
+        private readonly AnnounceWrapper $announceWrapper,
+        private readonly DeliverManager $deliverManager,
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(GenericAnnounceMessage $message): void
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
-    }
-
-    public function doWork(GenericAnnounceMessage $message): void
-    {
         if (!$this->settingsManager->get('KBIN_FEDERATION_ENABLED')) {
             return;
+        }
+        $this->workWrapper($message);
+    }
+
+    public function doWork(MessageInterface $message): void
+    {
+        if (!($message instanceof GenericAnnounceMessage)) {
+            throw new \LogicException();
         }
         $magazine = $this->magazineRepository->find($message->announcingMagazineId);
         if (null !== $magazine->apId) {

--- a/src/MessageHandler/ActivityPub/Outbox/LikeHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/LikeHandler.php
@@ -38,6 +38,11 @@ class LikeHandler
 
     public function __invoke(LikeMessage $message): void
     {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(LikeMessage $message): void
+    {
         if (!$this->settingsManager->get('KBIN_FEDERATION_ENABLED')) {
             return;
         }

--- a/src/MessageHandler/ActivityPub/Outbox/RemoveHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/RemoveHandler.php
@@ -6,6 +6,8 @@ namespace App\MessageHandler\ActivityPub\Outbox;
 
 use App\Factory\ActivityPub\AddRemoveFactory;
 use App\Message\ActivityPub\Outbox\RemoveMessage;
+use App\Message\Contracts\MessageInterface;
+use App\MessageHandler\MbinMessageHandler;
 use App\Repository\MagazineRepository;
 use App\Repository\UserRepository;
 use App\Service\DeliverManager;
@@ -14,7 +16,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
-class RemoveHandler
+class RemoveHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
@@ -24,17 +26,21 @@ class RemoveHandler
         private readonly AddRemoveFactory $factory,
         private readonly DeliverManager $deliverManager,
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(RemoveMessage $message): void
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
-    }
-
-    public function doWork(RemoveMessage $message): void
-    {
         if (!$this->settingsManager->get('KBIN_FEDERATION_ENABLED')) {
             return;
+        }
+        $this->workWrapper($message);
+    }
+
+    public function doWork(MessageInterface $message): void
+    {
+        if (!($message instanceof RemoveMessage)) {
+            throw new \LogicException();
         }
 
         $actor = $this->userRepository->find($message->userActorId);

--- a/src/MessageHandler/ActivityPub/Outbox/RemoveHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/RemoveHandler.php
@@ -10,12 +10,14 @@ use App\Repository\MagazineRepository;
 use App\Repository\UserRepository;
 use App\Service\DeliverManager;
 use App\Service\SettingsManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
 class RemoveHandler
 {
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly UserRepository $userRepository,
         private readonly MagazineRepository $magazineRepository,
         private readonly SettingsManager $settingsManager,
@@ -25,6 +27,11 @@ class RemoveHandler
     }
 
     public function __invoke(RemoveMessage $message): void
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(RemoveMessage $message): void
     {
         if (!$this->settingsManager->get('KBIN_FEDERATION_ENABLED')) {
             return;

--- a/src/MessageHandler/ActivityPub/Outbox/UpdateHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/UpdateHandler.php
@@ -33,6 +33,11 @@ class UpdateHandler
 
     public function __invoke(UpdateMessage $message): void
     {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(UpdateMessage $message): void
+    {
         if (!$this->settingsManager->get('KBIN_FEDERATION_ENABLED')) {
             return;
         }

--- a/src/MessageHandler/ActivityPub/UpdateActorHandler.php
+++ b/src/MessageHandler/ActivityPub/UpdateActorHandler.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\MessageHandler\ActivityPub;
 
 use App\Message\ActivityPub\UpdateActorMessage;
+use App\Message\Contracts\MessageInterface;
+use App\MessageHandler\MbinMessageHandler;
 use App\Repository\MagazineRepository;
 use App\Repository\UserRepository;
 use App\Service\ActivityPubManager;
@@ -14,7 +16,7 @@ use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
-class UpdateActorHandler
+class UpdateActorHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
@@ -24,15 +26,19 @@ class UpdateActorHandler
         private readonly MagazineRepository $magazineRepository,
         private readonly LoggerInterface $logger,
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(UpdateActorMessage $message): void
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(UpdateActorMessage $message): void
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof UpdateActorMessage)) {
+            throw new \LogicException();
+        }
         $actorUrl = $message->actorUrl;
         $lock = $this->lockFactory->createLock('update_actor_'.hash('sha256', $actorUrl), 60);
 

--- a/src/MessageHandler/AttachEntryEmbedHandler.php
+++ b/src/MessageHandler/AttachEntryEmbedHandler.php
@@ -29,6 +29,11 @@ class AttachEntryEmbedHandler
 
     public function __invoke(EntryEmbedMessage $message): void
     {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(EntryEmbedMessage $message): void
+    {
         $entry = $this->entryRepository->find($message->entryId);
 
         if (!$entry) {

--- a/src/MessageHandler/DeleteImageHandler.php
+++ b/src/MessageHandler/DeleteImageHandler.php
@@ -22,7 +22,12 @@ class DeleteImageHandler
     ) {
     }
 
-    public function __invoke(DeleteImageMessage $message)
+    public function __invoke(DeleteImageMessage $message): void
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(DeleteImageMessage $message): void
     {
         $image = $this->imageRepository->find($message->id);
 

--- a/src/MessageHandler/DeleteImageHandler.php
+++ b/src/MessageHandler/DeleteImageHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\MessageHandler;
 
+use App\Message\Contracts\MessageInterface;
 use App\Message\DeleteImageMessage;
 use App\Repository\ImageRepository;
 use App\Service\ImageManager;
@@ -12,7 +13,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
-class DeleteImageHandler
+class DeleteImageHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly ImageRepository $imageRepository,
@@ -20,15 +21,19 @@ class DeleteImageHandler
         private readonly EntityManagerInterface $entityManager,
         private readonly ManagerRegistry $managerRegistry
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(DeleteImageMessage $message): void
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(DeleteImageMessage $message): void
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof DeleteImageMessage)) {
+            throw new \LogicException();
+        }
         $image = $this->imageRepository->find($message->id);
 
         if ($image) {

--- a/src/MessageHandler/DeleteUserHandler.php
+++ b/src/MessageHandler/DeleteUserHandler.php
@@ -34,6 +34,11 @@ class DeleteUserHandler
 
     public function __invoke(DeleteUserMessage $message): void
     {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(DeleteUserMessage $message): void
+    {
         $this->user = $this->entityManager
             ->getRepository(User::class)
             ->find($message->id);

--- a/src/MessageHandler/DeleteUserHandler.php
+++ b/src/MessageHandler/DeleteUserHandler.php
@@ -7,6 +7,7 @@ namespace App\MessageHandler;
 use App\DTO\UserDto;
 use App\Entity\User;
 use App\Message\ActivityPub\Outbox\DeliverMessage;
+use App\Message\Contracts\MessageInterface;
 use App\Message\DeleteUserMessage;
 use App\Service\ActivityPub\Wrapper\DeleteWrapper;
 use App\Service\ImageManager;
@@ -18,7 +19,7 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsMessageHandler]
-class DeleteUserHandler
+class DeleteUserHandler extends MbinMessageHandler
 {
     private ?User $user;
 
@@ -30,15 +31,19 @@ class DeleteUserHandler
         private readonly MessageBusInterface $bus,
         private readonly EntityManagerInterface $entityManager
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(DeleteUserMessage $message): void
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(DeleteUserMessage $message): void
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof DeleteUserMessage)) {
+            throw new \LogicException();
+        }
         $this->user = $this->entityManager
             ->getRepository(User::class)
             ->find($message->id);

--- a/src/MessageHandler/MagazinePurgeHandler.php
+++ b/src/MessageHandler/MagazinePurgeHandler.php
@@ -12,6 +12,7 @@ use App\Entity\ModeratorRequest;
 use App\Entity\Post;
 use App\Entity\PostComment;
 use App\Entity\Report;
+use App\Message\Contracts\MessageInterface;
 use App\Message\MagazinePurgeMessage;
 use App\Service\EntryCommentManager;
 use App\Service\EntryManager;
@@ -23,7 +24,7 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsMessageHandler]
-class MagazinePurgeHandler
+class MagazinePurgeHandler extends MbinMessageHandler
 {
     private ?Magazine $magazine;
     private int $batchSize = 5;
@@ -36,15 +37,19 @@ class MagazinePurgeHandler
         private readonly MessageBusInterface $bus,
         private readonly EntityManagerInterface $entityManager
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(MagazinePurgeMessage $message): void
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(MagazinePurgeMessage $message): void
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof MagazinePurgeMessage)) {
+            throw new \LogicException();
+        }
         $this->magazine = $this->entityManager
             ->getRepository(Magazine::class)
             ->find($message->id);

--- a/src/MessageHandler/MagazinePurgeHandler.php
+++ b/src/MessageHandler/MagazinePurgeHandler.php
@@ -40,6 +40,11 @@ class MagazinePurgeHandler
 
     public function __invoke(MagazinePurgeMessage $message): void
     {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(MagazinePurgeMessage $message): void
+    {
         $this->magazine = $this->entityManager
             ->getRepository(Magazine::class)
             ->find($message->id);

--- a/src/MessageHandler/MbinMessageHandler.php
+++ b/src/MessageHandler/MbinMessageHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\Message\Contracts\MessageInterface;
+use Doctrine\DBAL\Exception;
+use Doctrine\ORM\EntityManagerInterface;
+
+abstract class MbinMessageHandler
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * @throws \Throwable
+     * @throws Exception
+     */
+    public function workWrapper(MessageInterface $message): void
+    {
+        $conn = $this->entityManager->getConnection();
+        if (!$conn->isConnected()) {
+            $conn->connect();
+        }
+
+        $conn->transactional(fn () => $this->doWork($message));
+
+        $conn->close();
+    }
+
+    abstract public function doWork(MessageInterface $message): void;
+}

--- a/src/MessageHandler/Notification/SentEntryCommentCreatedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentEntryCommentCreatedNotificationHandler.php
@@ -7,6 +7,7 @@ namespace App\MessageHandler\Notification;
 use App\Message\Notification\EntryCommentCreatedNotificationMessage;
 use App\Repository\EntryCommentRepository;
 use App\Service\NotificationManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
@@ -14,12 +15,18 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 class SentEntryCommentCreatedNotificationHandler
 {
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly EntryCommentRepository $repository,
         private readonly NotificationManager $manager
     ) {
     }
 
     public function __invoke(EntryCommentCreatedNotificationMessage $message)
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(EntryCommentCreatedNotificationMessage $message)
     {
         $comment = $this->repository->find($message->commentId);
 

--- a/src/MessageHandler/Notification/SentEntryCommentCreatedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentEntryCommentCreatedNotificationHandler.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\MessageHandler\Notification;
 
+use App\Message\Contracts\MessageInterface;
 use App\Message\Notification\EntryCommentCreatedNotificationMessage;
+use App\MessageHandler\MbinMessageHandler;
 use App\Repository\EntryCommentRepository;
 use App\Service\NotificationManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -12,22 +14,26 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
 #[AsMessageHandler]
-class SentEntryCommentCreatedNotificationHandler
+class SentEntryCommentCreatedNotificationHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly EntryCommentRepository $repository,
         private readonly NotificationManager $manager
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(EntryCommentCreatedNotificationMessage $message)
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(EntryCommentCreatedNotificationMessage $message)
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof EntryCommentCreatedNotificationMessage)) {
+            throw new \LogicException();
+        }
         $comment = $this->repository->find($message->commentId);
 
         if (!$comment) {

--- a/src/MessageHandler/Notification/SentEntryCommentDeletedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentEntryCommentDeletedNotificationHandler.php
@@ -7,6 +7,7 @@ namespace App\MessageHandler\Notification;
 use App\Message\Notification\EntryCommentDeletedNotificationMessage;
 use App\Repository\EntryCommentRepository;
 use App\Service\NotificationManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
@@ -14,12 +15,18 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 class SentEntryCommentDeletedNotificationHandler
 {
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly EntryCommentRepository $repository,
         private readonly NotificationManager $manager
     ) {
     }
 
     public function __invoke(EntryCommentDeletedNotificationMessage $message)
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(EntryCommentDeletedNotificationMessage $message)
     {
         $comment = $this->repository->find($message->commentId);
 

--- a/src/MessageHandler/Notification/SentEntryCommentDeletedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentEntryCommentDeletedNotificationHandler.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\MessageHandler\Notification;
 
+use App\Message\Contracts\MessageInterface;
 use App\Message\Notification\EntryCommentDeletedNotificationMessage;
+use App\MessageHandler\MbinMessageHandler;
 use App\Repository\EntryCommentRepository;
 use App\Service\NotificationManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -12,22 +14,26 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
 #[AsMessageHandler]
-class SentEntryCommentDeletedNotificationHandler
+class SentEntryCommentDeletedNotificationHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly EntryCommentRepository $repository,
         private readonly NotificationManager $manager
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(EntryCommentDeletedNotificationMessage $message)
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(EntryCommentDeletedNotificationMessage $message)
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof EntryCommentDeletedNotificationMessage)) {
+            throw new \LogicException();
+        }
         $comment = $this->repository->find($message->commentId);
 
         if (!$comment) {

--- a/src/MessageHandler/Notification/SentEntryCommentEditedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentEntryCommentEditedNotificationHandler.php
@@ -7,6 +7,7 @@ namespace App\MessageHandler\Notification;
 use App\Message\Notification\EntryCommentEditedNotificationMessage;
 use App\Repository\EntryCommentRepository;
 use App\Service\NotificationManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
@@ -14,12 +15,18 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 class SentEntryCommentEditedNotificationHandler
 {
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly EntryCommentRepository $repository,
         private readonly NotificationManager $manager
     ) {
     }
 
     public function __invoke(EntryCommentEditedNotificationMessage $message)
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(EntryCommentEditedNotificationMessage $message)
     {
         $comment = $this->repository->find($message->commentId);
 

--- a/src/MessageHandler/Notification/SentEntryCommentEditedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentEntryCommentEditedNotificationHandler.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\MessageHandler\Notification;
 
+use App\Message\Contracts\MessageInterface;
 use App\Message\Notification\EntryCommentEditedNotificationMessage;
+use App\MessageHandler\MbinMessageHandler;
 use App\Repository\EntryCommentRepository;
 use App\Service\NotificationManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -12,22 +14,26 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
 #[AsMessageHandler]
-class SentEntryCommentEditedNotificationHandler
+class SentEntryCommentEditedNotificationHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly EntryCommentRepository $repository,
         private readonly NotificationManager $manager
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(EntryCommentEditedNotificationMessage $message)
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(EntryCommentEditedNotificationMessage $message)
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof EntryCommentEditedNotificationMessage)) {
+            throw new \LogicException();
+        }
         $comment = $this->repository->find($message->commentId);
 
         if (!$comment) {

--- a/src/MessageHandler/Notification/SentEntryCreatedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentEntryCreatedNotificationHandler.php
@@ -7,6 +7,7 @@ namespace App\MessageHandler\Notification;
 use App\Message\Notification\EntryCreatedNotificationMessage;
 use App\Repository\EntryRepository;
 use App\Service\NotificationManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
@@ -14,12 +15,18 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 class SentEntryCreatedNotificationHandler
 {
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly EntryRepository $repository,
         private readonly NotificationManager $manager
     ) {
     }
 
     public function __invoke(EntryCreatedNotificationMessage $message)
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(EntryCreatedNotificationMessage $message)
     {
         $entry = $this->repository->find($message->entryId);
 

--- a/src/MessageHandler/Notification/SentEntryCreatedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentEntryCreatedNotificationHandler.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\MessageHandler\Notification;
 
+use App\Message\Contracts\MessageInterface;
 use App\Message\Notification\EntryCreatedNotificationMessage;
+use App\MessageHandler\MbinMessageHandler;
 use App\Repository\EntryRepository;
 use App\Service\NotificationManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -12,22 +14,26 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
 #[AsMessageHandler]
-class SentEntryCreatedNotificationHandler
+class SentEntryCreatedNotificationHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly EntryRepository $repository,
         private readonly NotificationManager $manager
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(EntryCreatedNotificationMessage $message)
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(EntryCreatedNotificationMessage $message)
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof EntryCreatedNotificationMessage)) {
+            throw new \LogicException();
+        }
         $entry = $this->repository->find($message->entryId);
 
         if (!$entry) {

--- a/src/MessageHandler/Notification/SentEntryDeletedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentEntryDeletedNotificationHandler.php
@@ -7,6 +7,7 @@ namespace App\MessageHandler\Notification;
 use App\Message\Notification\EntryDeletedNotificationMessage;
 use App\Repository\EntryRepository;
 use App\Service\NotificationManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
@@ -14,12 +15,18 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 class SentEntryDeletedNotificationHandler
 {
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly EntryRepository $repository,
         private readonly NotificationManager $manager
     ) {
     }
 
     public function __invoke(EntryDeletedNotificationMessage $message)
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(EntryDeletedNotificationMessage $message)
     {
         $entry = $this->repository->find($message->entryId);
 

--- a/src/MessageHandler/Notification/SentEntryEditedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentEntryEditedNotificationHandler.php
@@ -7,6 +7,7 @@ namespace App\MessageHandler\Notification;
 use App\Message\Notification\EntryEditedNotificationMessage;
 use App\Repository\EntryRepository;
 use App\Service\NotificationManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
@@ -14,12 +15,18 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 class SentEntryEditedNotificationHandler
 {
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly EntryRepository $repository,
         private readonly NotificationManager $manager
     ) {
     }
 
-    public function __invoke(EntryEditedNotificationMessage $message)
+    public function __invoke(EntryEditedNotificationMessage $message): void
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(EntryEditedNotificationMessage $message): void
     {
         $entry = $this->repository->find($message->entryId);
 

--- a/src/MessageHandler/Notification/SentEntryEditedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentEntryEditedNotificationHandler.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\MessageHandler\Notification;
 
+use App\Message\Contracts\MessageInterface;
 use App\Message\Notification\EntryEditedNotificationMessage;
+use App\MessageHandler\MbinMessageHandler;
 use App\Repository\EntryRepository;
 use App\Service\NotificationManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -12,22 +14,26 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
 #[AsMessageHandler]
-class SentEntryEditedNotificationHandler
+class SentEntryEditedNotificationHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly EntryRepository $repository,
         private readonly NotificationManager $manager
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(EntryEditedNotificationMessage $message): void
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(EntryEditedNotificationMessage $message): void
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof EntryEditedNotificationMessage)) {
+            throw new \LogicException();
+        }
         $entry = $this->repository->find($message->entryId);
 
         if (!$entry) {

--- a/src/MessageHandler/Notification/SentFavouriteNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentFavouriteNotificationHandler.php
@@ -11,6 +11,7 @@ use App\Service\GenerateHtmlClassService;
 use App\Service\SettingsManager;
 use App\Service\VotableRepositoryResolver;
 use App\Utils\IriGenerator;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Mercure\HubInterface;
 use Symfony\Component\Mercure\Update;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -19,6 +20,7 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 class SentFavouriteNotificationHandler
 {
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly MagazineFactory $magazineFactory,
         private readonly VotableRepositoryResolver $resolver,
         private readonly HubInterface $publisher,
@@ -28,6 +30,11 @@ class SentFavouriteNotificationHandler
     }
 
     public function __invoke(FavouriteNotificationMessage $message): void
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(FavouriteNotificationMessage $message): void
     {
         $repo = $this->resolver->resolve($message->subjectClass);
         $this->notifyMagazine($repo->find($message->subjectId));

--- a/src/MessageHandler/Notification/SentMagazineBanNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentMagazineBanNotificationHandler.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\MessageHandler\Notification;
 
+use App\Message\Contracts\MessageInterface;
 use App\Message\Notification\MagazineBanNotificationMessage;
+use App\MessageHandler\MbinMessageHandler;
 use App\Repository\MagazineBanRepository;
 use App\Service\NotificationManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -12,22 +14,26 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
 #[AsMessageHandler]
-class SentMagazineBanNotificationHandler
+class SentMagazineBanNotificationHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly MagazineBanRepository $repository,
         private readonly NotificationManager $manager
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(MagazineBanNotificationMessage $message): void
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(MagazineBanNotificationMessage $message): void
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof MagazineBanNotificationMessage)) {
+            throw new \LogicException();
+        }
         $ban = $this->repository->find($message->banId);
 
         if (!$ban) {

--- a/src/MessageHandler/Notification/SentMagazineBanNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentMagazineBanNotificationHandler.php
@@ -7,6 +7,7 @@ namespace App\MessageHandler\Notification;
 use App\Message\Notification\MagazineBanNotificationMessage;
 use App\Repository\MagazineBanRepository;
 use App\Service\NotificationManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
@@ -14,12 +15,18 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 class SentMagazineBanNotificationHandler
 {
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly MagazineBanRepository $repository,
         private readonly NotificationManager $manager
     ) {
     }
 
-    public function __invoke(MagazineBanNotificationMessage $message)
+    public function __invoke(MagazineBanNotificationMessage $message): void
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(MagazineBanNotificationMessage $message): void
     {
         $ban = $this->repository->find($message->banId);
 

--- a/src/MessageHandler/Notification/SentPostCommentCreatedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentPostCommentCreatedNotificationHandler.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\MessageHandler\Notification;
 
+use App\Message\Contracts\MessageInterface;
 use App\Message\Notification\PostCommentCreatedNotificationMessage;
+use App\MessageHandler\MbinMessageHandler;
 use App\Repository\PostCommentRepository;
 use App\Service\NotificationManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -12,22 +14,26 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
 #[AsMessageHandler]
-class SentPostCommentCreatedNotificationHandler
+class SentPostCommentCreatedNotificationHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly PostCommentRepository $repository,
         private readonly NotificationManager $manager
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(PostCommentCreatedNotificationMessage $message): void
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(PostCommentCreatedNotificationMessage $message): void
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof PostCommentCreatedNotificationMessage)) {
+            throw new \LogicException();
+        }
         $comment = $this->repository->find($message->commentId);
 
         if (!$comment) {

--- a/src/MessageHandler/Notification/SentPostCommentCreatedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentPostCommentCreatedNotificationHandler.php
@@ -7,6 +7,7 @@ namespace App\MessageHandler\Notification;
 use App\Message\Notification\PostCommentCreatedNotificationMessage;
 use App\Repository\PostCommentRepository;
 use App\Service\NotificationManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
@@ -14,12 +15,18 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 class SentPostCommentCreatedNotificationHandler
 {
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly PostCommentRepository $repository,
         private readonly NotificationManager $manager
     ) {
     }
 
-    public function __invoke(PostCommentCreatedNotificationMessage $message)
+    public function __invoke(PostCommentCreatedNotificationMessage $message): void
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(PostCommentCreatedNotificationMessage $message): void
     {
         $comment = $this->repository->find($message->commentId);
 

--- a/src/MessageHandler/Notification/SentPostCommentDeletedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentPostCommentDeletedNotificationHandler.php
@@ -7,6 +7,7 @@ namespace App\MessageHandler\Notification;
 use App\Message\Notification\PostCommentDeletedNotificationMessage;
 use App\Repository\PostCommentRepository;
 use App\Service\NotificationManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
@@ -14,12 +15,18 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 class SentPostCommentDeletedNotificationHandler
 {
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly PostCommentRepository $repository,
         private readonly NotificationManager $manager
     ) {
     }
 
-    public function __invoke(PostCommentDeletedNotificationMessage $message)
+    public function __invoke(PostCommentDeletedNotificationMessage $message): void
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(PostCommentDeletedNotificationMessage $message): void
     {
         $comment = $this->repository->find($message->commentId);
 

--- a/src/MessageHandler/Notification/SentPostCommentDeletedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentPostCommentDeletedNotificationHandler.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\MessageHandler\Notification;
 
+use App\Message\Contracts\MessageInterface;
 use App\Message\Notification\PostCommentDeletedNotificationMessage;
+use App\MessageHandler\MbinMessageHandler;
 use App\Repository\PostCommentRepository;
 use App\Service\NotificationManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -12,22 +14,26 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
 #[AsMessageHandler]
-class SentPostCommentDeletedNotificationHandler
+class SentPostCommentDeletedNotificationHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly PostCommentRepository $repository,
         private readonly NotificationManager $manager
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(PostCommentDeletedNotificationMessage $message): void
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(PostCommentDeletedNotificationMessage $message): void
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof PostCommentDeletedNotificationMessage)) {
+            throw new \LogicException();
+        }
         $comment = $this->repository->find($message->commentId);
 
         if (!$comment) {

--- a/src/MessageHandler/Notification/SentPostCommentEditedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentPostCommentEditedNotificationHandler.php
@@ -7,6 +7,7 @@ namespace App\MessageHandler\Notification;
 use App\Message\Notification\PostCommentEditedNotificationMessage;
 use App\Repository\PostCommentRepository;
 use App\Service\NotificationManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
@@ -14,12 +15,18 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 class SentPostCommentEditedNotificationHandler
 {
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly PostCommentRepository $repository,
         private readonly NotificationManager $manager
     ) {
     }
 
-    public function __invoke(PostCommentEditedNotificationMessage $message)
+    public function __invoke(PostCommentEditedNotificationMessage $message): void
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(PostCommentEditedNotificationMessage $message): void
     {
         $comment = $this->repository->find($message->commentId);
 

--- a/src/MessageHandler/Notification/SentPostCommentEditedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentPostCommentEditedNotificationHandler.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\MessageHandler\Notification;
 
+use App\Message\Contracts\MessageInterface;
 use App\Message\Notification\PostCommentEditedNotificationMessage;
+use App\MessageHandler\MbinMessageHandler;
 use App\Repository\PostCommentRepository;
 use App\Service\NotificationManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -12,22 +14,26 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
 #[AsMessageHandler]
-class SentPostCommentEditedNotificationHandler
+class SentPostCommentEditedNotificationHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly PostCommentRepository $repository,
         private readonly NotificationManager $manager
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(PostCommentEditedNotificationMessage $message): void
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(PostCommentEditedNotificationMessage $message): void
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof PostCommentEditedNotificationMessage)) {
+            throw new \LogicException();
+        }
         $comment = $this->repository->find($message->commentId);
 
         if (!$comment) {

--- a/src/MessageHandler/Notification/SentPostCreatedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentPostCreatedNotificationHandler.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\MessageHandler\Notification;
 
+use App\Message\Contracts\MessageInterface;
 use App\Message\Notification\PostCreatedNotificationMessage;
+use App\MessageHandler\MbinMessageHandler;
 use App\Repository\PostRepository;
 use App\Service\NotificationManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -12,22 +14,26 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
 #[AsMessageHandler]
-class SentPostCreatedNotificationHandler
+class SentPostCreatedNotificationHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly PostRepository $repository,
         private readonly NotificationManager $manager
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(PostCreatedNotificationMessage $message): void
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(PostCreatedNotificationMessage $message): void
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof PostCreatedNotificationMessage)) {
+            throw new \LogicException();
+        }
         $post = $this->repository->find($message->postId);
 
         if (!$post) {

--- a/src/MessageHandler/Notification/SentPostCreatedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentPostCreatedNotificationHandler.php
@@ -7,6 +7,7 @@ namespace App\MessageHandler\Notification;
 use App\Message\Notification\PostCreatedNotificationMessage;
 use App\Repository\PostRepository;
 use App\Service\NotificationManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
@@ -14,12 +15,18 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 class SentPostCreatedNotificationHandler
 {
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly PostRepository $repository,
         private readonly NotificationManager $manager
     ) {
     }
 
-    public function __invoke(PostCreatedNotificationMessage $message)
+    public function __invoke(PostCreatedNotificationMessage $message): void
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(PostCreatedNotificationMessage $message): void
     {
         $post = $this->repository->find($message->postId);
 

--- a/src/MessageHandler/Notification/SentPostDeletedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentPostDeletedNotificationHandler.php
@@ -7,6 +7,7 @@ namespace App\MessageHandler\Notification;
 use App\Message\Notification\PostDeletedNotificationMessage;
 use App\Repository\PostRepository;
 use App\Service\NotificationManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
@@ -14,12 +15,18 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 class SentPostDeletedNotificationHandler
 {
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly PostRepository $repository,
         private readonly NotificationManager $manager
     ) {
     }
 
     public function __invoke(PostDeletedNotificationMessage $message): void
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(PostDeletedNotificationMessage $message): void
     {
         $post = $this->repository->find($message->postId);
 

--- a/src/MessageHandler/Notification/SentPostDeletedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentPostDeletedNotificationHandler.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\MessageHandler\Notification;
 
+use App\Message\Contracts\MessageInterface;
 use App\Message\Notification\PostDeletedNotificationMessage;
+use App\MessageHandler\MbinMessageHandler;
 use App\Repository\PostRepository;
 use App\Service\NotificationManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -12,22 +14,26 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
 #[AsMessageHandler]
-class SentPostDeletedNotificationHandler
+class SentPostDeletedNotificationHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly PostRepository $repository,
         private readonly NotificationManager $manager
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(PostDeletedNotificationMessage $message): void
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(PostDeletedNotificationMessage $message): void
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof PostDeletedNotificationMessage)) {
+            throw new \LogicException();
+        }
         $post = $this->repository->find($message->postId);
 
         if (!$post) {

--- a/src/MessageHandler/Notification/SentPostEditedNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentPostEditedNotificationHandler.php
@@ -7,6 +7,7 @@ namespace App\MessageHandler\Notification;
 use App\Message\Notification\PostEditedNotificationMessage;
 use App\Repository\PostRepository;
 use App\Service\NotificationManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
@@ -14,12 +15,18 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 class SentPostEditedNotificationHandler
 {
     public function __construct(
+        private readonly EntityManagerInterface $entityManager,
         private readonly PostRepository $repository,
         private readonly NotificationManager $manager
     ) {
     }
 
-    public function __invoke(PostEditedNotificationMessage $message)
+    public function __invoke(PostEditedNotificationMessage $message): void
+    {
+        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+    }
+
+    public function doWork(PostEditedNotificationMessage $message): void
     {
         $post = $this->repository->find($message->postId);
 

--- a/src/MessageHandler/Notification/SentVoteNotificationHandler.php
+++ b/src/MessageHandler/Notification/SentVoteNotificationHandler.php
@@ -6,7 +6,9 @@ namespace App\MessageHandler\Notification;
 
 use App\Entity\Contracts\VotableInterface;
 use App\Factory\MagazineFactory;
+use App\Message\Contracts\MessageInterface;
 use App\Message\Notification\VoteNotificationMessage;
+use App\MessageHandler\MbinMessageHandler;
 use App\Service\GenerateHtmlClassService;
 use App\Service\SettingsManager;
 use App\Service\VotableRepositoryResolver;
@@ -17,7 +19,7 @@ use Symfony\Component\Mercure\Update;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
-class SentVoteNotificationHandler
+class SentVoteNotificationHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
@@ -27,15 +29,19 @@ class SentVoteNotificationHandler
         private readonly GenerateHtmlClassService $classService,
         private readonly SettingsManager $settingsManager
     ) {
+        parent::__construct($this->entityManager);
     }
 
     public function __invoke(VoteNotificationMessage $message): void
     {
-        $this->entityManager->wrapInTransaction(fn () => $this->doWork($message));
+        $this->workWrapper($message);
     }
 
-    public function doWork(VoteNotificationMessage $message): void
+    public function doWork(MessageInterface $message): void
     {
+        if (!($message instanceof VoteNotificationMessage)) {
+            throw new \LogicException();
+        }
         $repo = $this->resolver->resolve($message->subjectClass);
         $this->notifyMagazine($repo->find($message->subjectId));
     }

--- a/src/Service/ActivityPub/Page.php
+++ b/src/Service/ActivityPub/Page.php
@@ -12,6 +12,7 @@ use App\Entity\Contracts\ActivityPubActivityInterface;
 use App\Entity\Contracts\VisibilityInterface;
 use App\Entity\Entry;
 use App\Entity\User;
+use App\Exception\EntityNotFoundException;
 use App\Exception\TagBannedException;
 use App\Exception\UserBannedException;
 use App\Factory\ImageFactory;
@@ -40,7 +41,8 @@ class Page
     /**
      * @throws TagBannedException
      * @throws UserBannedException
-     * @throws \Exception          if the user could not be found or a sub exception occurred
+     * @throws EntityNotFoundException if the user could not be found or a sub exception occurred
+     * @throws \Exception              if there was an error
      */
     public function create(array $object, bool $stickyIt = false): Entry
     {
@@ -104,12 +106,12 @@ class Page
 
             return $this->entryManager->create($dto, $actor, false, $stickyIt);
         } else {
-            throw new \Exception('Actor could not be found for entry.');
+            throw new EntityNotFoundException('Actor could not be found for entry.');
         }
     }
 
     /**
-     * @throws \Exception
+     * @throws \LogicException
      */
     private function getVisibility(array $object, User $actor): string
     {
@@ -123,7 +125,7 @@ class Page
                     array_merge($object['to'] ?? [], $object['cc'] ?? [])
                 )
             ) {
-                throw new \Exception('PM: not implemented.');
+                throw new \LogicException('PM: not implemented.');
             }
 
             return VisibilityInterface::VISIBILITY_PRIVATE;


### PR DESCRIPTION
This PR aims to improve the scaling of the messengers by avoiding database dead locks

- move all previous invoke code in a `doWork` method and use the `__invoke` methods to wrap the `doWork` in a transaction using a new abstract class
- do not catch all exceptions in the `ChainActivityHandler`, but only those we want (did catch a deadlock exception as well which should not be caught)