### PR TITLE
Update _form_media.html.twig

### DIFF
--- a/assets/styles/components/_media.scss
+++ b/assets/styles/components/_media.scss
@@ -35,7 +35,6 @@
 
     .image-input {
       max-width: 100%;
-      width: 100%;
     }
   }
 
@@ -77,10 +76,6 @@
         color: var(--kbin-button-secondary-text-hover-color);
       }
     }
-  }
-  
-  .image-form {
-    width: 300px;
   }
 }
 

--- a/assets/styles/components/_media.scss
+++ b/assets/styles/components/_media.scss
@@ -78,6 +78,10 @@
       }
     }
   }
+  
+  .image-form {
+    width: 300px;
+  }
 }
 
 .comment-add,

--- a/assets/styles/components/_media.scss
+++ b/assets/styles/components/_media.scss
@@ -77,6 +77,10 @@
       }
     }
   }
+  
+  .image-form {
+    width: 100%;
+  }
 }
 
 .comment-add,

--- a/templates/layout/_form_media.html.twig
+++ b/templates/layout/_form_media.html.twig
@@ -3,23 +3,12 @@
         <img class="image-preview" src="#">
         <button type="button" class="image-preview-clear" data-action="image-upload#clearPreview">x</button>
     </div>
-    <div>
+    <div style="width:300px;">
         {% if form.image is defined %}
             {{ form_row(form.image, {label: 'image', attr: {class: 'image-input'}}) }}
         {% endif %}
-        {% if maxSize is defined %}
-            <div>{{ 'max_image_size'|trans }}: {{ maxSize }}</div>
-        {% endif %}
         <div hidden>
             {{ form_row(form.imageUrl, {label: 'url'}) }}
-        </div>
-        <div class="actions">
-            <button type="button" class="btn btn__secondary" data-action="media#add">
-                <i class="fa-solid fa-upload" aria-hidden="true"></i> {{ 'upload_file'|trans }}
-            </button>
-            <button type="button" class="btn btn__secondary" data-action="media#add">
-                <i class="fa-solid fa-globe" aria-hidden="true"></i> {{ 'from_url'|trans }}
-            </button>
         </div>
         {{ form_row(form.imageAlt, {label: 'image_alt'}) }}
     </div>

--- a/templates/layout/_form_media.html.twig
+++ b/templates/layout/_form_media.html.twig
@@ -3,7 +3,7 @@
         <img class="image-preview" src="#">
         <button type="button" class="image-preview-clear" data-action="image-upload#clearPreview">x</button>
     </div>
-    <div style="width:300px;">
+    <div class="image-form">
         {% if form.image is defined %}
             {{ form_row(form.image, {label: 'image', attr: {class: 'image-input'}}) }}
         {% endif %}

--- a/templates/layout/_form_media.html.twig
+++ b/templates/layout/_form_media.html.twig
@@ -7,6 +7,9 @@
         {% if form.image is defined %}
             {{ form_row(form.image, {label: 'image', attr: {class: 'image-input'}}) }}
         {% endif %}
+        {% if maxSize is defined %}
+            <div>{{ 'max_image_size'|trans }}: {{ maxSize }}</div>
+        {% endif %}
         <div hidden>
             {{ form_row(form.imageUrl, {label: 'url'}) }}
         </div>


### PR DESCRIPTION
A user tried uploading an image to my instance but clicked on upload file instead of add new photo. As this button does nothing, neither does the from url button, the user gave up. These buttons are useless but most of all confusing, so I propose;

Removing unused buttons on image upload dialog.

Adding width:300px to make it look good. Leaving the imageUrl, removing it may cause problems.

See what it looks like on [RimWorld.gallery](https://rimworld.gallery/m/debug/new/photo)