### PR TITLE
fix some oddities about nodeinfo fetching/handling

### DIFF
--- a/src/Payloads/NodeInfo/NodeInfoUsageUsers.php
+++ b/src/Payloads/NodeInfo/NodeInfoUsageUsers.php
@@ -7,6 +7,6 @@ namespace App\Payloads\NodeInfo;
 class NodeInfoUsageUsers
 {
     public int $total;
-    public int $activeHalfYear;
-    public int $activeMonth;
+    public ?int $activeHalfYear = 0;
+    public ?int $activeMonth = 0;
 }

--- a/src/Service/RemoteInstanceManager.php
+++ b/src/Service/RemoteInstanceManager.php
@@ -35,11 +35,14 @@ class RemoteInstanceManager
         if ($instance->getUpdatedAt() < new \DateTime('now - 1day') || $force) {
             $nodeInfoEndpointsRaw = $this->client->fetchInstanceNodeInfoEndpoints($instance->domain, false);
             $serializer = $this->getSerializer();
+            /** @var WellKnownNodeInfo */
             $nodeInfoEndpoints = $serializer->deserialize($nodeInfoEndpointsRaw, WellKnownNodeInfo::class, 'json');
+
             $linkToUse = null;
             foreach ($nodeInfoEndpoints->links as $link) {
                 if (NodeInfoController::NODE_REL_v21 === $link->rel) {
                     $linkToUse = $link;
+                    break;
                 } elseif (null === $linkToUse && NodeInfoController::NODE_REL_v20 === $link->rel) {
                     $linkToUse = $link;
                 }
@@ -54,6 +57,7 @@ class RemoteInstanceManager
 
             $nodeInfoRaw = $this->client->fetchInstanceNodeInfo($linkToUse->href, false);
             $this->logger->debug('got raw nodeinfo for url {url}: {raw}', ['raw' => $nodeInfoRaw, 'url' => $linkToUse]);
+            /** @var NodeInfo */
             $nodeInfo = $serializer->deserialize($nodeInfoRaw, NodeInfo::class, 'json');
 
             $instance->software = $nodeInfo?->software?->name;


### PR DESCRIPTION
these can unintentionally break incoming federation

- make nodeinfo deserializer accepts nullable usage.users.active{Month,Halfyear} as some software doesn't disclose these numbers by making them null, and doesn't look like we're reading these values anyway (seems to affect misskey/sharkey in particular)
- use `application/json` when fetching nodeinfo endpoint from instances in ApHttpClient, as some software would return HTTP 406 for such requests because it was using default `Accept: application/activity+json` which is, perhaps rightfully, not acceptable (seems to affect pleroma/akkoma family)