### PR TITLE
Fix AP context

### DIFF
--- a/src/Service/ActivityPub/ContextsProvider.php
+++ b/src/Service/ActivityPub/ContextsProvider.php
@@ -21,7 +21,7 @@ class ContextsProvider
             ActivityPubActivityInterface::SECURITY_URL,
             [
                 ...ActivityPubActivityInterface::ADDITIONAL_CONTEXTS,
-            ]
+            ],
         ];
     }
 

--- a/src/Service/ActivityPub/ContextsProvider.php
+++ b/src/Service/ActivityPub/ContextsProvider.php
@@ -16,11 +16,13 @@ class ContextsProvider
 
     public static function embeddedContexts(): array
     {
-        return array_values([
+        return [
             ActivityPubActivityInterface::CONTEXT_URL,
             ActivityPubActivityInterface::SECURITY_URL,
-            ...ActivityPubActivityInterface::ADDITIONAL_CONTEXTS,
-        ]);
+            [
+                ...ActivityPubActivityInterface::ADDITIONAL_CONTEXTS,
+            ]
+        ];
     }
 
     public function referencedContexts(): array


### PR DESCRIPTION
Return valid ActivityPub context. 

Issue was reported here: https://kbin.melroy.org/m/random/p/138512/BrowserPub-A-browser-for-debugging-ActivityPub-and-the-fediverse#post-comment-215905

See live: https://kbin.melroy.org/contexts