### PR TITLE
add default null to Instance entity nullables field

### DIFF
--- a/src/Entity/Instance.php
+++ b/src/Entity/Instance.php
@@ -27,22 +27,22 @@ class Instance
     }
 
     #[Column(nullable: true)]
-    public ?string $software;
+    public ?string $software = null;
 
     #[Column(nullable: true)]
-    public ?string $version;
+    public ?string $version = null;
 
     #[Column(unique: true)]
     public string $domain;
 
     #[Column(type: 'datetimetz_immutable', nullable: true)]
-    private ?\DateTimeImmutable $lastSuccessfulDeliver;
+    private ?\DateTimeImmutable $lastSuccessfulDeliver = null;
 
     #[Column(type: 'datetimetz_immutable', nullable: true)]
-    private ?\DateTimeImmutable $lastFailedDeliver;
+    private ?\DateTimeImmutable $lastFailedDeliver = null;
 
     #[Column(type: 'datetimetz_immutable', nullable: true)]
-    private ?\DateTimeImmutable $lastSuccessfulReceive;
+    private ?\DateTimeImmutable $lastSuccessfulReceive = null;
 
     #[Column]
     private int $failedDelivers = 0;


### PR DESCRIPTION
add default values of null to DB nullable properties in `Instance` entity to prevent access before initialization problems on php side

currently observed the error with the field `Instance::$lastSuccessfulReceive`
but added null default to all nullable fields just in case

    "Handling "App\Message\ActivityPub\Inbox\ActivityMessage" failed:
    Typed property App\Entity\Instance::$lastSuccessfulReceive must not be accessed before initialization"