### PR TITLE
Also check if filePath is not null

### DIFF
--- a/templates/layout/_magazine_activity_list.html.twig
+++ b/templates/layout/_magazine_activity_list.html.twig
@@ -7,7 +7,7 @@
         <ul>
             {% for subject in list %}
                 <li>
-                    {% if attribute(subject, actor).icon and (app.user or attribute(subject, actor).isAdult is same as false) %}
+                    {% if attribute(subject, actor).icon and attribute(subject, actor).icon.filePath and (app.user or attribute(subject, actor).isAdult is same as false) %}
                         <figure>
                             <img width="32" height="32"
                                  loading="lazy"


### PR DESCRIPTION
Check for filePath not null as well. Or it will cause 500 error like @DismalShadowX had.

So this error:

```
{"message":"Uncaught PHP Exception Twig\\Error\\RuntimeError: \"An exception has been thrown during the rendering of a template (\"Symfony\\Bridge\\Twig\\Extension\\AssetExtension::getAssetUrl(): Argument #1 ($path) must be of type string, null given, called in /var/www/mbin/var/cache/prod/twig/1c/1c737a7bdff942d195fff83b4530e26e.php on line 71\").\" at _magazine_activity_list.html.twig line 15","context":{"exception":{"class":"Twig\\Error\\RuntimeError","message":"An exception has been thrown during the rendering of a template (\"Symfony\\Bridge\\Twig\\Extension\\AssetExtension::getAssetUrl(): Argument #1 ($path) must be of type string, null given, called in /var/www/mbin/var/cache/prod/twig/1c/1c737a7bdff942d195fff83b4530e26e.php on line 71\").","code":0,"file":"/var/www/mbin/templates/layout/_magazine_activity_list.html.twig:15","previous":{"class":"TypeError","message":"Symfony\\Bridge\\Twig\\Extension\\AssetExtension::getAssetUrl(): Argument #1 ($path) must be of type string, null given, called in /var/www/mbin/var/cache/prod/twig/1c/1c737a7bdff942d195fff83b4530e26e.php on line 71","code":0,"file":"/var/www/mbin/vendor/symfony/twig-bridge/Extension/AssetExtension.php:44"}}},"level":500,"level_name":"CRITICAL","channel":"request","datetime":"2024-09-11T16:05:56.424670+00:00","extra":{}}```
```

Tested & working now on his instance at: hub.everythingbagel.me. Specifically: https://hub.everythingbagel.me/u/shadow/subscriptions