### PR TITLE
Add field to all content response DTOs: `canAuthUserModerate`

### DIFF
--- a/src/Controller/Api/Entry/EntriesBaseApi.php
+++ b/src/Controller/Api/Entry/EntriesBaseApi.php
@@ -45,7 +45,7 @@ class EntriesBaseApi extends BaseApi
         }
 
         if ($user = $this->getUser()) {
-            $response->canLoggedInUserModerate = $dto->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
+            $response->canAuthUserModerate = $dto->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
         }
 
         return $response;
@@ -109,7 +109,7 @@ class EntriesBaseApi extends BaseApi
         }
 
         if ($user = $this->getUser()) {
-            $response->canLoggedInUserModerate = $comment->magazine->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
+            $response->canAuthUserModerate = $comment->magazine->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
         }
 
         return $response;
@@ -184,7 +184,7 @@ class EntriesBaseApi extends BaseApi
         $commentTree = $this->commentsFactory->createResponseTree($comment, $depth);
 
         if ($user = $this->getUser()) {
-            $commentTree->canLoggedInUserModerate = $comment->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
+            $commentTree->canAuthUserModerate = $comment->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
         }
 
         return $commentTree->jsonSerialize();

--- a/src/Controller/Api/Entry/EntriesBaseApi.php
+++ b/src/Controller/Api/Entry/EntriesBaseApi.php
@@ -10,6 +10,7 @@ use App\DTO\EntryCommentRequestDto;
 use App\DTO\EntryCommentResponseDto;
 use App\DTO\EntryDto;
 use App\DTO\EntryRequestDto;
+use App\DTO\EntryResponseDto;
 use App\DTO\ImageDto;
 use App\Entity\Entry;
 use App\Entity\EntryComment;
@@ -34,13 +35,17 @@ class EntriesBaseApi extends BaseApi
     /**
      * Serialize a single entry to JSON.
      */
-    protected function serializeEntry(EntryDto|Entry $dto, array $tags)
+    protected function serializeEntry(EntryDto|Entry $dto, array $tags): EntryResponseDto
     {
         $response = $this->entryFactory->createResponseDto($dto, $tags);
 
         if ($this->isGranted('ROLE_OAUTH2_ENTRY:VOTE')) {
             $response->isFavourited = $dto instanceof EntryDto ? $dto->isFavourited : $dto->isFavored($this->getUserOrThrow());
             $response->userVote = $dto instanceof EntryDto ? $dto->userVote : $dto->getUserChoice($this->getUserOrThrow());
+        }
+
+        if ($user = $this->getUser()) {
+            $response->canLoggedInUserModerate = $dto->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
         }
 
         return $response;
@@ -101,6 +106,10 @@ class EntriesBaseApi extends BaseApi
         if ($this->isGranted('ROLE_OAUTH2_ENTRY_COMMENT:VOTE')) {
             $response->isFavourited = $comment->isFavourited;
             $response->userVote = $comment->userVote;
+        }
+
+        if ($user = $this->getUser()) {
+            $response->canLoggedInUserModerate = $comment->magazine->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
         }
 
         return $response;
@@ -173,6 +182,10 @@ class EntriesBaseApi extends BaseApi
         }
 
         $commentTree = $this->commentsFactory->createResponseTree($comment, $depth);
+
+        if ($user = $this->getUser()) {
+            $commentTree->canLoggedInUserModerate = $comment->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
+        }
 
         return $commentTree->jsonSerialize();
     }

--- a/src/Controller/Api/Entry/EntriesBaseApi.php
+++ b/src/Controller/Api/Entry/EntriesBaseApi.php
@@ -180,12 +180,13 @@ class EntriesBaseApi extends BaseApi
         if (null === $depth) {
             $depth = self::constrainDepth($this->request->getCurrentRequest()->get('d', self::DEPTH));
         }
-
-        $commentTree = $this->commentsFactory->createResponseTree($comment, $depth);
-
+        $canModerate = null;
         if ($user = $this->getUser()) {
-            $commentTree->canAuthUserModerate = $comment->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
+            $canModerate = $comment->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
         }
+
+        $commentTree = $this->commentsFactory->createResponseTree($comment, $depth, $canModerate);
+        $commentTree->canAuthUserModerate = $canModerate;
 
         return $commentTree->jsonSerialize();
     }

