### PR TITLE
Disable CSRF checks on some most-used forms

### DIFF
--- a/src/Controller/BoostController.php
+++ b/src/Controller/BoostController.php
@@ -23,7 +23,7 @@ class BoostController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function __invoke(VotableInterface $subject, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now.
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
         // $this->validateCsrf('boost', $request->getPayload()->get('token'));
 
         $this->manager->vote(VotableInterface::VOTE_UP, $subject, $this->getUserOrThrow());

--- a/src/Controller/BoostController.php
+++ b/src/Controller/BoostController.php
@@ -23,7 +23,8 @@ class BoostController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function __invoke(VotableInterface $subject, Request $request): Response
     {
-        $this->validateCsrf('boost', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now.
+        // $this->validateCsrf('boost', $request->getPayload()->get('token'));
 
         $this->manager->vote(VotableInterface::VOTE_UP, $subject, $this->getUserOrThrow());
 

--- a/src/Controller/Domain/DomainBlockController.php
+++ b/src/Controller/Domain/DomainBlockController.php
@@ -22,7 +22,7 @@ class DomainBlockController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function block(Domain $domain, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now.
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
         // $this->validateCsrf('block', $request->getPayload()->get('token'));
 
         $this->manager->block($domain, $this->getUserOrThrow());
@@ -37,7 +37,7 @@ class DomainBlockController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function unblock(Domain $domain, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now.
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
         // $this->validateCsrf('block', $request->getPayload()->get('token'));
 
         $this->manager->unblock($domain, $this->getUserOrThrow());

--- a/src/Controller/Domain/DomainBlockController.php
+++ b/src/Controller/Domain/DomainBlockController.php
@@ -22,7 +22,8 @@ class DomainBlockController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function block(Domain $domain, Request $request): Response
     {
-        $this->validateCsrf('block', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now.
+        // $this->validateCsrf('block', $request->getPayload()->get('token'));
 
         $this->manager->block($domain, $this->getUserOrThrow());
 
@@ -36,7 +37,8 @@ class DomainBlockController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function unblock(Domain $domain, Request $request): Response
     {
-        $this->validateCsrf('block', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now.
+        // $this->validateCsrf('block', $request->getPayload()->get('token'));
 
         $this->manager->unblock($domain, $this->getUserOrThrow());
 

--- a/src/Controller/Domain/DomainSubController.php
+++ b/src/Controller/Domain/DomainSubController.php
@@ -22,7 +22,7 @@ class DomainSubController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function subscribe(Domain $domain, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now.
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
         // $this->validateCsrf('subscribe', $request->getPayload()->get('token'));
 
         $this->manager->subscribe($domain, $this->getUserOrThrow());
@@ -37,7 +37,7 @@ class DomainSubController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function unsubscribe(Domain $domain, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now.
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
         // $this->validateCsrf('subscribe', $request->getPayload()->get('token'));
 
         $this->manager->unsubscribe($domain, $this->getUserOrThrow());

--- a/src/Controller/Domain/DomainSubController.php
+++ b/src/Controller/Domain/DomainSubController.php
@@ -22,7 +22,8 @@ class DomainSubController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function subscribe(Domain $domain, Request $request): Response
     {
-        $this->validateCsrf('subscribe', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now.
+        // $this->validateCsrf('subscribe', $request->getPayload()->get('token'));
 
         $this->manager->subscribe($domain, $this->getUserOrThrow());
 
@@ -36,7 +37,8 @@ class DomainSubController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function unsubscribe(Domain $domain, Request $request): Response
     {
-        $this->validateCsrf('subscribe', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now.
+        // $this->validateCsrf('subscribe', $request->getPayload()->get('token'));
 
         $this->manager->unsubscribe($domain, $this->getUserOrThrow());
 

--- a/src/Controller/FavouriteController.php
+++ b/src/Controller/FavouriteController.php
@@ -21,7 +21,8 @@ class FavouriteController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function __invoke(FavouriteInterface $subject, Request $request, FavouriteManager $manager): Response
     {
-        $this->validateCsrf('up_vote', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now.
+        // $this->validateCsrf('up_vote', $request->getPayload()->get('token'));
 
         $manager->toggle($this->getUserOrThrow(), $subject);
 

--- a/src/Controller/FavouriteController.php
+++ b/src/Controller/FavouriteController.php
@@ -21,7 +21,7 @@ class FavouriteController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function __invoke(FavouriteInterface $subject, Request $request, FavouriteManager $manager): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now.
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
         // $this->validateCsrf('up_vote', $request->getPayload()->get('token'));
 
         $manager->toggle($this->getUserOrThrow(), $subject);

--- a/src/Controller/Magazine/MagazineBlockController.php
+++ b/src/Controller/Magazine/MagazineBlockController.php
@@ -22,7 +22,8 @@ class MagazineBlockController extends AbstractController
     #[IsGranted('block', subject: 'magazine')]
     public function block(Magazine $magazine, Request $request): Response
     {
-        $this->validateCsrf('block', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now.
+        // $this->validateCsrf('block', $request->getPayload()->get('token'));
 
         $this->manager->block($magazine, $this->getUserOrThrow());
 
@@ -37,7 +38,8 @@ class MagazineBlockController extends AbstractController
     #[IsGranted('block', subject: 'magazine')]
     public function unblock(Magazine $magazine, Request $request): Response
     {
-        $this->validateCsrf('block', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now.
+        // $this->validateCsrf('block', $request->getPayload()->get('token'));
 
         $this->manager->unblock($magazine, $this->getUserOrThrow());
 

--- a/src/Controller/Magazine/MagazineBlockController.php
+++ b/src/Controller/Magazine/MagazineBlockController.php
@@ -22,7 +22,7 @@ class MagazineBlockController extends AbstractController
     #[IsGranted('block', subject: 'magazine')]
     public function block(Magazine $magazine, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now.
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
         // $this->validateCsrf('block', $request->getPayload()->get('token'));
 
         $this->manager->block($magazine, $this->getUserOrThrow());
@@ -38,7 +38,7 @@ class MagazineBlockController extends AbstractController
     #[IsGranted('block', subject: 'magazine')]
     public function unblock(Magazine $magazine, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now.
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
         // $this->validateCsrf('block', $request->getPayload()->get('token'));
 
         $this->manager->unblock($magazine, $this->getUserOrThrow());

--- a/src/Controller/Magazine/MagazineSubController.php
+++ b/src/Controller/Magazine/MagazineSubController.php
@@ -22,7 +22,7 @@ class MagazineSubController extends AbstractController
     #[IsGranted('subscribe', subject: 'magazine')]
     public function subscribe(Magazine $magazine, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now.
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
         // $this->validateCsrf('subscribe', $request->getPayload()->get('token'));
 
         $this->manager->subscribe($magazine, $this->getUserOrThrow());
@@ -38,7 +38,7 @@ class MagazineSubController extends AbstractController
     #[IsGranted('subscribe', subject: 'magazine')]
     public function unsubscribe(Magazine $magazine, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now.
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
         // $this->validateCsrf('subscribe', $request->getPayload()->get('token'));
 
         $this->manager->unsubscribe($magazine, $this->getUserOrThrow());

--- a/src/Controller/Magazine/MagazineSubController.php
+++ b/src/Controller/Magazine/MagazineSubController.php
@@ -22,7 +22,8 @@ class MagazineSubController extends AbstractController
     #[IsGranted('subscribe', subject: 'magazine')]
     public function subscribe(Magazine $magazine, Request $request): Response
     {
-        $this->validateCsrf('subscribe', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now.
+        // $this->validateCsrf('subscribe', $request->getPayload()->get('token'));
 
         $this->manager->subscribe($magazine, $this->getUserOrThrow());
 
@@ -37,7 +38,8 @@ class MagazineSubController extends AbstractController
     #[IsGranted('subscribe', subject: 'magazine')]
     public function unsubscribe(Magazine $magazine, Request $request): Response
     {
-        $this->validateCsrf('subscribe', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now.
+        // $this->validateCsrf('subscribe', $request->getPayload()->get('token'));
 
         $this->manager->unsubscribe($magazine, $this->getUserOrThrow());
 

--- a/src/Controller/Post/PostDeleteController.php
+++ b/src/Controller/Post/PostDeleteController.php
@@ -60,7 +60,8 @@ class PostDeleteController extends AbstractController
         Post $post,
         Request $request
     ): Response {
-        $this->validateCsrf('post_purge', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now.
+        // $this->validateCsrf('post_purge', $request->getPayload()->get('token'));
 
         $this->manager->purge($this->getUserOrThrow(), $post);
 

--- a/src/Controller/Post/PostDeleteController.php
+++ b/src/Controller/Post/PostDeleteController.php
@@ -28,7 +28,8 @@ class PostDeleteController extends AbstractController
         Post $post,
         Request $request
     ): Response {
-        $this->validateCsrf('post_delete', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
+        // $this->validateCsrf('post_delete', $request->getPayload()->get('token'));
 
         $this->manager->delete($this->getUserOrThrow(), $post);
 
@@ -44,7 +45,8 @@ class PostDeleteController extends AbstractController
         Post $post,
         Request $request
     ): Response {
-        $this->validateCsrf('post_restore', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
+        // $this->validateCsrf('post_restore', $request->getPayload()->get('token'));
 
         $this->manager->restore($this->getUserOrThrow(), $post);
 
@@ -60,7 +62,7 @@ class PostDeleteController extends AbstractController
         Post $post,
         Request $request
     ): Response {
-        // CSRF is causing a lot of issues, so we disable it for now.
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
         // $this->validateCsrf('post_purge', $request->getPayload()->get('token'));
 
         $this->manager->purge($this->getUserOrThrow(), $post);

--- a/src/Controller/User/Profile/UserNotificationController.php
+++ b/src/Controller/User/Profile/UserNotificationController.php
@@ -29,7 +29,7 @@ class UserNotificationController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function read(NotificationManager $manager, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now.
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
         // $this->validateCsrf('read_notifications', $request->getPayload()->get('token'));
 
         $manager->markAllAsRead($this->getUserOrThrow());
@@ -40,7 +40,7 @@ class UserNotificationController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function clear(NotificationManager $manager, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now.
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
         // $this->validateCsrf('clear_notifications', $request->getPayload()->get('token'));
 
         $manager->clear($this->getUserOrThrow());

--- a/src/Controller/User/Profile/UserNotificationController.php
+++ b/src/Controller/User/Profile/UserNotificationController.php
@@ -29,7 +29,8 @@ class UserNotificationController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function read(NotificationManager $manager, Request $request): Response
     {
-        $this->validateCsrf('read_notifications', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now.
+        // $this->validateCsrf('read_notifications', $request->getPayload()->get('token'));
 
         $manager->markAllAsRead($this->getUserOrThrow());
 
@@ -39,7 +40,8 @@ class UserNotificationController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function clear(NotificationManager $manager, Request $request): Response
     {
-        $this->validateCsrf('clear_notifications', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now.
+        // $this->validateCsrf('clear_notifications', $request->getPayload()->get('token'));
 
         $manager->clear($this->getUserOrThrow());
 

--- a/src/Controller/User/UserBlockController.php
+++ b/src/Controller/User/UserBlockController.php
@@ -17,7 +17,8 @@ class UserBlockController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function block(User $blocked, UserManager $manager, Request $request): Response
     {
-        $this->validateCsrf('block', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now.
+        // $this->validateCsrf('block', $request->getPayload()->get('token'));
 
         $manager->block($this->getUserOrThrow(), $blocked);
 
@@ -31,7 +32,8 @@ class UserBlockController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function unblock(User $blocked, UserManager $manager, Request $request): Response
     {
-        $this->validateCsrf('block', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now.
+        // $this->validateCsrf('block', $request->getPayload()->get('token'));
 
         $manager->unblock($this->getUserOrThrow(), $blocked);
 

--- a/src/Controller/User/UserBlockController.php
+++ b/src/Controller/User/UserBlockController.php
@@ -17,7 +17,7 @@ class UserBlockController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function block(User $blocked, UserManager $manager, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now.
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
         // $this->validateCsrf('block', $request->getPayload()->get('token'));
 
         $manager->block($this->getUserOrThrow(), $blocked);
@@ -32,7 +32,7 @@ class UserBlockController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function unblock(User $blocked, UserManager $manager, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now.
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
         // $this->validateCsrf('block', $request->getPayload()->get('token'));
 
         $manager->unblock($this->getUserOrThrow(), $blocked);

--- a/src/Controller/User/UserFollowController.php
+++ b/src/Controller/User/UserFollowController.php
@@ -18,7 +18,8 @@ class UserFollowController extends AbstractController
     #[IsGranted('follow', subject: 'following')]
     public function follow(User $following, UserManager $manager, Request $request): Response
     {
-        $this->validateCsrf('follow', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now.
+        // $this->validateCsrf('follow', $request->getPayload()->get('token'));
 
         $manager->follow($this->getUserOrThrow(), $following);
 
@@ -33,7 +34,8 @@ class UserFollowController extends AbstractController
     #[IsGranted('follow', subject: 'following')]
     public function unfollow(User $following, UserManager $manager, Request $request): Response
     {
-        $this->validateCsrf('follow', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now.
+        // $this->validateCsrf('follow', $request->getPayload()->get('token'));
 
         $manager->unfollow($this->getUserOrThrow(), $following);
 

--- a/src/Controller/User/UserFollowController.php
+++ b/src/Controller/User/UserFollowController.php
@@ -18,7 +18,7 @@ class UserFollowController extends AbstractController
     #[IsGranted('follow', subject: 'following')]
     public function follow(User $following, UserManager $manager, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now.
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
         // $this->validateCsrf('follow', $request->getPayload()->get('token'));
 
         $manager->follow($this->getUserOrThrow(), $following);
@@ -34,7 +34,7 @@ class UserFollowController extends AbstractController
     #[IsGranted('follow', subject: 'following')]
     public function unfollow(User $following, UserManager $manager, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now.
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
         // $this->validateCsrf('follow', $request->getPayload()->get('token'));
 
         $manager->unfollow($this->getUserOrThrow(), $following);

--- a/src/Controller/VoteController.php
+++ b/src/Controller/VoteController.php
@@ -30,7 +30,7 @@ class VoteController extends AbstractController
     #[IsGranted('vote', subject: 'votable')]
     public function __invoke(VotableInterface $votable, int $choice, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now.
+        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
         // $this->validateCsrf('down_vote', $request->getPayload()->get('token'));
         if (VotableInterface::VOTE_DOWN === $choice && DownvotesMode::Disabled === $this->settingsManager->getDownvotesMode()) {
             throw new BadRequestException('Downvotes are disabled!');

--- a/src/Controller/VoteController.php
+++ b/src/Controller/VoteController.php
@@ -30,7 +30,8 @@ class VoteController extends AbstractController
     #[IsGranted('vote', subject: 'votable')]
     public function __invoke(VotableInterface $votable, int $choice, Request $request): Response
     {
-        $this->validateCsrf('down_vote', $request->getPayload()->get('token'));
+        // CSRF is causing a lot of issues, so we disable it for now.
+        // $this->validateCsrf('down_vote', $request->getPayload()->get('token'));
         if (VotableInterface::VOTE_DOWN === $choice && DownvotesMode::Disabled === $this->settingsManager->getDownvotesMode()) {
             throw new BadRequestException('Downvotes are disabled!');
         }


### PR DESCRIPTION
We see a lot of issues with CSRF in your forms with Mbin... We disable CSRF checks for now on the forms that doesn't have actions that seems very harmful, even if it would be exploited by a CSRF attack..

Especially on the following **CSRF IDs**:

 - up_vote
 - down_vote
 - boost
 - subscribe
 - block
 - clear_notifications
 - read_notifications
 - follow

Since the impact on CSRF attacks on these kind of actions are minimal and slim. I will disable the validate check for now in the controller code. Until we fully have resolved this issue, since it affects a lot of people!

This is trying to resolve bullet 13th at: https://github.com/MbinOrg/mbin/issues/1119