### PR TITLE
Add user password set/reset command to `bin/console`

### DIFF
--- a/src/Command/UserPasswordCommand.php
+++ b/src/Command/UserPasswordCommand.php
@@ -48,7 +48,7 @@ class UserPasswordCommand extends Command
             return Command::FAILURE;
         }
 
-        if($user->apId) {
+        if ($user->apId) {
             $io->error('The specified account is not a local user!');
 
             return Command::FAILURE;

--- a/src/Command/UserPasswordCommand.php
+++ b/src/Command/UserPasswordCommand.php
@@ -48,6 +48,12 @@ class UserPasswordCommand extends Command
             return Command::FAILURE;
         }
 
+        if($user->apId) {
+            $io->error('The specified account is not a local user!');
+
+            return Command::FAILURE;
+        }
+
         // Encode(hash) the plain password, and set it.
         $encodedPassword = $this->userPasswordHasher->hashPassword(
             $user,

--- a/src/Command/UserPasswordCommand.php
+++ b/src/Command/UserPasswordCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Repository\UserRepository;
+use App\Service\UserManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+#[AsCommand(
+    name: 'mbin:user:password',
+    description: 'This command allows you to manually set or reset a users password.',
+)]
+class UserPasswordCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly UserPasswordHasherInterface $userPasswordHasher,
+        private readonly UserRepository $repository,
+        private readonly UserManager $manager
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('username', InputArgument::REQUIRED)
+            ->addArgument('password', InputArgument::REQUIRED);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $password = $input->getArgument('password');
+        $user = $this->repository->findOneByUsername($input->getArgument('username'));
+
+        if (!$user) {
+            $io->error('User does not exist!');
+
+            return Command::FAILURE;
+        }
+
+        // Encode(hash) the plain password, and set it.
+        $encodedPassword = $this->userPasswordHasher->hashPassword(
+            $user,
+            $password
+        );
+
+        $user->setPassword($encodedPassword);
+        $this->entityManager->flush();
+
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
Add `mbin:user:password <user> <password>` command to `bin/console` so admins can set or reset a user's password from the command line.

![image](https://github.com/user-attachments/assets/76ed3d94-ce58-4d17-a93c-6bdf3ce49e60)
