### PR TITLE
Replace MAX_IMAGE_BYTES constant in `ImageManager.php` with admin configurable environmental variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,10 @@ KBIN_HEADER_LOGO=false
 KBIN_FEDERATION_PAGE_ENABLED=true
 MBIN_DEFAULT_THEME=default
 
+# Max image filesize (in bytes)
+# This should be set to <= `upload_max_filesize` and `post_max_size` in the server's php.ini file
+MAX_IMAGE_BYTES=6000000
+
 # Captcha (also enable in admin panel/settings)
 KBIN_CAPTCHA_ENABLED=false
 ###> meteo-concept/hcaptcha-bundle ###

--- a/.env.example_docker
+++ b/.env.example_docker
@@ -32,6 +32,10 @@ KBIN_HEADER_LOGO=false
 KBIN_FEDERATION_PAGE_ENABLED=true
 MBIN_DEFAULT_THEME=default
 
+# Max image filesize (in bytes)
+# This should be set to <= `upload_max_filesize` and `post_max_size` in the server's php.ini file
+MAX_IMAGE_BYTES=6000000
+
 # Captcha (also enable in admin panel/settings)
 KBIN_CAPTCHA_ENABLED=false
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -107,6 +107,9 @@ parameters:
     exif_exiftool_path: '%env(default::EXIF_EXIFTOOL_PATH)%'
     exif_exiftool_timeout: '%env(int:default::EXIF_EXIFTOOL_TIMEOUT)%'
 
+    max_image_bytes: "%env(int:default:max_image_bytes_default:MAX_IMAGE_BYTES)%"
+    max_image_bytes_default: 6000000
+
 services:
     # default configuration for services in *this* file
     _defaults:
@@ -174,6 +177,7 @@ services:
             $kbinFederationPageEnabled: "%env(bool:KBIN_FEDERATION_PAGE_ENABLED)%"
             $kbinAdminOnlyOauthClients: "%env(bool:KBIN_ADMIN_ONLY_OAUTH_CLIENTS)%"
             $mbinSsoOnlyMode: "%sso_only_mode%"
+            $maxImageBytes: "%max_image_bytes%"
 
     # Markdown
     App\Markdown\Factory\EnvironmentFactory:

--- a/src/DTO/SettingsDto.php
+++ b/src/DTO/SettingsDto.php
@@ -35,7 +35,8 @@ class SettingsDto implements \JsonSerializable
         public bool $MBIN_SIDEBAR_SECTIONS_LOCAL_ONLY,
         public bool $MBIN_SSO_REGISTRATIONS_ENABLED,
         public bool $MBIN_RESTRICT_MAGAZINE_CREATION,
-        public bool $MBIN_SSO_SHOW_FIRST
+        public bool $MBIN_SSO_SHOW_FIRST,
+        public int $MAX_IMAGE_BYTES
     ) {
     }
 
@@ -66,6 +67,7 @@ class SettingsDto implements \JsonSerializable
         $dto->MBIN_SSO_REGISTRATIONS_ENABLED = $this->MBIN_SSO_REGISTRATIONS_ENABLED ?? $dto->MBIN_SSO_REGISTRATIONS_ENABLED;
         $dto->MBIN_RESTRICT_MAGAZINE_CREATION = $this->MBIN_RESTRICT_MAGAZINE_CREATION ?? $dto->MBIN_RESTRICT_MAGAZINE_CREATION;
         $dto->MBIN_SSO_SHOW_FIRST = $this->MBIN_SSO_SHOW_FIRST ?? $dto->MBIN_SSO_SHOW_FIRST;
+        $dto->MAX_IMAGE_BYTES = $this->MAX_IMAGE_BYTES ?? $dto->MAX_IMAGE_BYTES;
 
         return $dto;
     }
@@ -98,6 +100,7 @@ class SettingsDto implements \JsonSerializable
             'MBIN_SSO_REGISTRATIONS_ENABLED' => $this->MBIN_SSO_REGISTRATIONS_ENABLED,
             'MBIN_RESTRICT_MAGAZINE_CREATION' => $this->MBIN_RESTRICT_MAGAZINE_CREATION,
             'MBIN_SSO_SHOW_FIRST' => $this->MBIN_SSO_SHOW_FIRST,
+            'MAX_IMAGE_BYTES' => $this->MAX_IMAGE_BYTES,
         ];
     }
 }

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -22,7 +22,6 @@ class ImageManager
         'image/webp', 'image/avif',
     ];
     public const IMAGE_MIMETYPE_STR = 'image/jpeg, image/jpg, image/gif, image/png, image/jxl, image/heic, image/heif, image/webp, image/avif';
-    public const MAX_IMAGE_BYTES = 6000000;
 
     public function __construct(
         private readonly string $storageUrl,
@@ -31,6 +30,7 @@ class ImageManager
         private readonly MimeTypesInterface $mimeTypeGuesser,
         private readonly ValidatorInterface $validator,
         private readonly LoggerInterface $logger,
+        private readonly SettingsManager $settings,
     ) {
     }
 
@@ -56,8 +56,8 @@ class ImageManager
         $fh = fopen($source, 'rb');
 
         try {
-            if (filesize($source) > self::MAX_IMAGE_BYTES) {
-                throw new ImageDownloadTooLargeException('the image is too large, max size is '.self::MAX_IMAGE_BYTES);
+            if (filesize($source) > $this->settings->get('MAX_IMAGE_BYTES')) {
+                throw new ImageDownloadTooLargeException('the image is too large, max size is '.$this->settings->get('MAX_IMAGE_BYTES'));
             }
 
             $this->validate($source);

--- a/src/Service/SettingsManager.php
+++ b/src/Service/SettingsManager.php
@@ -36,6 +36,7 @@ class SettingsManager
         private readonly bool $kbinFederationPageEnabled,
         private readonly bool $kbinAdminOnlyOauthClients,
         private readonly bool $mbinSsoOnlyMode,
+        private readonly int $maxImageBytes
     ) {
         if (!self::$dto) {
             $results = $this->repository->findAll();
@@ -73,7 +74,8 @@ class SettingsManager
                 $this->find($results, 'MBIN_SIDEBAR_SECTIONS_LOCAL_ONLY', FILTER_VALIDATE_BOOLEAN) ?? false,
                 $this->find($results, 'MBIN_SSO_REGISTRATIONS_ENABLED', FILTER_VALIDATE_BOOLEAN) ?? true,
                 $this->find($results, 'MBIN_RESTRICT_MAGAZINE_CREATION', FILTER_VALIDATE_BOOLEAN) ?? false,
-                $this->find($results, 'MBIN_SSO_SHOW_FIRST', FILTER_VALIDATE_BOOLEAN) ?? false
+                $this->find($results, 'MBIN_SSO_SHOW_FIRST', FILTER_VALIDATE_BOOLEAN) ?? false,
+                $this->find($results, 'MAX_IMAGE_BYTES', FILTER_VALIDATE_INT) ?? $this->maxImageBytes
             );
         }
     }


### PR DESCRIPTION
Closes https://github.com/MbinOrg/mbin/issues/797

Retains "sane" default of 6000000 if admins forget to set the variable in the `.env` file.