### PR TITLE
increase issue stale time to a year

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: "This issue is stale because it has been open 50 days with no activity. Remove stale label or comment or this will be closed in 6 days."
+          stale-issue-message: "This issue is stale because it has been open a year with no activity."
           stale-pr-message: "This PR is stale because it has been open 40 days with no activity."
           close-issue-message: "This issue was closed because it has been stalled for 6 days with no activity."
           exempt-issue-labels: "high priority"
-          days-before-issue-stale: 50
+          days-before-issue-stale: 365
           days-before-pr-stale: 40
           days-before-issue-close: -1
           days-before-pr-close: -1


### PR DESCRIPTION
I think it is very annoying to have issues going stale so soon. I increased the time to a year for now, but this is very much open for discussion.

Additionally I removed the part about issues closing, this is not the case anymore