### PR TITLE
Store sessions in DB + improve cookies/sessions

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -13,13 +13,19 @@ framework:
             'x-forwarded-prefix',
         ]
 
-    # Enables session support. Note that the session will ONLY be started if you read or write from it.
-    # Remove or comment this section to explicitly disable session support.
+    # Sessions are stored in database, because saving sessions in Redis can give race conditions.
+    # See last paragraph of https://symfony.com/doc/current/session.html#store-sessions-in-a-key-value-database-redis
+    #
+    # PHP session handling is often (in Debian/Ubuntu) not doing gargage collection for sessions
+    # (session.gc_probability option in PHP).
+    # Hence we do also not want to set gc_maxlifetime for idle periods.
+    # We set our cookie session lifetime to the same value as remember_me token.
+    # More info: https://symfony.com/doc/current/session.html#session-idle-time-keep-alive
     session:
-        handler_id: '%env(REDIS_DNS)%'
+        handler_id: Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler
         cookie_secure: auto
         cookie_samesite: lax
-        gc_maxlifetime: 1814400 # Match the remember_me lifetime
+        cookie_lifetime: 10512000 # 4 months long lifetime
         storage_factory_id: session.storage.factory.native
 
     http_client:

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -49,7 +49,7 @@ security:
             user_checker: App\Security\UserChecker
             remember_me:
                 secret: '%kernel.secret%'
-                lifetime: 1814400
+                lifetime: 10512000 # 4 Months
                 path: /
                 token_provider:
                     doctrine: true

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,77 +1,76 @@
 framework:
     serializer:
         mapping:
-            paths: ["%kernel.project_dir%/config/kbin_serialization"]
+            paths: ['%kernel.project_dir%/config/kbin_serialization']
 
 parameters:
-    kbin_domain: "%env(KBIN_DOMAIN)%"
-    kbin_title: "%env(KBIN_TITLE)%"
-    kbin_meta_title: "%env(KBIN_META_TITLE)%"
-    kbin_meta_description: "%env(KBIN_META_DESCRIPTION)%"
-    kbin_meta_keywords: "%env(KBIN_META_KEYWORDS)%"
-    kbin_contact_email: "%env(KBIN_CONTACT_EMAIL)%"
-    kbin_sender_email: "%env(KBIN_SENDER_EMAIL)%"
-    kbin_default_lang: "%env(KBIN_DEFAULT_LANG)%"
-    kbin_api_items_per_page: "%env(KBIN_API_ITEMS_PER_PAGE)%"
-    kbin_js_enabled: "%env(bool:KBIN_JS_ENABLED)%"
-    kbin_federation_enabled: "%env(KBIN_FEDERATION_ENABLED)%"
-    kbin_registrations_enabled: "%env(KBIN_REGISTRATIONS_ENABLED)%"
+    kbin_domain: '%env(KBIN_DOMAIN)%'
+    kbin_title: '%env(KBIN_TITLE)%'
+    kbin_meta_title: '%env(KBIN_META_TITLE)%'
+    kbin_meta_description: '%env(KBIN_META_DESCRIPTION)%'
+    kbin_meta_keywords: '%env(KBIN_META_KEYWORDS)%'
+    kbin_contact_email: '%env(KBIN_CONTACT_EMAIL)%'
+    kbin_sender_email: '%env(KBIN_SENDER_EMAIL)%'
+    kbin_default_lang: '%env(KBIN_DEFAULT_LANG)%'
+    kbin_api_items_per_page: '%env(KBIN_API_ITEMS_PER_PAGE)%'
+    kbin_js_enabled: '%env(bool:KBIN_JS_ENABLED)%'
+    kbin_federation_enabled: '%env(KBIN_FEDERATION_ENABLED)%'
+    kbin_registrations_enabled: '%env(KBIN_REGISTRATIONS_ENABLED)%'
     kbin_ap_route_condition: 'request.getAcceptableContentTypes() and request.getAcceptableContentTypes()[0] in ["application/activity+json", "application/ld+json", "application/json"]'
-    kbin_storage_url: "%env(KBIN_STORAGE_URL)%"
+    kbin_storage_url: '%env(KBIN_STORAGE_URL)%'
 
     # Grab the default theme to use from the MBIN_DEFAULT_THEME env var
     # with a fall back of light/dark auto detection based on user setting
     default_theme: default
-    mbin_default_theme: "%env(default:default_theme:MBIN_DEFAULT_THEME)%"
+    mbin_default_theme: '%env(default:default_theme:MBIN_DEFAULT_THEME)%'
 
