### PR TITLE
Use different values for `timeout` and `max_duration`

### DIFF
--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -42,6 +42,7 @@ enum ApRequestType
 class ApHttpClient
 {
     public const TIMEOUT = 8;
+    public const MAX_DURATION = 15;
 
     public function __construct(
         private readonly string $kbinDomain,
@@ -64,7 +65,7 @@ class ApHttpClient
 
             $client = new CurlHttpClient();
             $r = $client->request('GET', $url, [
-                'max_duration' => self::TIMEOUT,
+                'max_duration' => self::MAX_DURATION,
                 'timeout' => self::TIMEOUT,
                 'headers' => $this->getInstanceHeaders($url),
             ]);
@@ -127,7 +128,7 @@ class ApHttpClient
                 try {
                     $client = new CurlHttpClient();
                     $r = $client->request('GET', $url, [
-                        'max_duration' => self::TIMEOUT,
+                        'max_duration' => self::MAX_DURATION,
                         'timeout' => self::TIMEOUT,
                         'headers' => $this->getInstanceHeaders($url, null, 'get', ApRequestType::WebFinger),
                     ]);
@@ -171,7 +172,7 @@ class ApHttpClient
                     // Set-up request
                     $client = new CurlHttpClient();
                     $response = $client->request('GET', $apProfileId, [
-                        'max_duration' => self::TIMEOUT,
+                        'max_duration' => self::MAX_DURATION,
                         'timeout' => self::TIMEOUT,
                         'headers' => $this->getInstanceHeaders($apProfileId, null, 'get', ApRequestType::ActivityPub),
                     ]);
@@ -244,7 +245,7 @@ class ApHttpClient
                     // Set-up request
                     $client = new CurlHttpClient();
                     $response = $client->request('GET', $apAddress, [
-                        'max_duration' => self::TIMEOUT,
+                        'max_duration' => self::MAX_DURATION,
                         'timeout' => self::TIMEOUT,
                         'headers' => $this->getInstanceHeaders($apAddress, null, 'get', ApRequestType::ActivityPub),
                     ]);
@@ -295,7 +296,7 @@ class ApHttpClient
         // Set-up request
         $client = new CurlHttpClient();
         $response = $client->request('POST', $url, [
-            'max_duration' => self::TIMEOUT,
+            'max_duration' => self::MAX_DURATION,
             'timeout' => self::TIMEOUT,
             'body' => json_encode($body),
             'headers' => $this->getHeaders($url, $actor, $body),
@@ -373,7 +374,7 @@ class ApHttpClient
         $client = new CurlHttpClient();
         $this->logger->debug("ApHttpClient:generalFetch:url: $url");
         $r = $client->request('GET', $url, [
-            'max_duration' => self::TIMEOUT,
+            'max_duration' => self::MAX_DURATION,
             'timeout' => self::TIMEOUT,
             'headers' => $this->getInstanceHeaders($url, requestType: $requestType),
         ]);


### PR DESCRIPTION
Currently we use the same values for the two properties, although they mean different things:
- `max_duration`: the maximum duration a request can run for
- `timeout`: the maximum duration we are willing to wait while the socket is idling

[Symfony Docs](https://symfony.com/doc/current/http_client.html#dealing-with-network-timeouts):
> Timeouts control how long one is willing to wait while the HTTP transaction is idle. Big responses can last as long as needed to complete, provided they remain active during the transfer and never pause for longer than specified.
>
> Use the max_duration option to limit the time a full request/response can last.