--- a/src/Controller/Api/Post/PostsBaseApi.php
+++ b/src/Controller/Api/Post/PostsBaseApi.php
@@ -156,11 +156,13 @@ class PostsBaseApi extends BaseApi
             $depth = self::constrainDepth($this->request->getCurrentRequest()->get('d', self::DEPTH));
         }
 
-        $commentTree = $this->postCommentFactory->createResponseTree($comment, $depth);
-
+        $canModerate = null;
         if ($user = $this->getUser()) {
-            $commentTree->canAuthUserModerate = $comment->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
+            $canModerate = $comment->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
         }
+
+        $commentTree = $this->postCommentFactory->createResponseTree($comment, $depth, $canModerate);
+        $commentTree->canAuthUserModerate = $canModerate;
 
         return $commentTree->jsonSerialize();
     }

--- a/src/Controller/Api/Post/PostsBaseApi.php
+++ b/src/Controller/Api/Post/PostsBaseApi.php
@@ -30,6 +30,10 @@ class PostsBaseApi extends BaseApi
             $response->userVote = $dto instanceof PostDto ? $dto->userVote : $dto->getUserChoice($this->getUserOrThrow());
         }
 
+        if ($user = $this->getUser()) {
+            $response->canLoggedInUserModerate = $dto->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
+        }
+
         return $response;
     }
 
@@ -81,6 +85,10 @@ class PostsBaseApi extends BaseApi
         if ($this->isGranted('ROLE_OAUTH2_POST_COMMENT:VOTE')) {
             $response->isFavourited = $comment instanceof PostCommentDto ? $comment->isFavourited : $comment->isFavored($this->getUserOrThrow());
             $response->userVote = $comment instanceof PostCommentDto ? $comment->userVote : $comment->getUserChoice($this->getUserOrThrow());
+        }
+
+        if ($user = $this->getUser()) {
+            $response->canLoggedInUserModerate = $comment->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
         }
 
         return $response;
@@ -149,6 +157,10 @@ class PostsBaseApi extends BaseApi
         }
 
         $commentTree = $this->postCommentFactory->createResponseTree($comment, $depth);
+
+        if ($user = $this->getUser()) {
+            $commentTree->canLoggedInUserModerate = $comment->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
+        }
 
         return $commentTree->jsonSerialize();
     }

--- a/src/Controller/Api/Post/PostsBaseApi.php
+++ b/src/Controller/Api/Post/PostsBaseApi.php
@@ -31,7 +31,7 @@ class PostsBaseApi extends BaseApi
         }
 
         if ($user = $this->getUser()) {
-            $response->canLoggedInUserModerate = $dto->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
+            $response->canAuthUserModerate = $dto->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
         }
 
         return $response;
@@ -88,7 +88,7 @@ class PostsBaseApi extends BaseApi
         }
 
         if ($user = $this->getUser()) {
-            $response->canLoggedInUserModerate = $comment->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
+            $response->canAuthUserModerate = $comment->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
         }
 
         return $response;
@@ -159,7 +159,7 @@ class PostsBaseApi extends BaseApi
         $commentTree = $this->postCommentFactory->createResponseTree($comment, $depth);
 
         if ($user = $this->getUser()) {
-            $commentTree->canLoggedInUserModerate = $comment->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
+            $commentTree->canAuthUserModerate = $comment->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
         }
 
         return $commentTree->jsonSerialize();

--- a/src/DTO/EntryCommentResponseDto.php
+++ b/src/DTO/EntryCommentResponseDto.php
@@ -88,6 +88,7 @@ class EntryCommentResponseDto implements \JsonSerializable
     public array $children = [];
     #[OA\Property(description: 'The total number of children the comment has.')]
     public int $childCount = 0;
+    public ?bool $canLoggedInUserModerate = null;
 
     public static function create(
         ?int $id = null,
@@ -111,6 +112,7 @@ class EntryCommentResponseDto implements \JsonSerializable
         ?\DateTimeImmutable $editedAt = null,
         ?\DateTime $lastActive = null,
         int $childCount = 0,
+        ?bool $canLoggedInUserModerate = null,
     ): self {
         $dto = new EntryCommentResponseDto();
         $dto->commentId = $id;
@@ -134,6 +136,7 @@ class EntryCommentResponseDto implements \JsonSerializable
         $dto->editedAt = $editedAt;
         $dto->lastActive = $lastActive;
         $dto->childCount = $childCount;
+        $dto->canLoggedInUserModerate = $canLoggedInUserModerate;
 
         return $dto;
     }
