### PR TITLE
Send out update activities on actor updates

### DIFF
--- a/src/Controller/Api/Entry/Comments/EntryCommentsUpdateApi.php
+++ b/src/Controller/Api/Entry/Comments/EntryCommentsUpdateApi.php
@@ -105,7 +105,7 @@ class EntryCommentsUpdateApi extends EntriesBaseApi
             throw new BadRequestHttpException((string) $errors);
         }
 
-        $comment = $manager->edit($comment, $dto);
+        $comment = $manager->edit($comment, $dto, $this->getUserOrThrow());
 
         return new JsonResponse(
             $this->serializeCommentTree($comment),

--- a/src/Controller/Api/Entry/EntriesUpdateApi.php
+++ b/src/Controller/Api/Entry/EntriesUpdateApi.php
@@ -93,7 +93,7 @@ class EntriesUpdateApi extends EntriesBaseApi
             throw new BadRequestHttpException((string) $errors);
         }
 
-        $entry = $manager->edit($entry, $dto);
+        $entry = $manager->edit($entry, $dto, $this->getUserOrThrow());
 
         return new JsonResponse(
             $this->serializeEntry($entry, $this->tagLinkRepository->getTagsOfEntry($entry)),

--- a/src/Controller/Api/Magazine/Admin/MagazineUpdateApi.php
+++ b/src/Controller/Api/Magazine/Admin/MagazineUpdateApi.php
@@ -99,7 +99,7 @@ class MagazineUpdateApi extends MagazineBaseApi
             throw new BadRequestHttpException('Magazine name cannot be edited');
         }
 
-        $magazine = $manager->edit($magazine, $dto);
+        $magazine = $manager->edit($magazine, $dto, $this->getUserOrThrow());
 
         return new JsonResponse(
             $this->serializeMagazine($factory->createDto($magazine)),

--- a/src/Controller/Api/Post/Comments/PostCommentsUpdateApi.php
+++ b/src/Controller/Api/Post/Comments/PostCommentsUpdateApi.php
@@ -105,7 +105,7 @@ class PostCommentsUpdateApi extends PostsBaseApi
             throw new BadRequestHttpException((string) $errors);
         }
 
