### PR TITLE
Fix updating actor icons in specific cases

### DIFF
--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -364,6 +364,8 @@ class ActivityPubManager
 
             // Only update avatar if icon is set
             if (isset($actor['icon'])) {
+                // we only have to wrap the property in an array if it is not already an array, though that is not that easy to determine
+                // because each json object is an associative array -> each image has to have a 'type' property so use that to check it
                 $icon = !\array_key_exists('type', $actor['icon']) ? $actor['icon'] : [$actor['icon']];
                 $newImage = $this->handleImages($icon);
                 if ($user->avatar && $newImage !== $user->avatar) {
@@ -374,6 +376,8 @@ class ActivityPubManager
 
             // Only update cover if image is set
             if (isset($actor['image'])) {
+                // we only have to wrap the property in an array if it is not already an array, though that is not that easy to determine
+                // because each json object is an associative array -> each image has to have a 'type' property so use that to check it
                 $cover = !\array_key_exists('type', $actor['image']) ? $actor['image'] : [$actor['image']];
                 $newImage = $this->handleImages($cover);
                 if ($user->cover && $newImage !== $user->cover) {
@@ -423,6 +427,7 @@ class ActivityPubManager
             try {
                 $imageObject = $images[0];
                 if (isset($imageObject['height'])) {
+                    // determine the highest resolution image
                     foreach ($images as $i) {
                         if (isset($i['height']) && $i['height'] ?? 0 > $imageObject['height'] ?? 0) {
                             $imageObject = $i;
@@ -498,6 +503,8 @@ class ActivityPubManager
             }
 
             if (isset($actor['icon'])) {
+                // we only have to wrap the property in an array if it is not already an array, though that is not that easy to determine
+                // because each json object is an associative array -> each image has to have a 'type' property so use that to check it
                 $icon = !\array_key_exists('type', $actor['icon']) ? $actor['icon'] : [$actor['icon']];
                 $newImage = $this->handleImages($icon);
                 if ($magazine->icon && $newImage !== $magazine->icon) {

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -364,7 +364,8 @@ class ActivityPubManager
 
             // Only update avatar if icon is set
             if (isset($actor['icon'])) {
-                $newImage = $this->handleImages([$actor['icon']]);
+                $icon = !\array_key_exists('type', $actor['icon']) ? $actor['icon'] : [$actor['icon']];
+                $newImage = $this->handleImages($icon);
                 if ($user->avatar && $newImage !== $user->avatar) {
                     $this->bus->dispatch(new DeleteImageMessage($user->avatar->getId()));
                 }
@@ -373,7 +374,8 @@ class ActivityPubManager
 
             // Only update cover if image is set
             if (isset($actor['image'])) {
-                $newImage = $this->handleImages([$actor['image']]);
+                $cover = !\array_key_exists('type', $actor['image']) ? $actor['image'] : [$actor['image']];
+                $newImage = $this->handleImages($cover);
                 if ($user->cover && $newImage !== $user->cover) {
                     $this->bus->dispatch(new DeleteImageMessage($user->cover->getId()));
                 }
@@ -488,7 +490,8 @@ class ActivityPubManager
             }
 
             if (isset($actor['icon'])) {
-                $newImage = $this->handleImages([$actor['icon']]);
+                $icon = !\array_key_exists('type', $actor['icon']) ? $actor['icon'] : [$actor['icon']];
+                $newImage = $this->handleImages($icon);
                 if ($magazine->icon && $newImage !== $magazine->icon) {
                     $this->bus->dispatch(new DeleteImageMessage($magazine->icon->getId()));
                 }

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -421,11 +421,19 @@ class ActivityPubManager
 
         if (\count($images)) {
             try {
-                if ($tempFile = $this->imageManager->download($images[0]['url'])) {
+                $imageObject = $images[0];
+                if (isset($imageObject['height'])) {
+                    foreach ($images as $i) {
+                        if (isset($i['height']) && $i['height'] ?? 0 > $imageObject['height'] ?? 0) {
+                            $imageObject = $i;
+                        }
+                    }
+                }
+                if ($tempFile = $this->imageManager->download($imageObject['url'])) {
                     $image = $this->imageRepository->findOrCreateFromPath($tempFile);
-                    $image->sourceUrl = $images[0]['url'];
-                    if ($image && isset($images[0]['name'])) {
-                        $image->altText = $images[0]['name'];
+                    $image->sourceUrl = $imageObject['url'];
+                    if ($image && isset($imageObject['name'])) {
+                        $image->altText = $imageObject['name'];
                     }
                     $this->entityManager->persist($image);
                     $this->entityManager->flush();


### PR DESCRIPTION
If an actor has an array as the icon or image our code can't handle that, because we previously wrapped the icon and image object in an array. Now we only wrap the object in an array if it is not already an array. Problem here: we parse json as associative array, so each object is an array as well. An image object has to have the key `type` (checked in `handleImages` anyways) so we just differentiate the cases with the existing of the `type` key

I specifically observed it in the case of https://tilvids.com/accounts/thelinuxexperiment

```json
{
  "@context": [
    "https://www.w3.org/ns/activitystreams",
    "https://w3id.org/security/v1",
    {
      "RsaSignature2017": "https://w3id.org/security#RsaSignature2017"
    },
    {
      "pt": "https://joinpeertube.org/ns#",
      "sc": "http://schema.org/",
      "playlists": {
        "@id": "pt:playlists",
        "@type": "@id"
      },
      "support": {
        "@type": "sc:Text",
        "@id": "pt:support"
      },
      "lemmy": "https://join-lemmy.org/ns#",
      "postingRestrictedToMods": "lemmy:postingRestrictedToMods",
      "icons": "as:icon"
    }
  ],
  "type": "Person",
  "id": "https://tilvids.com/accounts/thelinuxexperiment",
  "following": "https://tilvids.com/accounts/thelinuxexperiment/following",
  "followers": "https://tilvids.com/accounts/thelinuxexperiment/followers",
  "playlists": "https://tilvids.com/accounts/thelinuxexperiment/playlists",
  "inbox": "https://tilvids.com/accounts/thelinuxexperiment/inbox",
  "outbox": "https://tilvids.com/accounts/thelinuxexperiment/outbox",
  "preferredUsername": "thelinuxexperiment",
  "url": "https://tilvids.com/accounts/thelinuxexperiment",
  "name": "The Linux Experiment",
  "endpoints": {
    "sharedInbox": "https://tilvids.com/inbox"
  },
  "publicKey": {
    "id": "https://tilvids.com/accounts/thelinuxexperiment#main-key",
    "owner": "https://tilvids.com/accounts/thelinuxexperiment",
    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqbMvBSLhwEA3VXQ3TPgd\nDCeVpicrjGlk5tRg9OMBMY/xRhT4M3T8H2uYMUmIQJubUcooqAImWL7bYyXig0Ms\nby18vLyAgIR7V7ymvJbJxF2WZV33CC7Ad1yjqLlnhydcG+pWKWqkjP7SXzAy/EHo\n46OhDQK1+Q6FXfDrLAGEDRq5z+qTi5dh1hi/c9ZvI0+3PBg1IfAf5zLeo1AoydV7\nvISCm7kyClABwOW3OjPP86SbAlQL6STFOO3s6EdvvVifTkacC/gl8ad8TI8610Wa\n5wLsjdE8LIky9lLUsFYvVPrJ6v5havxCSmc6W1tkDicitpFylN2X914L36bn609M\n8QIDAQAB\n-----END PUBLIC KEY-----"
  },
  "published": "2020-06-30T13:45:17.950Z",
  "icon": [
    {
      "type": "Image",
      "mediaType": "image/jpeg",
      "height": 48,
      "width": 48,
      "url": "https://tilvids.com/lazy-static/avatars/e74c2c6b-1f6b-4506-9d03-2cbba1635b20.jpg"
    },
    {
      "type": "Image",
      "mediaType": "image/jpeg",
      "height": 120,
      "width": 120,
      "url": "https://tilvids.com/lazy-static/avatars/bdaa7218-ba3c-43ba-abd3-cfd081394c18.jpg"
    }
  ],
  "summary": "I'm Nick, and I like to tinker with Linux stuff. I'll bumble through distro reviews, tutorials, and general helpful tidbits and impressions on Linux desktop environments, applications, and news. \n\nYou might see a bit of Linux gaming here and there, and some more personal opinion pieces, but in the end, it's more or less all about Linux and FOSS !\n\nIf you want to stay up to snuff, follow me on Mastodon @TheLinuxEXP@mastodon.social"
}
```

This fixes the icons for peertube channels and users, I think they changed this in a recent version update