### PR TITLE
Recommend new installs use php8.3

### DIFF
--- a/docs/02-admin/01-installation/bare_metal.md
+++ b/docs/02-admin/01-installation/bare_metal.md
@@ -48,6 +48,9 @@ sudo apt-get update
 sudo apt-get install php8.3 php8.3-common php8.3-fpm php8.3-cli php8.3-amqp php8.3-bcmath php8.3-pgsql php8.3-gd php8.3-curl php8.3-xml php8.3-redis php8.3-mbstring php8.3-zip php8.3-bz2 php8.3-intl php8.3-bcmath -y
 ```
 
+> [!NOTE]
+> If you are upgrading to PHP 8.3 from an older version, please re-review the [PHP configuration]("#php") section of this guide as existing `ini` settings are NOT copied to new versions.
+
 Install Composer:
 
 ```bash

--- a/docs/02-admin/01-installation/bare_metal.md
+++ b/docs/02-admin/01-installation/bare_metal.md
@@ -49,7 +49,7 @@ sudo apt-get install php8.3 php8.3-common php8.3-fpm php8.3-cli php8.3-amqp php8
 ```
 
 > [!NOTE]
-> If you are upgrading to PHP 8.3 from an older version, please re-review the [PHP configuration]("#php") section of this guide as existing `ini` settings are NOT copied to new versions.
+> If you are upgrading to PHP 8.3 from an older version, please re-review the [PHP configuration](#php) section of this guide as existing `ini` settings are NOT copied to new versions.
 
 Install Composer:
 

--- a/docs/02-admin/01-installation/bare_metal.md
+++ b/docs/02-admin/01-installation/bare_metal.md
@@ -29,7 +29,7 @@ Install prequirements:
 sudo apt-get install lsb-release ca-certificates curl wget unzip gnupg apt-transport-https software-properties-common python3-launchpadlib git redis-server postgresql postgresql-contrib nginx acl -y
 ```
 
-On **Ubuntu 22.04 LTS** or older, prepare latest PHP package repositoy (8.2 or 8.3) by using a Ubuntu PPA (this step is optional for Ubuntu 23.10 or later) via:
+On **Ubuntu 22.04 LTS** or older, prepare latest PHP package repositoy (8.3) by using a Ubuntu PPA (this step is optional for Ubuntu 23.10 or later) via:
 
 ```bash
 sudo add-apt-repository ppa:ondrej/php -y
@@ -41,16 +41,7 @@ On **Debian 12** or later, you can install the latest PHP package repository (th
 sudo sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 ```
 
-You can choose between PHP 8.2 or 8.3, but it is recommended to use PHP 8.3.
-
-Install _PHP 8.2_ with some important PHP extensions:
-
-```bash
-sudo apt-get update
-sudo apt-get install php8.2 php8.2-common php8.2-fpm php8.2-cli php8.2-amqp php8.2-bcmath php8.2-pgsql php8.2-gd php8.2-curl php8.2-xml php8.2-redis php8.2-mbstring php8.2-zip php8.2-bz2 php8.2-intl php8.2-bcmath -y
-```
-
-Or install _PHP 8.3_ with PHP extensions:
+Install _PHP 8.3_ with PHP extensions:
 
 ```bash
 sudo apt-get update
@@ -297,7 +288,7 @@ pm.max_spare_servers = 10
 Be sure to restart (or reload) the PHP-FPM service after you applied any changing to the `php.ini` file:
 
 ```bash
-sudo systemctl restart php8.2-fpm.service
+sudo systemctl restart php8.3-fpm.service
 ```
 
 ### Composer


### PR DESCRIPTION
Only mention php8.3 for bare metal install guide, no issues observed across multiple existing mbin instances after upgrading.

The tip below https://docs.joinmbin.org/admin/configuration/nginx#mbin-nginx-server-block still mentions how to change the version of php socket used if necessary.