@@ -184,6 +187,7 @@ class EntryCommentResponseDto implements \JsonSerializable
             'lastActive' => $this->lastActive?->format(\DateTimeInterface::ATOM),
             'childCount' => $this->childCount,
             'children' => $this->children,
+            'canLoggedInUserModerate' => $this->canLoggedInUserModerate,
         ]);
     }
 }

--- a/src/DTO/EntryCommentResponseDto.php
+++ b/src/DTO/EntryCommentResponseDto.php
@@ -88,7 +88,7 @@ class EntryCommentResponseDto implements \JsonSerializable
     public array $children = [];
     #[OA\Property(description: 'The total number of children the comment has.')]
     public int $childCount = 0;
-    public ?bool $canLoggedInUserModerate = null;
+    public ?bool $canAuthUserModerate = null;
 
     public static function create(
         ?int $id = null,
@@ -112,7 +112,7 @@ class EntryCommentResponseDto implements \JsonSerializable
         ?\DateTimeImmutable $editedAt = null,
         ?\DateTime $lastActive = null,
         int $childCount = 0,
-        ?bool $canLoggedInUserModerate = null,
+        ?bool $canAuthUserModerate = null,
     ): self {
         $dto = new EntryCommentResponseDto();
         $dto->commentId = $id;
@@ -136,7 +136,7 @@ class EntryCommentResponseDto implements \JsonSerializable
         $dto->editedAt = $editedAt;
         $dto->lastActive = $lastActive;
         $dto->childCount = $childCount;
-        $dto->canLoggedInUserModerate = $canLoggedInUserModerate;
+        $dto->canAuthUserModerate = $canAuthUserModerate;
 
         return $dto;
     }
@@ -187,7 +187,7 @@ class EntryCommentResponseDto implements \JsonSerializable
             'lastActive' => $this->lastActive?->format(\DateTimeInterface::ATOM),
             'childCount' => $this->childCount,
             'children' => $this->children,
-            'canLoggedInUserModerate' => $this->canLoggedInUserModerate,
+            'canAuthUserModerate' => $this->canAuthUserModerate,
         ]);
     }
 }

--- a/src/DTO/EntryResponseDto.php
+++ b/src/DTO/EntryResponseDto.php
@@ -44,6 +44,7 @@ class EntryResponseDto implements \JsonSerializable
     public ?string $type = null;
     public ?string $slug = null;
     public ?string $apId = null;
+    public ?bool $canLoggedInUserModerate = null;
 
     public static function create(
         ?int $id = null,

--- a/src/DTO/EntryResponseDto.php
+++ b/src/DTO/EntryResponseDto.php
@@ -44,7 +44,7 @@ class EntryResponseDto implements \JsonSerializable
     public ?string $type = null;
     public ?string $slug = null;
     public ?string $apId = null;
-    public ?bool $canLoggedInUserModerate = null;
+    public ?bool $canAuthUserModerate = null;
 
     public static function create(
         ?int $id = null,
@@ -71,7 +71,8 @@ class EntryResponseDto implements \JsonSerializable
         ?\DateTime $lastActive = null,
         ?string $type = null,
         ?string $slug = null,
-        ?string $apId = null
+        ?string $apId = null,
+        ?bool $canAuthUserModerate = null,
     ): self {
         $dto = new EntryResponseDto();
         $dto->entryId = $id;
@@ -99,6 +100,7 @@ class EntryResponseDto implements \JsonSerializable
         $dto->type = $type;
         $dto->slug = $slug;
         $dto->apId = $apId;
+        $dto->canAuthUserModerate = $canAuthUserModerate;
 
         return $dto;
     }
@@ -151,6 +153,7 @@ class EntryResponseDto implements \JsonSerializable
             'type' => $this->type,
             'slug' => $this->slug,
             'apId' => $this->apId,
+            'canAuthUserModerate' => $this->canAuthUserModerate,
         ]);
     }
 }

--- a/src/DTO/PostCommentResponseDto.php
+++ b/src/DTO/PostCommentResponseDto.php
@@ -80,7 +80,7 @@ class PostCommentResponseDto implements \JsonSerializable
         ]
     )]
     public array $children = [];
