### PR TITLE
Fix `ActivityHandler` errors regarding the payload

### DIFF
--- a/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
@@ -31,6 +31,7 @@ use App\Service\SettingsManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsMessageHandler]
@@ -60,7 +61,13 @@ class ActivityHandler extends MbinMessageHandler
         if (!($message instanceof ActivityMessage)) {
             throw new \LogicException();
         }
+
         $payload = @json_decode($message->payload, true);
+
+        if (null === $payload) {
+            $this->logger->warning('activity message from was empty: {json}, ignoring it', ['json' => json_encode($message->payload)]);
+            throw new UnrecoverableMessageHandlingException('activity message from was empty');
+        }
 
         if ($message->request && $message->headers) {
             try {
@@ -76,6 +83,11 @@ class ActivityHandler extends MbinMessageHandler
 
                 return;
             }
+        }
+
+        if (null === $payload['id']) {
+            $this->logger->warning('activity message has no id field which is required: {json}', ['json' => json_encode($message->payload)]);
+            throw new UnrecoverableMessageHandlingException('activity message has no id field');
         }
 
         $idHost = parse_url($payload['id'], PHP_URL_HOST);


### PR DESCRIPTION
- when the payload is null ignore message
- when the payload has no id field ignore the message

I've seen a lot of errors coming from this on my server. I don't know if it is people trying to troll posting empty bodies to the inbox or whatever, though this should fix the errors in the logs. I am not quite sure if this should really throw the `UnrecoverableMessageHandlingException` or if it should just do a `return` instead