### PR TITLE
Reduce error pollution even more on post request failures

### DIFF
--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -90,8 +90,8 @@ class ApHttpClient
     {
         $this->logger->debug("ApHttpClient:getActivityObject:url: $url");
 
-        $client = new CurlHttpClient();
         try {
+            $client = new CurlHttpClient();
             $r = $client->request('GET', $url, [
                 'max_duration' => self::MAX_DURATION,
                 'timeout' => self::TIMEOUT,

--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -329,7 +329,7 @@ class ApHttpClient
     }
 
     /**
-     * Helper function for logging get/post/.. requests to the error log with additional info.
+     * Helper function for logging get/post/.. requests to the error & debug log with additional info.
      *
      * @param ResponseInterface|null $response    Optional response object
      * @param string                 $requestUrl  Full URL of the request

--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -336,7 +336,7 @@ class ApHttpClient
      * @param string                 $requestType an additional string where the error happened in the code
      * @param \Exception             $e           Error object
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidApPostException rethrows the error
      */
     private function logRequestException(?ResponseInterface $response, string $requestUrl, string $requestType, \Exception $e): void
     {
@@ -374,7 +374,7 @@ class ApHttpClient
      * @param User|Magazine $actor The actor initiating the request, either a User or Magazine object
      * @param array|null    $body  (Optional) The body of the POST request. Defaults to null.
      *
-     * @throws InvalidApPostException rethrows the error
+     * @throws InvalidApPostException if the POST request fails with a non-2xx response status code
      */
     public function post(string $url, User|Magazine $actor, ?array $body = null): void
     {

--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -399,15 +399,16 @@ class ApHttpClient
                 // Do NOT include the response content in the error message, this will be often a full HTML page
                 throw new InvalidApPostException("Post failed: $url, status code: $statusCode, request body: $jsonBody");
             }
-
-            // build cache
-            $item = $this->cache->getItem($cacheKey);
-            $item->set(true);
-            $item->expiresAt(new \DateTime('+45 minutes'));
-            $this->cache->save($item);
         } catch (\Exception $e) {
             $this->logRequestException($response, $url, 'ApHttpClient:post', $e);
         }
+
+        // build cache
+        $item = $this->cache->getItem($cacheKey);
+        $item->set(true);
+        $item->expiresAt(new \DateTime('+45 minutes'));
+        $this->cache->save($item);
+
     }
 
     public function fetchInstanceNodeInfoEndpoints(string $domain, bool $decoded = true): array|string|null

--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -328,6 +328,16 @@ class ApHttpClient
         return $response->getContent();
     }
 
+    /**
+     * Helper function for logging get/post/.. requests to the error log with additional info.
+     *
+     * @param ResponseInterface|null $response    Optional response object
+     * @param string                 $requestUrl  Full URL of the request
+     * @param string                 $requestType an additional string where the error happened in the code
+     * @param \Exception             $e           Error object
+     *
+     * @throws InvalidArgumentException
+     */
     private function logRequestException(?ResponseInterface $response, string $requestUrl, string $requestType, \Exception $e): void
     {
         if (null !== $response) {
@@ -341,7 +351,7 @@ class ApHttpClient
 
         // Often 400, 404 errors just return the full HTML page, so we don't want to log the full content of them
         // We truncate the content to 200 characters max.
-        $this->logger->error('{type} get fail: {address}, ex: {e}: {msg}. Truncated content: {content}', [
+        $this->logger->error('{type} failed: {address}, ex: {e}: {msg}. Truncated content: {content}', [
             'type' => $requestType,
             'address' => $requestUrl,
             'e' => \get_class($e),

--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -408,7 +408,6 @@ class ApHttpClient
         $item->set(true);
         $item->expiresAt(new \DateTime('+45 minutes'));
         $this->cache->save($item);
-
     }
 
     public function fetchInstanceNodeInfoEndpoints(string $domain, bool $decoded = true): array|string|null

--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -374,7 +374,7 @@ class ApHttpClient
      * @param User|Magazine $actor The actor initiating the request, either a User or Magazine object
      * @param array|null    $body  (Optional) The body of the POST request. Defaults to null.
      *
-     * @throws InvalidApPostException if the POST request fails with a non-2xx response status code
+     * @throws InvalidApPostException rethrows the error
      */
     public function post(string $url, User|Magazine $actor, ?array $body = null): void
     {

--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -89,16 +89,16 @@ class ApHttpClient
     private function getActivityObjectImpl(string $url): ?string
     {
         $this->logger->debug("ApHttpClient:getActivityObject:url: $url");
-
+        $content = null;
         try {
             $client = new CurlHttpClient();
-            $r = $client->request('GET', $url, [
+            $response = $client->request('GET', $url, [
                 'max_duration' => self::MAX_DURATION,
                 'timeout' => self::TIMEOUT,
                 'headers' => $this->getInstanceHeaders($url),
             ]);
 
-            $statusCode = $r->getStatusCode();
+            $statusCode = $response->getStatusCode();
             // Accepted status code are 2xx or 410 (used Tombstone types)
             if (!str_starts_with((string) $statusCode, '2') && 410 !== $statusCode) {
                 // Do NOT include the response content in the error message, this will be often a full HTML page
@@ -106,10 +106,10 @@ class ApHttpClient
             }
 
             // Read also non-OK responses (like 410) by passing 'false'
-            $content = $r->getContent(false);
+            $content = $response->getContent(false);
             $this->logger->debug('ApHttpClient:getActivityObject:url: {url} - content: {content}', ['url' => $url, 'content' => $content]);
         } catch (\Exception $e) {
-            $this->logRequestException($r, $url, 'ApHttpClient:getActivityObject', $e);
+            $this->logRequestException($response, $url, 'ApHttpClient:getActivityObject', $e);
         }
 
         return $content;
@@ -171,19 +171,19 @@ class ApHttpClient
     private function getWebfingerObjectImpl(string $url): ?string
     {
         $this->logger->debug("ApHttpClient:getWebfingerObject:url: $url");
-        $r = null;
+        $response = null;
         try {
             $client = new CurlHttpClient();
-            $r = $client->request('GET', $url, [
+            $response = $client->request('GET', $url, [
                 'max_duration' => self::MAX_DURATION,
                 'timeout' => self::TIMEOUT,
                 'headers' => $this->getInstanceHeaders($url, null, 'get', ApRequestType::WebFinger),
             ]);
         } catch (\Exception $e) {
-            $this->logRequestException($r, $url, 'ApHttpClient:getWebfingerObject', $e);
+            $this->logRequestException($response, $url, 'ApHttpClient:getWebfingerObject', $e);
         }
 
-        return $r->getContent();
+        return $response->getContent();
     }
 
     private function getActorCacheKey(string $apProfileId): string
@@ -354,7 +354,7 @@ class ApHttpClient
                 'content' => $content,
             ]);
         }
-        throw $e;
+        throw $e; // re-throw the exception
     }
 
     /**


### PR DESCRIPTION
This will fix the 16th [miscellaneous issue](https://github.com/MbinOrg/mbin/issues/1119), with too much verbose error logging.

I try to handle the post request basically the same way as the previously implemented `InvalidApPostException` exceptions like in the `getCollectionObjectImpl` function.

 
This meaning the content logging will be part of the catch -> `logRequestException` function instead. And the `InvalidApPostException` exception will only log the request body, but no longer the response content. Also we log the status code now as well for failed post requests. Plus some small refactoring.

Last but not least, I will only do a `json_encode` once. 