### PR TITLE
actually building user agent in ProjectInfoService

### DIFF
--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -422,7 +422,7 @@ class ApHttpClient
         $signatureHeader = 'keyId="'.$keyId.'",headers="'.$signedHeaders.'",algorithm="rsa-sha256",signature="'.$signature.'"';
         unset($headers['(request-target)']);
         $headers['Signature'] = $signatureHeader;
-        $headers['User-Agent'] = $this->projectInfo->getUserAgent().'/'.$this->projectInfo->getVersion().' (+https://'.$this->kbinDomain.'/agent)';
+        $headers['User-Agent'] = $this->projectInfo->getUserAgent();
         $headers['Accept'] = 'application/activity+json';
         $headers['Content-Type'] = 'application/activity+json';
 
@@ -442,7 +442,7 @@ class ApHttpClient
         $signatureHeader = 'keyId="'.$keyId.'",headers="'.$signedHeaders.'",algorithm="rsa-sha256",signature="'.$signature.'"';
         unset($headers['(request-target)']);
         $headers['Signature'] = $signatureHeader;
-        $headers['User-Agent'] = $this->projectInfo->getUserAgent().'/'.$this->projectInfo->getVersion().' (+https://'.$this->kbinDomain.'/agent)';
+        $headers['User-Agent'] = $this->projectInfo->getUserAgent();
         $headers = array_merge($headers, $this->getFetchAcceptHeaders($requestType));
 
         return $headers;

--- a/src/Service/ProjectInfoService.php
+++ b/src/Service/ProjectInfoService.php
@@ -12,8 +12,13 @@ class ProjectInfoService
     // If updating version, please also update http client UA in [/config/packages/framework.yaml]
     private const VERSION = '1.7.1-rc4'; // TODO: Retrieve the version from git tags or getenv()?
     private const NAME = 'mbin';
-    private const USER_AGENT = 'Mbin';
+    private const CANONICAL_NAME = 'Mbin';
     private const REPOSITORY_URL = 'https://github.com/MbinOrg/mbin';
+
+    public function __construct(
+        private readonly string $kbinDomain,
+    ) {
+    }
 
     /**
      * Get Mbin current project version.
@@ -36,13 +41,23 @@ class ProjectInfoService
     }
 
     /**
-     * Get user-agent name we use as HTTP client requests.
+     * Get project canonical name.
+     *
+     * @return string canonical name
+     */
+    public function getCanonicalName(): string
+    {
+        return self::CANONICAL_NAME;
+    }
+
+    /**
+     * Get user-agent name usable as HTTP client requests.
      *
      * @return user-agent string
      */
     public function getUserAgent(): string
     {
-        return self::USER_AGENT;
+        return "{$this->getCanonicalName()}/{$this->getVersion()} (+https://{$this->kbinDomain}/agent)";
     }
 
     /**


### PR DESCRIPTION
adjust `ProjectInfoService::getUserAgent()` to actually generate a user agent string suitable for use in http client (e.g. in `ApHttpClient`) with no further assembling on the caller part