### PR TITLE
Change attributed to parsing to not expect a url

### DIFF
--- a/src/EventSubscriber/ActivityPub/MagazineModeratorAddedRemovedSubscriber.php
+++ b/src/EventSubscriber/ActivityPub/MagazineModeratorAddedRemovedSubscriber.php
@@ -69,8 +69,10 @@ class MagazineModeratorAddedRemovedSubscriber implements EventSubscriberInterfac
         try {
             $this->cache->delete('ap_'.hash('sha256', $magazine->apProfileId));
             $this->cache->delete('ap_'.hash('sha256', $magazine->apId));
-            $this->cache->delete('ap_'.hash('sha256', $magazine->apAttributedToUrl));
-            $this->cache->delete('ap_collection'.hash('sha256', $magazine->apAttributedToUrl));
+            if (null !== $magazine->apAttributedToUrl) {
+                $this->cache->delete('ap_'.hash('sha256', $magazine->apAttributedToUrl));
+                $this->cache->delete('ap_collection'.hash('sha256', $magazine->apAttributedToUrl));
+            }
         } catch (InvalidArgumentException $e) {
             $this->logger->warning("There was an error while clearing the cache for magazine '{$magazine->name}' ({$magazine->getId()})");
         }

--- a/src/Factory/ActivityPub/AddRemoveFactory.php
+++ b/src/Factory/ActivityPub/AddRemoveFactory.php
@@ -23,7 +23,7 @@ class AddRemoveFactory
 
     public function buildAddModerator(User $actor, User $added, Magazine $magazine): array
     {
-        $url = $magazine->apAttributedToUrl ?? $this->urlGenerator->generate(
+        $url = null !== $magazine->apId ? $magazine->apAttributedToUrl : $this->urlGenerator->generate(
             'ap_magazine_moderators', ['name' => $magazine->name], UrlGeneratorInterface::ABSOLUTE_URL
         );
         $addedUserUrl = null !== $added->apId ? $added->apPublicUrl : $this->urlGenerator->generate(
@@ -35,7 +35,7 @@ class AddRemoveFactory
 
     public function buildRemoveModerator(User $actor, User $removed, Magazine $magazine): array
     {
-        $url = $magazine->apAttributedToUrl ?? $this->urlGenerator->generate(
+        $url = null !== $magazine->apId ? $magazine->apAttributedToUrl : $this->urlGenerator->generate(
             'ap_magazine_moderators', ['name' => $magazine->name], UrlGeneratorInterface::ABSOLUTE_URL
         );
         $removedUserUrl = null !== $removed->apId ? $removed->apPublicUrl : $this->urlGenerator->generate(

--- a/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
@@ -115,10 +115,10 @@ class ActivityHandler extends MbinMessageHandler
 
         try {
             if (isset($payload['actor']) || isset($payload['attributedTo'])) {
-                if (!$this->verifyInstanceDomain($payload['actor'] ?? $this->manager->getActorFromAttributedTo($payload['attributedTo']))) {
+                if (!$this->verifyInstanceDomain($payload['actor'] ?? $this->manager->getSingleActorFromAttributedTo($payload['attributedTo']))) {
                     return;
                 }
-                $user = $this->manager->findActorOrCreate($payload['actor'] ?? $this->manager->getActorFromAttributedTo($payload['attributedTo']));
+                $user = $this->manager->findActorOrCreate($payload['actor'] ?? $this->manager->getSingleActorFromAttributedTo($payload['attributedTo']));
             } else {
                 if (!$this->verifyInstanceDomain($payload['id'])) {
                     return;

--- a/src/Service/ActivityPub/Page.php
+++ b/src/Service/ActivityPub/Page.php
@@ -49,7 +49,7 @@ class Page
      */
     public function create(array $object, bool $stickyIt = false): Entry
     {
-        $actorUrl = $this->activityPubManager->getActorFromAttributedTo($object['attributedTo']);
+        $actorUrl = $this->activityPubManager->getSingleActorFromAttributedTo($object['attributedTo']);
         $actor = $this->activityPubManager->findActorOrCreate($actorUrl);
         if (!empty($actor)) {
             if ($actor->isBanned) {


### PR DESCRIPTION
Previously we extracted exactly one url from the `attributedTo` field, then fetched it and expected it to be a collection of user ids. In the case of PeerTube channels that meant, that we get a user id and expect to retrieve a moderators collection from that url, which we do not, so that does not work. Now we only handle it this way if the `attributedTo` field is a string. If it is not a string, but an array we put all contained `id`s into an array and get the moderators from that.

PeerTube `attributedTo` of a channel:
```json
{
  "attributedTo": [
    {
      "type": "Person",
      "id": "https://instance.tld/accoutns/someuser"
    }
  ]
}
```