-    amazon.s3.key: "%env(S3_KEY)%"
-    amazon.s3.secret: "%env(S3_SECRET)%"
-    amazon.s3.bucket: "%env(S3_BUCKET)%"
-    amazon.s3.region: "%env(S3_REGION)%"
-    amazon.s3.version: "%env(S3_VERSION)%"
-    amazon.s3.endpoint: "%env(S3_ENDPOINT)%"
+    amazon.s3.key: '%env(S3_KEY)%'
+    amazon.s3.secret: '%env(S3_SECRET)%'
+    amazon.s3.bucket: '%env(S3_BUCKET)%'
+    amazon.s3.region: '%env(S3_REGION)%'
+    amazon.s3.version: '%env(S3_VERSION)%'
+    amazon.s3.endpoint: '%env(S3_ENDPOINT)%'
 
-    hcaptcha_site_key: "%env(resolve:HCAPTCHA_SITE_KEY)%"
-    hcaptcha_secret: "%env(resolve:HCAPTCHA_SECRET)%"
+    hcaptcha_site_key: '%env(resolve:HCAPTCHA_SITE_KEY)%'
+    hcaptcha_secret: '%env(resolve:HCAPTCHA_SECRET)%'
 
-    oauth_azure_id: "%env(default::OAUTH_AZURE_ID)%"
-    oauth_azure_secret: "%env(OAUTH_AZURE_SECRET)%"
-    oauth_azure_tenant: "%env(OAUTH_AZURE_TENANT)%"
+    oauth_azure_id: '%env(default::OAUTH_AZURE_ID)%'
+    oauth_azure_secret: '%env(OAUTH_AZURE_SECRET)%'
+    oauth_azure_tenant: '%env(OAUTH_AZURE_TENANT)%'
 
-    oauth_facebook_id: "%env(default::OAUTH_FACEBOOK_ID)%"
-    oauth_facebook_secret: "%env(OAUTH_FACEBOOK_SECRET)%"
+    oauth_facebook_id: '%env(default::OAUTH_FACEBOOK_ID)%'
+    oauth_facebook_secret: '%env(OAUTH_FACEBOOK_SECRET)%'
 
-    oauth_google_id: "%env(default::OAUTH_GOOGLE_ID)%"
-    oauth_google_secret: "%env(OAUTH_GOOGLE_SECRET)%"
+    oauth_google_id: '%env(default::OAUTH_GOOGLE_ID)%'
+    oauth_google_secret: '%env(OAUTH_GOOGLE_SECRET)%'
 
-    oauth_discord_id: "%env(default::OAUTH_DISCORD_ID)%"
-    oauth_discord_secret: "%env(OAUTH_DISCORD_SECRET)%"
+    oauth_discord_id: '%env(default::OAUTH_DISCORD_ID)%'
+    oauth_discord_secret: '%env(OAUTH_DISCORD_SECRET)%'
 
-    oauth_github_id: "%env(default::OAUTH_GITHUB_ID)%"
-    oauth_github_secret: "%env(OAUTH_GITHUB_SECRET)%"
+    oauth_github_id: '%env(default::OAUTH_GITHUB_ID)%'
+    oauth_github_secret: '%env(OAUTH_GITHUB_SECRET)%'
 
-    oauth_privacyportal_id: "%env(default::OAUTH_PRIVACYPORTAL_ID)%"
-    oauth_privacyportal_secret: "%env(OAUTH_PRIVACYPORTAL_SECRET)%"
+    oauth_privacyportal_id: '%env(default::OAUTH_PRIVACYPORTAL_ID)%'
+    oauth_privacyportal_secret: '%env(OAUTH_PRIVACYPORTAL_SECRET)%'
 
-    oauth_keycloak_id: "%env(default::OAUTH_KEYCLOAK_ID)%"
-    oauth_keycloak_secret: "%env(OAUTH_KEYCLOAK_SECRET)%"
-    oauth_keycloak_uri: "%env(OAUTH_KEYCLOAK_URI)%"
-    oauth_keycloak_realm: "%env(OAUTH_KEYCLOAK_REALM)%"
-    oauth_keycloak_version: "%env(OAUTH_KEYCLOAK_VERSION)%"
+    oauth_keycloak_id: '%env(default::OAUTH_KEYCLOAK_ID)%'
+    oauth_keycloak_secret: '%env(OAUTH_KEYCLOAK_SECRET)%'
+    oauth_keycloak_uri: '%env(OAUTH_KEYCLOAK_URI)%'
+    oauth_keycloak_realm: '%env(OAUTH_KEYCLOAK_REALM)%'
+    oauth_keycloak_version: '%env(OAUTH_KEYCLOAK_VERSION)%'
 
