### PR TITLE
push navbar front route generation into twig func

### DIFF
--- a/src/Twig/Runtime/FrontExtensionRuntime.php
+++ b/src/Twig/Runtime/FrontExtensionRuntime.php
@@ -49,16 +49,18 @@ class FrontExtensionRuntime implements RuntimeExtensionInterface
         $content = $params['content'] ?? null;
         $subscription = $params['subscription'] ?? null;
 
-        if (\in_array($currentRoute, ['front_sub', 'front_content']) && $content && $subscription) {
-            return 'front';
-        } elseif ('front_short' === $currentRoute) {
-            return match (true) {
-                !empty($content) => 'front_content',
-                !empty($subscription) => 'front_sub',
-                default => 'front',
-            };
+        if ('home' === $subscription) {
+            $subscription = null;
         }
 
-        return 'front';
+        if ($content && $subscription) {
+            return 'front';
+        } elseif ($subscription) {
+            return 'front_sub';
+        } elseif ($content) {
+            return 'front_content';
+        } else {
+            return 'front_short';
+        }
     }
 }

--- a/src/Twig/Runtime/NavbarExtensionRuntime.php
+++ b/src/Twig/Runtime/NavbarExtensionRuntime.php
@@ -13,12 +13,21 @@ class NavbarExtensionRuntime implements RuntimeExtensionInterface
 {
     public function __construct(
         private readonly RequestStack $requestStack,
-        private readonly UrlGeneratorInterface $urlGenerator
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly FrontExtensionRuntime $frontExtension,
     ) {
     }
 
     public function navbarThreadsUrl(?Magazine $magazine): string
     {
+        if ($this->isRouteNameStartsWith('front')) {
+            return $this->frontExtension->frontOptionsUrl(
+                'content', 'threads',
+                $magazine instanceof Magazine ? 'front_magazine' : 'front',
+                ['name' => $magazine?->name, 'p' => null],
+            );
+        }
+
         if ($magazine instanceof Magazine) {
             return $this->urlGenerator->generate('front_magazine', [
                 'name' => $magazine->name,
@@ -45,6 +54,14 @@ class NavbarExtensionRuntime implements RuntimeExtensionInterface
 
     public function navbarPostsUrl(?Magazine $magazine): string
     {
+        if ($this->isRouteNameStartsWith('front')) {
+            return $this->frontExtension->frontOptionsUrl(
+                'content', 'microblog',
+                $magazine instanceof Magazine ? 'front_magazine' : 'front',
+                ['name' => $magazine?->name, 'p' => null, 'type' => null],
+            );
+        }
+
         if ($magazine instanceof Magazine) {
             return $this->urlGenerator->generate('magazine_posts', [
                 'name' => $magazine->name,
@@ -124,7 +141,7 @@ class NavbarExtensionRuntime implements RuntimeExtensionInterface
         if ('∞' !== $timeOption) {
             $options['time'] = $timeOption;
         }
-        if (null !== $subscriptionOption) {
+        if (!\in_array($subscriptionOption, [null, 'home'])) {
             $options['subscription'] = $subscriptionOption;
         }
 

--- a/templates/layout/_header_nav.html.twig
+++ b/templates/layout/_header_nav.html.twig
@@ -18,40 +18,12 @@
 
 {% if header_nav is empty %}
     <li>
-        <a href="
-            {% if magazine is defined and magazine %}
-                {% if is_route_name_starts_with('front') %}
-                    {{ options_url('content', 'threads', 'front_magazine', {'name': magazine.name, 'p': null}) }}
-                {% else %}
-                    {{ navbar_threads_url(magazine) }}
-                {% endif %}
-            {% else %}
-                {% if is_route_name_starts_with('front') %}
-                    {{ options_url('content', 'threads', 'front', {'p': null}) }}
-                {% else %}
-                    {{ navbar_threads_url(null) }}
-                {% endif %}
-            {% endif %}
-        " class="{{ html_classes({'active': activeLink == 'threads'}) }}">
+        <a href="{{ navbar_threads_url(magazine) }}" class="{{ html_classes({'active': activeLink == 'threads'}) }}">
             {{ 'threads'|trans }} {% if magazine is defined and magazine %}({{ magazine.entryCount }}){% endif %}
         </a>
     </li>
     <li>
-        <a href="
-            {% if magazine is defined and magazine %}
-                {% if is_route_name_starts_with('front') %}
-                    {{ options_url('content', 'microblog', 'front_magazine', {'name': magazine.name,'p': null,'type':null}) }}
-                {% else %}
-                    {{ navbar_posts_url(magazine) }}
-                {% endif %}
-            {% else %}
-                {% if is_route_name_starts_with('front') %}
-                    {{ options_url('content', 'microblog', 'front', {'p': null,'type':null}) }}
-                {% else %}
-                    {{ navbar_posts_url(null) }}
-                {% endif %}
-            {% endif
-        %}" class="{{ html_classes({'active': activeLink == 'microblog'}) }}">
+        <a href="{{ navbar_posts_url(magazine) }}" class="{{ html_classes({'active': activeLink == 'microblog'}) }}">
             {{ 'microblog'|trans }} {% if magazine is defined and magazine %}({{ magazine.postCount }}){% endif %}
         </a>
     </li>


### PR DESCRIPTION
pushed the block of conditions that's used in templating head navbar link to threads/microblogs page from twig templates to existing `navbar_*_url` function

makes the template a bit easier to work with and consolidate new path selection/generation logic into one place