### PR TITLE
Use composer audit & npm audit

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -95,15 +95,37 @@ jobs:
           SYMFONY_DEPRECATIONS_HELPER: disabled
         run: php bin/phpunit tests/Unit
 
-  security-check:
+  audit-check:
     runs-on: ubuntu-latest
     container:
       image: danger89/mbin-pipeline:1.2.0
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run security checker
-        run: local-php-security-checker
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Calculate composer.lock hash
+        id: composer-lock-hash
+        run: |
+          echo "hash=$(md5sum composer.lock)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ steps.composer-lock-hash.outputs.hash }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - run: cp .env.example .env
+      - name: Composer install
+        run: composer install --no-scripts --no-progress
+
+      - name: Run Composer audit
+        env:
+          COMPOSER_AUDIT_ABANDONED: ignore
+        run: composer audit
 
   fixer-dry-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -100,6 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: danger89/mbin-pipeline:1.2.0
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -59,6 +59,7 @@ jobs:
         run: npm ci --include=dev
         env:
           NODE_ENV: production
+
       - name: Build frontend (production)
         run: npm run build
 
@@ -121,6 +122,9 @@ jobs:
       - run: cp .env.example .env
       - name: Composer install
         run: composer install --no-scripts --no-progress
+
+      - name: Run Npm audit
+        run: npm audit --omit=dev
 
       - name: Run Composer audit
         env:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For developers:
 - Improved [bare metal/VM guide](https://docs.joinmbin.org/admin/installation/bare_metal) and [Docker guide](https://docs.joinmbin.org/admin/installation/docker/)
 - [Improved Docker setup](https://github.com/MbinOrg/mbin/pulls?q=is%3Apr+is%3Amerged+label%3Adocker)
 - _Developer_ server explained (see [Development Server documentation here](https://docs.joinmbin.org/contributing/development_server) )
-- GitHub Security advisories, vulnerability reporting, [Dependabot](https://github.com/features/security) and [Advanced code scanning](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning) enabled. And we run [`local-php-security-checker`](https://github.com/fabpot/local-php-security-checker).
+- GitHub Security advisories, vulnerability reporting, [Dependabot](https://github.com/features/security) and [Advanced code scanning](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning) enabled. And we run `composer audit`.
 - Improved **code documentation**
 - **Tight integration** with [Mbin Weblate project](https://hosted.weblate.org/engage/mbin/) for translations (Two way sync)
 - Last but not least, a **community-focus project embracing the [Collective Code Construction Contract](./C4.md)** (C4). No single maintainer.
@@ -291,7 +291,6 @@ Unofficial magazines:
 	<tbody>
 </table>
 <!-- readme: contributors -end -->
-
 
 ## Getting Started
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -17,11 +17,5 @@ RUN chmod +x /usr/local/bin/install-php-extensions
 
 RUN install-php-extensions amqp intl redis gd zip bcmath xsl
 
-# Install local-php-security-checker (same as used by "symfony security:check")
-RUN curl -sSLf \
-  -o /usr/local/bin/local-php-security-checker \
-  https://github.com/fabpot/local-php-security-checker/releases/download/v2.1.3/local-php-security-checker_linux_amd64
-RUN chmod +x /usr/local/bin/local-php-security-checker
-
 # Unlimited memory
 RUN echo "memory_limit = -1" >>/usr/local/etc/php/conf.d/docker-php-memlimit.ini


### PR DESCRIPTION
[Local PHP Security Checker repo is archived](https://github.com/fabpot/local-php-security-checker), and recommends to use `composer audit`:

```
COMPOSER_AUDIT_ABANDONED=ignore composer audit
```

So we don't depend anymore on this `local-php-security-checker` script, remove it from the Dockerfile for CICD and change both the README & workflow files.

Finally, I renamed the job from `security-check` to `audit-check`, to be consistent with the commands we are using (I will fix that in the branch settings when you approve it). Example of the audit check job: https://github.com/MbinOrg/mbin/actions/runs/11262147066/job/31317174935?pr=1179

More info: https://github.com/fabpot/local-php-security-checker