### PR TITLE
Add a leaf icon next to users and magazines if they are new

### DIFF
--- a/assets/styles/components/_magazine.scss
+++ b/assets/styles/components/_magazine.scss
@@ -337,3 +337,7 @@ td {
 
 
 }
+
+.new-magazine-icon {
+  color: green;
+}

--- a/assets/styles/components/_sidebar.scss
+++ b/assets/styles/components/_sidebar.scss
@@ -190,6 +190,10 @@
       padding: 0;
     }
 
+    li.moderator-item {
+      height: calc(30px + 1rem);
+    }
+
     ul li {
       align-items: center;
       border-top: var(--kbin-meta-border);

--- a/assets/styles/components/_user.scss
+++ b/assets/styles/components/_user.scss
@@ -333,3 +333,7 @@ td .user__actions {
     margin-bottom: 1rem;
   }
 }
+
+.new-user-icon {
+  color: green;
+}

--- a/src/Entity/Traits/CreatedAtTrait.php
+++ b/src/Entity/Traits/CreatedAtTrait.php
@@ -8,6 +8,8 @@ use Doctrine\ORM\Mapping as ORM;
 
 trait CreatedAtTrait
 {
+    public const NEW_FOR_DAYS = 30;
+
     #[ORM\Column(type: 'datetimetz_immutable')]
     public \DateTimeImmutable $createdAt;
 
@@ -19,5 +21,11 @@ trait CreatedAtTrait
     public function getCreatedAt(): \DateTimeImmutable
     {
         return $this->createdAt;
+    }
+
+    public function isNew(): bool
+    {
+        $days = self::NEW_FOR_DAYS;
+        return $this->getCreatedAt() >= new \DateTime("now -$days days");
     }
 }

--- a/src/Entity/Traits/CreatedAtTrait.php
+++ b/src/Entity/Traits/CreatedAtTrait.php
@@ -26,6 +26,7 @@ trait CreatedAtTrait
     public function isNew(): bool
     {
         $days = self::NEW_FOR_DAYS;
+
         return $this->getCreatedAt() >= new \DateTime("now -$days days");
     }
 }

--- a/templates/components/magazine_box.html.twig
+++ b/templates/components/magazine_box.html.twig
@@ -28,6 +28,10 @@
                        title="{{ 'magazine_posting_restricted_to_mods_warning'|trans }}"
                        aria-describedby="{{ 'magazine_posting_restricted_to_mods_warning'|trans }}"></i>
                 {% endif %}
+                {% if magazine.isNew() %}
+                    {% set days = constant('App\\Entity\\Magazine::NEW_FOR_DAYS') %}
+                    <i class="fa-solid fa-leaf new-magazine-icon" title="{{ 'new_magazine_description'|trans({ '%days%': days }) }}" aria-description="{{ 'new_magazine_description'|trans({ '%days%': days }) }}"></i>
+                {% endif %}
             </h4>
             <p class="magazine__name">
                 <span>{{ ('@'~magazine.name)|username(true) }} {% if magazine.isAdult %}<small class="badge danger">18+</small>{% endif %}</span>

--- a/templates/components/magazine_inline.html.twig
+++ b/templates/components/magazine_inline.html.twig
@@ -27,4 +27,8 @@
                aria-describedby="{{ 'magazine_posting_restricted_to_mods_warning'|trans }}"></i>
         {% endif %}
     {% endif %}
+    {% if magazine.isNew() %}
+        {% set days = constant('App\\Entity\\Magazine::NEW_FOR_DAYS') %}
+        <i class="fa-solid fa-leaf new-magazine-icon" title="{{ 'new_magazine_description'|trans({ '%days%': days }) }}" aria-description="{{ 'new_magazine_description'|trans({ '%days%': days }) }}"></i>
+    {% endif %}
 </a>

--- a/templates/components/user_box.html.twig
+++ b/templates/components/user_box.html.twig
@@ -38,6 +38,10 @@
                             {% if (user.type) == "Service" %}
                               <code title="{{ 'user_badge_bot'|trans }}">{{ 'user_badge_bot'|trans }}</code>
                             {% endif %}
+                            {% if user.isNew() %}
+                                {% set days = constant('App\\Entity\\User::NEW_FOR_DAYS') %}
+                                <i class="fa-solid fa-leaf new-user-icon" title="{{ 'new_user_description'|trans({ '%days%': days }) }}" aria-description="{{ 'new_user_description'|trans({ '%days%': days }) }}"></i>
+                            {% endif %}
 
                             {% if user.admin() %}
                               <code title="{{ 'user_badge_admin'|trans }}">{{ 'user_badge_admin'|trans }}</code>
