### PR TITLE
Do not stealth anti-spam error messages in log

### DIFF
--- a/config/packages/antispam.yaml
+++ b/config/packages/antispam.yaml
@@ -7,8 +7,12 @@
 # For more details on the options available visit https://omines.github.io/antispam-bundle/configuration/
 #
 antispam:
+    stealth: false
+
     profiles:
         default:
+            stealth: false
+        
             # Insert a honeypot called "email_address" on all forms to lure bots into filling it in
             honeypot: email_address
 


### PR DESCRIPTION
- We disable stealth in antispam bundle, so the admin can see the actual error message in case a user can't register correctly in the form. (eg. IP change errors due to CDN services or alike).

By default the anti-spam bundle will only report a very generic message, which doesn't help anyone. The reason they do this is to avoid potentially inform the client about the anti-spam restriction, however we do not return this information back to the client AFAIK.