### PR TITLE
Check if EntryComment is defined and not null

### DIFF
--- a/templates/entry/comment/view.html.twig
+++ b/templates/entry/comment/view.html.twig
@@ -41,16 +41,20 @@
     </div>
     {% set autoAction = 'notifications:EntryCommentCreatedNotification@window->subject-list#addComment' %}
     {% set manualAction = 'notifications:EntryCommentCreatedNotification@window->subject-list#increaseCounter' %}
-    <div class="{{ html_classes('comments entry-comments comments-tree', {
-        'show-comment-avatar' : SHOW_COMMENT_USER_AVATARS is same as V_TRUE
-        }) }}"
-        data-controller="subject-list"
-        data-action="{{- DYNAMIC_LISTS is same as V_TRUE ? autoAction : manualAction -}}">
-        {{ component('entry_comment', {
-            comment: comment.root ?? comment,
-            showEntryTitle: false,
-            showMagazineName: false,
-            showNested: true,
-        }) }}
-    </div>
+
+    {% set entryComment = comment.root ?? comment %}
+    {% if entryComment is defined and entryComment is not null %}
+        <div class="{{ html_classes('comments entry-comments comments-tree', {
+            'show-comment-avatar' : SHOW_COMMENT_USER_AVATARS is same as V_TRUE
+            }) }}"
+            data-controller="subject-list"
+            data-action="{{- DYNAMIC_LISTS is same as V_TRUE ? autoAction : manualAction -}}">
+            {{ component('entry_comment', {
+                comment: entryComment,
+                showEntryTitle: false,
+                showMagazineName: false,
+                showNested: true,
+            }) }}
+        </div>
+    {% endif %}
 {% endblock %}

--- a/templates/entry/comment/view.html.twig
+++ b/templates/entry/comment/view.html.twig
@@ -41,20 +41,28 @@
     </div>
     {% set autoAction = 'notifications:EntryCommentCreatedNotification@window->subject-list#addComment' %}
     {% set manualAction = 'notifications:EntryCommentCreatedNotification@window->subject-list#increaseCounter' %}
-
-    {% set entryComment = comment.root ?? comment %}
-    {% if entryComment is defined and entryComment is not null %}
-        <div class="{{ html_classes('comments entry-comments comments-tree', {
-            'show-comment-avatar' : SHOW_COMMENT_USER_AVATARS is same as V_TRUE
-            }) }}"
-            data-controller="subject-list"
-            data-action="{{- DYNAMIC_LISTS is same as V_TRUE ? autoAction : manualAction -}}">
+    <div class="{{ html_classes('comments entry-comments comments-tree', {
+        'show-comment-avatar' : SHOW_COMMENT_USER_AVATARS is same as V_TRUE
+        }) }}"
+        data-controller="subject-list"
+        data-action="{{- DYNAMIC_LISTS is same as V_TRUE ? autoAction : manualAction -}}">
+        {% set entryComment = comment.root ?? comment %}
+        {% if entryComment is defined and entryComment is not null %}
             {{ component('entry_comment', {
                 comment: entryComment,
                 showEntryTitle: false,
                 showMagazineName: false,
                 showNested: true,
             }) }}
+        {% else %}
+        <div class="section alert alert__danger">
+            <p>
+                <a href="{{ entry_url(entry) }}" class="btn btn-link btn__danger">
+                    <i class="fa-solid fa-arrow-left-long" title="{{ 'back'|trans }}"> {{ 'back'|trans }}
+                </a>
+                {{ 'comment_not_found'|trans }}
+            </p>
         </div>
-    {% endif %}
+        {% endif %}
+    </div>
 {% endblock %}

--- a/templates/entry/comment/view.html.twig
+++ b/templates/entry/comment/view.html.twig
@@ -57,10 +57,10 @@
         {% else %}
         <div class="section alert alert__danger">
             <p>
-                <a href="{{ entry_url(entry) }}" class="btn btn-link btn__danger">
+                <a href="{{ entry_url(entry) }}" class="btn btn-link btn__danger" style="margin-right: 10px;">
                     <i class="fa-solid fa-arrow-left-long" title="{{ 'back'|trans }}"></i> {{ 'back'|trans }}
                 </a>
-                &nbsp; {{ 'comment_not_found'|trans }}
+                {{ 'comment_not_found'|trans }}
             </p>
         </div>
         {% endif %}

--- a/templates/entry/comment/view.html.twig
+++ b/templates/entry/comment/view.html.twig
@@ -60,7 +60,7 @@
                 <a href="{{ entry_url(entry) }}" class="btn btn-link btn__danger">
                     <i class="fa-solid fa-arrow-left-long" title="{{ 'back'|trans }}"></i> {{ 'back'|trans }}
                 </a>
-                {{ 'comment_not_found'|trans }}
+                &nbsp; {{ 'comment_not_found'|trans }}
             </p>
         </div>
         {% endif %}

--- a/templates/entry/comment/view.html.twig
+++ b/templates/entry/comment/view.html.twig
@@ -58,7 +58,7 @@
         <div class="section alert alert__danger">
             <p>
                 <a href="{{ entry_url(entry) }}" class="btn btn-link btn__danger">
-                    <i class="fa-solid fa-arrow-left-long" title="{{ 'back'|trans }}"> {{ 'back'|trans }}
+                    <i class="fa-solid fa-arrow-left-long" title="{{ 'back'|trans }}"></i> {{ 'back'|trans }}
                 </a>
                 {{ 'comment_not_found'|trans }}
             </p>

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -896,3 +896,4 @@ admin_users_suspended: Suspended
 admin_users_banned: Banned
 user_verify: Activate account
 max_image_size: Maximum file size
+comment_not_found: Comment not found


### PR DESCRIPTION
[EntryComment can be null after all](https://github.com/MbinOrg/mbin/blob/4d930f6c8cf276bb2ec14ed5e579f4400af4222c/src/Controller/Entry/Comment/EntryCommentViewController.php#L35) during the __invoke. So `comment` can still be null. Let's update Twig to check for defined and not null, to avoid template errors..

---

100% repeatable now. Eg. https://kbin.melroy.org/m/games@sh.itjust.works/t/457088/The-entire-staff-of-beloved-game-publisher-Annapurna-Interactive-has/comment (so without any comment ID at the end provided in the URL)

Will give:

```json
{"message":"Uncaught PHP Exception Twig\\Error\\RuntimeError: \"Error rendering \"entry_comment\" component: Expected argument of type \"App\\Entity\\EntryComment\", \"null\" given at property path \"comment\".\" at view.html.twig line 49","context":{"exception":{"class":"Twig\\Error\\RuntimeError","message":"Error rendering \"entry_comment\" component: Expected argument of type \"App\\Entity\\EntryComment\", \"null\" given at property path \"comment\".","code":0,"file":"/var/www/kbin.melroy.org/html/templates/entry/comment/view.html.twig:49","previous": ... }
```

With error:

![image](https://github.com/user-attachments/assets/3be34779-1717-4c35-a76c-edb5a8977010)


---

However, with this patch. You will no longer get this 500 error ⛱️ . And show an error instead:

![image](https://github.com/user-attachments/assets/8a726602-9ccb-4696-b2da-d51ada839bfe)


