### PR TITLE
Add warning message to logger in case of invalid reg form submission

### DIFF
--- a/src/Controller/Security/RegisterController.php
+++ b/src/Controller/Security/RegisterController.php
@@ -53,7 +53,7 @@ class RegisterController extends AbstractController
         } elseif ($form->isSubmitted() && !$form->isValid()) {
             $this->logger->warning('Registration form submission was invalid.', [
                 'data' => $form->getData(),
-                'errors' => $form->getErrors(true),
+                'errors' => $form->getErrors(true, false),
             ]);
         }
 

--- a/src/Controller/Security/RegisterController.php
+++ b/src/Controller/Security/RegisterController.php
@@ -53,7 +53,7 @@ class RegisterController extends AbstractController
         } elseif ($form->isSubmitted() && !$form->isValid()) {
             $this->logger->warning('Registration form submission was invalid.', [
                 'data' => $form->getData(),
-                'errors' => $form->getErrors(true, false),
+                'errors' => $form->getErrors(true),
             ]);
         }
 

--- a/src/Controller/Security/RegisterController.php
+++ b/src/Controller/Security/RegisterController.php
@@ -53,7 +53,7 @@ class RegisterController extends AbstractController
         } elseif ($form->isSubmitted() && !$form->isValid()) {
             $this->logger->warning('Registration form submission was invalid.', [
                 'data' => $form->getData(),
-                'errors' => $form->getErrors(),
+                'errors' => $form->getErrors(true, false),
             ]);
         }
 

--- a/src/Controller/Security/RegisterController.php
+++ b/src/Controller/Security/RegisterController.php
@@ -9,6 +9,7 @@ use App\Form\UserRegisterType;
 use App\Service\IpResolver;
 use App\Service\SettingsManager;
 use App\Service\UserManager;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -18,6 +19,7 @@ class RegisterController extends AbstractController
         private readonly UserManager $manager,
         private readonly IpResolver $ipResolver,
         private readonly SettingsManager $settingsManager,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -48,6 +50,11 @@ class RegisterController extends AbstractController
             );
 
             return $this->redirectToRoute('front');
+        } elseif ($form->isSubmitted() && !$form->isValid()) {
+            $this->logger->warning('Registration form submission was invalid.', [
+                'data' => $form->getData(),
+                'errors' => $form->getErrors(),
+            ]);
         }
 
         return $this->render(

--- a/src/Controller/Security/RegisterController.php
+++ b/src/Controller/Security/RegisterController.php
@@ -51,8 +51,7 @@ class RegisterController extends AbstractController
 
             return $this->redirectToRoute('front');
         } elseif ($form->isSubmitted() && !$form->isValid()) {
-            $this->logger->warning('Registration form submission was invalid.', [
-                'data' => $form->getData(),
+            $this->logger->error('Registration form submission was invalid.', [
                 'errors' => $form->getErrors(true, false),
             ]);
         }


### PR DESCRIPTION
Log a warning in case the registration failed due to a invalid form submission. We use `getErrors(true, false)` to get all the errors and NOT flatten the output.

Example of thus an error/warning log (not flatten):

```
{"message":"Registration form submission was invalid.","context":{"errors":"ERROR: The CSRF token is invalid. Please try to resubmit the form.\nusername:\n    ERROR: This value is already used.\nplainPassword:\n    first:\n        ERROR: This value is too short. It should have 6 characters or more.\ncaptcha:\n    ERROR: The CAPTCHA is invalid.\n"},"level":400,"level_name":"ERROR","channel":"app","datetime":"2024-09-04T00:06:23.040098+02:00","extra":{}}

```

If you would do: `getErrors(true, true)` or just `getErrors(true)`, the output is:

```
{"message":"Registration form submission was invalid.","context":{"errors":"ERROR: The CSRF token is invalid. Please try to resubmit the form.\nERROR: This value is already used.\nERROR: This value is too short. It should have 6 characters or more.\nERROR: The CAPTCHA is invalid.\n"},"level":400,"level_name":"ERROR","channel":"app","datetime":"2024-09-04T00:13:54.347038+02:00","extra":{}}
```

This is NOT what we want, since now the field names are not part of the error output anymore. Hence the reason I use: `getErrors(true, false)`..