### PR TITLE
Fix error when updating an actor and the instance has no nodeinfo endpoint

### DIFF
--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -319,7 +319,13 @@ class ApHttpClient
             $item->expiresAt(new \DateTime('+1 day'));
             try {
                 return $this->generalFetch($url, ApRequestType::NodeInfo);
-            } catch (\Exception) {
+            } catch (\Exception $e) {
+                $this->logger->warning('There was an exception fetching nodeinfo endpoints from {url}: {e} - {msg}', [
+                    'url' => $url,
+                    'e' => \get_class($e),
+                    'msg' => $e->getMessage(),
+                ]);
+
                 return null;
             }
         });
@@ -338,7 +344,13 @@ class ApHttpClient
 
             try {
                 return $this->generalFetch($url, ApRequestType::NodeInfo);
-            } catch (\Exception) {
+            } catch (\Exception $e) {
+                $this->logger->warning('There was an exception fetching the nodeinfo from {url}: {e} - {msg}', [
+                    'url' => $url,
+                    'e' => \get_class($e),
+                    'msg' => $e->getMessage(),
+                ]);
+
                 return null;
             }
         });

--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -21,6 +21,10 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\CurlHttpClient;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 /*
  * source:
@@ -313,8 +317,11 @@ class ApHttpClient
         $url = "https://$domain/.well-known/nodeinfo";
         $resp = $this->cache->get('nodeinfo_endpoints_'.hash('sha256', $url), function (ItemInterface $item) use ($url) {
             $item->expiresAt(new \DateTime('+1 day'));
-
-            return $this->generalFetch($url, ApRequestType::NodeInfo);
+            try {
+                return $this->generalFetch($url, ApRequestType::NodeInfo);
+            } catch (\Exception) {
+                return null;
+            }
         });
 
         if (!$resp) {
@@ -329,7 +336,11 @@ class ApHttpClient
         $resp = $this->cache->get('nodeinfo_'.hash('sha256', $url), function (ItemInterface $item) use ($url) {
             $item->expiresAt(new \DateTime('+1 day'));
 
-            return $this->generalFetch($url, ApRequestType::NodeInfo);
+            try {
+                return $this->generalFetch($url, ApRequestType::NodeInfo);
+            } catch (\Exception) {
+                return null;
+            }
         });
 
         if (!$resp) {
@@ -339,6 +350,12 @@ class ApHttpClient
         return $decoded ? json_decode($resp, true) : $resp;
     }
 
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ClientExceptionInterface
+     */
     private function generalFetch(string $url, ApRequestType $requestType = ApRequestType::ActivityPub): string
     {
         $client = new CurlHttpClient();

--- a/src/Service/RemoteInstanceManager.php
+++ b/src/Service/RemoteInstanceManager.php
@@ -35,7 +35,7 @@ class RemoteInstanceManager
         if ($instance->getUpdatedAt() < new \DateTime('now - 1day') || $force) {
             $nodeInfoEndpointsRaw = $this->client->fetchInstanceNodeInfoEndpoints($instance->domain, false);
             $serializer = $this->getSerializer();
-            /** @var WellKnownNodeInfo */
+            /** @var WellKnownNodeInfo $nodeInfoEndpoints */
             $nodeInfoEndpoints = $serializer->deserialize($nodeInfoEndpointsRaw, WellKnownNodeInfo::class, 'json');
 
             $linkToUse = null;
@@ -57,7 +57,7 @@ class RemoteInstanceManager
 
             $nodeInfoRaw = $this->client->fetchInstanceNodeInfo($linkToUse->href, false);
             $this->logger->debug('got raw nodeinfo for url {url}: {raw}', ['raw' => $nodeInfoRaw, 'url' => $linkToUse]);
-            /** @var NodeInfo */
+            /** @var NodeInfo $nodeInfo */
             $nodeInfo = $serializer->deserialize($nodeInfoRaw, NodeInfo::class, 'json');
 
             $instance->software = $nodeInfo?->software?->name;


### PR DESCRIPTION
I noticed this kind of errors in my log:
> Error: \"Handling \"App\\Message\\ActivityPub\\UpdateActorMessage\" failed: HTTP/2 404  returned for \"https://www.threads.net/.well-known/nodeinfo\"

threads.net might not be the best example, but an update actor should not fail, because an instance does not have an nodeinfo endpoint