-        $comment = $manager->edit($comment, $dto);
+        $comment = $manager->edit($comment, $dto, $this->getUserOrThrow());
 
         return new JsonResponse(
             $this->serializePostCommentTree($comment),

--- a/src/Controller/Api/Post/PostsUpdateApi.php
+++ b/src/Controller/Api/Post/PostsUpdateApi.php
@@ -85,7 +85,8 @@ class PostsUpdateApi extends PostsBaseApi
     ): JsonResponse {
         $headers = $this->rateLimit($apiUpdateLimiter);
 
-        if ($post->user->getId() !== $this->getUserOrThrow()->getId()) {
+        $user = $this->getUserOrThrow();
+        if ($post->user->getId() !== $user->getId()) {
             throw new AccessDeniedHttpException();
         }
 
@@ -96,7 +97,7 @@ class PostsUpdateApi extends PostsBaseApi
             throw new BadRequestHttpException((string) $errors);
         }
 
-        $post = $manager->edit($post, $dto);
+        $post = $manager->edit($post, $dto, $user);
 
         return new JsonResponse(
             $this->serializePost($factory->createDto($post), $this->tagLinkRepository->getTagsOfPost($post)),

--- a/src/Controller/Entry/Comment/EntryCommentEditController.php
+++ b/src/Controller/Entry/Comment/EntryCommentEditController.php
@@ -95,7 +95,7 @@ class EntryCommentEditController extends AbstractController
 
     private function handleValidRequest(EntryCommentDto $dto, EntryComment $comment, Request $request): Response
     {
-        $comment = $this->manager->edit($comment, $dto);
+        $comment = $this->manager->edit($comment, $dto, $this->getUserOrThrow());
 
         if ($request->isXmlHttpRequest()) {
             return $this->getJsonCommentSuccessResponse($comment);

--- a/src/Controller/Entry/EntryEditController.php
+++ b/src/Controller/Entry/EntryEditController.php
@@ -45,7 +45,7 @@ class EntryEditController extends AbstractController
                     throw new AccessDeniedHttpException();
                 }
 
-                $entry = $this->manager->edit($entry, $dto);
+                $entry = $this->manager->edit($entry, $dto, $this->getUserOrThrow());
 
                 $this->addFlash('success', 'flash_thread_edit_success');
 

--- a/src/Controller/Magazine/Panel/MagazineEditController.php
+++ b/src/Controller/Magazine/Panel/MagazineEditController.php
@@ -29,7 +29,7 @@ class MagazineEditController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->manager->edit($magazine, $magazineDto);
+            $this->manager->edit($magazine, $magazineDto, $this->getUserOrThrow());
 
             $this->addFlash('success', 'flash_magazine_edit_success');
 

--- a/src/Controller/Post/Comment/PostCommentEditController.php
+++ b/src/Controller/Post/Comment/PostCommentEditController.php
@@ -106,7 +106,7 @@ class PostCommentEditController extends AbstractController
 
     private function handleValidRequest(PostCommentDto $dto, PostComment $comment, Request $request): Response
     {
-        $comment = $this->manager->edit($comment, $dto);
+        $comment = $this->manager->edit($comment, $dto, $this->getUserOrThrow());
 
         if ($request->isXmlHttpRequest()) {
             return $this->getPostCommentJsonSuccessResponse($comment);

--- a/src/Controller/Post/PostEditController.php
+++ b/src/Controller/Post/PostEditController.php
@@ -46,7 +46,7 @@ class PostEditController extends AbstractController
                     throw new AccessDeniedHttpException();
                 }
 
-                $post = $this->manager->edit($post, $dto);
+                $post = $this->manager->edit($post, $dto, $this->getUserOrThrow());
 
                 if ($request->isXmlHttpRequest()) {
                     return new JsonResponse(

--- a/src/Entity/Magazine.php
+++ b/src/Entity/Magazine.php
@@ -476,4 +476,13 @@ class Magazine implements VisibilityInterface, ActivityPubActorInterface, ApiRes
 
         return false;
     }
+
+    public function canUpdateMagazine(User $actor): bool
+    {
+        if (null === $this->apId) {
+            return $actor->isAdmin() || $actor->isModerator() || $this->userIsModerator($actor);
+        } else {
+            return $this->apDomain === $actor->apDomain || $this->userIsModerator($actor);
+        }
+    }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -871,4 +871,13 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Visibil
             );
         }
     }
+
+    public function canUpdateUser(User $actor): bool
+    {
+        if (null === $this->apId) {
+            return null === $actor->apId && $actor->isAdmin();
+        } else {
+            return $this->apDomain === $actor->apDomain;
+        }
+    }
 }

--- a/src/Event/Entry/EntryEditedEvent.php
+++ b/src/Event/Entry/EntryEditedEvent.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace App\Event\Entry;
 
 use App\Entity\Entry;
+use App\Entity\User;
 
 class EntryEditedEvent
 {
-    public function __construct(public Entry $entry)
+    public function __construct(public Entry $entry, public ?User $editedBy = null)
     {
     }
 }

--- a/src/Event/EntryComment/EntryCommentEditedEvent.php
+++ b/src/Event/EntryComment/EntryCommentEditedEvent.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace App\Event\EntryComment;
 
 use App\Entity\EntryComment;
+use App\Entity\User;
 
 class EntryCommentEditedEvent
 {
-    public function __construct(public EntryComment $comment)
+    public function __construct(public EntryComment $comment, public ?User $editedByUser = null)
     {
     }
 }

--- a/src/Event/Magazine/MagazineUpdatedEvent.php
+++ b/src/Event/Magazine/MagazineUpdatedEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Event\Magazine;
+
+use App\Entity\Magazine;
+use App\Entity\User;
+
+class MagazineUpdatedEvent
+{
+    public function __construct(
+        public Magazine $magazine,
+        public User $editedBy,
+    ) {
+    }
+}

--- a/src/Event/Post/PostEditedEvent.php
+++ b/src/Event/Post/PostEditedEvent.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace App\Event\Post;
 
 use App\Entity\Post;
+use App\Entity\User;
 
 class PostEditedEvent
 {
-    public function __construct(public Post $post)
+    public function __construct(public Post $post, public ?User $editedBy)
     {
     }
 }

--- a/src/Event/PostComment/PostCommentEditedEvent.php
+++ b/src/Event/PostComment/PostCommentEditedEvent.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace App\Event\PostComment;
 
 use App\Entity\PostComment;
+use App\Entity\User;
 
 class PostCommentEditedEvent
 {
-    public function __construct(public PostComment $comment)
+    public function __construct(public PostComment $comment, public ?User $editedBy = null)
     {
     }
 }

--- a/src/Event/User/UserEditedEvent.php
+++ b/src/Event/User/UserEditedEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Event\User;
+
+class UserEditedEvent
+{
+    public function __construct(
+        public int $userId
+    ) {
+    }
+}

--- a/src/EventSubscriber/Entry/EntryEditSubscriber.php
+++ b/src/EventSubscriber/Entry/EntryEditSubscriber.php
@@ -32,7 +32,7 @@ class EntryEditSubscriber implements EventSubscriberInterface
         }
 
         if (!$event->entry->apId) {
-            $this->bus->dispatch(new UpdateMessage($event->entry->getId(), \get_class($event->entry)));
+            $this->bus->dispatch(new UpdateMessage($event->entry->getId(), \get_class($event->entry), $event->editedBy->getId()));
         }
     }
 }

