### PR TITLE
move private vars out of some services/handlers

### DIFF
--- a/src/MessageHandler/DeleteUserHandler.php
+++ b/src/MessageHandler/DeleteUserHandler.php
@@ -21,8 +21,6 @@ use Symfony\Component\Messenger\MessageBusInterface;
 #[AsMessageHandler]
 class DeleteUserHandler extends MbinMessageHandler
 {
-    private ?User $user;
-
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly ImageManager $imageManager,
@@ -44,54 +42,55 @@ class DeleteUserHandler extends MbinMessageHandler
         if (!($message instanceof DeleteUserMessage)) {
             throw new \LogicException();
         }
-        $this->user = $this->entityManager
+        /** @var ?User $user */
+        $user = $this->entityManager
             ->getRepository(User::class)
             ->find($message->id);
 
-        if (!$this->user) {
+        if (!$user) {
             throw new UnrecoverableMessageHandlingException('User not found');
-        } elseif ($this->user->isDeleted && null === $this->user->markedForDeletionAt) {
+        } elseif ($user->isDeleted && null === $user->markedForDeletionAt) {
             throw new UnrecoverableMessageHandlingException('User already deleted');
         }
 
-        $isLocal = null === $this->user->apId;
+        $isLocal = null === $user->apId;
 
-        $privateKey = $this->user->getPrivateKey();
-        $publicKey = $this->user->getPublicKey();
+        $privateKey = $user->getPrivateKey();
+        $publicKey = $user->getPublicKey();
 
-        $inboxes = $this->getInboxes();
+        $inboxes = $this->getInboxes($user);
 
         // note: email cannot be null. For remote accounts email is set to their 'handle@domain.tld' who knows why...
-        $userDto = UserDto::create($this->user->username, email: $this->user->username, createdAt: $this->user->createdAt);
+        $userDto = UserDto::create($user->username, email: $user->username, createdAt: $user->createdAt);
         $userDto->plainPassword = ''.time();
         if (!$isLocal) {
-            $userDto->apId = $this->user->apId;
-            $userDto->apProfileId = $this->user->apProfileId;
+            $userDto->apId = $user->apId;
+            $userDto->apProfileId = $user->apProfileId;
         }
 
         try {
-            $this->userManager->detachAvatar($this->user);
+            $this->userManager->detachAvatar($user);
         } catch (\Exception|\Error $e) {
-            $this->logger->error("couldn't delete the avatar of {user} at '{path}': {message}", ['user' => $this->user->username, 'path' => $this->user->avatar?->filePath, 'message' => \get_class($e).': '.$e->getMessage()]);
+            $this->logger->error("couldn't delete the avatar of {user} at '{path}': {message}", ['user' => $user->username, 'path' => $user->avatar?->filePath, 'message' => \get_class($e).': '.$e->getMessage()]);
         }
         try {
-            $this->userManager->detachCover($this->user);
+            $this->userManager->detachCover($user);
         } catch (\Exception|\Error $e) {
-            $this->logger->error("couldn't delete the cover of {user} at '{path}': {message}", ['user' => $this->user->username, 'path' => $this->user->cover?->filePath, 'message' => \get_class($e).': '.$e->getMessage()]);
+            $this->logger->error("couldn't delete the cover of {user} at '{path}': {message}", ['user' => $user->username, 'path' => $user->cover?->filePath, 'message' => \get_class($e).': '.$e->getMessage()]);
         }
-        $filePathsOfUser = $this->userManager->getAllImageFilePathsOfUser($this->user);
+        $filePathsOfUser = $this->userManager->getAllImageFilePathsOfUser($user);
         foreach ($filePathsOfUser as $path) {
             try {
                 $this->imageManager->remove($path);
             } catch (\Exception|\Error $e) {
-                $this->logger->error("couldn't delete image of {user} at '{path}': {message}", ['user' => $this->user->username, 'path' => $path, 'message' => \get_class($e).': '.$e->getMessage()]);
+                $this->logger->error("couldn't delete image of {user} at '{path}': {message}", ['user' => $user->username, 'path' => $path, 'message' => \get_class($e).': '.$e->getMessage()]);
             }
         }
 
         $this->entityManager->beginTransaction();
 
         // delete the original user, so all the content is cascade deleted
-        $this->entityManager->remove($this->user);
+        $this->entityManager->remove($user);
         $this->entityManager->flush();
 
         // recreate a user with the same name, so this handle is blocked
@@ -115,9 +114,9 @@ class DeleteUserHandler extends MbinMessageHandler
         $this->entityManager->commit();
     }
 
-    private function getInboxes(): array
+    private function getInboxes(?User $user): array
     {
-        return array_unique(array_filter($this->userManager->getAllInboxesOfInteractions($this->user)));
+        return array_unique(array_filter($this->userManager->getAllInboxesOfInteractions($user)));
     }
 
     private function sendDeleteMessages(array $targetInboxes, User $deletedUser): void


### PR DESCRIPTION
refactored some services/handlers that pass extra data by means of private variables to pass them all as function arguments

functionality should remain the same, if anything it'd be more troubling if something's changed

in an ideal scenario this should not be a problem, but after what's happened with embed thumbnails, the assumption that all services/handlers will starts with a clean slate is no longer reliable

this is just from what I could trivially find at the moment