### PR TITLE
Add spoiler to markdown editor

### DIFF
--- a/assets/controllers/markdown_toolbar_controller.js
+++ b/assets/controllers/markdown_toolbar_controller.js
@@ -25,7 +25,7 @@ export default class extends Controller {
         }
 
         const spoiler = `
-::: spoiler spoiler
+::: spoiler spoiler-title
 ${spoilerBody}
 :::`;
 

--- a/assets/controllers/markdown_toolbar_controller.js
+++ b/assets/controllers/markdown_toolbar_controller.js
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2023-2024 /kbin & Mbin contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { Controller } from '@hotwired/stimulus';
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    addSpoiler(event) {
+        event.preventDefault();
+
+        const input = document.getElementById(this.element.getAttribute('for'));
+        let spoilerBody = '_____';
+        let contentAfterCursor;
+
+        const start = input.selectionStart;
+        const end = input.selectionEnd;
+
+        const contentBeforeCursor = input.value.substring(0, start);
+        if (start === end) {
+            contentAfterCursor = input.value.substring(start);
+        } else {
+            contentAfterCursor = input.value.substring(end);
+            spoilerBody = input.value.substring(start, end);
+        }
+
+        const spoiler = `
+::: spoiler spoiler
+${spoilerBody}
+:::`;
+
+        input.value = contentBeforeCursor + spoiler + contentAfterCursor;
+        input.dispatchEvent(new Event('input'));
+
+        const spoilerTitlePosition = contentBeforeCursor.length + '::: spoiler '.length + 1;
+        input.setSelectionRange(spoilerTitlePosition, spoilerTitlePosition);
+        input.focus();
+    }
+}

--- a/assets/controllers/markdown_toolbar_controller.js
+++ b/assets/controllers/markdown_toolbar_controller.js
@@ -10,7 +10,7 @@ export default class extends Controller {
         event.preventDefault();
 
         const input = document.getElementById(this.element.getAttribute('for'));
-        let spoilerBody = '_____';
+        let spoilerBody = 'spoiler body';
         let contentAfterCursor;
 
         const start = input.selectionStart;

--- a/templates/components/editor_toolbar.html.twig
+++ b/templates/components/editor_toolbar.html.twig
@@ -1,10 +1,10 @@
-<markdown-toolbar for="{{ id }}" class="markdown meta">
+<markdown-toolbar for="{{ id }}" class="markdown meta" data-controller="markdown-toolbar">
     <md-bold title="{{ 'toolbar.bold'|trans }}" aria-label="{{ 'toolbar.bold'|trans }}">
         <i class="fa-solid fa-bold" aria-hidden="true"></i>
     </md-bold>
     <md-italic title="{{ 'toolbar.italic'|trans }}" aria-label="{{ 'toolbar.italic'|trans }}">
         <i class="fa-solid fa-italic" aria-hidden="true"></i>
-    </md-italic >
+    </md-italic>
     <md-strikethrough title="{{ 'toolbar.strikethrough'|trans }}" aria-label="{{ 'toolbar.strikethrough'|trans }}">
         <i class="fa-solid fa-strikethrough" aria-hidden="true"></i>
     </md-strikethrough>
@@ -32,4 +32,7 @@
     <md-mention title="{{ 'toolbar.mention'|trans }}" aria-label="{{ 'toolbar.mention'|trans }}">
         <i class="fa-solid fa-at" aria-hidden="true"></i>
     </md-mention>
+    <md-spoiler title="{{ 'toolbar.spoiler'|trans }}" aria-label="{{ 'toolbar.spoiler'|trans }}" data-action="click->markdown-toolbar#addSpoiler">
+        <i class="fa-solid fa-triangle-exclamation"></i>
+    </md-spoiler>
 </markdown-toolbar>

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -448,6 +448,7 @@ toolbar.image: Image
 toolbar.unordered_list: Unordered List
 toolbar.ordered_list: Ordered List
 toolbar.mention: Mention
+toolbar.spoiler: Spoiler
 federation_page_enabled: Federation page enabled
 federation_page_allowed_description: Known instances we federate with
 federation_page_disallowed_description: Instances we do not federate with


### PR DESCRIPTION
Add spoiler insert button to markdown editor.

![image](https://github.com/user-attachments/assets/e343a4b9-d4e5-4a37-acd9-b4b65828ffec)


Demo: https://kbin.melroy.org/m/testing/t/452875/Spoiler-testing