### PR TITLE
Use a different cache key for activity object

### DIFF
--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -59,7 +59,7 @@ class ApHttpClient
 
     public function getActivityObject(string $url, bool $decoded = true): array|string|null
     {
-        $resp = $this->cache->get('ap_'.hash('sha256', $url), function (ItemInterface $item) use ($url) {
+        $resp = $this->cache->get($this->getActivityObjectCacheKey($url), function (ItemInterface $item) use ($url) {
             $this->logger->debug("ApHttpClient:getActivityObject:url: $url");
 
             $client = new CurlHttpClient();
@@ -89,6 +89,11 @@ class ApHttpClient
         }
 
         return $decoded ? json_decode($resp, true) : $resp;
+    }
+
+    public function getActivityObjectCacheKey(string $url): string
+    {
+        return 'ap_object_'.hash('sha256', $url);
     }
 
     /**


### PR DESCRIPTION
Right now `getActivityObject` and `getActorObject` use the same cache key layout, change prefix for `getActivityObject` to `ap_object`

This is mostly done for logging purposes, as they should never overlap from the hash keys