### PR TITLE
Increase the interval for fetch_user_notifications

### DIFF
--- a/assets/controllers/notifications_controller.js
+++ b/assets/controllers/notifications_controller.js
@@ -116,7 +116,7 @@ export default class extends Controller {
                 if (typeof data.messages === "number") {
                     this.setMessageCount(data.messages)
                 }
-                window.setTimeout(() => this.fetchAndSetNewNotificationAndMessageCount(), 10 * 1000)
+                window.setTimeout(() => this.fetchAndSetNewNotificationAndMessageCount(), 30 * 1000)
             })
     }
 


### PR DESCRIPTION
Users just leave the site open for hours and hours. And days after days.. Weeks after weeks.

With only a very small user base on kbin.melroy.org, I'm seeing 25694 requests in just 12 hours! Because it's getting trigger every 10 secs.

![image](https://github.com/user-attachments/assets/7fa22778-4e0e-4736-9d58-a9c238858f9d)

My proposal is to reduce the Ajax interval from 10 seconds to 30 seconds. After each new page load, this call will be executed anyways, so this `setTimeout` is only for checking for new notifications if people leave the site / browser tab open. 30 seconds is still plenty enough IMO.

I know the API request itself might not be very heavy, but these numbers are a bit absurd high for such a small instance. 