### PR TITLE
Fix user getting deleted when unregistering push

### DIFF
--- a/src/Controller/Api/Notification/NotificationPushApi.php
+++ b/src/Controller/Api/Notification/NotificationPushApi.php
@@ -149,21 +149,26 @@ class NotificationPushApi extends NotificationBaseApi
      */
     public function deleteSubscription(
         RateLimiterFactory $apiNotificationLimiter,
-        UserPushSubscriptionRepository $repository,
     ): JsonResponse {
         $headers = $this->rateLimit($apiNotificationLimiter);
         $user = $this->getUserOrThrow();
         $token = $this->getOAuthToken();
         $apiToken = $this->getAccessToken($token);
 
-        $sub = $repository->findOneBy(['user' => $user, 'apiToken' => $apiToken]);
-        if ($sub) {
-            $this->entityManager->remove($sub);
-            $this->entityManager->flush();
+        try {
+            $conn = $this->entityManager->getConnection();
+            $stmt = $conn->prepare('DELETE FROM user_push_subscription WHERE user_id = :user AND api_token = :token');
+            $stmt->executeQuery(['user' => $user, 'token' => $apiToken]);
 
             return new JsonResponse(headers: $headers);
-        } else {
-            throw new BadRequestException(message: 'PushSubscription not found', statusCode: 404);
+        } catch (\Exception $e) {
+            $this->logger->error('There was an exception while deleting a UserPushSubscription: {e} - {m}. {o}', [
+                'e' => \get_class($e),
+                'm' => $e->getMessage(),
+                'o' => json_encode($e),
+            ]);
+
+            return new JsonResponse(status: 500, headers: $headers);
         }
     }
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -221,7 +221,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Visibil
     #[OneToMany(mappedBy: 'user', targetEntity: Notification::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     #[OrderBy(['createdAt' => 'DESC'])]
     public Collection $notifications;
-    #[OneToMany(mappedBy: 'user', targetEntity: UserPushSubscription::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
+    #[OneToMany(mappedBy: 'user', targetEntity: UserPushSubscription::class, fetch: 'EXTRA_LAZY')]
     public Collection $pushSubscriptions;
     #[Id]
     #[GeneratedValue]


### PR DESCRIPTION
- when unregistering push notifications via the api the user who did it would be deleted

I honestly have no idea why doctrine does it. If you delete a push subscription via the entity manager it will still also delete the user. I removed the cascade deletes from the user side so I think that this is actually a doctrine bug, though I am not sure