-    oauth_simplelogin_id: "%env(default::OAUTH_SIMPLELOGIN_ID)%"
-    oauth_simplelogin_secret: "%env(OAUTH_SIMPLELOGIN_SECRET)%"
+    oauth_simplelogin_id: '%env(default::OAUTH_SIMPLELOGIN_ID)%'
+    oauth_simplelogin_secret: '%env(OAUTH_SIMPLELOGIN_SECRET)%'
 
-    oauth_zitadel_id: "%env(default::OAUTH_ZITADEL_ID)%"
-    oauth_zitadel_secret: "%env(OAUTH_ZITADEL_SECRET)%"
-    oauth_zitadel_base_url: "%env(OAUTH_ZITADEL_BASE_URL)%"
+    oauth_zitadel_id: '%env(default::OAUTH_ZITADEL_ID)%'
+    oauth_zitadel_secret: '%env(OAUTH_ZITADEL_SECRET)%'
+    oauth_zitadel_base_url: '%env(OAUTH_ZITADEL_BASE_URL)%'
 
-    oauth_authentik_id: "%env(default::OAUTH_AUTHENTIK_ID)%"
-    oauth_authentik_secret: "%env(OAUTH_AUTHENTIK_SECRET)%"
-    oauth_authentik_base_url: "%env(OAUTH_AUTHENTIK_BASE_URL)%"
+    oauth_authentik_id: '%env(default::OAUTH_AUTHENTIK_ID)%'
+    oauth_authentik_secret: '%env(OAUTH_AUTHENTIK_SECRET)%'
+    oauth_authentik_base_url: '%env(OAUTH_AUTHENTIK_BASE_URL)%'
 
-
-    router.request_context.host: "%env(KBIN_DOMAIN)%"
+    router.request_context.host: '%env(KBIN_DOMAIN)%'
     router.request_context.scheme: https
 
     html5_validation: true
@@ -88,16 +87,16 @@ parameters:
 
     stats_type: general|content|votes
 
-    number_regex: "[1-9][0-9]{0,17}"
+    number_regex: '[1-9][0-9]{0,17}'
     username_regex: '\w{2,25}|!deleted\d+'
 
-    uploads_dir_name: "media"
-    uploads_base_url: "/"
+    uploads_dir_name: 'media'
+    uploads_base_url: '/'
 
-    mercure_public_url: "%env(MERCURE_PUBLIC_URL)%"
-    mercure_subscriptions_token: "%env(MERCURE_JWT_SECRET)%"
+    mercure_public_url: '%env(MERCURE_PUBLIC_URL)%'
+    mercure_subscriptions_token: '%env(MERCURE_JWT_SECRET)%'
 
-    sso_only_mode: "%env(bool:default::SSO_ONLY_MODE)%"
+    sso_only_mode: '%env(bool:default::SSO_ONLY_MODE)%'
 
     exif_default_uploaded: 'sanitize'
     exif_default_external: 'none'
@@ -107,7 +106,7 @@ parameters:
     exif_exiftool_path: '%env(default::EXIF_EXIFTOOL_PATH)%'
     exif_exiftool_timeout: '%env(int:default::EXIF_EXIFTOOL_TIMEOUT)%'
 
-    max_image_bytes: "%env(int:default:max_image_bytes_default:MAX_IMAGE_BYTES)%"
+    max_image_bytes: '%env(int:default:max_image_bytes_default:MAX_IMAGE_BYTES)%'
     max_image_bytes_default: 6000000
 
     mbin_downvotes_mode_default: 'enabled'
@@ -119,41 +118,41 @@ services:
         autowire: true # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
         bind:
-            $kbinDomain: "%kbin_domain%"
-            $html5Validation: "%html5_validation%"
-            $uploadedAssetsBaseUrl: "%uploads_base_url%"
-            $mercurePublicUrl: "%mercure_public_url%"
-            $mercureSubscriptionsToken: "%mercure_subscriptions_token%"
-            $kbinApiItemsPerPage: "%kbin_api_items_per_page%"
-            $storageUrl: "%kbin_storage_url%"
-            $publicDir: "%kernel.project_dir%/public"
+            $kbinDomain: '%kbin_domain%'
+            $html5Validation: '%html5_validation%'
+            $uploadedAssetsBaseUrl: '%uploads_base_url%'
+            $mercurePublicUrl: '%mercure_public_url%'
+            $mercureSubscriptionsToken: '%mercure_subscriptions_token%'
+            $kbinApiItemsPerPage: '%kbin_api_items_per_page%'
+            $storageUrl: '%kbin_storage_url%'
+            $publicDir: '%kernel.project_dir%/public'
 
     kbin.s3_client:
         class: Aws\S3\S3Client
         arguments:
