### PR TITLE
Exclude InvalidApPostException from rolling back the transaction

### DIFF
--- a/src/MessageHandler/ActivityPub/Outbox/DeliverHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/DeliverHandler.php
@@ -53,6 +53,7 @@ class DeliverHandler extends MbinMessageHandler
             $this->doWork($message);
             $conn->commit();
         } catch (InvalidApPostException $e) {
+            $conn->commit();
             // we don't roll back on an InvalidApPostException, so the failed delivery attempt gets written to the DB
             throw $e;
         } catch (\Exception $e) {

--- a/src/MessageHandler/ActivityPub/Outbox/DeliverHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/DeliverHandler.php
@@ -42,6 +42,27 @@ class DeliverHandler extends MbinMessageHandler
         $this->workWrapper($message);
     }
 
+    public function workWrapper(MessageInterface $message): void
+    {
+        $conn = $this->entityManager->getConnection();
+        if (!$conn->isConnected()) {
+            $conn->connect();
+        }
+        $conn->beginTransaction();
+        try {
+            $this->doWork($message);
+            $conn->commit();
+        } catch (InvalidApPostException $e) {
+            // we don't roll back on an InvalidApPostException, so the failed delivery attempt gets written to the DB
+            throw $e;
+        } catch (\Exception $e) {
+            $conn->rollBack();
+            throw $e;
+        }
+
+        $conn->close();
+    }
+
     public function doWork(MessageInterface $message): void
     {
         if (!($message instanceof DeliverMessage)) {


### PR DESCRIPTION
Overwrite the default workWrapper method so the `transactional` method is not called. Instead implement a custom behaviour that does not roll back the db changes if the exception was a `InvalidApPostException`