--- a/src/EventSubscriber/EntryComment/EntryCommentEditSubscriber.php
+++ b/src/EventSubscriber/EntryComment/EntryCommentEditSubscriber.php
@@ -35,7 +35,7 @@ class EntryCommentEditSubscriber implements EventSubscriberInterface
         }
 
         if (!$event->comment->apId) {
-            $this->bus->dispatch(new UpdateMessage($event->comment->getId(), \get_class($event->comment)));
+            $this->bus->dispatch(new UpdateMessage($event->comment->getId(), \get_class($event->comment), $event->editedByUser->getId()));
         }
     }
 }

--- a/src/EventSubscriber/Magazine/MagazineUpdatedSubscriber.php
+++ b/src/EventSubscriber/Magazine/MagazineUpdatedSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber\Magazine;
+
+use App\Entity\Magazine;
+use App\Event\Magazine\MagazineUpdatedEvent;
+use App\Message\ActivityPub\Outbox\GenericAnnounceMessage;
+use App\Message\ActivityPub\Outbox\UpdateMessage;
+use App\Service\ActivityPub\Wrapper\UpdateWrapper;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class MagazineUpdatedSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly MessageBusInterface $bus,
+        private readonly UpdateWrapper $updateWrapper,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            MagazineUpdatedEvent::class => 'onMagazineUpdated',
+        ];
+    }
+
+    public function onMagazineUpdated(MagazineUpdatedEvent $event): void
+    {
+        $mag = $event->magazine;
+        if (null === $mag->apId) {
+            $activity = $this->updateWrapper->buildForActor($mag, $event->editedBy);
+            $this->bus->dispatch(new GenericAnnounceMessage($mag->getId(), $activity, $event->editedBy->apDomain));
+        } elseif (null !== $event->editedBy && null === $event->editedBy->apId) {
+            $this->bus->dispatch(new UpdateMessage($mag->getId(), Magazine::class, $event->editedBy->getId()));
+        }
+    }
+}

--- a/src/EventSubscriber/Post/PostEditSubscriber.php
+++ b/src/EventSubscriber/Post/PostEditSubscriber.php
@@ -24,7 +24,7 @@ class PostEditSubscriber implements EventSubscriberInterface
         ];
     }
 
-    public function onPostEdited(PostEditedEvent $event)
+    public function onPostEdited(PostEditedEvent $event): void
     {
         $this->bus->dispatch(new PostEditedNotificationMessage($event->post->getId()));
         if ($event->post->body) {
@@ -32,7 +32,7 @@ class PostEditSubscriber implements EventSubscriberInterface
         }
 
         if (!$event->post->apId) {
-            $this->bus->dispatch(new UpdateMessage($event->post->getId(), \get_class($event->post)));
+            $this->bus->dispatch(new UpdateMessage($event->post->getId(), \get_class($event->post), $event->editedBy->getId()));
         }
     }
 }

