### PR TITLE
Remove dead kbin.run link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ For developers:
 
 - [Official repository on GitHub](https://github.com/MbinOrg/mbin)
 - [Matrix Space for discussions](https://matrix.to/#/#mbin:melroy.org)
-- [Unofficial magazine for discussions within the fediverse](https://kbin.run/m/Mdev)
 - [Translations](https://hosted.weblate.org/engage/mbin/)
 - [Contribution guidelines](CONTRIBUTING.md) - please read first, including before opening an issue!
 


### PR DESCRIPTION
Remove debounced server, which is now down forever. Feel free to later add new links.