### PR TITLE
Fine-tune messenger retry strategy 

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -17,10 +17,10 @@ framework:
                     exchange:
                         name: async
                 retry_strategy:
-                    max_retries: 7
+                    max_retries: 5
                     delay: 300000
                     multiplier: 4
-                    max_delay: 86400000
+                    max_delay: 76800000
                     jitter: 0
                 serializer: messenger.transport.symfony_serializer
             inbox:
@@ -34,10 +34,10 @@ framework:
                     exchange:
                         name: inbox
                 retry_strategy:
-                    max_retries: 7
+                    max_retries: 5
                     delay: 300000
                     multiplier: 4
-                    max_delay: 86400000
+                    max_delay: 76800000
                     jitter: 0
                 serializer: messenger.transport.symfony_serializer
             receive:
@@ -51,10 +51,10 @@ framework:
                     exchange:
                         name: receive
                 retry_strategy:
-                    max_retries: 7
+                    max_retries: 5
                     delay: 300000
                     multiplier: 4
-                    max_delay: 86400000
+                    max_delay: 76800000
                     jitter: 0
                 serializer: messenger.transport.symfony_serializer
             deliver:
@@ -68,10 +68,10 @@ framework:
                     exchange:
                         name: deliver
                 retry_strategy:
-                    max_retries: 7
+                    max_retries: 5
                     delay: 300000
                     multiplier: 4
-                    max_delay: 86400000
+                    max_delay: 76800000
                     jitter: 0
                 serializer: messenger.transport.symfony_serializer
             outbox:
@@ -85,10 +85,10 @@ framework:
                     exchange:
                         name: outbox
                 retry_strategy:
-                    max_retries: 7
+                    max_retries: 5
                     delay: 300000
                     multiplier: 4
-                    max_delay: 86400000
+                    max_delay: 76800000
                     jitter: 0
                 serializer: messenger.transport.symfony_serializer
             resolve:
@@ -102,10 +102,10 @@ framework:
                     exchange:
                         name: resolve
                 retry_strategy:
-                    max_retries: 7
+                    max_retries: 5
                     delay: 300000
                     multiplier: 4
-                    max_delay: 86400000
+                    max_delay: 76800000
                     jitter: 0
                 serializer: messenger.transport.symfony_serializer
             old:
@@ -114,10 +114,10 @@ framework:
                     queues:
                         messages: ~
                 retry_strategy:
-                    max_retries: 7
+                    max_retries: 5
                     delay: 300000
                     multiplier: 4
-                    max_delay: 86400000
+                    max_delay: 76800000
                     jitter: 0
                 serializer: messenger.transport.symfony_serializer
             failed:


### PR DESCRIPTION
Since RabbitMQ is unable to handle huge amount of queue sizes and backlogs, when hitting above 200k messages or higher, RabbitMQ will drain slowly to a halt. And CPU usage will spike.

To prevent this, I & Jerry are running the follow retry strategy for the past months instead. To avoid stability issues with RabbitMQ proactively, reducing the retries looks very promising to us. Even when running RabbitMQ v4.0.

- Changing max retries from `7` to `5`
- And with that, change max. delay from `86400000` to `76800000`

We have observed, in case of network / congestions issues on my server and/or when running a large instance like @Jerry-infosecexchange , that decrease the RabbitMQ retries queues benefit a lot in terms of stability of RabbitMQ. 

Above changes are still plenty of retries with a long enough delay duration.