@@ -51,6 +55,10 @@
 
                             {% if (user.type) == "Service" %}
                                 <code title="{{ 'user_badge_bot'|trans }}">{{ 'user_badge_bot'|trans }}</code>
+                            {% endif %}
+                            {% if user.isNew() %}
+                                {% set days = constant('App\\Entity\\User::NEW_FOR_DAYS') %}
+                                <i class="fa-solid fa-leaf new-user-icon" title="{{ 'new_user_description'|trans({ '%days%': days }) }}" aria-description="{{ 'new_user_description'|trans({ '%days%': days }) }}"></i>
                             {% endif %}
 
                             {% if user.admin() %}

--- a/templates/components/user_inline.html.twig
+++ b/templates/components/user_inline.html.twig
@@ -11,4 +11,8 @@
              alt="{{ user.username ~' '~ 'avatar'|trans|lower }}">
     {% endif %}
     {{ user.apPreferredUsername ?? user.username|username -}}
+    {% if user.isNew() %}
+        {% set days = constant('App\\Entity\\User::NEW_FOR_DAYS') %}
+        <i class="fa-solid fa-leaf new-user-icon" title="{{ 'new_user_description'|trans({ '%days%': days }) }}" aria-description="{{ 'new_user_description'|trans({ '%days%': days }) }}"></i>
+    {% endif %}
 </a>

--- a/templates/entry/_form_image.html.twig
+++ b/templates/entry/_form_image.html.twig
@@ -12,6 +12,14 @@
         'data-action' : 'input-length#updateDisplay',
         'data-input-length-max-value' : constant('App\\Entity\\Entry::MAX_TITLE_LENGTH')
     }}) }}
+    {{ component('editor_toolbar', {id: 'entry_image_body'}) }}
+    {{ form_row(form.body, {
+    label: false, attr: {
+        placeholder: 'body',
+        'data-controller': 'rich-textarea input-length autogrow',
+        'data-action' : 'input-length#updateDisplay',
+        'data-input-length-max-value' : constant('App\\Entity\\Entry::MAX_BODY_LENGTH')
+    }}) }}
     {{ form_row(form.magazine, {label: false}) }}
     {{ form_row(form.tags, {label: 'tags'}) }}
     {{ form_row(form.badges, {label: 'badges'}) }}

--- a/templates/magazine/_moderators_sidebar.html.twig
+++ b/templates/magazine/_moderators_sidebar.html.twig
@@ -1,5 +1,5 @@
 <section class="user-list section">
-    <h3 style="display: flex;justify-content: space-between;">
+    <h3 style="display: flex;justify-content: space-between;margin:0;">
         {{ 'moderators'|trans }}
         {% if app.user and magazine.apId is same as null and app.user.visibility is same as 'visible' %}
         <a href="{{ path('magazine_moderators', {name: magazine.name}) }}" title="{{ 'apply_for_moderator'|trans }}" aria-label="{{ 'apply_for_moderator'|trans }}">
@@ -11,18 +11,9 @@
         {% endif %}
     </h3>
     <ul>
-        {% for moderator in magazine.moderators|slice(0, 5) %}
-            <li>
-                {% if moderator.user.avatar %}
-                  <img class="image-inline"
-                       width="30"
-                       height="30"
-                       loading="lazy"
-                       src="{{ moderator.user.avatar.filePath ? (asset(moderator.user.avatar.filePath)|imagine_filter('avatar_thumb')) : moderator.user.avatar.sourceUrl }}"
-                       alt="{{ moderator.user.username ~ ' ' ~ 'avatar'|trans|lower }}">
-                {% endif %}
-                <a href="{{ path('user_overview', {username: moderator.user.username}) }}"
-                   class="stretched-link">{{ moderator.user.username|username }}</a>
+        {% for moderator in magazine.moderators %}
+            <li class="moderator-item">
+                {{ component('user_inline', { user: moderator.user }) }}
             </li>
         {% endfor %}
     </ul>

--- a/templates/magazine/_moderators_sidebar.html.twig
+++ b/templates/magazine/_moderators_sidebar.html.twig
@@ -11,7 +11,7 @@
         {% endif %}
     </h3>
     <ul>
