### PR TITLE
Bump docker php to 8.3 and rabbitmq versions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm-alpine as base
+FROM php:8.3-fpm-alpine as base
 
 # Install php extensions, by docker-php-extension-installer
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -118,7 +118,7 @@ services:
       - POSTGRES_USER=kbin
 
   rabbitmq:
-    image: rabbitmq:3.13.0-management-alpine
+    image: rabbitmq:3.13.6-management-alpine
     container_name: mbin-rabbitmq
     restart: unless-stopped
     networks:


### PR DESCRIPTION
Bump to php8.3 for docker, minor update to rabbitmq to match latest bare metal version.