### PR TITLE
Don't log full html pages (stop error log pollution)

### DIFF
--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -343,7 +343,7 @@ class ApHttpClient
             'type' => $requestType,
             'address' => $requestUrl,
             'e' => \get_class($e),
-            'msg' => $e->getMessage()
+            'msg' => $e->getMessage(),
         ]);
         // Therefore, we only log the content in debug log mode
         $this->logger->debug('Response body content: {content}', [

--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -345,7 +345,7 @@ class ApHttpClient
             'address' => $requestUrl,
             'e' => \get_class($e),
             'msg' => $e->getMessage(),
-            'content' => substr($content, 0, 200) ?? 'No content provided',
+            'content' => substr($content ?? 'No content provided', 0, 200),
         ]);
         // And only log the full content in debug log mode
         if ($content) {

--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -101,7 +101,7 @@ class ApHttpClient
             $statusCode = $r->getStatusCode();
             // Accepted status code are 2xx or 410 (used Tombstone types)
             if (!str_starts_with((string) $statusCode, '2') && 410 !== $statusCode) {
-                // Do NOT include the content in the log, this will be often a full HTML page
+                // Do NOT include the content in the error message, this will be often a full HTML page
                 throw new InvalidApPostException("Invalid status code while getting: $url : $statusCode");
             }
 
@@ -317,7 +317,8 @@ class ApHttpClient
             $statusCode = $response->getStatusCode();
             // Accepted status code are 2xx or 410 (used Tombstone types)
             if (!str_starts_with((string) $statusCode, '2') && 410 !== $statusCode) {
-                throw new InvalidApPostException("Invalid status code while getting: $apAddress : $statusCode, ".substr($response->getContent(false), 0, 1000));
+                // Do NOT include the content in the error message, this will be often a full HTML page
+                throw new InvalidApPostException("Invalid status code while getting: $apAddress : $statusCode");
             }
         } catch (\Exception $e) {
             $this->logRequestException($response, $apAddress, 'ApHttpClient:getCollectionObject', $e);

--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -338,17 +338,21 @@ class ApHttpClient
             }
         }
 
-        // Often 400, 404 errors just return the full HTML page, so we don't want to log the content of them
-        $this->logger->error('{type} get fail: {address}, ex: {e}: {msg}', [
+        // Often 400, 404 errors just return the full HTML page, so we don't want to log the full content of them
+        // We truncate the content to 200 characters max.
+        $this->logger->error('{type} get fail: {address}, ex: {e}: {msg}. Truncated content: {content}', [
             'type' => $requestType,
             'address' => $requestUrl,
             'e' => \get_class($e),
             'msg' => $e->getMessage(),
+            'content' => substr($content, 0, 200) ?? 'No content provided',
         ]);
-        // Therefore, we only log the content in debug log mode
-        $this->logger->debug('Response body content: {content}', [
-            'content' => $content ?? 'No content provided',
-        ]);
+        // And only log the full content in debug log mode
+        if ($content) {
+            $this->logger->debug('Full response body content: {content}', [
+                'content' => $content,
+            ]);
+        }
         throw $e;
     }
 


### PR DESCRIPTION
- Stop logging the whole HTML content TWICE to the production log
- Only log the content once in the `logRequestException` function, and truncate the content to 200 chars.
- In case of HTTP requests error, just only log the error with error message (without the content)
- In case of debug mode, we will log the full content (if present)

Fixes the [15th bullet of the miscellaneous errors](https://github.com/MbinOrg/mbin/issues/1119).

