### PR TITLE
Add trusted proxy config to framework configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,11 @@ KBIN_HEADER_LOGO=false
 KBIN_FEDERATION_PAGE_ENABLED=true
 MBIN_DEFAULT_THEME=default
 
+# If you are running Mbin behind a reverse proxy, uncomment the line below and adjust the proxy address/range below
+# to your server's IP address if it does not already fall within the private IP spaces specified.
+#TRUSTED_PROXIES=::1,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+TRUSTED_PROXIES=
+
 # Max image filesize (in bytes)
 # This should be set to <= `upload_max_filesize` and `post_max_size` in the server's php.ini file
 MAX_IMAGE_BYTES=6000000

--- a/.env.example_docker
+++ b/.env.example_docker
@@ -32,6 +32,11 @@ KBIN_HEADER_LOGO=false
 KBIN_FEDERATION_PAGE_ENABLED=true
 MBIN_DEFAULT_THEME=default
 
+# If you are running Mbin behind a reverse proxy, uncomment the line below and adjust the proxy address/range below
+# to your server's IP address if it does not already fall within the private IP spaces specified.
+#TRUSTED_PROXIES=::1,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+TRUSTED_PROXIES=
+
 # Max image filesize (in bytes)
 # This should be set to <= `upload_max_filesize` and `post_max_size` in the server's php.ini file
 MAX_IMAGE_BYTES=6000000

--- a/.env.example_docker
+++ b/.env.example_docker
@@ -34,8 +34,8 @@ MBIN_DEFAULT_THEME=default
 
 # If you are running Mbin behind a reverse proxy, uncomment the line below and adjust the proxy address/range below
 # to your server's IP address if it does not already fall within the private IP spaces specified.
-#TRUSTED_PROXIES=::1,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
-TRUSTED_PROXIES=
+TRUSTED_PROXIES=::1,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+#TRUSTED_PROXIES=
 
 # Max image filesize (in bytes)
 # This should be set to <= `upload_max_filesize` and `post_max_size` in the server's php.ini file

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -4,6 +4,8 @@ framework:
     annotations: false #no longer supported
     http_method_override: false
     handle_all_throwables: true
+    trusted_proxies: '%env(string:default::TRUSTED_PROXIES)%'
+    trusted_headers: ['x-forwarded-for', 'x-forwarded-proto', 'x-forwarded-port', 'x-forwarded-prefix']
 
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.


### PR DESCRIPTION
The framework was not being configured with `TRUSTED_PROXIES`, I've added this configuration and `.env` variable to properly get the users actual IP as passed in the `x-forwarded-for` header, this should also resolve any rate limiter issues we could see if running behind a reverse proxy as `$request->getClientIp()` will return the `x-forwarded-for` IP if configured correctly.
https://symfony.com/doc/current/deployment/proxies.html#solution-settrustedproxies