### PR TITLE
Tombstones for deleted remote users

### DIFF
--- a/src/Exception/UserDeletedException.php
+++ b/src/Exception/UserDeletedException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+final class UserDeletedException extends \Exception
+{
+}

--- a/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
@@ -10,6 +10,7 @@ use App\Entity\Post;
 use App\Entity\PostComment;
 use App\Exception\TagBannedException;
 use App\Exception\UserBannedException;
+use App\Exception\UserDeletedException;
 use App\Message\ActivityPub\Inbox\AnnounceMessage;
 use App\Message\ActivityPub\Inbox\ChainActivityMessage;
 use App\Message\ActivityPub\Inbox\DislikeMessage;
@@ -116,6 +117,8 @@ class ChainActivityHandler
             }
         } catch (UserBannedException) {
             $this->logger->error('the user is banned, url: {url}', ['url' => $apUrl]);
+        } catch (UserDeletedException) {
+            $this->logger->error('the user is deleted, url: {url}', ['url' => $apUrl]);
         } catch (TagBannedException) {
             $this->logger->error('one of the used tags is banned, url: {url}', ['url' => $apUrl]);
         } catch (\Exception $e) {

--- a/src/MessageHandler/ActivityPub/Inbox/CreateHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/CreateHandler.php
@@ -8,6 +8,7 @@ use App\Entity\Entry;
 use App\Entity\EntryComment;
 use App\Exception\TagBannedException;
 use App\Exception\UserBannedException;
+use App\Exception\UserDeletedException;
 use App\Message\ActivityPub\Inbox\ChainActivityMessage;
 use App\Message\ActivityPub\Inbox\CreateMessage;
 use App\Message\ActivityPub\Outbox\AnnounceMessage;
@@ -58,11 +59,18 @@ class CreateHandler
             }
         } catch (UserBannedException) {
             $this->logger->info('Did not create the post, because the user is banned');
+        } catch (UserDeletedException) {
+            $this->logger->info('Did not create the post, because the user is deleted');
         } catch (TagBannedException) {
             $this->logger->info('Did not create the post, because one of the used tags is banned');
         }
     }
 
+    /**
+     * @throws TagBannedException
+     * @throws UserBannedException
+     * @throws UserDeletedException
+     */
     private function handleChain(): void
     {
         if (isset($this->object['inReplyTo']) && $this->object['inReplyTo']) {
@@ -87,6 +95,7 @@ class CreateHandler
     /**
      * @throws \Exception
      * @throws UserBannedException
+     * @throws UserDeletedException
      * @throws TagBannedException
      */
     private function handlePage(): void


### PR DESCRIPTION
- when deleting remote users a tombstone for them is now created
- create a new exception for when a remote user that is deleted on the local instance creates something
- add some banned checks as well

Closes #629