### PR TITLE
Add missing checks for banned instance

### DIFF
--- a/src/Exception/InstanceBannedException.php
+++ b/src/Exception/InstanceBannedException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+final class InstanceBannedException extends \Exception
+{
+}

--- a/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
@@ -9,6 +9,7 @@ use App\Entity\EntryComment;
 use App\Entity\Post;
 use App\Entity\PostComment;
 use App\Exception\EntityNotFoundException;
+use App\Exception\InstanceBannedException;
 use App\Exception\TagBannedException;
 use App\Exception\UserBannedException;
 use App\Exception\UserDeletedException;
@@ -22,7 +23,6 @@ use App\Repository\ApActivityRepository;
 use App\Service\ActivityPub\ApHttpClient;
 use App\Service\ActivityPub\Note;
 use App\Service\ActivityPub\Page;
-use Doctrine\DBAL\Exception;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -141,6 +141,8 @@ class ChainActivityHandler extends MbinMessageHandler
             $this->logger->error('one of the used tags is banned, url: {url}', ['url' => $apUrl]);
         } catch (EntityNotFoundException $e) {
             $this->logger->error('There was an exception while getting {url}: {ex} - {m}. {o}', ['url' => $apUrl, 'ex' => \get_class($e), 'm' => $e->getMessage(), 'o' => $e]);
+        } catch (InstanceBannedException $e) {
+            $this->logger->error('the user\'s instance is banned, url: {url}', ['url' => $apUrl]);
         }
 
         return null;

--- a/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
@@ -134,15 +134,15 @@ class ChainActivityHandler extends MbinMessageHandler
                     $this->logger->warning('Could not create an object from type {t} on {url}: {o}', ['t' => $object['type'], 'url' => $apUrl, 'o' => $object]);
             }
         } catch (UserBannedException) {
-            $this->logger->error('the user is banned, url: {url}', ['url' => $apUrl]);
+            $this->logger->info('the user is banned, url: {url}', ['url' => $apUrl]);
         } catch (UserDeletedException) {
-            $this->logger->error('the user is deleted, url: {url}', ['url' => $apUrl]);
+            $this->logger->info('the user is deleted, url: {url}', ['url' => $apUrl]);
         } catch (TagBannedException) {
-            $this->logger->error('one of the used tags is banned, url: {url}', ['url' => $apUrl]);
+            $this->logger->info('one of the used tags is banned, url: {url}', ['url' => $apUrl]);
         } catch (EntityNotFoundException $e) {
             $this->logger->error('There was an exception while getting {url}: {ex} - {m}. {o}', ['url' => $apUrl, 'ex' => \get_class($e), 'm' => $e->getMessage(), 'o' => $e]);
         } catch (InstanceBannedException $e) {
-            $this->logger->error('the user\'s instance is banned, url: {url}', ['url' => $apUrl]);
+            $this->logger->info('the user\'s instance is banned, url: {url}', ['url' => $apUrl]);
         }
 
         return null;

--- a/src/MessageHandler/ActivityPub/Inbox/CreateHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/CreateHandler.php
@@ -89,7 +89,7 @@ class CreateHandler extends MbinMessageHandler
             }
             $this->logger->info('Did not create the post, because the magazine {m} restricts posting to mods and {u} is not a mod', ['m' => $e->magazine, 'u' => $username]);
         } catch (InstanceBannedException $e) {
-            $this->logger->error('Did not create the post, because the user\'s instance is banned');
+            $this->logger->info('Did not create the post, because the user\'s instance is banned');
         }
     }
 

--- a/src/MessageHandler/ActivityPub/Inbox/CreateHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/CreateHandler.php
@@ -9,6 +9,7 @@ use App\Entity\EntryComment;
 use App\Entity\Post;
 use App\Entity\PostComment;
 use App\Entity\User;
+use App\Exception\InstanceBannedException;
 use App\Exception\PostingRestrictedException;
 use App\Exception\TagBannedException;
 use App\Exception\UserBannedException;
@@ -87,6 +88,8 @@ class CreateHandler extends MbinMessageHandler
                 $username = $e->actor->name;
             }
             $this->logger->info('Did not create the post, because the magazine {m} restricts posting to mods and {u} is not a mod', ['m' => $e->magazine, 'u' => $username]);
+        } catch (InstanceBannedException $e) {
+            $this->logger->error('Did not create the post, because the user\'s instance is banned');
         }
     }
 
@@ -94,6 +97,7 @@ class CreateHandler extends MbinMessageHandler
      * @throws TagBannedException
      * @throws UserBannedException
      * @throws UserDeletedException
+     * @throws InstanceBannedException
      */
     private function handleChain(): void
     {
@@ -121,6 +125,7 @@ class CreateHandler extends MbinMessageHandler
      * @throws UserDeletedException
      * @throws TagBannedException
      * @throws PostingRestrictedException
+     * @throws InstanceBannedException
      */
     private function handlePage(): void
     {

--- a/src/Service/ActivityPub/Note.php
+++ b/src/Service/ActivityPub/Note.php
@@ -15,6 +15,7 @@ use App\Entity\EntryComment;
 use App\Entity\Post;
 use App\Entity\PostComment;
 use App\Entity\User;
+use App\Exception\InstanceBannedException;
 use App\Exception\TagBannedException;
 use App\Exception\UserBannedException;
 use App\Exception\UserDeletedException;
@@ -48,6 +49,7 @@ class Note
      * @throws TagBannedException
      * @throws UserBannedException
      * @throws UserDeletedException
+     * @throws InstanceBannedException
      * @throws \Exception
      */
     public function create(array $object, ?array $root = null, bool $stickyIt = false): EntryComment|PostComment|Post
@@ -55,6 +57,9 @@ class Note
         $current = $this->repository->findByObjectId($object['id']);
         if ($current) {
             return $this->entityManager->getRepository($current['type'])->find((int) $current['id']);
+        }
+        if ($this->settingsManager->isBannedInstance($object['id'])) {
+            throw new InstanceBannedException();
         }
 
         if (\is_string($object['to'])) {


### PR DESCRIPTION
currently it is only checked if an instance is banned when receiving activities. Add the check to:
- CreateHandler: creating content (not so relevant, should already covered by the check in the ActivityHandler)
- ChainActivityHandler: creating content when a dependency of replies, likes, etc (probably the most relevant one)
- ActivityPubManager: when updating actors, creating users and magazines