### PR TITLE
Fix some leftover magazine undefined errors in the nav

### DIFF
--- a/templates/layout/_header_nav.html.twig
+++ b/templates/layout/_header_nav.html.twig
@@ -18,12 +18,12 @@
 
 {% if header_nav is empty %}
     <li>
-        <a href="{{ navbar_threads_url(magazine) }}" class="{{ html_classes({'active': activeLink == 'threads'}) }}">
+        <a href="{{ navbar_threads_url(magazine ?? null) }}" class="{{ html_classes({'active': activeLink == 'threads'}) }}">
             {{ 'threads'|trans }} {% if magazine is defined and magazine %}({{ magazine.entryCount }}){% endif %}
         </a>
     </li>
     <li>
-        <a href="{{ navbar_posts_url(magazine) }}" class="{{ html_classes({'active': activeLink == 'microblog'}) }}">
+        <a href="{{ navbar_posts_url(magazine ?? null) }}" class="{{ html_classes({'active': activeLink == 'microblog'}) }}">
             {{ 'microblog'|trans }} {% if magazine is defined and magazine %}({{ magazine.postCount }}){% endif %}
         </a>
     </li>


### PR DESCRIPTION
I got this error on my dev environment today:
![](https://github.com/user-attachments/assets/fc3b82d2-9549-45ab-9b46-8392ad6992e1)

This commit fixes this error, though I did not see it on https://gehirneimer.de . I have no idea why I didn't saw it on my machine, but :shrug: 