-        {% for moderator in magazine.moderators %}
+        {% for moderator in magazine.moderators|slice(0, 5) %}
             <li class="moderator-item">
                 {{ component('user_inline', { user: moderator.user }) }}
             </li>

--- a/templates/user/_user_popover.html.twig
+++ b/templates/user/_user_popover.html.twig
@@ -11,16 +11,16 @@
         <div>
             <h3>
                 <a class="link-muted" href="{{ path('user_overview', {username: user.username}) }}">{{ user.username|username }}</a>
+                {% if user.isNew() %}
+                    {% set days = constant('App\\Entity\\User::NEW_FOR_DAYS') %}
+                    <i class="fa-solid fa-leaf new-user-icon" title="{{ 'new_user_description'|trans({ '%days%': days }) }}" aria-description="{{ 'new_user_description'|trans({ '%days%': days }) }}"></i>
+                {% endif %}
             </h3>
             <p class="user__name">
                 <span>
                     {{ user.username|username(true) }}
                     {% if user.apManuallyApprovesFollowers is same as true %}
                         <i class="fa-solid fa-lock" aria-description="{{ 'manually_approves_followers'|trans }}" title="{{ 'manually_approves_followers'|trans }}" aria-describedby="{{ 'manually_approves_followers'|trans }}"></i>
-                    {% endif %}
-                    {% if user.isNew() %}
-                        {% set days = constant('App\\Entity\\User::NEW_FOR_DAYS') %}
-                        <i class="fa-solid fa-leaf new-user-icon" title="{{ 'new_user_description'|trans({ '%days%': days }) }}" aria-description="{{ 'new_user_description'|trans({ '%days%': days }) }}"></i>
                     {% endif %}
                 </span>
                 {% if user.apProfileId %}

--- a/templates/user/_user_popover.html.twig
+++ b/templates/user/_user_popover.html.twig
@@ -18,6 +18,10 @@
                     {% if user.apManuallyApprovesFollowers is same as true %}
                         <i class="fa-solid fa-lock" aria-description="{{ 'manually_approves_followers'|trans }}" title="{{ 'manually_approves_followers'|trans }}" aria-describedby="{{ 'manually_approves_followers'|trans }}"></i>
                     {% endif %}
+                    {% if user.isNew() %}
+                        {% set days = constant('App\\Entity\\User::NEW_FOR_DAYS') %}
+                        <i class="fa-solid fa-leaf new-user-icon" title="{{ 'new_user_description'|trans({ '%days%': days }) }}" aria-description="{{ 'new_user_description'|trans({ '%days%': days }) }}"></i>
+                    {% endif %}
                 </span>
                 {% if user.apProfileId %}
                     <a href="{{ user.apProfileId }}" rel="noopener noreferrer nofollow" target="_blank" title="{{ 'go_to_original_instance'|trans }}" aria-label="{{ 'go_to_original_instance'|trans }}">

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -877,3 +877,5 @@ last_successful_deliver: Last successful deliver
 last_successful_receive: Last successful receive
 last_failed_contact: Last failed contact
 magazine_posting_restricted_to_mods: Restrict thread creation to moderators
+new_user_description: This user is new (active for less than %days% days)
+new_magazine_description: This magazine is new (active for less than %days% days)


### PR DESCRIPTION
- whether a user or magazine is new is controlled via a method and a constant in the `CreatedAtTrait`, though the constant exists only in the classes that use the trait
- ~~removed the limit of the moderators list (previously 5)~~
- fix the spacing in the moderator list and use the user_inline component

List View:
![grafik](https://github.com/user-attachments/assets/dc0c5cba-5e22-4ea4-8cef-d6706b4f4711)

Popover:
![grafik](https://github.com/user-attachments/assets/441d2d24-22c2-47a2-aaf8-e9647823f3a3)

Profile:
![grafik](https://github.com/user-attachments/assets/92a2ddd4-2d85-46a0-bf89-725a4ff31725)

Magazine Box:
![grafik](https://github.com/user-attachments/assets/088242c1-54ce-4f7e-b7cf-ea1689e3b274)

Magazine list:
![grafik](https://github.com/user-attachments/assets/18f01543-9978-4f9f-a244-1e96f62aa2a3)

Moderator list:
![grafik](https://github.com/user-attachments/assets/7029b521-867b-4b70-ae45-001d1505b351)

(I set the day limit to 300 for testing so that basically everything counts as new)