### PR TITLE
Add missing option to limit thread creation to mods on magazine creation

### DIFF
--- a/src/Entity/Magazine.php
+++ b/src/Entity/Magazine.php
@@ -116,6 +116,7 @@ class Magazine implements VisibilityInterface, ActivityPubActorInterface, ApiRes
         ?string $description,
         ?string $rules,
         bool $isAdult,
+        bool $postingRestrictedToMods,
         ?Image $icon
     ) {
         $this->name = $name;
@@ -123,6 +124,7 @@ class Magazine implements VisibilityInterface, ActivityPubActorInterface, ApiRes
         $this->description = $description;
         $this->rules = $rules;
         $this->isAdult = $isAdult;
+        $this->postingRestrictedToMods = $postingRestrictedToMods;
         $this->icon = $icon;
         $this->moderators = new ArrayCollection();
         $this->entries = new ArrayCollection();

--- a/src/Factory/MagazineFactory.php
+++ b/src/Factory/MagazineFactory.php
@@ -44,6 +44,7 @@ class MagazineFactory
             $dto->description,
             $dto->rules,
             $dto->isAdult,
+            $dto->isPostingRestrictedToMods,
             $dto->icon
         );
     }

--- a/templates/magazine/create.html.twig
+++ b/templates/magazine/create.html.twig
@@ -47,6 +47,7 @@
                 'data-input-length-max-value': constant('App\\Entity\\Magazine::MAX_RULES_LENGTH')
                 }}) }}
             {{ form_row(form.isAdult, {label:'is_adult', row_attr: {class: 'checkbox'}}) }}
+            {{ form_row(form.isPostingRestrictedToMods, {row_attr: {class: 'checkbox'}}) }}
             <div class="row actions">
                 {{ form_row(form.submit, {label: 'create_new_magazine', attr: {class: 'btn btn__primary'}, row_attr: {class: 'float-end'}}) }}
             </div>

--- a/templates/magazine/create.html.twig
+++ b/templates/magazine/create.html.twig
@@ -47,7 +47,7 @@
                 'data-input-length-max-value': constant('App\\Entity\\Magazine::MAX_RULES_LENGTH')
                 }}) }}
             {{ form_row(form.isAdult, {label:'is_adult', row_attr: {class: 'checkbox'}}) }}
-            {{ form_row(form.isPostingRestrictedToMods, {row_attr: {class: 'checkbox'}}) }}
+            {{ form_row(form.isPostingRestrictedToMods, {label:'magazine_posting_restricted_to_mods',row_attr: {class: 'checkbox'}}) }}
             <div class="row actions">
                 {{ form_row(form.submit, {label: 'create_new_magazine', attr: {class: 'btn btn__primary'}, row_attr: {class: 'float-end'}}) }}
             </div>

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -876,3 +876,4 @@ version: Version
 last_successful_deliver: Last successful deliver
 last_successful_receive: Last successful receive
 last_failed_contact: Last failed contact
+magazine_posting_restricted_to_mods: Restrict thread creation to moderators


### PR DESCRIPTION
I missed this in my initial testing, but magazine creation with thread restricted to moderators checked is currently not functional. This PR fixes it.