### PR TITLE
Clean up doctrine deprecation warnings

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -21,7 +21,7 @@ doctrine:
         enable_lazy_ghost_objects: true
         # This option needs to be set to 'false', otherwise PHP class inheritance will fail with
         # a separate sequence number generator table in PostgreSQL for each child class
-        report_fields_where_declared: false
+        report_fields_where_declared: true
         validate_xml_mapping: true
         naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
         auto_mapping: true

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -19,8 +19,6 @@ doctrine:
                 JSONB_CONTAINS: Scienta\DoctrineJsonFunctions\Query\AST\Functions\Postgresql\JsonbContains
         auto_generate_proxy_classes: true
         enable_lazy_ghost_objects: true
-        # This option needs to be set to 'false', otherwise PHP class inheritance will fail with
-        # a separate sequence number generator table in PostgreSQL for each child class
         report_fields_where_declared: true
         validate_xml_mapping: true
         naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace App;
 
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
@@ -26,5 +30,24 @@ class Kernel extends BaseKernel
         } else {
             $routes->import($projectDir.'/config/{routes}.php');
         }
+    }
+
+    #[Override]
+    protected function build(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new class() implements CompilerPassInterface {
+            public function process(ContainerBuilder $container): void
+            {
+                $container->getDefinition('doctrine.orm.default_configuration')
+                    ->addMethodCall(
+                        'setIdentityGenerationPreferences',
+                        [
+                            [
+                                PostgreSQLPlatform::class => ClassMetadata::GENERATOR_TYPE_SEQUENCE,
+                            ],
+                        ]
+                    );
+            }
+        });
     }
 }


### PR DESCRIPTION
Resolves issue with `report_fields_where_declared` being set to `true` and sequence generation by explicitly building with recommended identify generator preference of `GENERATOR_TYPE_SEQUENCE`.

![image](https://github.com/user-attachments/assets/22be43a8-a63e-4c10-8ca5-6f0ed95c6fca)

Copied solution from: https://github.com/doctrine/orm/issues/8893#issuecomment-1905791768

Also the  `report_fields_where_declared` being set to `true` issue noted here https://github.com/doctrine/orm/issues/10953#issuecomment-1783615940 seemed to be fixed by https://github.com/doctrine/orm/pull/11050? @melroy89 can you review this, please?
