### PR TITLE
Fix 2nd miscellaneous bug

### DIFF
--- a/src/Service/ActivityPub/Page.php
+++ b/src/Service/ActivityPub/Page.php
@@ -51,6 +51,10 @@ class Page
      */
     public function create(array $object, bool $stickyIt = false): Entry
     {
+        $current = $this->repository->findByObjectId($object['id']);
+        if ($current) {
+            return $this->entityManager->getRepository($current['type'])->find((int) $current['id']);
+        }
         $actorUrl = $this->activityPubManager->getSingleActorFromAttributedTo($object['attributedTo']);
         if ($this->settingsManager->isBannedInstance($actorUrl)) {
             throw new InstanceBannedException();


### PR DESCRIPTION
When creating a page we didn't look whether this object existed before, while we do it with note objects. So just copy over the code that checks whether a note already exists and we should be golden