### PR TITLE
Invalidate collection cache before getting collection for likes, dislikes and shares

### DIFF
--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -1082,6 +1082,7 @@ class ActivityPubManager
     {
         if (!empty($apObject['likes'])) {
             if (false !== filter_var($apObject['likes'], FILTER_VALIDATE_URL)) {
+                $this->apHttpClient->invalidateCollectionObjectCache($apObject['likes']);
                 $collection = $this->apHttpClient->getCollectionObject($apObject['likes']);
                 if (isset($collection['totalItems']) && \is_int($collection['totalItems'])) {
                     return $collection['totalItems'];
@@ -1096,6 +1097,7 @@ class ActivityPubManager
     {
         if (!empty($apObject['dislikes'])) {
             if (false !== filter_var($apObject['dislikes'], FILTER_VALIDATE_URL)) {
+                $this->apHttpClient->invalidateCollectionObjectCache($apObject['dislikes']);
                 $collection = $this->apHttpClient->getCollectionObject($apObject['dislikes']);
                 if (isset($collection['totalItems']) && \is_int($collection['totalItems'])) {
                     return $collection['totalItems'];
@@ -1110,6 +1112,7 @@ class ActivityPubManager
     {
         if (!empty($apObject['shares'])) {
             if (false !== filter_var($apObject['shares'], FILTER_VALIDATE_URL)) {
+                $this->apHttpClient->invalidateCollectionObjectCache($apObject['shares']);
                 $collection = $this->apHttpClient->getCollectionObject($apObject['shares']);
                 if (isset($collection['totalItems']) && \is_int($collection['totalItems'])) {
                     return $collection['totalItems'];


### PR DESCRIPTION
I observed that PeerTube videos do not have the correct amount of like. The first 24 hours it just stays at 0. This fixes it.

I think this is the best fix, since we only invalidate the collection cache when we received an `Update` activity indicating that the collections are not up to date anymore. 