### PR TITLE
Update theme-dark.scss

### DIFF
--- a/assets/styles/mixins/theme-dark.scss
+++ b/assets/styles/mixins/theme-dark.scss
@@ -109,8 +109,8 @@
    --kbin-boosted-color: var(--kbin-upvoted-color);
 
   // alerts
-  --kbin-alert-info-bg: rgba(153,116,4,0.9);
-  --kbin-alert-info-border: 1px solid rgba(153,116,4, 1);
+  --kbin-alert-info-bg: rgba(153,116,4,0.15);
+  --kbin-alert-info-border: 1px solid rgba(153,116,4, 0.04);
   --kbin-alert-info-text-color: #997404;
   --kbin-alert-info-link-color: #997404;
 

--- a/assets/styles/mixins/theme-dark.scss
+++ b/assets/styles/mixins/theme-dark.scss
@@ -109,13 +109,13 @@
    --kbin-boosted-color: var(--kbin-upvoted-color);
 
   // alerts
-  --kbin-alert-info-bg: rgba(153,116,4,1);
-  --kbin-alert-info-border: 1px solid rgba(153,116,4,0.4);
+  --kbin-alert-info-bg: rgba(153,116,4,0.9);
+  --kbin-alert-info-border: 1px solid rgba(153,116,4, 1);
   --kbin-alert-info-text-color: #997404;
   --kbin-alert-info-link-color: #997404;
 
-  --kbin-alert-danger-bg: rgba(220, 47, 63, 0.15);
-  --kbin-alert-danger-border: 1px solid rgba(220, 47, 63, 0.4);
+  --kbin-alert-danger-bg: rgba(171, 28, 40, 0.9);
+  --kbin-alert-danger-border: 1px solid rgba(171, 28, 40, 1);
   --kbin-alert-danger-text-color: var(--kbin-danger-color);
   --kbin-alert-danger-link-color: var(--kbin-danger-color);
 

--- a/assets/styles/mixins/theme-dark.scss
+++ b/assets/styles/mixins/theme-dark.scss
@@ -109,7 +109,7 @@
    --kbin-boosted-color: var(--kbin-upvoted-color);
 
   // alerts
-  --kbin-alert-info-bg: rgba(153,116,4,0.15);
+  --kbin-alert-info-bg: rgba(153,116,4,1);
   --kbin-alert-info-border: 1px solid rgba(153,116,4,0.4);
   --kbin-alert-info-text-color: #997404;
   --kbin-alert-info-link-color: #997404;

--- a/assets/styles/mixins/theme-solarized-dark.scss
+++ b/assets/styles/mixins/theme-solarized-dark.scss
@@ -127,8 +127,8 @@ $green: #859900;
    --kbin-boosted-color: var(--kbin-upvoted-color);
 
   // alerts
-  --kbin-alert-info-bg: rgba(153,116,4,0.9);
-  --kbin-alert-info-border: 1px solid rgba(153,116,4,1);
+  --kbin-alert-info-bg: rgba(153,116,4,0.15);
+  --kbin-alert-info-border: 1px solid rgba(153,116,4,0.4);
   --kbin-alert-info-text-color: #997404;
   --kbin-alert-info-link-color: #997404;
 

--- a/assets/styles/mixins/theme-solarized-dark.scss
+++ b/assets/styles/mixins/theme-solarized-dark.scss
@@ -127,7 +127,7 @@ $green: #859900;
    --kbin-boosted-color: var(--kbin-upvoted-color);
 
   // alerts
-  --kbin-alert-info-bg: rgba(153,116,4,0.15);
+  --kbin-alert-info-bg: rgba(153,116,4,1);
   --kbin-alert-info-border: 1px solid rgba(153,116,4,0.4);
   --kbin-alert-info-text-color: #997404;
   --kbin-alert-info-link-color: #997404;

--- a/assets/styles/mixins/theme-solarized-dark.scss
+++ b/assets/styles/mixins/theme-solarized-dark.scss
@@ -127,13 +127,13 @@ $green: #859900;
    --kbin-boosted-color: var(--kbin-upvoted-color);
 
   // alerts