--- a/src/EventSubscriber/PostComment/PostCommentEditSubscriber.php
+++ b/src/EventSubscriber/PostComment/PostCommentEditSubscriber.php
@@ -40,7 +40,7 @@ class PostCommentEditSubscriber implements EventSubscriberInterface
         }
 
         if (!$event->comment->apId) {
-            $this->bus->dispatch(new UpdateMessage($event->comment->getId(), \get_class($event->comment)));
+            $this->bus->dispatch(new UpdateMessage($event->comment->getId(), \get_class($event->comment), $event->editedBy->getId()));
         }
     }
 }

--- a/src/EventSubscriber/User/UserEditedSubscriber.php
+++ b/src/EventSubscriber/User/UserEditedSubscriber.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber\User;
+
+use App\Entity\User;
+use App\Event\User\UserEditedEvent;
+use App\Message\ActivityPub\Outbox\UpdateMessage;
+use App\Repository\UserRepository;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class UserEditedSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly UserRepository $userRepository,
+        private readonly MessageBusInterface $bus,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            UserEditedEvent::class => 'onUserEdited',
+        ];
+    }
+
+    public function onUserEdited(UserEditedEvent $event): void
+    {
+        $user = $this->userRepository->findOneBy(['id' => $event->userId]);
+        if (null === $user->apId) {
+            $this->bus->dispatch(new UpdateMessage($user->getId(), User::class, $user->getId()));
+        }
+    }
+}

--- a/src/Factory/ActivityPub/GroupFactory.php
+++ b/src/Factory/ActivityPub/GroupFactory.php
@@ -21,7 +21,7 @@ class GroupFactory
     ) {
     }
 
-    public function create(Magazine $magazine): array
+    public function create(Magazine $magazine, bool $includeContext = true): array
     {
         $markdownSummary = $magazine->description ?? '';
 
@@ -96,6 +96,10 @@ class GroupFactory
                 'type' => 'Image',
                 'url' => $this->imageManager->getUrl($magazine->icon),
             ];
+        }
+
+        if (!$includeContext) {
+            unset($group['@context']);
         }
 
         return $group;

--- a/src/Message/ActivityPub/Outbox/UpdateMessage.php
+++ b/src/Message/ActivityPub/Outbox/UpdateMessage.php
@@ -8,7 +8,7 @@ use App\Message\Contracts\ActivityPubOutboxInterface;
 
 class UpdateMessage implements ActivityPubOutboxInterface
 {
-    public function __construct(public int $id, public string $type)
+    public function __construct(public int $id, public string $type, public ?int $editedByUserId = null)
     {
     }
 }

