### PR TITLE
Add the downvotes mode to the .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,12 @@ TRUSTED_PROXIES=
 # This should be set to <= `upload_max_filesize` and `post_max_size` in the server's php.ini file
 MAX_IMAGE_BYTES=6000000
 
+# possible values:
+# 'enabled' => default mode downvotes are enabled
+# 'hidden' => downvotes are counted and users can downvote, but the number is hidden
+# 'disabled' => downvotes are ignored and the downvote button is hidden. They also do not count in the sorting
+MBIN_DOWNVOTES_MODE=enabled
+
 # Captcha (also enable in admin panel/settings)
 KBIN_CAPTCHA_ENABLED=false
 ###> meteo-concept/hcaptcha-bundle ###

--- a/.env.example_docker
+++ b/.env.example_docker
@@ -41,6 +41,12 @@ TRUSTED_PROXIES=::1,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 # This should be set to <= `upload_max_filesize` and `post_max_size` in the server's php.ini file
 MAX_IMAGE_BYTES=6000000
 
+# possible values:
+# 'enabled' => default mode downvotes are enabled
+# 'hidden' => downvotes are counted and users can downvote, but the number is hidden
+# 'disabled' => downvotes are ignored and the downvote button is hidden. They also do not count in the sorting
+MBIN_DOWNVOTES_MODE=enabled
+
 # Captcha (also enable in admin panel/settings)
 KBIN_CAPTCHA_ENABLED=false
 


### PR DESCRIPTION
Add the `MBIN_DOWNVOTES_MODE` env var to the example `.env` files and add some documentation there as well

This was overlooked by me in #1022 