### PR TITLE
Remove federated users view from admin panel users page

### DIFF
--- a/config/kbin_routes/admin.yaml
+++ b/config/kbin_routes/admin.yaml
@@ -1,7 +1,6 @@
 admin_users:
     controller: App\Controller\Admin\AdminUserController
-    defaults: { withFederated: false }
-    path: /admin/users/{withFederated}
+    path: /admin/users
     methods: [GET]
 
 admin_reports:

--- a/src/Controller/Admin/AdminUserController.php
+++ b/src/Controller/Admin/AdminUserController.php
@@ -16,16 +16,14 @@ class AdminUserController extends AbstractController
     }
 
     #[IsGranted('ROLE_ADMIN')]
-    public function __invoke(?bool $withFederated = null)
+    public function __invoke()
     {
         return $this->render(
             'admin/users.html.twig',
             [
                 'users' => $this->repository->findAllPaginated(
-                    (int) $this->request->getCurrentRequest()->get('p', 1),
-                    !($withFederated ?? false)
+                    (int) $this->request->getCurrentRequest()->get('p', 1), true
                 ),
-                'withFederated' => $withFederated,
             ]
         );
     }

--- a/templates/admin/users.html.twig
+++ b/templates/admin/users.html.twig
@@ -18,14 +18,6 @@
         {{ pagerfanta(users, null, {'pageParameter':'[p]'}) }}
     {% endif %}
     <div class="section" id="content">
-        <div class="flex" data-controller="selection">
-            <label class="select">
-                <select data-action="selection#changeLocation">"
-                    <option value="{{ options_url('withFederated', false) }}">{{ 'local'|trans }}</option>
-                    <option value="{{ options_url('withFederated', true) }}" {{ withFederated is same as true ? 'selected' : '' }}>{{ 'federated'|trans }}</option>
-                </select>
-            </label>
-        </div>
         <table>
             <thead>
             <tr>
@@ -46,7 +38,6 @@
                         <td>{{ component('date', {date: user.lastActive}) }}</td>
                         <td>
                             <button class="btn btn__secondary">{{ (user.isVerified or user.apId) and not user.isBanned ? 'active'|trans : 'inactive'|trans }}</button>
-                            <button class="btn btn__secondary">{{ user.apId ? 'federated'|trans : 'local'|trans }}</button>
                             {% if user.isTotpAuthenticationEnabled %}
                                 <button class="btn btn__secondary" title="{{ '2fa.user_active_tfa.title'|trans }}" aria-label="{{ '2fa.user_active_tfa.title'|trans }}"><i class="fa fa-mobile" aria-hidden="true"></i></button>
                             {% endif %}


### PR DESCRIPTION
I don't think I've ever used or wanted to use the federated user view in the users page in the admin panel. In kbin.run's case, it generates over 7000 pages of federated users when selected... This PR removes it.

Before:
![image](https://github.com/user-attachments/assets/f3d216bb-0ed2-457d-8666-93fd760167a4)

After:
![image](https://github.com/user-attachments/assets/1c939665-8ac9-419e-801a-0f3d4ae3d540)
