### PR TITLE
Fix the docker build error due to an old symfon/cache version

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7734,16 +7734,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v7.1.4",
+            "version": "v7.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "b61e464d7687bb7e8f677d5031c632bf3820df18"
+                "reference": "86e5296b10e4dec8c8441056ca606aedb8a3be0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/b61e464d7687bb7e8f677d5031c632bf3820df18",
-                "reference": "b61e464d7687bb7e8f677d5031c632bf3820df18",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/86e5296b10e4dec8c8441056ca606aedb8a3be0a",
+                "reference": "86e5296b10e4dec8c8441056ca606aedb8a3be0a",
                 "shasum": ""
             },
             "require": {
@@ -7811,7 +7811,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v7.1.4"
+                "source": "https://github.com/symfony/cache/tree/v7.1.5"
             },
             "funding": [
                 {
@@ -7827,7 +7827,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-12T09:59:40+00:00"
+            "time": "2024-09-17T09:16:35+00:00"
         },
         {
             "name": "symfony/cache-contracts",


### PR DESCRIPTION
Fixes



    [php builder-composer 7/7] RUN composer run-script --no-dev post-install-cmd && chmod +x bin/console && sync:
    0.627
    0.627 Run composer recipes at any time to see the status of your Symfony recipes.
    0.627
    0.658 Executing script cache:clear [KO]
    3.345 [KO]
    3.345 Script cache:clear returned with error code 255
    3.345 !! PHP Fatal error: Declaration of Symfony\Component\Cache\Traits\Redis6ProxyTrait::hSet($key, $fields_and_vals): Redis|int|false must be compatible with Redis::hSet(string $key, mixed ...$fields_and_vals): Redis|int|false in /var/www/mbin/vendor/symfony/cache/Traits/Redis6ProxyTrait.php on line 30
    3.345 !!

    3.345 Script @auto-scripts was called via post-install-cmd

    failed to solve: process "/bin/sh -c composer run-script --no-dev post-install-cmd && chmod +x bin/console && sync" did not complete successfully: exit code: 255

