### PR TITLE
Add php8.3 to docs + how to switch

### DIFF
--- a/docs/02-admin/01-installation/bare_metal.md
+++ b/docs/02-admin/01-installation/bare_metal.md
@@ -29,7 +29,7 @@ Install prequirements:
 sudo apt-get install lsb-release ca-certificates curl wget unzip gnupg apt-transport-https software-properties-common python3-launchpadlib git redis-server postgresql postgresql-contrib nginx acl -y
 ```
 
-On **Ubuntu 22.04 LTS** or older, prepare latest PHP package repositoy (8.2) by using a Ubuntu PPA (this step is optional for Ubuntu 23.10 or later) via:
+On **Ubuntu 22.04 LTS** or older, prepare latest PHP package repositoy (8.2 or 8.3) by using a Ubuntu PPA (this step is optional for Ubuntu 23.10 or later) via:
 
 ```bash
 sudo add-apt-repository ppa:ondrej/php -y
@@ -41,11 +41,20 @@ On **Debian 12** or later, you can install the latest PHP package repository (th
 sudo sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 ```
 
-Install PHP 8.2 with some important PHP extensions:
+You can choose between PHP 8.2 or 8.3, but it is recommended to use PHP 8.3.
+
+Install _PHP 8.2_ with some important PHP extensions:
 
 ```bash
 sudo apt-get update
 sudo apt-get install php8.2 php8.2-common php8.2-fpm php8.2-cli php8.2-amqp php8.2-bcmath php8.2-pgsql php8.2-gd php8.2-curl php8.2-xml php8.2-redis php8.2-mbstring php8.2-zip php8.2-bz2 php8.2-intl php8.2-bcmath -y
+```
+
+Or install _PHP 8.3_ with PHP extensions:
+
+```bash
+sudo apt-get update
+sudo apt-get install php8.3 php8.3-common php8.3-fpm php8.3-cli php8.3-amqp php8.3-bcmath php8.3-pgsql php8.3-gd php8.3-curl php8.3-xml php8.3-redis php8.3-mbstring php8.3-zip php8.3-bz2 php8.3-intl php8.3-bcmath -y
 ```
 
 Install Composer:

--- a/docs/02-admin/02-configuration/README.md
+++ b/docs/02-admin/02-configuration/README.md
@@ -1,1 +1,11 @@
 # Configuration
+
+These configuration guides can help you configure specific services in more detail.  
+Assuming you have already Mbin installed and followed the installation guide.
+
+Currently, the following configuration guides are provided:
+
+- [Mbin config](./mbin_config_files.md)
+- [Nginx](./nginx.md)
+- [Let's Encrypt](./letsencrypt.md)
+- [Redis / KeyDB](./redis.md)

--- a/docs/02-admin/02-configuration/nginx.md
+++ b/docs/02-admin/02-configuration/nginx.md
@@ -199,7 +199,7 @@ server {
 > If have multiple PHP versions installed. You can switch the PHP version that Nginx is using (`/var/run/php/php-fpm.sock`) via the the following command:
 > `sudo update-alternatives --config php-fpm.sock`
 >
-> Same is true for the php CLI command (`/usr/bin/php`), via the following command:
+> Same is true for the PHP CLI command (`/usr/bin/php`), via the following command:
 > `sudo update-alternatives --config php`
 
 > [!WARNING]

--- a/docs/02-admin/02-configuration/nginx.md
+++ b/docs/02-admin/02-configuration/nginx.md
@@ -195,6 +195,13 @@ server {
 }
 ```
 
+> [!TIP]
+> If have multiple PHP versions installed. You can switch the PHP version that Nginx is using (`/var/run/php/php-fpm.sock`) via the the following command:
+> `sudo update-alternatives --config php-fpm.sock`
+>
+> Same is true for the php CLI command (`/usr/bin/php`), via the following command:
+> `sudo update-alternatives --config php`
+
 > [!WARNING]
 > If also want to also configure your `www.domain.tld` subdomain; our advise is to use a HTTP 301 redirect from the `www` subdomain towards the root domain. Do _NOT_ try to setup a double instance (you want to _avoid_ that ActivityPub will see `www` as a separate instance). See Nginx example below
 


### PR DESCRIPTION
- Add PHP v8.3 to the bare metal guide. Keep the PHP 8.2 section for now.
- Add how to switch PHP versions to the Nginx guide
- Introduce a configuration page (content was empty)