-  --kbin-alert-info-bg: rgba(153,116,4,1);
-  --kbin-alert-info-border: 1px solid rgba(153,116,4,0.4);
+  --kbin-alert-info-bg: rgba(153,116,4,0.9);
+  --kbin-alert-info-border: 1px solid rgba(153,116,4,1);
   --kbin-alert-info-text-color: #997404;
   --kbin-alert-info-link-color: #997404;
 
-  --kbin-alert-danger-bg: rgba(220, 47, 63, 0.15);
-  --kbin-alert-danger-border: 1px solid rgba(220, 47, 63, 0.4);
+  --kbin-alert-danger-bg: rgba(171, 28, 40, 0.9);
+  --kbin-alert-danger-border: 1px solid rgba(171, 28, 40, 1);
   --kbin-alert-danger-text-color: var(--kbin-danger-color);
   --kbin-alert-danger-link-color: var(--kbin-danger-color);
 

--- a/assets/styles/themes/_kbin.scss
+++ b/assets/styles/themes/_kbin.scss
@@ -107,13 +107,13 @@
    --kbin-boosted-color: var(--kbin-upvoted-color);
 
   // alerts
-  --kbin-alert-info-bg: rgba(153,116,4,1);
-  --kbin-alert-info-border: 1px solid rgba(153,116,4,0.4);
+  --kbin-alert-info-bg: rgba(153,116,4,0.9);
+  --kbin-alert-info-border: 1px solid rgba(153,116,4,1);
   --kbin-alert-info-text-color: #997404;
   --kbin-alert-info-link-color: #997404;
 
-  --kbin-alert-danger-bg: rgba(220, 47, 63, 0.15);
-  --kbin-alert-danger-border: 1px solid rgba(220, 47, 63, 0.4);
+  --kbin-alert-danger-bg: rgba(171, 28, 40, 0.9);
+  --kbin-alert-danger-border: 1px solid rgba(171, 28, 40, 1);
   --kbin-alert-danger-text-color: var(--kbin-danger-color);
   --kbin-alert-danger-link-color: var(--kbin-danger-color);
 

--- a/assets/styles/themes/_kbin.scss
+++ b/assets/styles/themes/_kbin.scss
@@ -107,8 +107,8 @@
    --kbin-boosted-color: var(--kbin-upvoted-color);
 
   // alerts
-  --kbin-alert-info-bg: rgba(153,116,4,0.9);
-  --kbin-alert-info-border: 1px solid rgba(153,116,4,1);
+  --kbin-alert-info-bg: rgba(153,116,4,0.15);
+  --kbin-alert-info-border: 1px solid rgba(153,116,4,0.4);
   --kbin-alert-info-text-color: #997404;
   --kbin-alert-info-link-color: #997404;
 

--- a/assets/styles/themes/_kbin.scss
+++ b/assets/styles/themes/_kbin.scss
@@ -107,7 +107,7 @@
    --kbin-boosted-color: var(--kbin-upvoted-color);
 
   // alerts
-  --kbin-alert-info-bg: rgba(153,116,4,0.15);
+  --kbin-alert-info-bg: rgba(153,116,4,1);
   --kbin-alert-info-border: 1px solid rgba(153,116,4,0.4);
   --kbin-alert-info-text-color: #997404;
   --kbin-alert-info-link-color: #997404;


### PR DESCRIPTION
Alert-dangers are given with 0.15 alpha in some themes. With custom background they are hard to read. They can be changed with custom CSS. But for ignorant magazine admins/moderators (looks in mirror) this is easy to overlook while these messages should NOT be easy to overlook.

![image](https://github.com/user-attachments/assets/9e9d390f-b6f8-4eaa-8f08-d103c6d69124)

Besides that, for being alert-dangers they should be prominent. The transparency look is nice, but this is much better for catching the users' attention

![image](https://github.com/user-attachments/assets/7538f1f7-441c-4d57-8e07-be9d7b38263d)

Also, normal notifications have no alpha either, so might as well follow suit

![image](https://github.com/user-attachments/assets/6f578fdd-2ada-4c9a-8f1c-02f4bf6d0898)
