### PR TITLE
Use is defined on twig report notification objects

### DIFF
--- a/templates/notifications/_blocks.html.twig
+++ b/templates/notifications/_blocks.html.twig
@@ -106,7 +106,7 @@
         <a href="{{ path('entry_single', { 'magazine_name': entry.magazine.name, 'entry_id': entry.id, 'slug': entry.slug }) }}">
             {{ entry.title }}
         </a>
-    {% elseif notification.report.entryComment is defined and  notification.report.entryComment is not same as null %}
+    {% elseif notification.report.entryComment is defined and notification.report.entryComment is not same as null %}
         {% set entryComment = notification.report.entryComment %}
         <a href="{{ path('entry_comment_view', { 'magazine_name': entryComment.magazine.name, 'entry_id': entryComment.entry.id, 'slug': entryComment.entry.slug, 'comment_id': entryComment.id }) }}">
             {{ entryComment.getShortTitle() }}

--- a/templates/notifications/_blocks.html.twig
+++ b/templates/notifications/_blocks.html.twig
@@ -101,22 +101,22 @@
 {% endblock magazine_ban_notification %}
 
 {% block reportlink %}
-    {% if notification.report.entry is defined and attribute(notification.report, 'entry') is not null %}
+    {% if notification.report.entry is defined and notification.report.entry is not same as null %}
         {% set entry = notification.report.entry %}
         <a href="{{ path('entry_single', { 'magazine_name': entry.magazine.name, 'entry_id': entry.id, 'slug': entry.slug }) }}">
             {{ entry.title }}
         </a>
-    {% elseif notification.report.entryComment is defined and attribute(notification.report, 'entryComment') is not null %}
+    {% elseif notification.report.entryComment is defined and  notification.report.entryComment is not same as null %}
         {% set entryComment = notification.report.entryComment %}
         <a href="{{ path('entry_comment_view', { 'magazine_name': entryComment.magazine.name, 'entry_id': entryComment.entry.id, 'slug': entryComment.entry.slug, 'comment_id': entryComment.id }) }}">
             {{ entryComment.getShortTitle() }}
         </a>
-    {% elseif notification.report.post is defined and attribute(notification.report, 'post') is not null %}
+    {% elseif notification.report.post is defined and notification.report.post is not same as null %}
         {% set post = notification.report.post %}
         <a href="{{ path('post_single', { 'magazine_name': post.magazine.name, 'post_id': post.id, 'slug': post.slug }) }}">
             {{ post.getShortTitle() }}
         </a>
-    {% elseif notification.report.postComment is defined and attribute(notification.report, 'postComment') is not null %}
+    {% elseif notification.report.postComment is defined and notification.report.postComment is not same as null %}
         {% set postComment = notification.report.postComment %}
         <a href="{{ path('post_single', { 'magazine_name': postComment.post.magazine.name, 'post_id': postComment.post.id, 'slug': postComment.post.slug }) }}#post-comment-{{ postComment.id }}">
             {{ post.getShortTitle() }}

--- a/templates/notifications/_blocks.html.twig
+++ b/templates/notifications/_blocks.html.twig
@@ -101,22 +101,22 @@
 {% endblock magazine_ban_notification %}
 
 {% block reportlink %}
-    {% if notification.report.entry is not same as null %}
+    {% if attribute(notification.report, 'entry') is not null %}
         {% set entry = notification.report.entry %}
         <a href="{{ path('entry_single', { 'magazine_name': entry.magazine.name, 'entry_id': entry.id, 'slug': entry.slug }) }}">
             {{ entry.title }}
         </a>
-    {% elseif notification.report.entryComment is not same as null %}
+    {% elseif attribute(notification.report, 'entryComment') is not null %}
         {% set entryComment = notification.report.entryComment %}
         <a href="{{ path('entry_comment_view', { 'magazine_name': entryComment.magazine.name, 'entry_id': entryComment.entry.id, 'slug': entryComment.entry.slug, 'comment_id': entryComment.id }) }}">
             {{ entryComment.getShortTitle() }}
         </a>
-    {% elseif notification.report.post is not same as null %}
+    {% elseif attribute(notification.report, 'post') is not null %}
         {% set post = notification.report.post %}
         <a href="{{ path('post_single', { 'magazine_name': post.magazine.name, 'post_id': post.id, 'slug': post.slug }) }}">
             {{ post.getShortTitle() }}
         </a>
-    {% elseif notification.report.postComment is not same as null %}
+    {% elseif attribute(notification.report, 'postComment') is not null %}
         {% set postComment = notification.report.postComment %}
         <a href="{{ path('post_single', { 'magazine_name': postComment.post.magazine.name, 'post_id': postComment.post.id, 'slug': postComment.post.slug }) }}#post-comment-{{ postComment.id }}">
             {{ post.getShortTitle() }}

--- a/templates/notifications/_blocks.html.twig
+++ b/templates/notifications/_blocks.html.twig
@@ -101,22 +101,22 @@
 {% endblock magazine_ban_notification %}
 
 {% block reportlink %}
-    {% if attribute(notification.report, 'entry') is not null %}
+    {% if notification.report.entry is defined and attribute(notification.report, 'entry') is not null %}
         {% set entry = notification.report.entry %}
         <a href="{{ path('entry_single', { 'magazine_name': entry.magazine.name, 'entry_id': entry.id, 'slug': entry.slug }) }}">
             {{ entry.title }}
         </a>
-    {% elseif attribute(notification.report, 'entryComment') is not null %}
+    {% elseif notification.report.entryComment is defined and attribute(notification.report, 'entryComment') is not null %}
         {% set entryComment = notification.report.entryComment %}
         <a href="{{ path('entry_comment_view', { 'magazine_name': entryComment.magazine.name, 'entry_id': entryComment.entry.id, 'slug': entryComment.entry.slug, 'comment_id': entryComment.id }) }}">
             {{ entryComment.getShortTitle() }}
         </a>
-    {% elseif attribute(notification.report, 'post') is not null %}
+    {% elseif notification.report.post is defined and attribute(notification.report, 'post') is not null %}
         {% set post = notification.report.post %}
         <a href="{{ path('post_single', { 'magazine_name': post.magazine.name, 'post_id': post.id, 'slug': post.slug }) }}">
             {{ post.getShortTitle() }}
         </a>
-    {% elseif attribute(notification.report, 'postComment') is not null %}
+    {% elseif notification.report.postComment is defined and attribute(notification.report, 'postComment') is not null %}
         {% set postComment = notification.report.postComment %}
         <a href="{{ path('post_single', { 'magazine_name': postComment.post.magazine.name, 'post_id': postComment.post.id, 'slug': postComment.post.slug }) }}#post-comment-{{ postComment.id }}">
             {{ post.getShortTitle() }}


### PR DESCRIPTION
Use `is defined`, to be sure the key exists on the object. 

Fixes: #1071