-            - version: "%amazon.s3.version%"
-              region: "%amazon.s3.region%"
-              endpoint: "%amazon.s3.endpoint%"
+            - version: '%amazon.s3.version%'
+              region: '%amazon.s3.region%'
+              endpoint: '%amazon.s3.endpoint%'
               #use_path_style_endpoint: true
               credentials:
-                  key: "%amazon.s3.key%"
-                  secret: "%amazon.s3.secret%"
+                  key: '%amazon.s3.key%'
+                  secret: '%amazon.s3.secret%'
                   #proxies: [ 'https://media.domain.tld' ]
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name
     App\:
-        resource: "../src/"
+        resource: '../src/'
         exclude:
-            - "../src/DependencyInjection/"
-            - "../src/Entity/"
-            - "../src/Kernel.php"
+            - '../src/DependencyInjection/'
+            - '../src/Entity/'
+            - '../src/Kernel.php'
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
     App\Controller\:
-        resource: "../src/Controller/"
-        tags: ["controller.service_arguments"]
+        resource: '../src/Controller/'
+        tags: ['controller.service_arguments']
 
     #  App\Http\RequestDTOResolver:
     #    arguments:
@@ -164,24 +163,24 @@ services:
     # Instance settings
     App\Service\SettingsManager:
         arguments:
-            $kbinTitle: "%kbin_title%"
-            $kbinMetaTitle: "%kbin_meta_title%"
-            $kbinMetaDescription: "%kbin_meta_description%"
-            $kbinMetaKeywords: "%kbin_meta_keywords%"
-            $kbinDefaultLang: "%kbin_default_lang%"
-            $kbinContactEmail: "%kbin_contact_email%"
-            $kbinSenderEmail: "%kbin_sender_email%"
-            $mbinDefaultTheme: "%mbin_default_theme%"
-            $kbinJsEnabled: "%env(bool:KBIN_JS_ENABLED)%"
-            $kbinFederationEnabled: "%env(bool:KBIN_FEDERATION_ENABLED)%"
-            $kbinRegistrationsEnabled: "%env(bool:KBIN_REGISTRATIONS_ENABLED)%"
-            $kbinHeaderLogo: "%env(bool:KBIN_HEADER_LOGO)%"
-            $kbinCaptchaEnabled: "%env(bool:KBIN_CAPTCHA_ENABLED)%"
-            $kbinFederationPageEnabled: "%env(bool:KBIN_FEDERATION_PAGE_ENABLED)%"
-            $kbinAdminOnlyOauthClients: "%env(bool:KBIN_ADMIN_ONLY_OAUTH_CLIENTS)%"
-            $mbinSsoOnlyMode: "%sso_only_mode%"
-            $maxImageBytes: "%max_image_bytes%"
-            $mbinDownvotesMode: "%mbin_downvotes_mode%"
+            $kbinTitle: '%kbin_title%'
+            $kbinMetaTitle: '%kbin_meta_title%'
+            $kbinMetaDescription: '%kbin_meta_description%'
+            $kbinMetaKeywords: '%kbin_meta_keywords%'
+            $kbinDefaultLang: '%kbin_default_lang%'
+            $kbinContactEmail: '%kbin_contact_email%'
+            $kbinSenderEmail: '%kbin_sender_email%'
+            $mbinDefaultTheme: '%mbin_default_theme%'
+            $kbinJsEnabled: '%env(bool:KBIN_JS_ENABLED)%'
+            $kbinFederationEnabled: '%env(bool:KBIN_FEDERATION_ENABLED)%'
+            $kbinRegistrationsEnabled: '%env(bool:KBIN_REGISTRATIONS_ENABLED)%'
+            $kbinHeaderLogo: '%env(bool:KBIN_HEADER_LOGO)%'
+            $kbinCaptchaEnabled: '%env(bool:KBIN_CAPTCHA_ENABLED)%'
+            $kbinFederationPageEnabled: '%env(bool:KBIN_FEDERATION_PAGE_ENABLED)%'
+            $kbinAdminOnlyOauthClients: '%env(bool:KBIN_ADMIN_ONLY_OAUTH_CLIENTS)%'
+            $mbinSsoOnlyMode: '%sso_only_mode%'
+            $maxImageBytes: '%max_image_bytes%'
+            $mbinDownvotesMode: '%mbin_downvotes_mode%'
 
     # Markdown
     App\Markdown\Factory\EnvironmentFactory:
@@ -192,7 +191,7 @@ services:
                 League\CommonMark\Extension\Strikethrough\StrikethroughExtension: '@League\CommonMark\Extension\Strikethrough\StrikethroughExtension'
                 League\CommonMark\Extension\Table\TableExtension: '@League\CommonMark\Extension\Table\TableExtension'
                 App\Markdown\MarkdownExtension: '@App\Markdown\MarkdownExtension'
-            $config: "%commonmark.configuration%"
+            $config: '%commonmark.configuration%'
 
     # Language
     App\EventListener\LanguageListener:
@@ -202,7 +201,7 @@ services:
                   event: kernel.request,
                   priority: 200,
               }
-        arguments: ["%kbin_default_lang%"]
+        arguments: ['%kbin_default_lang%']
 
     # Federation
     App\EventListener\FederationStatusListener:
@@ -241,3 +240,8 @@ services:
 
     messenger.failure.add_error_details_stamp_listener:
         class: App\Utils\AddErrorDetailsStampListener
+
+    # Store session in database using PdoSessionHandler, by providing the DB DSN
+    Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler:
+        arguments:
+            - '%env(DATABASE_URL)%'

--- a/migrations/Version20240923164233.php
+++ b/migrations/Version20240923164233.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240923164233 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Introducing the sessions table for session management.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE sessions (sess_id VARCHAR(128) NOT NULL, sess_data BYTEA NOT NULL, sess_lifetime INT NOT NULL, sess_time INT NOT NULL, PRIMARY KEY(sess_id))');
+        $this->addSql('CREATE INDEX sess_lifetime_idx ON sessions (sess_lifetime)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE sessions');
+    }
+}

