### PR TITLE
Fix the managers checking wrong fields for editing permissions

### DIFF
--- a/src/Service/EntryCommentManager.php
+++ b/src/Service/EntryCommentManager.php
@@ -106,8 +106,8 @@ class EntryCommentManager implements ContentManagerInterface
     public function canUserEditComment(EntryComment $comment, User $user): bool
     {
         $entryCommentHost = null !== $comment->apId ? parse_url($comment->apId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
-        $userHost = null !== $user->apId ? parse_url($user->apId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
-        $magazineHost = null !== $comment->magazine->apId ? parse_url($comment->magazine->apId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
+        $userHost = null !== $user->apId ? parse_url($user->apProfileId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
+        $magazineHost = null !== $comment->magazine->apId ? parse_url($comment->magazine->apProfileId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
 
         return $entryCommentHost === $userHost || $userHost === $magazineHost || $comment->magazine->userIsModerator($user);
     }

--- a/src/Service/EntryManager.php
+++ b/src/Service/EntryManager.php
@@ -174,8 +174,8 @@ class EntryManager implements ContentManagerInterface
     public function canUserEditEntry(Entry $entry, User $user): bool
     {
         $entryHost = null !== $entry->apId ? parse_url($entry->apId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
-        $userHost = null !== $user->apId ? parse_url($user->apId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
-        $magazineHost = null !== $entry->magazine->apId ? parse_url($entry->magazine->apId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
+        $userHost = null !== $user->apId ? parse_url($user->apProfileId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
+        $magazineHost = null !== $entry->magazine->apId ? parse_url($entry->magazine->apProfileId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
 
         return $entryHost === $userHost || $userHost === $magazineHost || $entry->magazine->userIsModerator($user);
     }

--- a/src/Service/PostCommentManager.php
+++ b/src/Service/PostCommentManager.php
@@ -111,8 +111,8 @@ class PostCommentManager implements ContentManagerInterface
     public function canUserEditPostComment(PostComment $postComment, User $user): bool
     {
         $postCommentHost = null !== $postComment->apId ? parse_url($postComment->apId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
-        $userHost = null !== $user->apId ? parse_url($user->apId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
-        $magazineHost = null !== $postComment->magazine->apId ? parse_url($postComment->magazine->apId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
+        $userHost = null !== $user->apId ? parse_url($user->apProfileId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
+        $magazineHost = null !== $postComment->magazine->apId ? parse_url($postComment->magazine->apProfileId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
 
         return $postCommentHost === $userHost || $userHost === $magazineHost || $postComment->magazine->userIsModerator($user);
     }

--- a/src/Service/PostManager.php
+++ b/src/Service/PostManager.php
@@ -125,8 +125,8 @@ class PostManager implements ContentManagerInterface
     public function canUserEditPost(Post $post, User $user): bool
     {
         $postHost = null !== $post->apId ? parse_url($post->apId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
-        $userHost = null !== $user->apId ? parse_url($user->apId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
-        $magazineHost = null !== $post->magazine->apId ? parse_url($post->magazine->apId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
+        $userHost = null !== $user->apId ? parse_url($user->apProfileId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
+        $magazineHost = null !== $post->magazine->apId ? parse_url($post->magazine->apProfileId, PHP_URL_HOST) : $this->settingsManager->get('KBIN_DOMAIN');
 
         return $postHost === $userHost || $userHost === $magazineHost || $post->magazine->userIsModerator($user);
     }


### PR DESCRIPTION
I noticed that editing an entry was not really working sometimes, the reason being (after testing locally) that it tries to parse a url from the users and magazines apId. This is not working, as the ap id looks like this: `normaluser@mbin.instance.tld`

That is not a url, so yeah that cannot work. Since this has been used to check whether a user is from the same instance as the content they try to edit, this check is failing, when the magazines ap id is not used, since one of the checks is `$magazineHost === $userHost`

However if the `UpdateMessage` is sent to another instance to which the magazine is a remote magazine (through user follows). This check is basically bypassed, because `$magazineHost` and `$userHost` are both `null` since the url check failed...

Fixes Regression from #893