--- a/src/Repository/ApActivityRepository.php
+++ b/src/Repository/ApActivityRepository.php
@@ -80,6 +80,10 @@ class ApActivityRepository extends ServiceEntityRepository
         if ($parsed['host'] === $this->settingsManager->get('KBIN_DOMAIN')) {
             $exploded = array_filter(explode('/', $parsed['path']));
             $id = \intval(end($exploded));
+            if (\sizeof($exploded) < 3) {
+                return null;
+            }
+
             if ('p' === $exploded[3]) {
                 if (4 === \count($exploded)) {
                     return [

--- a/src/Service/ActivityPub/Wrapper/UpdateWrapper.php
+++ b/src/Service/ActivityPub/Wrapper/UpdateWrapper.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\ActivityPub\Wrapper;
+
+use App\Entity\Contracts\ActivityPubActivityInterface;
+use App\Entity\Contracts\ActivityPubActorInterface;
+use App\Entity\Magazine;
+use App\Entity\User;
+use App\Factory\ActivityPub\ActivityFactory;
+use App\Factory\ActivityPub\GroupFactory;
+use App\Factory\ActivityPub\PersonFactory;
+use JetBrains\PhpStorm\ArrayShape;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Uid\Uuid;
+
+class UpdateWrapper
+{
+    public function __construct(
+        private readonly ActivityFactory $factory,
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly GroupFactory $groupFactory,
+        private readonly PersonFactory $personFactory,
+    ) {
+    }
+
+    #[ArrayShape([
+        '@context' => 'mixed',
+        'id' => 'mixed',
+        'type' => 'string',
+        'actor' => 'mixed',
+        'published' => 'mixed',
+        'to' => 'mixed',
+        'cc' => 'mixed',
+        'object' => 'array',
+    ])]
+    public function buildForActivity(ActivityPubActivityInterface $activity, ?User $editedBy = null): array
+    {
+        $entity = $this->factory->create($activity, true);
+        $id = Uuid::v4()->toRfc4122();
+
+        $context = $entity['@context'];
+        unset($entity['@context']);
+
+        $entity['object']['updated'] = $activity->editedAt ? $activity->editedAt->format(DATE_ATOM) : (new \DateTime())->format(DATE_ATOM);
+
+        $actorUrl = $entity['attributedTo'];
+        if (null !== $editedBy) {
+            $actorUrl = $this->urlGenerator->generate('ap_user', ['username' => $editedBy->username], UrlGeneratorInterface::ABSOLUTE_URL);
+        }
+
+        return [
+            '@context' => $context,
+            'id' => $this->urlGenerator->generate('ap_object', ['id' => $id], UrlGeneratorInterface::ABSOLUTE_URL),
+            'type' => 'Update',
+            'actor' => $actorUrl,
+            'published' => $entity['published'],
+            'to' => $entity['to'],
+            'cc' => $entity['cc'],
+            'object' => $entity,
+        ];
+    }
+
+    #[ArrayShape([
+        '@context' => 'mixed',
+        'id' => 'mixed',
+        'type' => 'string',
+        'actor' => 'mixed',
+        'published' => 'mixed',
+        'to' => 'mixed',
+        'cc' => 'mixed',
+        'object' => 'array',
+    ])]
+    public function buildForActor(ActivityPubActorInterface $item, ?User $editedBy = null): array
+    {
+        if ($item instanceof User) {
+            $activity = $this->personFactory->create($item, false);
+            $cc = $this->urlGenerator->generate('ap_user_followers', ['username' => $item->username], UrlGeneratorInterface::ABSOLUTE_URL);
+        } elseif ($item instanceof Magazine) {
+            $activity = $this->groupFactory->create($item, false);
+            $cc = $this->urlGenerator->generate('ap_magazine_followers', ['name' => $item->name], UrlGeneratorInterface::ABSOLUTE_URL);
+        } else {
+            throw new \LogicException('Unknown actor type: '.\get_class($item));
+        }
+        $id = Uuid::v4()->toRfc4122();
+
+        $actorUrl = $activity['id'];
+        if (null !== $editedBy) {
+            $actorUrl = $this->urlGenerator->generate('ap_user', ['username' => $editedBy->username], UrlGeneratorInterface::ABSOLUTE_URL);
+        }
+
+        return [
+            '@context' => [$this->urlGenerator->generate('ap_contexts', [], UrlGeneratorInterface::ABSOLUTE_URL)],
+            'id' => $this->urlGenerator->generate('ap_object', ['id' => $id], UrlGeneratorInterface::ABSOLUTE_URL),
+            'type' => 'Update',
+            'actor' => $actorUrl,
+            'published' => $activity['published'],
+            'to' => [ActivityPubActivityInterface::PUBLIC_URL],
+            'cc' => $cc,
+            'object' => $activity,
+        ];
+    }
+}

--- a/src/Service/EntryCommentManager.php
+++ b/src/Service/EntryCommentManager.php
@@ -112,7 +112,7 @@ class EntryCommentManager implements ContentManagerInterface
         return $entryCommentHost === $userHost || $userHost === $magazineHost || $comment->magazine->userIsModerator($user);
     }
 
-    public function edit(EntryComment $comment, EntryCommentDto $dto): EntryComment
+    public function edit(EntryComment $comment, EntryCommentDto $dto, ?User $editedByUser = null): EntryComment
     {
         Assert::same($comment->entry->getId(), $dto->entry->getId());
 
@@ -145,7 +145,7 @@ class EntryCommentManager implements ContentManagerInterface
             $this->bus->dispatch(new DeleteImageMessage($oldImage->getId()));
         }
 
-        $this->dispatcher->dispatch(new EntryCommentEditedEvent($comment));
+        $this->dispatcher->dispatch(new EntryCommentEditedEvent($comment, $editedByUser));
 
         return $comment;
     }

--- a/src/Service/EntryManager.php
+++ b/src/Service/EntryManager.php
@@ -173,7 +173,7 @@ class EntryManager implements ContentManagerInterface
         return $entryHost === $userHost || $userHost === $magazineHost || $entry->magazine->userIsModerator($user);
     }
 
