### PR TITLE
Remove `\intval` around `MAX_IMAGE_BYTES` in `src/Service/SettingsManager.php`, breaks settings name resolution

### DIFF
--- a/src/Service/SettingsManager.php
+++ b/src/Service/SettingsManager.php
@@ -75,7 +75,7 @@ class SettingsManager
                 $this->find($results, 'MBIN_SSO_REGISTRATIONS_ENABLED', FILTER_VALIDATE_BOOLEAN) ?? true,
                 $this->find($results, 'MBIN_RESTRICT_MAGAZINE_CREATION', FILTER_VALIDATE_BOOLEAN) ?? false,
                 $this->find($results, 'MBIN_SSO_SHOW_FIRST', FILTER_VALIDATE_BOOLEAN) ?? false,
-                \intval($this->find($results, 'MAX_IMAGE_BYTES', FILTER_VALIDATE_INT)) ?? $this->maxImageBytes
+                $this->find($results, 'MAX_IMAGE_BYTES', FILTER_VALIDATE_INT) ?? $this->maxImageBytes
             );
         }
     }


### PR DESCRIPTION
Image uploads are currently broken, introduced by https://github.com/MbinOrg/mbin/pull/997. PR removes it, settings can still be saved in settings page of admin panel.

![image](https://github.com/user-attachments/assets/b454d7f3-57da-4619-a377-20bcc8cb9446)

Mentioned in https://github.com/MbinOrg/mbin/issues/780#issuecomment-2278457578 and confirmed in dev.