-    public ?bool $canLoggedInUserModerate = null;
+    public ?bool $canAuthUserModerate = null;
 
     public static function create(
         int $id,
@@ -103,7 +103,7 @@ class PostCommentResponseDto implements \JsonSerializable
         ?\DateTimeImmutable $createdAt = null,
         ?\DateTimeImmutable $editedAt = null,
         ?\DateTime $lastActive = null,
-        ?bool $canLoggedInUserModerate = null,
+        ?bool $canAuthUserModerate = null,
     ): self {
         $dto = new PostCommentResponseDto();
         $dto->commentId = $id;
@@ -127,7 +127,7 @@ class PostCommentResponseDto implements \JsonSerializable
         $dto->editedAt = $editedAt;
         $dto->lastActive = $lastActive;
         $dto->childCount = $childCount;
-        $dto->canLoggedInUserModerate = $canLoggedInUserModerate;
+        $dto->canAuthUserModerate = $canAuthUserModerate;
 
         return $dto;
     }
@@ -174,7 +174,7 @@ class PostCommentResponseDto implements \JsonSerializable
             'lastActive' => $this->lastActive?->format(\DateTimeInterface::ATOM),
             'childCount' => $this->childCount,
             'children' => $this->children,
-            'canLoggedInUserModerate' => $this->canLoggedInUserModerate,
+            'canAuthUserModerate' => $this->canAuthUserModerate,
         ]);
     }
 

--- a/src/DTO/PostCommentResponseDto.php
+++ b/src/DTO/PostCommentResponseDto.php
@@ -80,6 +80,7 @@ class PostCommentResponseDto implements \JsonSerializable
         ]
     )]
     public array $children = [];
+    public ?bool $canLoggedInUserModerate = null;
 
     public static function create(
         int $id,
@@ -102,6 +103,7 @@ class PostCommentResponseDto implements \JsonSerializable
         ?\DateTimeImmutable $createdAt = null,
         ?\DateTimeImmutable $editedAt = null,
         ?\DateTime $lastActive = null,
+        ?bool $canLoggedInUserModerate = null,
     ): self {
         $dto = new PostCommentResponseDto();
         $dto->commentId = $id;
@@ -125,6 +127,7 @@ class PostCommentResponseDto implements \JsonSerializable
         $dto->editedAt = $editedAt;
         $dto->lastActive = $lastActive;
         $dto->childCount = $childCount;
+        $dto->canLoggedInUserModerate = $canLoggedInUserModerate;
 
         return $dto;
     }
@@ -171,6 +174,7 @@ class PostCommentResponseDto implements \JsonSerializable
             'lastActive' => $this->lastActive?->format(\DateTimeInterface::ATOM),
             'childCount' => $this->childCount,
             'children' => $this->children,
+            'canLoggedInUserModerate' => $this->canLoggedInUserModerate,
         ]);
     }
 

--- a/src/DTO/PostResponseDto.php
+++ b/src/DTO/PostResponseDto.php
@@ -36,7 +36,7 @@ class PostResponseDto implements \JsonSerializable
     public ?\DateTimeImmutable $createdAt = null;
     public ?\DateTimeImmutable $editedAt = null;
     public ?\DateTime $lastActive = null;
-    public ?bool $canLoggedInUserModerate = null;
+    public ?bool $canAuthUserModerate = null;
 
     public static function create(
         int $id,
@@ -59,7 +59,7 @@ class PostResponseDto implements \JsonSerializable
         ?\DateTimeImmutable $editedAt = null,
         ?\DateTime $lastActive = null,
         ?string $slug = null,
-        ?bool $canLoggedInUserModerate = null,
+        ?bool $canAuthUserModerate = null,
     ): self {
         $dto = new PostResponseDto();
         $dto->postId = $id;
@@ -82,7 +82,7 @@ class PostResponseDto implements \JsonSerializable
         $dto->editedAt = $editedAt;
         $dto->lastActive = $lastActive;
         $dto->slug = $slug;
-        $dto->canLoggedInUserModerate = $canLoggedInUserModerate;
+        $dto->canAuthUserModerate = $canAuthUserModerate;
 
         return $dto;
     }
@@ -127,7 +127,7 @@ class PostResponseDto implements \JsonSerializable
             'editedAt' => $this->editedAt?->format(\DateTimeInterface::ATOM),
             'lastActive' => $this->lastActive?->format(\DateTimeInterface::ATOM),
             'slug' => $this->slug,
-            'canLoggedInUserModerate' => $this->canLoggedInUserModerate,
+            'canAuthUserModerate' => $this->canAuthUserModerate,
         ]);
     }
 }

