### PR TITLE
Improve Nginx logging, by introducing a separate inbox log

### DIFF
--- a/docs/02-admin/01-installation/bare_metal.md
+++ b/docs/02-admin/01-installation/bare_metal.md
@@ -62,6 +62,8 @@ sudo php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=compose
 
 If you have a firewall installed (or you're behind a NAT), be sure to open port `443` for the web server. Mbin should run behind a reverse proxy like Nginx.
 
+For Nginx see: [Nginx configuration](../02-configuration/nginx.md).
+
 ## Install NodeJS (frontend tools)
 
 1. Prepare & download keyring:

--- a/docs/02-admin/01-installation/docker.md
+++ b/docs/02-admin/01-installation/docker.md
@@ -191,6 +191,19 @@ files.
 NGINX reverse proxy example for the Mbin Docker instance:
 
 ```nginx
+# Map between POST requests on inbox vs the rest
+map $request $inboxRequest {
+    ~^POST\ \/f\/inbox   1;
+    ~^POST\ \/i\/inbox   1;
+    default              0;
+}
+
+map $request $regularRequest {
+    ~^POST\ \/f\/inbox  0;
+    ~^POST\ \/i\/inbox  0;
+    default             1;
+}
+
 # Redirect HTTP to HTTPS
 server {
     server_name domain.tld;
@@ -200,7 +213,8 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
+    http2 on;
     server_name domain.tld;
 
     charset utf-8;
@@ -225,7 +239,8 @@ server {
 
     # Logs
     error_log /var/log/nginx/mbin_error.log;
-    access_log /var/log/nginx/mbin_access.log;
+    access_log /var/log/nginx/mbin_access.log if=$regularRequest;
+    access_log /var/log/nginx/mbin_inbox.log if=$inboxRequest;
 
     location / {
         proxy_set_header HOST $host;

--- a/docs/02-admin/01-installation/docker.md
+++ b/docs/02-admin/01-installation/docker.md
@@ -200,12 +200,9 @@ map $request $inboxRequest {
     default                 0;
 }
 
-map $request $regularRequest {
-    ~^POST\ \/f\/inbox      0;
-    ~^POST\ \/i\/inbox      0;
-    ~^POST\ \/m\/.+\/inbox  0;
-    ~^POST\ \/u\/.+\/inbox  0;
-    default                 1;
+map $inboxRequest $regularRequest {
+    1 0;
+    default 1;
 }
 
 # Redirect HTTP to HTTPS

--- a/docs/02-admin/01-installation/docker.md
+++ b/docs/02-admin/01-installation/docker.md
@@ -193,15 +193,19 @@ NGINX reverse proxy example for the Mbin Docker instance:
 ```nginx
 # Map between POST requests on inbox vs the rest
 map $request $inboxRequest {
-    ~^POST\ \/f\/inbox   1;
-    ~^POST\ \/i\/inbox   1;
-    default              0;
+    ~^POST\ \/f\/inbox      1;
+    ~^POST\ \/i\/inbox      1;
+    ~^POST\ \/m\/.+\/inbox  1;
+    ~^POST\ \/u\/.+\/inbox  1;
+    default                 0;
 }
 
 map $request $regularRequest {
-    ~^POST\ \/f\/inbox  0;
-    ~^POST\ \/i\/inbox  0;
-    default             1;
+    ~^POST\ \/f\/inbox      0;
+    ~^POST\ \/i\/inbox      0;
+    ~^POST\ \/m\/.+\/inbox  0;
+    ~^POST\ \/u\/.+\/inbox  0;
+    default                 1;
 }
 
 # Redirect HTTP to HTTPS

--- a/docs/02-admin/01-installation/docker.md
+++ b/docs/02-admin/01-installation/docker.md
@@ -244,7 +244,7 @@ server {
     # Logs
     error_log /var/log/nginx/mbin_error.log;
     access_log /var/log/nginx/mbin_access.log if=$regularRequest;
-    access_log /var/log/nginx/mbin_inbox.log if=$inboxRequest;
+    access_log /var/log/nginx/mbin_inbox.log if=$inboxRequest buffer=32k flush=5m;
 
     location / {
         proxy_set_header HOST $host;

--- a/docs/02-admin/02-configuration/nginx.md
+++ b/docs/02-admin/02-configuration/nginx.md
@@ -141,7 +141,7 @@ server {
     # Logs
     error_log /var/log/nginx/mbin_error.log;
     access_log /var/log/nginx/mbin_access.log if=$regularRequest;
-    access_log /var/log/nginx/mbin_inbox.log if=$inboxRequest;
+    access_log /var/log/nginx/mbin_inbox.log if=$inboxRequest buffer=32k flush=5m;
 
     location / {
         # try to serve file directly, fallback to index.php

--- a/docs/02-admin/02-configuration/nginx.md
+++ b/docs/02-admin/02-configuration/nginx.md
@@ -85,6 +85,19 @@ sudo nano /etc/nginx/sites-available/mbin.conf
 With the content:
 
 ```nginx
+# Map between POST requests on inbox vs the rest
+map $request $inboxRequest {
+    ~^POST\ \/f\/inbox   1;
+    ~^POST\ \/i\/inbox   1;
+    default              0;
+}
+
+map $request $regularRequest {
+    ~^POST\ \/f\/inbox  0;
+    ~^POST\ \/i\/inbox  0;
+    default             1;
+}
+
 # Redirect HTTP to HTTPS
 server {
     server_name domain.tld;
@@ -123,15 +136,16 @@ server {
 
     # Logs
     error_log /var/log/nginx/mbin_error.log;
-    access_log /var/log/nginx/mbin_access.log;
+    access_log /var/log/nginx/mbin_access.log if=$regularRequest;
+    access_log /var/log/nginx/mbin_inbox.log if=$inboxRequest;
 
     location / {
-        # try to serve file directly, fallback to app.php
+        # try to serve file directly, fallback to index.php
         try_files $uri /index.php$is_args$args;
     }
 
     location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
+    location = /robots.txt  { allow all; access_log off; log_not_found off; }
 
     location /.well-known/mercure {
         proxy_pass http://127.0.0.1:3000$request_uri;
@@ -167,30 +181,23 @@ server {
       try_files $uri $uri/ /index.php?$query_string;
     }
 
-    # assets, documents, archives, media
-    location ~* \.(?:css(\.map)?|js(\.map)?|jpe?g|png|tgz|gz|rar|bz2|doc|pdf|ptt|tar|gif|ico|cur|heic|webp|tiff?|mp3|m4a|aac|ogg|midi?|wav|mp4|mov|webm|mpe?g|avi|ogv|flv|wmv)$ {
+    # Static assets
+    location ~* \.(?:css(\.map)?|js(\.map)?|jpe?g|png|tgz|gz|rar|bz2|doc|pdf|ptt|tar|gif|ico|cur|heic|webp|tiff?|mp3|m4a|aac|ogg|midi?|wav|mp4|mov|webm|mpe?g|avi|ogv|flv|wmv|svgz?|ttf|ttc|otf|eot|woff2?)$ {
         expires    30d;
         add_header Access-Control-Allow-Origin "*";
         add_header Cache-Control "public, no-transform";
         access_log off;
-    }
-
-    # svg, fonts
-    location ~* \.(?:svgz?|ttf|ttc|otf|eot|woff2?)$ {
-        expires    30d;
-        add_header Access-Control-Allow-Origin "*";
-        add_header Cache-Control "public, no-transform";
-        access_log off;
-    }
-
-    location ~ /\.(?!well-known).* {
-        deny all;
     }
 
     # return 404 for all other php files not matching the front controller
     # this prevents access to other php files you don't want to be accessible.
     location ~ \.php$ {
         return 404;
+    }
+
+    # Deny dot folders and files, except for the .well-known folder
+    location ~ /\.(?!well-known).* {
+        deny all;
     }
 }
 ```

--- a/docs/02-admin/02-configuration/nginx.md
+++ b/docs/02-admin/02-configuration/nginx.md
@@ -94,12 +94,9 @@ map $request $inboxRequest {
     default                 0;
 }
 
-map $request $regularRequest {
-    ~^POST\ \/f\/inbox      0;
-    ~^POST\ \/i\/inbox      0;
-    ~^POST\ \/m\/.+\/inbox  0;
-    ~^POST\ \/u\/.+\/inbox  0;
-    default                 1;
+map $inboxRequest $regularRequest {
+    1 0;
+    default 1;
 }
 
 # Redirect HTTP to HTTPS

--- a/docs/02-admin/02-configuration/nginx.md
+++ b/docs/02-admin/02-configuration/nginx.md
@@ -87,15 +87,19 @@ With the content:
 ```nginx
 # Map between POST requests on inbox vs the rest
 map $request $inboxRequest {
-    ~^POST\ \/f\/inbox   1;
-    ~^POST\ \/i\/inbox   1;
-    default              0;
+    ~^POST\ \/f\/inbox      1;
+    ~^POST\ \/i\/inbox      1;
+    ~^POST\ \/m\/.+\/inbox  1;
+    ~^POST\ \/u\/.+\/inbox  1;
+    default                 0;
 }
 
 map $request $regularRequest {
-    ~^POST\ \/f\/inbox  0;
-    ~^POST\ \/i\/inbox  0;
-    default             1;
+    ~^POST\ \/f\/inbox      0;
+    ~^POST\ \/i\/inbox      0;
+    ~^POST\ \/m\/.+\/inbox  0;
+    ~^POST\ \/u\/.+\/inbox  0;
+    default                 1;
 }
 
 # Redirect HTTP to HTTPS

--- a/docs/02-admin/05-troubleshooting/bare_metal.md
+++ b/docs/02-admin/05-troubleshooting/bare_metal.md
@@ -29,12 +29,12 @@ Or:
 
 Web-server (Nginx):
 
-- `sudo tail -f /var/log/nginx/mbin_access.log`
-- `sudo tail -f /var/log/nginx/mbin_error.log`
+- Normal access log: `sudo tail -f /var/log/nginx/mbin_access.log`
+- Inbox access log: `sudo tail -f /var/log/nginx/mbin_inbox.log`
+- Error log: `sudo tail -f /var/log/nginx/mbin_error.log`
 
 ## Debugging
 
 **Please, check the logs above first.** If you are really stuck, visit to our [Matrix space](https://matrix.to/#/%23mbin:melroy.org), there is a 'General' room and dedicated room for 'Issues/Support'.
 
 Test PostgreSQL connections if using a remote server, same with Redis (or KeyDB is you are using that instead). Ensure no firewall rules blocking are any incoming or out-coming traffic (eg. port on 80 and 443).
-


### PR DESCRIPTION
- Split inbox requests and other access requests logs in Nginx, for both bare metal & Docker
   - Outbox is so less, so I didn't bother splitting that into a separate log file, it's less of an issue. But the **inbox** end-point is heavily requested.
- Extend troubleshooting page
- Combine the static assets section
- Improve Nginx configuration / improve markdown.
- Add `buffer=32k flush=5m` to the inbox.log, to reduce disk I/O!

**Rationale:** This makes debugging easier as well as reduce the strain on logging parsers and/or dashboards like Grafana or alike. Since the `inbox` boxes are receiving a lot of requests per second/minute or day. Filtering the inbox requests to a separate log will help a lot.

This PR allows you to manage the logs and processing of them (or exclude the inbox log for example) much easier when you're using external tools.

Inspired by: https://lemmy.cafe/u/Illecors

---

An alternative approach using variables in the log file was been tested as well, however this will hamper performance due to: `the file is opened and closed for each log write. ` See also: http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log. So I'm not implementing a variable in the log file path.