### PR TITLE
Implement "posting restricted to mods"

### DIFF
--- a/migrations/Version20240729174207.php
+++ b/migrations/Version20240729174207.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240729174207 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the posting_restricted_to_mods column to the magazine table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE magazine ADD posting_restricted_to_mods BOOLEAN NOT NULL DEFAULT FALSE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE magazine DROP posting_restricted_to_mods');
+    }
+}

--- a/src/Controller/Entry/EntryCreateController.php
+++ b/src/Controller/Entry/EntryCreateController.php
@@ -7,6 +7,7 @@ namespace App\Controller\Entry;
 use App\Controller\AbstractController;
 use App\DTO\EntryDto;
 use App\Entity\Magazine;
+use App\Exception\PostingRestrictedException;
 use App\Exception\TagBannedException;
 use App\PageView\EntryPageView;
 use App\Repository\Criteria;
@@ -90,6 +91,19 @@ class EntryCreateController extends AbstractController
         } catch (TagBannedException $e) {
             // Show an error to the user
             $this->addFlash('error', 'flash_thread_tag_banned_error');
+            $this->logger->error($e);
+
+            return $this->render(
+                $this->getTemplateName((new EntryPageView(1))->resolveType($type)),
+                [
+                    'magazine' => $magazine,
+                    'user' => $user,
+                    'form' => $form->createView(),
+                ],
+                new Response(null, 422)
+            );
+        } catch (PostingRestrictedException $e) {
+            $this->addFlash('error', 'flash_posting_restricted_error');
             $this->logger->error($e);
 
             return $this->render(

--- a/src/DTO/MagazineDto.php
+++ b/src/DTO/MagazineDto.php
@@ -38,6 +38,7 @@ class MagazineDto
     public int $postCount = 0;
     public int $postCommentCount = 0;
     public bool $isAdult = false;
+    public bool $isPostingRestrictedToMods = false;
     public ?bool $isUserSubscribed = null;
     public ?bool $isBlockedByUser = null;
     public ?array $tags = null;

--- a/src/Exception/PostingRestrictedException.php
+++ b/src/Exception/PostingRestrictedException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use App\Entity\Magazine;
+use App\Entity\User;
+
+final class PostingRestrictedException extends \Exception
+{
+    public function __construct(public Magazine $magazine, public User|Magazine $actor)
+    {
+        if ($this->actor instanceof User) {
+            $username = $this->actor->getUsername();
+        } else {
+            $username = $this->actor->name;
+        }
+        $m = \sprintf('Posting in magazine %s is restricted to mods and %s is not a mod', $this->magazine->apId ?? $this->magazine->name, $username);
+        parent::__construct($m, 0, null);
+    }
+}

--- a/src/Factory/ActivityPub/GroupFactory.php
+++ b/src/Factory/ActivityPub/GroupFactory.php
@@ -77,7 +77,7 @@ class GroupFactory
                 ['name' => $magazine->name],
                 UrlGeneratorInterface::ABSOLUTE_URL
             ),
-            'postingRestrictedToMods' => false,
+            'postingRestrictedToMods' => $magazine->postingRestrictedToMods,
             'endpoints' => [
                 'sharedInbox' => $this->urlGenerator->generate(
                     'ap_shared_inbox',

--- a/src/Factory/MagazineFactory.php
+++ b/src/Factory/MagazineFactory.php
@@ -60,6 +60,7 @@ class MagazineFactory
         $dto->postCount = $magazine->postCount;
         $dto->postCommentCount = $magazine->postCommentCount;
         $dto->isAdult = $magazine->isAdult;
+        $dto->isPostingRestrictedToMods = $magazine->postingRestrictedToMods;
         $dto->tags = $magazine->tags;
         $dto->badges = $magazine->badges;
         $dto->moderators = $magazine->moderators;

--- a/src/Form/MagazineType.php
+++ b/src/Form/MagazineType.php
@@ -24,6 +24,7 @@ class MagazineType extends AbstractType
             ->add('description', TextareaType::class, ['required' => false])
             ->add('rules', TextareaType::class, ['required' => false])
             ->add('isAdult', CheckboxType::class, ['required' => false])
+            ->add('isPostingRestrictedToMods', CheckboxType::class, ['required' => false])
             ->add('submit', SubmitType::class);
 
         $builder->addEventSubscriber(new DisableFieldsOnMagazineEdit());

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -512,6 +512,7 @@ class ActivityPubManager
             $magazine->apTimeoutAt = null;
             $magazine->apFetchedAt = new \DateTime();
             $magazine->isAdult = $actor['sensitive'] ?? false;
+            $magazine->postingRestrictedToMods = filter_var($actor['postingRestrictedToMods'] ?? false, FILTER_VALIDATE_BOOLEAN) ?? false;
 
             if (null !== $magazine->apFollowersUrl) {
                 try {

--- a/src/Service/MagazineManager.php
+++ b/src/Service/MagazineManager.php
@@ -141,6 +141,7 @@ class MagazineManager
         $magazine->description = $dto->description;
         $magazine->rules = $dto->rules;
         $magazine->isAdult = $dto->isAdult;
+        $magazine->postingRestrictedToMods = $dto->isPostingRestrictedToMods;
 
         $this->entityManager->flush();
 

--- a/templates/components/magazine_box.html.twig
+++ b/templates/components/magazine_box.html.twig
@@ -18,8 +18,17 @@
             </figure>
         {% endif %}
         <header>
-            <h4><a href="{{ path('front_magazine', {name: magazine.name}) }}"
-                   class="{{ html_classes({'stretched-link': false}) }}">{{ computed.magazine.title }}</a></h4>
+            <h4>
+                <a href="{{ path('front_magazine', {name: magazine.name}) }}" class="{{ html_classes({'stretched-link': false}) }}">
+                    {{ computed.magazine.title }}
+                </a>
+                {% if magazine.postingRestrictedToMods %}
+                    <i class="fa-solid fa-lock"
+                       aria-description="{{ 'magazine_posting_restricted_to_mods_warning'|trans }}"
+                       title="{{ 'magazine_posting_restricted_to_mods_warning'|trans }}"
+                       aria-describedby="{{ 'magazine_posting_restricted_to_mods_warning'|trans }}"></i>
+                {% endif %}
+            </h4>
             <p class="magazine__name">
                 <span>{{ ('@'~magazine.name)|username(true) }} {% if magazine.isAdult %}<small class="badge danger">18+</small>{% endif %}</span>
                 {% if magazine.apId %}

--- a/templates/components/magazine_inline.html.twig
+++ b/templates/components/magazine_inline.html.twig
@@ -12,7 +12,19 @@
     {% endif %}
     {% if fullName %}
         {{ magazine.name }} {% if magazine.isAdult %}<small class="badge danger">18+</small>{% endif %}
+        {% if magazine.postingRestrictedToMods %}
+            <i class="fa-solid fa-lock"
+               aria-description="{{ 'magazine_posting_restricted_to_mods_warning'|trans }}"
+               title="{{ 'magazine_posting_restricted_to_mods_warning'|trans }}"
+               aria-describedby="{{ 'magazine_posting_restricted_to_mods_warning'|trans }}"></i>
+        {% endif %}
     {% else %}
         {{ magazine.title }}
+        {% if magazine.postingRestrictedToMods %}
+            <i class="fa-solid fa-lock"
+               aria-description="{{ 'magazine_posting_restricted_to_mods_warning'|trans }}"
+               title="{{ 'magazine_posting_restricted_to_mods_warning'|trans }}"
+               aria-describedby="{{ 'magazine_posting_restricted_to_mods_warning'|trans }}"></i>
+        {% endif %}
     {% endif %}
 </a>

--- a/templates/entry/front.html.twig
+++ b/templates/entry/front.html.twig
@@ -52,6 +52,7 @@
     {% include 'entry/_options.html.twig' %}
     {% include 'layout/_flash.html.twig' %}
     {% if magazine is defined and magazine %}
+        {% include 'magazine/_restricted_info.html.twig' %}
         {% include 'magazine/_federated_info.html.twig' %}
         {% include 'magazine/_visibility_info.html.twig' %}
     {% endif %}

--- a/templates/magazine/_restricted_info.html.twig
+++ b/templates/magazine/_restricted_info.html.twig
@@ -1,0 +1,5 @@
+{% if magazine.postingRestrictedToMods and (app.user is not defined or app.user is same as null or magazine.isActorPostingRestricted(app.user)) %}
+    <div class="alert alert__info">
+        {{ 'magazine_posting_restricted_to_mods_warning'|trans }}
+    </div>
+{% endif %}

--- a/templates/magazine/panel/general.html.twig
+++ b/templates/magazine/panel/general.html.twig
@@ -40,6 +40,10 @@
                 {{ form_label(form.isAdult) }}
                 {{ form_widget(form.isAdult) }}
             </div>
+            <div class="checkbox">
+                {{ form_label(form.isPostingRestrictedToMods) }}
+                {{ form_widget(form.isPostingRestrictedToMods) }}
+            </div>
             <div class="actions">
                 {{ form_row(form.submit, { 'label': 'done'|trans, 'attr': {'class': 'btn btn__primary'} }) }}
             </div>

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -867,3 +867,5 @@ show_related_entries: Show random threads
 show_related_posts: Show random posts
 show_active_users: Show active users
 notification_title_new_report: A new report was created
+magazine_posting_restricted_to_mods_warning: Only mods can create threads in this magazine
+flash_posting_restricted_error: Creating threads is restricted to mods in this magazine and you are not one


### PR DESCRIPTION
- magazines have a new option to restrict the creation of entries to mods. This does not affect comments or microblogs
- if the posting in a magazine is restricted exceptions are thrown which are caught by the messengers and logged and show a flash message in the UI
- magazines which restrict posting have a lock icon next to their name

Closes #528 