### PR TITLE
Improve anti-spam config a little

### DIFF
--- a/config/packages/antispam.yaml
+++ b/config/packages/antispam.yaml
@@ -16,9 +16,9 @@ antispam:
             # Insert a honeypot called "full_name" on all forms to lure bots into filling it in
             honeypot: full_name
 
-            # Reject all forms that have been submitted either within 3 seconds, or after more than 30 minutes
+            # Reject all forms that have been submitted either within 6 seconds, or after more than 30 minutes
             timer:
-                min: 3
+                min: 6
                 max: 1800
 
             # The measures above should already have notable effect on the amount of spam that gets through

--- a/config/packages/antispam.yaml
+++ b/config/packages/antispam.yaml
@@ -12,16 +12,15 @@ antispam:
     profiles:
         default:
             stealth: false
-        
-            # Insert a honeypot called "email_address" on all forms to lure bots into filling it in
-            honeypot: email_address
 
-            # Reject all forms that have been submitted either within 3 seconds, or after more than an hour
+            # Insert a honeypot called "full_name" on all forms to lure bots into filling it in
+            honeypot: full_name
+
+            # Reject all forms that have been submitted either within 3 seconds, or after more than 30 minutes
             timer:
                 min: 3
-                max: 3600
+                max: 1800
 
-            #
             # The measures above should already have notable effect on the amount of spam that gets through
             # your forms. Still getting annoying amounts? Analyze the patterns of uncaught spam, then
             # consider uncommenting and modifying some of the examples below after careful consideration
@@ -29,17 +28,17 @@ antispam:
             #
 
             # Reject text fields that contain (lame attempts at) HTML or BBCode
-#            banned_markup: true
+            banned_markup: true
 
             # Reject text fields that consist for more than 40% of Cyrillic (Russian) characters
-#            banned_scripts:
-#                scripts: [ cyrillic ]
-#                max_percentage: 40
+            # banned_scripts:
+            #     scripts: [ cyrillic ]
+            #     max_percentage: 40
 
             # Reject fields that contain more than 3 URLs, or repeat a single URL more than once
-#            url_count:
-#                max: 3
-#                max_identical: 1
+            # url_count:
+            #     max: 3
+            #     max_identical: 1
 
 when@test:
     antispam:


### PR DESCRIPTION
- Increase the min time (I don't think real people can fill in these forms within 6 secs)
- Decrease the max time-out time (if you can't fill in these forms within 30 minutes, well..)
- Change the default hidden email address field (which we already have, called: `email`) to `full_name` or something, so it's seems at least more unique.
- We seem to only use anti-spam on the contact field & register forms, so let's set `banned_markup` = true