### PR TITLE
Only match magazine by hashtag if post was in random

### DIFF
--- a/src/EventSubscriber/Post/PostCreateSubscriber.php
+++ b/src/EventSubscriber/Post/PostCreateSubscriber.php
@@ -56,14 +56,13 @@ class PostCreateSubscriber implements EventSubscriberInterface
 
     private function handleMagazine(Post $post): void
     {
+        if ('random' !== $post->magazine->name) {
+            // do not overwrite matched magazines
+            return;
+        }
         $tags = $this->tagLinkRepository->getTagsOfPost($post);
 
         foreach ($tags as $tag) {
-            if ($magazine = $this->magazineRepository->findOneByName($tag)) {
-                $this->postManager->changeMagazine($post, $magazine);
-                break;
-            }
-
             if ($magazine = $this->magazineRepository->findByTag($tag)) {
                 $this->postManager->changeMagazine($post, $magazine);
                 break;

--- a/src/MessageHandler/ActivityPub/Inbox/CreateHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/CreateHandler.php
@@ -6,6 +6,8 @@ namespace App\MessageHandler\ActivityPub\Inbox;
 
 use App\Entity\Entry;
 use App\Entity\EntryComment;
+use App\Entity\Post;
+use App\Entity\PostComment;
 use App\Entity\User;
 use App\Exception\PostingRestrictedException;
 use App\Exception\TagBannedException;
@@ -105,8 +107,7 @@ class CreateHandler extends MbinMessageHandler
         }
 
         $note = $this->note->create($this->object, stickyIt: $this->stickyIt);
-        // TODO atm post and post comment are not announced, because of the micro blog spam towards lemmy. If we implement magazine name as hashtag to be optional than this may be reverted
-        if ($note instanceof EntryComment /* or $note instanceof Post or $note instanceof PostComment */) {
+        if ($note instanceof EntryComment || $note instanceof Post || $note instanceof PostComment) {
             if (null !== $note->apId and null === $note->magazine->apId and 'random' !== $note->magazine->name) {
                 // local magazine, but remote post. Random magazine is ignored, as it should not be federated at all
                 $this->bus->dispatch(new AnnounceMessage(null, $note->magazine->getId(), $note->getId(), \get_class($note)));


### PR DESCRIPTION
- only change the magazine of a post via hashtag matching when the post was in the random magazine
- don't use a magazines name to hashtag match, only the defined hashtags of a magazine
- re-add the announcement of posts and post comments