### PR TITLE
Fix private comments being retrieved via API

### DIFF
--- a/src/Controller/Api/Entry/Comments/EntryCommentsRetrieveApi.php
+++ b/src/Controller/Api/Entry/Comments/EntryCommentsRetrieveApi.php
@@ -155,8 +155,13 @@ class EntryCommentsRetrieveApi extends EntriesBaseApi
 
         $dtos = [];
         foreach ($comments->getCurrentPageResults() as $value) {
-            \assert($value instanceof EntryComment);
-            array_push($dtos, $this->serializeCommentTree($value));
+            try {
+                \assert($value instanceof EntryComment);
+                $this->handlePrivateContent($value);
+                array_push($dtos, $this->serializeCommentTree($value));
+            } catch (\Exception $e) {
+                continue;
+            }
         }
 
         return new JsonResponse(


### PR DESCRIPTION
This change applies the same behaviour to the `EntryCommentsRetrieveApi` that is found in the `EntriesRetrieveApi`, `PostsRetrieveApi` and `PostCommentsRetrieveApi`:
- https://github.com/MbinOrg/mbin/blob/24ed9529fc409a32899f9d4920c385f5be699bee/src/Controller/Api/Entry/EntriesRetrieveApi.php#L301-L309
- https://github.com/MbinOrg/mbin/blob/24ed9529fc409a32899f9d4920c385f5be699bee/src/Controller/Api/Post/PostsRetrieveApi.php#L191-L199
- https://github.com/MbinOrg/mbin/blob/a1e47bc8da24dc8ea36b9b6fe4452a3cc3e42e68/src/Controller/Api/Post/Comments/PostCommentsRetrieveApi.php#L201-L209