### PR TITLE
Fix the regex, so FF is no longer complaining

### DIFF
--- a/src/Utils/RegPatterns.php
+++ b/src/Utils/RegPatterns.php
@@ -7,7 +7,7 @@ namespace App\Utils;
 class RegPatterns
 {
     public const MAGAZINE_NAME = '/^[a-zA-Z0-9_]{2,25}$/';
-    public const USERNAME = '/^[a-zA-Z0-9_-]{1,30}$/';
+    public const USERNAME = '/^[a-zA-Z0-9_\-]{1,30}$/';
     public const LOCAL_MAGAZINE = '/^@\w{2,25}\b/';
     public const LOCAL_USER = '/^@[a-zA-Z0-9_-]{1,30}\b/';
     public const AP_MAGAZINE = '/^(!\w{2,25})(@)(([a-z0-9|-]+\.)*[a-z0-9|-]+\.[a-z]+)/';


### PR DESCRIPTION
Firefox complained about an improper regex, because the `-` was not escaped