### PR TITLE
Allow admins to view user IP addresses in the admin panel users table

### DIFF
--- a/migrations/Version20240808230919.php
+++ b/migrations/Version20240808230919.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240808230919 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add user IP column';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" ADD ip VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" DROP ip');
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -93,6 +93,8 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Visibil
     public ?Image $cover = null;
     #[Column(type: 'string', unique: true, nullable: false)]
     public string $email;
+    #[Column(type: 'string', nullable: true)]
+    public ?string $ip = null;
     #[Column(type: 'string', unique: true, nullable: false)]
     public string $username;
     #[Column(type: 'json', nullable: false, options: ['jsonb' => true])]

--- a/src/Security/GithubAuthenticator.php
+++ b/src/Security/GithubAuthenticator.php
@@ -6,6 +6,7 @@ namespace App\Security;
 
 use App\DTO\UserDto;
 use App\Entity\User;
+use App\Service\IpResolver;
 use App\Service\SettingsManager;
 use App\Service\UserManager;
 use App\Utils\Slugger;
@@ -31,6 +32,7 @@ class GithubAuthenticator extends OAuth2Authenticator
         private readonly RouterInterface $router,
         private readonly EntityManagerInterface $entityManager,
         private readonly UserManager $userManager,
+        private readonly IpResolver $ipResolver,
         private readonly Slugger $slugger,
         private readonly SettingsManager $settingsManager
     ) {
@@ -84,6 +86,7 @@ class GithubAuthenticator extends OAuth2Authenticator
                 );
 
                 $dto->plainPassword = bin2hex(random_bytes(20));
+                $dto->ip = $this->ipResolver->resolve();
 
                 $user = $this->userManager->create($dto, false);
                 $user->oauthGithubId = \strval($githubUser->getId());

--- a/src/Security/UserChecker.php
+++ b/src/Security/UserChecker.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Security;
 
 use App\Entity\User as AppUser;
+use App\Service\IpResolver;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
@@ -16,7 +18,9 @@ class UserChecker implements UserCheckerInterface
 {
     public function __construct(
         private readonly TranslatorInterface $translator,
-        private readonly UrlGeneratorInterface $urlGenerator
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly IpResolver $ipResolver
     ) {
     }
 
@@ -45,5 +49,8 @@ class UserChecker implements UserCheckerInterface
         if (!$user instanceof AppUser) {
             return;
         }
+
+        $user->ip = $this->ipResolver->resolve();
+        $this->entityManager->flush();
     }
 }

--- a/src/Service/EntryCommentManager.php
+++ b/src/Service/EntryCommentManager.php
@@ -48,6 +48,10 @@ class EntryCommentManager implements ContentManagerInterface
 
     public function create(EntryCommentDto $dto, User $user, $rateLimit = true): EntryComment
     {
+        if (!$user->apId) {
+            $user->ip = $dto->ip;
+        }
+        
         if ($rateLimit) {
             $limiter = $this->entryCommentLimiter->create($dto->ip);
             if ($limiter && false === $limiter->consume()->isAccepted()) {

--- a/src/Service/EntryManager.php
+++ b/src/Service/EntryManager.php
@@ -75,6 +75,10 @@ class EntryManager implements ContentManagerInterface
      */
     public function create(EntryDto $dto, User $user, bool $rateLimit = true, bool $stickyIt = false): Entry
     {
+        if (!$user->apId) {
+            $user->ip = $dto->ip;
+        }
+
         if ($rateLimit) {
             $limiter = $this->entryLimiter->create($dto->ip);
             if (false === $limiter->consume()->isAccepted()) {
@@ -182,6 +186,10 @@ class EntryManager implements ContentManagerInterface
 
     public function edit(Entry $entry, EntryDto $dto, User $editedBy): Entry
     {
+        if (!$editedBy->apId) {
+            $editedBy->ip = $dto->ip;
+        }
+
         Assert::same($entry->magazine->getId(), $dto->magazine->getId());
 
         $entry->title = $dto->title;

--- a/src/Service/PostCommentManager.php
+++ b/src/Service/PostCommentManager.php
@@ -54,6 +54,10 @@ class PostCommentManager implements ContentManagerInterface
      */
     public function create(PostCommentDto $dto, User $user, $rateLimit = true): PostComment
     {
+        if (!$user->apId) {
+            $user->ip = $dto->ip;
+        }
+        
         if ($rateLimit) {
             $limiter = $this->postCommentLimiter->create($dto->ip);
             if ($limiter && false === $limiter->consume()->isAccepted()) {

--- a/src/Service/PostManager.php
+++ b/src/Service/PostManager.php
@@ -66,6 +66,10 @@ class PostManager implements ContentManagerInterface
      */
     public function create(PostDto $dto, User $user, $rateLimit = true, bool $stickyIt = false): Post
     {
+        if (!$user->apId) {
+            $user->ip = $dto->ip;
+        }
+
         if ($rateLimit) {
             $limiter = $this->postLimiter->create($dto->ip);
             if ($limiter && false === $limiter->consume()->isAccepted()) {
@@ -133,6 +137,10 @@ class PostManager implements ContentManagerInterface
 
     public function edit(Post $post, PostDto $dto, ?User $editedBy = null): Post
     {
+        if (null !== $editedBy && !$editedBy->apId) {
+            $editedBy->ip = $dto->ip;
+        }
+
         Assert::same($post->magazine->getId(), $dto->magazine->getId());
 
         $post->body = $dto->body;

--- a/templates/admin/users.html.twig
+++ b/templates/admin/users.html.twig
@@ -71,6 +71,9 @@
             <tr>
                 <th>{{ 'username'|trans }}</th>
                 <th>{{ 'email'|trans }}</th>
+                {% if withFederated is not defined or withFederated is same as false %}
+                <th>{{ 'IP' }}</th>
+                {% endif %}
                 <th>{{ 'created_at'|trans }}</th>
                 <th>{{ 'last_active'|trans }}</th>
             </tr>
@@ -80,6 +83,9 @@
                     <tr>
                         <td>{{ component('user_inline', {user: user}) }}</td>
                         <td>{{ user.apId ? '-' : user.email }}</td>
+                        {% if withFederated is not defined or withFederated is same as false %}
+                        <td>{{ user.ip }}</td>
+                        {% endif %}
                         <td>{{ component('date', {date: user.createdAt}) }}</td>
                         <td>{{ component('date', {date: user.lastActive}) }}</td>
                     </tr>


### PR DESCRIPTION
Introduces admin ability to view local users IP addresses as resolved from `src/Service/IpResolver.php`:

![image](https://github.com/user-attachments/assets/36a41abc-8497-48b6-bc06-54feb60f7b92)

A user's IP address is updated on:

- [ ] successful authentication
- [ ] entry creation
- [ ] entry edit
- [ ] entry comment creation
- [ ] entry comment edit
- [ ] post creation
- [ ] post edit
- [ ] post comment creation
- [ ] post comment edit

I also noticed the GitHub authenticator was missing the IP being set in the user dto which will cause the registration limiter to be ineffective, so I added it in to be consistent with the other authentication mechanisms.

Closes: https://github.com/MbinOrg/mbin/issues/833