-    public function edit(Entry $entry, EntryDto $dto): Entry
+    public function edit(Entry $entry, EntryDto $dto, User $editedBy): Entry
     {
         Assert::same($entry->magazine->getId(), $dto->magazine->getId());
 
@@ -213,7 +213,7 @@ class EntryManager implements ContentManagerInterface
             $this->bus->dispatch(new DeleteImageMessage($oldImage->getId()));
         }
 
-        $this->dispatcher->dispatch(new EntryEditedEvent($entry));
+        $this->dispatcher->dispatch(new EntryEditedEvent($entry, $editedBy));
 
         return $entry;
     }

--- a/src/Service/MagazineManager.php
+++ b/src/Service/MagazineManager.php
@@ -19,6 +19,7 @@ use App\Event\Magazine\MagazineBlockedEvent;
 use App\Event\Magazine\MagazineModeratorAddedEvent;
 use App\Event\Magazine\MagazineModeratorRemovedEvent;
 use App\Event\Magazine\MagazineSubscribedEvent;
+use App\Event\Magazine\MagazineUpdatedEvent;
 use App\Exception\UserCannotBeBanned;
 use App\Factory\MagazineFactory;
 use App\Message\DeleteImageMessage;
@@ -133,7 +134,7 @@ class MagazineManager
         $this->dispatcher->dispatch(new MagazineSubscribedEvent($magazine, $user));
     }
 
-    public function edit(Magazine $magazine, MagazineDto $dto): Magazine
+    public function edit(Magazine $magazine, MagazineDto $dto, User $editedBy): Magazine
     {
         Assert::same($magazine->name, $dto->name);
 
@@ -143,6 +144,8 @@ class MagazineManager
         $magazine->isAdult = $dto->isAdult;
 
         $this->entityManager->flush();
+
+        $this->dispatcher->dispatch(new MagazineUpdatedEvent($magazine, $editedBy));
 
         return $magazine;
     }

--- a/src/Service/PostCommentManager.php
+++ b/src/Service/PostCommentManager.php
@@ -120,7 +120,7 @@ class PostCommentManager implements ContentManagerInterface
     /**
      * @throws \Exception
      */
-    public function edit(PostComment $comment, PostCommentDto $dto): PostComment
+    public function edit(PostComment $comment, PostCommentDto $dto, ?User $editedBy = null): PostComment
     {
         Assert::same($comment->post->getId(), $dto->post->getId());
 
@@ -153,7 +153,7 @@ class PostCommentManager implements ContentManagerInterface
             $this->bus->dispatch(new DeleteImageMessage($oldImage->getId()));
         }
 
-        $this->dispatcher->dispatch(new PostCommentEditedEvent($comment));
+        $this->dispatcher->dispatch(new PostCommentEditedEvent($comment, $editedBy));
 
         return $comment;
     }

--- a/src/Service/PostManager.php
+++ b/src/Service/PostManager.php
@@ -131,7 +131,7 @@ class PostManager implements ContentManagerInterface
         return $postHost === $userHost || $userHost === $magazineHost || $post->magazine->userIsModerator($user);
     }
 
-    public function edit(Post $post, PostDto $dto): Post
+    public function edit(Post $post, PostDto $dto, ?User $editedBy = null): Post
     {
         Assert::same($post->magazine->getId(), $dto->magazine->getId());
 
@@ -163,7 +163,7 @@ class PostManager implements ContentManagerInterface
             $this->bus->dispatch(new DeleteImageMessage($oldImage->getId()));
         }
 
-        $this->dispatcher->dispatch(new PostEditedEvent($post));
+        $this->dispatcher->dispatch(new PostEditedEvent($post, $editedBy));
 
         return $post;
     }


### PR DESCRIPTION
when a magazine is edited there are 2 cases:

  - remote magazine, but the editing user is a mod in that magazine: send an update activity to the source instance
  - local magazine: announce the update to all subscribers

when a user is edited send an update activity to all their followers

receive:
- user: dispatch an update actor message, completely ignoring the content of the payload
- magazine: do a bit manually, as we need a dto for the changes, so we can use the `MagazineManager::edit`. That then takes care of announcing the update if the magazine is a local one