--- a/src/DTO/PostResponseDto.php
+++ b/src/DTO/PostResponseDto.php
@@ -36,6 +36,7 @@ class PostResponseDto implements \JsonSerializable
     public ?\DateTimeImmutable $createdAt = null;
     public ?\DateTimeImmutable $editedAt = null;
     public ?\DateTime $lastActive = null;
+    public ?bool $canLoggedInUserModerate = null;
 
     public static function create(
         int $id,
@@ -57,7 +58,8 @@ class PostResponseDto implements \JsonSerializable
         ?\DateTimeImmutable $createdAt = null,
         ?\DateTimeImmutable $editedAt = null,
         ?\DateTime $lastActive = null,
-        ?string $slug = null
+        ?string $slug = null,
+        ?bool $canLoggedInUserModerate = null,
     ): self {
         $dto = new PostResponseDto();
         $dto->postId = $id;
@@ -80,6 +82,7 @@ class PostResponseDto implements \JsonSerializable
         $dto->editedAt = $editedAt;
         $dto->lastActive = $lastActive;
         $dto->slug = $slug;
+        $dto->canLoggedInUserModerate = $canLoggedInUserModerate;
 
         return $dto;
     }
@@ -124,6 +127,7 @@ class PostResponseDto implements \JsonSerializable
             'editedAt' => $this->editedAt?->format(\DateTimeInterface::ATOM),
             'lastActive' => $this->lastActive?->format(\DateTimeInterface::ATOM),
             'slug' => $this->slug,
+            'canLoggedInUserModerate' => $this->canLoggedInUserModerate,
         ]);
     }
 }

--- a/src/Factory/EntryCommentFactory.php
+++ b/src/Factory/EntryCommentFactory.php
@@ -62,12 +62,13 @@ class EntryCommentFactory
         );
     }
 
-    public function createResponseTree(EntryComment $comment, int $depth = -1): EntryCommentResponseDto
+    public function createResponseTree(EntryComment $comment, int $depth = -1, ?bool $canModerate = null): EntryCommentResponseDto
     {
         $commentDto = $this->createDto($comment);
         $toReturn = $this->createResponseDto($commentDto, $this->tagLinkRepository->getTagsOfEntryComment($comment), array_reduce($comment->children->toArray(), EntryCommentResponseDto::class.'::recursiveChildCount', 0));
         $toReturn->isFavourited = $commentDto->isFavourited;
         $toReturn->userVote = $commentDto->userVote;
+        $toReturn->canAuthUserModerate = $canModerate;
 
         if (0 === $depth) {
             return $toReturn;
@@ -75,7 +76,7 @@ class EntryCommentFactory
 
         foreach ($comment->children as $childComment) {
             \assert($childComment instanceof EntryComment);
-            $child = $this->createResponseTree($childComment, $depth > 0 ? $depth - 1 : -1);
+            $child = $this->createResponseTree($childComment, $depth > 0 ? $depth - 1 : -1, $canModerate);
             array_push($toReturn->children, $child);
         }
 

--- a/src/Factory/PostCommentFactory.php
+++ b/src/Factory/PostCommentFactory.php
@@ -63,12 +63,13 @@ class PostCommentFactory
         );
     }
 
-    public function createResponseTree(PostComment $comment, int $depth): PostCommentResponseDto
+    public function createResponseTree(PostComment $comment, int $depth, ?bool $canModerate = null): PostCommentResponseDto
     {
         $commentDto = $this->createDto($comment);
         $toReturn = $this->createResponseDto($commentDto, $this->tagLinkRepository->getTagsOfPostComment($comment), array_reduce($comment->children->toArray(), PostCommentResponseDto::class.'::recursiveChildCount', 0));
         $toReturn->isFavourited = $commentDto->isFavourited;
         $toReturn->userVote = $commentDto->userVote;
+        $toReturn->canAuthUserModerate = $canModerate;
 
         if (0 === $depth) {
             return $toReturn;
@@ -76,7 +77,7 @@ class PostCommentFactory
 
         foreach ($comment->children as $childComment) {
             \assert($childComment instanceof PostComment);
-            $child = $this->createResponseTree($childComment, $depth > 0 ? $depth - 1 : -1);
+            $child = $this->createResponseTree($childComment, $depth > 0 ? $depth - 1 : -1, $canModerate);
             array_push($toReturn->children, $child);
         }
 


### PR DESCRIPTION
- All content response DTOs (entry, entry_comment, post, post_comment) now have a field `canLoggedInUserModerate` which indicates whether the loggedin user can moderate said content

Link #1001 