--- a/migrations/Version20240923164233.php
+++ b/migrations/Version20240923164233.php
@@ -7,9 +7,6 @@ namespace DoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 final class Version20240923164233 extends AbstractMigration
 {
     public function getDescription(): string

--- a/src/Controller/BoostController.php
+++ b/src/Controller/BoostController.php
@@ -23,9 +23,6 @@ class BoostController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function __invoke(VotableInterface $subject, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('boost', $request->getPayload()->get('token'));
-
         $this->manager->vote(VotableInterface::VOTE_UP, $subject, $this->getUserOrThrow());
 
         if ($request->isXmlHttpRequest()) {

--- a/src/Controller/Domain/DomainBlockController.php
+++ b/src/Controller/Domain/DomainBlockController.php
@@ -22,9 +22,6 @@ class DomainBlockController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function block(Domain $domain, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('block', $request->getPayload()->get('token'));
-
         $this->manager->block($domain, $this->getUserOrThrow());
 
         if ($request->isXmlHttpRequest()) {
@@ -37,9 +34,6 @@ class DomainBlockController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function unblock(Domain $domain, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('block', $request->getPayload()->get('token'));
-
         $this->manager->unblock($domain, $this->getUserOrThrow());
 
         if ($request->isXmlHttpRequest()) {

--- a/src/Controller/Domain/DomainSubController.php
+++ b/src/Controller/Domain/DomainSubController.php
@@ -22,9 +22,6 @@ class DomainSubController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function subscribe(Domain $domain, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('subscribe', $request->getPayload()->get('token'));
-
         $this->manager->subscribe($domain, $this->getUserOrThrow());
 
         if ($request->isXmlHttpRequest()) {
@@ -37,9 +34,6 @@ class DomainSubController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function unsubscribe(Domain $domain, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('subscribe', $request->getPayload()->get('token'));
-
         $this->manager->unsubscribe($domain, $this->getUserOrThrow());
 
         if ($request->isXmlHttpRequest()) {

--- a/src/Controller/FavouriteController.php
+++ b/src/Controller/FavouriteController.php
@@ -21,9 +21,6 @@ class FavouriteController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function __invoke(FavouriteInterface $subject, Request $request, FavouriteManager $manager): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('up_vote', $request->getPayload()->get('token'));
-
         $manager->toggle($this->getUserOrThrow(), $subject);
 
         if ($request->isXmlHttpRequest()) {

--- a/src/Controller/Magazine/MagazineBlockController.php
+++ b/src/Controller/Magazine/MagazineBlockController.php
@@ -22,9 +22,6 @@ class MagazineBlockController extends AbstractController
     #[IsGranted('block', subject: 'magazine')]
     public function block(Magazine $magazine, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('block', $request->getPayload()->get('token'));
-
         $this->manager->block($magazine, $this->getUserOrThrow());
 
         if ($request->isXmlHttpRequest()) {
@@ -38,9 +35,6 @@ class MagazineBlockController extends AbstractController
     #[IsGranted('block', subject: 'magazine')]
     public function unblock(Magazine $magazine, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('block', $request->getPayload()->get('token'));
-
         $this->manager->unblock($magazine, $this->getUserOrThrow());
 
         if ($request->isXmlHttpRequest()) {

--- a/src/Controller/Magazine/MagazineSubController.php
+++ b/src/Controller/Magazine/MagazineSubController.php
@@ -22,9 +22,6 @@ class MagazineSubController extends AbstractController
     #[IsGranted('subscribe', subject: 'magazine')]
     public function subscribe(Magazine $magazine, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('subscribe', $request->getPayload()->get('token'));
-
         $this->manager->subscribe($magazine, $this->getUserOrThrow());
 
         if ($request->isXmlHttpRequest()) {
@@ -38,9 +35,6 @@ class MagazineSubController extends AbstractController
     #[IsGranted('subscribe', subject: 'magazine')]
     public function unsubscribe(Magazine $magazine, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('subscribe', $request->getPayload()->get('token'));
-
         $this->manager->unsubscribe($magazine, $this->getUserOrThrow());
 
         if ($request->isXmlHttpRequest()) {

--- a/src/Controller/Post/PostDeleteController.php
+++ b/src/Controller/Post/PostDeleteController.php
@@ -28,9 +28,6 @@ class PostDeleteController extends AbstractController
         Post $post,
         Request $request
     ): Response {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('post_delete', $request->getPayload()->get('token'));
-
         $this->manager->delete($this->getUserOrThrow(), $post);
 
         return $this->redirectToRefererOrHome($request);
@@ -45,9 +42,6 @@ class PostDeleteController extends AbstractController
         Post $post,
         Request $request
     ): Response {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('post_restore', $request->getPayload()->get('token'));
-
         $this->manager->restore($this->getUserOrThrow(), $post);
 
         return $this->redirectToRefererOrHome($request);
@@ -62,9 +56,6 @@ class PostDeleteController extends AbstractController
         Post $post,
         Request $request
     ): Response {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('post_purge', $request->getPayload()->get('token'));
-
         $this->manager->purge($this->getUserOrThrow(), $post);
 
         return $this->redirectToMagazine($magazine);

--- a/src/Controller/User/Profile/UserNotificationController.php
+++ b/src/Controller/User/Profile/UserNotificationController.php
@@ -29,9 +29,6 @@ class UserNotificationController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function read(NotificationManager $manager, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('read_notifications', $request->getPayload()->get('token'));
-
         $manager->markAllAsRead($this->getUserOrThrow());
 
         return $this->redirectToRefererOrHome($request);
@@ -40,9 +37,6 @@ class UserNotificationController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function clear(NotificationManager $manager, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('clear_notifications', $request->getPayload()->get('token'));
-
         $manager->clear($this->getUserOrThrow());
 
         return $this->redirectToRefererOrHome($request);

--- a/src/Controller/User/UserBlockController.php
+++ b/src/Controller/User/UserBlockController.php
@@ -17,9 +17,6 @@ class UserBlockController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function block(User $blocked, UserManager $manager, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('block', $request->getPayload()->get('token'));
-
         $manager->block($this->getUserOrThrow(), $blocked);
 
         if ($request->isXmlHttpRequest()) {
@@ -32,9 +29,6 @@ class UserBlockController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function unblock(User $blocked, UserManager $manager, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('block', $request->getPayload()->get('token'));
-
         $manager->unblock($this->getUserOrThrow(), $blocked);
 
         if ($request->isXmlHttpRequest()) {

--- a/src/Controller/User/UserFollowController.php
+++ b/src/Controller/User/UserFollowController.php
@@ -18,9 +18,6 @@ class UserFollowController extends AbstractController
     #[IsGranted('follow', subject: 'following')]
     public function follow(User $following, UserManager $manager, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('follow', $request->getPayload()->get('token'));
-
         $manager->follow($this->getUserOrThrow(), $following);
 
         if ($request->isXmlHttpRequest()) {
@@ -34,9 +31,6 @@ class UserFollowController extends AbstractController
     #[IsGranted('follow', subject: 'following')]
     public function unfollow(User $following, UserManager $manager, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('follow', $request->getPayload()->get('token'));
-
         $manager->unfollow($this->getUserOrThrow(), $following);
 
         if ($request->isXmlHttpRequest()) {

--- a/src/Controller/VoteController.php
+++ b/src/Controller/VoteController.php
@@ -30,8 +30,6 @@ class VoteController extends AbstractController
     #[IsGranted('vote', subject: 'votable')]
     public function __invoke(VotableInterface $votable, int $choice, Request $request): Response
     {
-        // CSRF is causing a lot of issues, so we disable it for now. See PR: https://github.com/MbinOrg/mbin/pull/1136
-        // $this->validateCsrf('down_vote', $request->getPayload()->get('token'));
         if (VotableInterface::VOTE_DOWN === $choice && DownvotesMode::Disabled === $this->settingsManager->getDownvotesMode()) {
             throw new BadRequestException('Downvotes are disabled!');
         }

--- a/templates/components/boost.html.twig
+++ b/templates/components/boost.html.twig
@@ -2,7 +2,6 @@
 {%- set user_choice = is_granted('ROLE_USER') ? subject.userChoice(app.user) : null -%}
 <form method="post"
       action="{{ path(formDest~'_boost', {id: subject.id}) }}">
-    <input type="hidden" name="token" value="{{ csrf_token('boost') }}">
     <button class="{{ html_classes('boost-link', 'stretched-link', {'active': app.user and user_choice is same as(VOTE_UP) }) }}"
             type="submit"
             data-action="subject#favourite">

--- a/templates/components/domain_sub.html.twig
+++ b/templates/components/domain_sub.html.twig
@@ -12,7 +12,6 @@
                 data-action="subs#send">
             {{ is_domain_subscribed(domain) ? 'unsubscribe'|trans : 'subscribe'|trans }}
         </button>
-        <input type="hidden" name="token" value="{{ csrf_token('subscribe') }}">
     </form>
     <form action="{{ path('domain_' ~ (is_domain_blocked(domain) ? 'unblock' : 'block'), {name: domain.name}) }}"
           name="domain_block"
@@ -22,6 +21,5 @@
                 data-action="subs#send">
             <i class="fa-solid fa-ban" aria-hidden="true"></i><span>{{ is_domain_blocked(domain) ? 'unblock'|trans : 'block'|trans  }}</span>
         </button>
-        <input type="hidden" name="token" value="{{ csrf_token('block') }}">
     </form>
 </aside>

--- a/templates/components/favourite.html.twig
+++ b/templates/components/favourite.html.twig
@@ -1,6 +1,5 @@
 <form method="post"
       action="{{ path(formDest~'_favourite', {id: subject.id}) }}">
-    <input type="hidden" name="token" value="{{ csrf_token('up_vote') }}">
     <button class="{{ html_classes('stretched-link', {'active': app.user and subject.isFavored(app.user) }) }}"
             type="submit"
             data-action="subject#favourite">

--- a/templates/components/magazine_sub.html.twig
+++ b/templates/components/magazine_sub.html.twig
@@ -16,7 +16,6 @@
                 <i class="fa-sharp fa-solid fa-folder-plus" aria-hidden="true"></i><span>{{ 'subscribe'|trans }}</span>
             {% endif %}
         </button>
-        <input type="hidden" name="token" value="{{ csrf_token('subscribe') }}">
     </form>
     <form action="{{ path('magazine_' ~ (is_magazine_blocked(magazine) ? 'unblock' : 'block'), {name: magazine.name}) }}"
           name="magazine_block"
@@ -26,6 +25,5 @@
                 data-action="subs#send">
             <i class="fa-solid fa-ban" aria-hidden="true"></i><span>{{ is_magazine_blocked(magazine) ? 'unblock'|trans : 'block'|trans }}</span>
         </button>
-        <input type="hidden" name="token" value="{{ csrf_token('block') }}">
     </form>
 </aside>

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -128,7 +128,6 @@
                             <form method="post"
                                   action="{{ path('post_restore', {magazine_name: post.magazine.name, post_id: post.id}) }}"
                                   data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
-                                <input type="hidden" name="token" value="{{ csrf_token('post_restore') }}">
                                 <button type="submit">{{ 'restore'|trans }}</button>
                             </form>
                         </li>

--- a/templates/components/user_actions.html.twig
+++ b/templates/components/user_actions.html.twig
@@ -18,7 +18,6 @@
             {% endif %}
 
             </button>
-            <input type="hidden" name="token" value="{{ csrf_token('follow') }}">
         </form>
         <form action="{{ path('user_' ~ (is_user_blocked(user) ? 'unblock' : 'block'), {username: user.username}) }}"
               name="user_block"
@@ -34,7 +33,6 @@
             {% endif %}
 
             </button>
-            <input type="hidden" name="token" value="{{ csrf_token('block') }}">
         </form>
         <a href="{{ path('messages_create', {username: user.username}) }}" title="{{ 'direct_message'|trans }}" aria-label="{{ 'direct_message'|trans }}">
             <button class="btn btn__secondary">

--- a/templates/components/vote.html.twig
+++ b/templates/components/vote.html.twig
@@ -33,7 +33,6 @@
                 data-action="subject#vote">
             <span data-subject-target="favCounter">{{ subject.apLikeCount ?? subject.favouriteCount }}</span> <span><i class="fa-solid fa-arrow-up" aria-hidden="true"></i></span>
         </button>
-        <input type="hidden" name="token" value="{{ csrf_token('up_vote') }}">
     </form>
     {% set downvoteMode = mbin_downvotes_mode() %}
     {% if showDownvote and downvoteMode is not same as DOWNVOTES_DISABLED %}
@@ -51,7 +50,6 @@
                 {% endif %}
                 <span><i class="fa-solid fa-arrow-down" aria-hidden="true"></i></span>
             </button>
-            <input type="hidden" name="token" value="{{ csrf_token('down_vote') }}">
         </form>
     {% endif %}
 </aside>

--- a/templates/notifications/front.html.twig
+++ b/templates/notifications/front.html.twig
@@ -19,14 +19,12 @@
     <div class="pills">
         <div>
             <form action="{{ path('notifications_read') }}" method="POST" class="me-2">
-                <input type="hidden" name="token" value="{{ csrf_token('read_notifications') }}">
                 <button class="btn btn__primary" type="submit">
                     {{ 'read_all'|trans }}
                 </button>
             </form>
             <form method="post" action="{{ path('notifications_clear') }}"
                   data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
-                <input type="hidden" name="token" value="{{ csrf_token('clear_notifications') }}">
                 <button class="btn btn__secondary" type="submit">
                     <i class="fa-solid fa-dumpster" aria-hidden="true"></i> <span>{{ 'purge'|trans }}</span>
                 </button>

--- a/templates/post/_menu.html.twig
+++ b/templates/post/_menu.html.twig
@@ -51,7 +51,6 @@
                 <form method="post"
                         action="{{ post_delete_url(post) }}"
                         data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
-                    <input type="hidden" name="token" value="{{ csrf_token('post_delete') }}">
                     <button type="submit">{{ 'delete'|trans }}</button>
                 </form>
             </li>

--- a/templates/post/_moderate_panel.html.twig
+++ b/templates/post/_moderate_panel.html.twig
@@ -32,7 +32,6 @@
             <form action="{{ post_delete_url(post) }}"
                   method="post"
                   data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
-                <input type="hidden" name="token" value="{{ csrf_token('post_delete') }}">
                 <button type="submit" class="btn btn__secondary">
                     <i class="fa fa-dumpster" aria-hidden="true"></i> <span>{{ 'delete'|trans }}</span>
                 </button>
@@ -43,7 +42,6 @@
                 <form action="{{ path('post_purge', {magazine_name: post.magazine.name, post_id: post.id,}) }}"
                       method="post"
                       data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
-                    <input type="hidden" name="token" value="{{ csrf_token('post_purge') }}">
                     <button type="submit" class="btn btn__danger">
                         <i class="fa fa-dumpster" aria-hidden="true"></i> <span>{{ 'purge'|trans }}</span>
                     </button>


### PR DESCRIPTION
After seeing a lot of "Invalid CSRF token" errors. It could be because we are actually using Redis. According to their [own docs](https://symfony.com/doc/current/session.html#store-sessions-in-a-key-value-database-redis) it says:

> Symfony will now use your Redis server to read and write the session data. The main drawback of this solution is that Redis does not perform session locking, so you can face race conditions when accessing sessions. For example, you may see an "Invalid CSRF token" error because two requests were made in parallel and only the first one stored the CSRF token in the session.


- Move to DB sessions
- Remove unused CSRF tokens from both PHP & forms. This will automatically now also take care of no longer generating CSRF tokens for anonymous visitors (eg. users that aren't logged-in or bots). 



**Background**

We still do not want to use sessions files. So this PR is trying to move away from Redis _towards_ PostgreSQL DB storage, which still allows horizontal scaling across multiple instances. The PR also include a migration file for introducing the correct `sessions` table.

I also took a closer look at all the session, cookies options. I believe we can improve here as well especially since people also get logged out too soon. We do not want to set garage collection lifetime (this normally log out people after an given idle period). And the normal session/cookie lifetime can be very high ([normally in months or even year](https://symfony.com/doc/current/session.html#session-idle-time-keep-alive)), so I increase this to 4 months now.