### PR TITLE
Use the latest pipeline docker image

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: danger89/mbin-pipeline:1.1.0
+      image: danger89/mbin-pipeline:1.2.0
     steps:
       - uses: actions/checkout@v4
 
@@ -63,7 +63,7 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     container:
-      image: danger89/mbin-pipeline:1.1.0
+      image: danger89/mbin-pipeline:1.2.0
     steps:
       - uses: actions/checkout@v4
 
@@ -96,7 +96,7 @@ jobs:
   security-check:
     runs-on: ubuntu-latest
     container:
-      image: danger89/mbin-pipeline:1.1.0
+      image: danger89/mbin-pipeline:1.2.0
     steps:
       - uses: actions/checkout@v4
 
@@ -106,7 +106,7 @@ jobs:
   fixer-dry-run:
     runs-on: ubuntu-latest
     container:
-      image: danger89/mbin-pipeline:1.1.0
+      image: danger89/mbin-pipeline:1.2.0
     steps:
       - uses: actions/checkout@v4
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.3
 
 # Add composer
-COPY --from=composer:2.7.7 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.7.8 /usr/bin/composer /usr/bin/composer
 
 # Add NodeJS
 RUN apt-get update && apt-get install -y nodejs npm
@@ -15,7 +15,7 @@ RUN curl -sSLf \
   https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions
 RUN chmod +x /usr/local/bin/install-php-extensions
 
-RUN install-php-extensions amqp intl redis gd zip bcmath
+RUN install-php-extensions amqp intl redis gd zip bcmath xsl
 
 # Install local-php-security-checker (same as used by "symfony security:check")
 RUN curl -sSLf \


### PR DESCRIPTION
Without merging https://github.com/MbinOrg/mbin/pull/1016, we can already use the latest docker image on main.