### PR TITLE
Add a warning message when we hit the cache in post

### DIFF
--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -286,6 +286,11 @@ class ApHttpClient
         $cacheKey = 'ap_'.hash('sha256', $url.':'.$body['id']);
 
         if ($this->cache->hasItem($cacheKey)) {
+            $this->logger->warning('not posting activity with id {id} to {inbox} again, as we already did that sometime in the last 45 minutes', [
+                'id' => $body['id'],
+                'inbox' => $url
+            ]);
+
             return;
         }
 

--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -288,7 +288,7 @@ class ApHttpClient
         if ($this->cache->hasItem($cacheKey)) {
             $this->logger->warning('not posting activity with id {id} to {inbox} again, as we already did that sometime in the last 45 minutes', [
                 'id' => $body['id'],
-                'inbox' => $url
+                'inbox' => $url,
             ]);
 
             return;


### PR DESCRIPTION
- the cache in the post method is only hit when we sent something with the same ap id multiple times in 45 minutes, so log a warning when that happens