### PR TITLE
[Feature] Admin approval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,9 @@ S3_VERSION=
 # Only let admins generated oauth clients
 KBIN_ADMIN_ONLY_OAUTH_CLIENTS=false
 
+# Manually approve every new user
+MBIN_NEW_USERS_NEED_APPROVAL=false
+
 # oAuth (optional)
 OAUTH_AZURE_ID=
 OAUTH_AZURE_SECRET=

--- a/.env.example_docker
+++ b/.env.example_docker
@@ -70,6 +70,9 @@ S3_VERSION=
 # Only let admins generate oauth clients
 KBIN_ADMIN_ONLY_OAUTH_CLIENTS=false
 
+# Manually approve every new user
+MBIN_NEW_USERS_NEED_APPROVAL=false
+
 # oAuth (optional)
 OAUTH_AZURE_ID=
 OAUTH_AZURE_SECRET=

--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,7 @@
         "twig/extra-bundle": "^3.10.0",
         "twig/html-extra": "^3.10.0",
         "twig/intl-extra": "^3.10.0",
-        "twig/twig": "^3.10.3",
+        "twig/twig": "^3.15.0",
         "webmozart/assert": "^1.11.0",
         "wohali/oauth2-discord-new": "^1.2.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b66e16b3d61acf4006bbcacb3a1af7a",
+    "content-hash": "4412672911f84ad7d4f12c4bcdd288fb",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -14643,16 +14643,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.14.2",
+            "version": "v3.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "0b6f9d8370bb3b7f1ce5313ed8feb0fafd6e399a"
+                "reference": "2d5b3964cc21d0188633d7ddce732dc8e874db02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/0b6f9d8370bb3b7f1ce5313ed8feb0fafd6e399a",
-                "reference": "0b6f9d8370bb3b7f1ce5313ed8feb0fafd6e399a",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/2d5b3964cc21d0188633d7ddce732dc8e874db02",
+                "reference": "2d5b3964cc21d0188633d7ddce732dc8e874db02",
                 "shasum": ""
             },
             "require": {
@@ -14706,7 +14706,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.14.2"
+                "source": "https://github.com/twigphp/Twig/tree/v3.15.0"
             },
             "funding": [
                 {
@@ -14718,7 +14718,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-07T12:36:22+00:00"
+            "time": "2024-11-17T15:59:19+00:00"
         },
         {
             "name": "web-token/jwt-library",
@@ -17846,7 +17846,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -17862,6 +17862,6 @@
         "ext-openssl": "*",
         "ext-redis": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/config/kbin_routes/admin.yaml
+++ b/config/kbin_routes/admin.yaml
@@ -77,6 +77,21 @@ admin_magazine_ownership_requests_reject:
     path: /admin/magazine_ownership/{name}/{username}/reject
     methods: [POST]
 
+admin_signup_requests:
+    controller: App\Controller\Admin\AdminSignupRequestsController::requests
+    path: /admin/signup_requests
+    methods: [ GET ]
+
+admin_signup_requests_approve:
+    controller: App\Controller\Admin\AdminSignupRequestsController::approve
+    path: /admin/signup_requests/{id}/approve
+    methods: [ POST ]
+
+admin_signup_requests_reject:
+    controller: App\Controller\Admin\AdminSignupRequestsController::reject
+    path: /admin/signup_requests/{id}/reject
+    methods: [ POST ]
+
 admin_cc:
     controller: App\Controller\Admin\AdminClearCacheController
     path: /admin/cc

--- a/config/kbin_routes/admin_api.yaml
+++ b/config/kbin_routes/admin_api.yaml
@@ -111,3 +111,21 @@ api_admin_purge_magazine:
   path: /api/admin/magazine/{magazine_id}/purge
   methods: [ DELETE ]
   format: json
+
+api_admin_view_user_applications:
+    controller: App\Controller\Api\User\Admin\UserApplicationApi::retrieve
+    path: /api/admin/users/applications
+    methods: [ GET ]
+    format: json
+
+api_admin_view_user_application_approve:
+    controller: App\Controller\Api\User\Admin\UserApplicationApi::approve
+    path: /api/admin/users/applications/{user_id}/approve
+    methods: [ GET ]
+    format: json
+
+api_admin_view_user_application_reject:
+    controller: App\Controller\Api\User\Admin\UserApplicationApi::reject
+    path: /api/admin/users/applications/{user_id}/reject
+    methods: [ GET ]
+    format: json

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -3,6 +3,7 @@ doctrine:
         url: '%env(resolve:DATABASE_URL)%'
         types:
             citext: App\DoctrineExtensions\DBAL\Types\Citext
+            enumApplicationStatus: App\DoctrineExtensions\DBAL\Types\EnumApplicationStatus
         mapping_types:
             user_type: string
             citext: citext

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -113,6 +113,8 @@ parameters:
     mbin_downvotes_mode_default: 'enabled'
     mbin_downvotes_mode: '%env(enum:\App\Utils\DownvotesMode:default:mbin_downvotes_mode_default:MBIN_DOWNVOTES_MODE)%'
 
+    mbin_new_users_need_approval: '%env(bool:default::MBIN_NEW_USERS_NEED_APPROVAL)%'
+
 services:
     # default configuration for services in *this* file
     _defaults:
@@ -182,6 +184,7 @@ services:
             $mbinSsoOnlyMode: '%sso_only_mode%'
             $maxImageBytes: '%max_image_bytes%'
             $mbinDownvotesMode: '%mbin_downvotes_mode%'
+            $mbinNewUsersNeedApproval: '%mbin_new_users_need_approval%'
 
     # Markdown
     App\Markdown\Factory\EnvironmentFactory:

--- a/docs/02-admin/03-optional-features/user_application.md
+++ b/docs/02-admin/03-optional-features/user_application.md
@@ -1,0 +1,10 @@
+# Manually Approving New Users
+
+If you want to manually approve users before they can log into your server, 
+you can either tick the checkbox in the admin settings put this in the `.env` file:
+```dotenv
+MBIN_NEW_USERS_NEED_APPROVAL=true
+```
+
+You will then see a new admin panel called `Applications` where new users will appear until you approve or deny them.
+When you have decided on one or the other, the user will get an email notification about it.

--- a/migrations/Version20241104162329.php
+++ b/migrations/Version20241104162329.php
@@ -11,20 +11,20 @@ final class Version20241104162655 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Add application_text and is_approved to the user table';
+        return 'Add application_text and application_status to the user table';
     }
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE "user" ADD application_text VARCHAR(255) DEFAULT NULL');
-        $this->addSql('ALTER TABLE "user" ADD is_approved BOOLEAN DEFAULT true NOT NULL');
-        $this->addSql('ALTER TABLE "user" ADD is_rejected BOOLEAN DEFAULT false NOT NULL');
+        $this->addSql('CREATE TYPE enumApplicationStatus AS ENUM (\'Approved\', \'Rejected\', \'Pending\')');
+        $this->addSql('ALTER TABLE "user" ADD application_text TEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE "user" ADD application_status enumApplicationStatus DEFAULT \'Approved\' NOT NULL');
     }
 
     public function down(Schema $schema): void
     {
         $this->addSql('ALTER TABLE "user" DROP application_text');
-        $this->addSql('ALTER TABLE "user" DROP is_approved');
-        $this->addSql('ALTER TABLE "user" DROP is_rejected');
+        $this->addSql('ALTER TABLE "user" DROP application_status');
+        $this->addSql('DROP TYPE enumApplicationStatus');
     }
 }

--- a/migrations/Version20241104162329.php
+++ b/migrations/Version20241104162329.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241104162655 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add application_text and is_approved to the user table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" ADD application_text VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE "user" ADD is_approved BOOLEAN DEFAULT true NOT NULL');
+        $this->addSql('ALTER TABLE "user" ADD is_rejected BOOLEAN DEFAULT false NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" DROP application_text');
+        $this->addSql('ALTER TABLE "user" DROP is_approved');
+        $this->addSql('ALTER TABLE "user" DROP is_rejected');
+    }
+}

--- a/src/Command/UserCommand.php
+++ b/src/Command/UserCommand.php
@@ -35,7 +35,7 @@ class UserCommand extends Command
         $this->addArgument('username', InputArgument::REQUIRED)
             ->addArgument('email', InputArgument::REQUIRED)
             ->addArgument('password', InputArgument::REQUIRED)
-            ->addOption('applicationText', 'a', InputOption::VALUE_NONE, 'The application text of the user')
+            ->addOption('applicationText', 'a', InputOption::VALUE_REQUIRED, 'The application text of the user, if set the user will not be pre-approved')
             ->addOption('remove', 'r', InputOption::VALUE_NONE, 'Remove user')
             ->addOption('admin', null, InputOption::VALUE_NONE, 'Grant administrator privileges')
             ->addOption('moderator', null, InputOption::VALUE_NONE, 'Grant global moderator privileges');
@@ -70,10 +70,14 @@ class UserCommand extends Command
 
     private function createUser(InputInterface $input, SymfonyStyle $io): void
     {
-        $dto = (new UserDto())->create($input->getArgument('username'), $input->getArgument('email'));
+        $applicationText = $input->getOption('applicationText');
+        if ('' === $applicationText) {
+            $applicationText = null;
+        }
+        $dto = (new UserDto())->create($input->getArgument('username'), $input->getArgument('email'), applicationText: $applicationText);
         $dto->plainPassword = $input->getArgument('password');
 
-        $user = $this->manager->create($dto, false, false);
+        $user = $this->manager->create($dto, false, false, preApprove: null === $applicationText);
 
         if ($input->getOption('admin')) {
             $user->setOrRemoveAdminRole();

--- a/src/Command/UserCommand.php
+++ b/src/Command/UserCommand.php
@@ -35,6 +35,7 @@ class UserCommand extends Command
         $this->addArgument('username', InputArgument::REQUIRED)
             ->addArgument('email', InputArgument::REQUIRED)
             ->addArgument('password', InputArgument::REQUIRED)
+            ->addOption('applicationText', 'a', InputOption::VALUE_NONE, 'The application text of the user')
             ->addOption('remove', 'r', InputOption::VALUE_NONE, 'Remove user')
             ->addOption('admin', null, InputOption::VALUE_NONE, 'Grant administrator privileges')
             ->addOption('moderator', null, InputOption::VALUE_NONE, 'Grant global moderator privileges');

--- a/src/Controller/ActivityPub/User/UserController.php
+++ b/src/Controller/ActivityPub/User/UserController.php
@@ -25,6 +25,10 @@ class UserController extends AbstractController
             throw $this->createNotFoundException();
         }
 
+        if (!$user->isApproved || $user->isRejected) {
+            throw $this->createNotFoundException();
+        }
+
         if (!$user->isDeleted || null !== $user->markedForDeletionAt) {
             $response = new JsonResponse($this->personFactory->create($user, true));
         } else {

--- a/src/Controller/ActivityPub/User/UserController.php
+++ b/src/Controller/ActivityPub/User/UserController.php
@@ -6,6 +6,7 @@ namespace App\Controller\ActivityPub\User;
 
 use App\Controller\AbstractController;
 use App\Entity\User;
+use App\Enums\EApplicationStatus;
 use App\Factory\ActivityPub\PersonFactory;
 use App\Factory\ActivityPub\TombstoneFactory;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -25,7 +26,7 @@ class UserController extends AbstractController
             throw $this->createNotFoundException();
         }
 
-        if (!$user->isApproved || $user->isRejected) {
+        if (EApplicationStatus::Approved !== $user->getApplicationStatus()) {
             throw $this->createNotFoundException();
         }
 

--- a/src/Controller/Admin/AdminSignupRequestsController.php
+++ b/src/Controller/Admin/AdminSignupRequestsController.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Controller\AbstractController;
+use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Service\UserManager;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+class AdminSignupRequestsController extends AbstractController
+{
+    public function __construct(
+        private readonly UserRepository $repository,
+        private readonly UserManager $userManager,
+    ) {
+    }
+
+    #[IsGranted('ROLE_ADMIN')]
+    public function requests(#[MapQueryParameter] int $page): Response
+    {
+        $requests = $this->repository->findAllSignupRequestsPaginated($page);
+
+        return $this->render('admin/signup_requests.html.twig', [
+            'requests' => $requests,
+            'page' => $page,
+        ]);
+    }
+
+    #[IsGranted('ROLE_ADMIN')]
+    public function approve(#[MapQueryParameter] int $page, #[MapEntity(id: 'id')] User $user): Response
+    {
+        $this->userManager->approveUserApplication($user);
+
+        return $this->redirectToRoute('admin_signup_requests', ['page' => $page]);
+    }
+
+    #[IsGranted('ROLE_ADMIN')]
+    public function reject(#[MapQueryParameter] int $page, #[MapEntity(id: 'id')] User $user): Response
+    {
+        $this->userManager->rejectUserApplication($user);
+
+        return $this->redirectToRoute('admin_signup_requests', ['page' => $page]);
+    }
+}

--- a/src/Controller/Api/BaseApi.php
+++ b/src/Controller/Api/BaseApi.php
@@ -40,10 +40,12 @@ use App\Repository\OAuth2ClientAccessRepository;
 use App\Repository\PostCommentRepository;
 use App\Repository\PostRepository;
 use App\Repository\TagLinkRepository;
+use App\Repository\UserRepository;
 use App\Schema\PaginationSchema;
 use App\Service\BookmarkManager;
 use App\Service\IpResolver;
 use App\Service\ReportManager;
+use App\Service\UserManager;
 use Doctrine\ORM\EntityManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Model\AccessToken;
 use League\Bundle\OAuth2ServerBundle\Security\Authentication\Token\OAuth2Token;
@@ -91,6 +93,8 @@ class BaseApi extends AbstractController
         protected readonly BookmarkListRepository $bookmarkListRepository,
         protected readonly BookmarkRepository $bookmarkRepository,
         protected readonly BookmarkManager $bookmarkManager,
+        protected readonly UserManager $userManager,
+        protected readonly UserRepository $userRepository,
         private readonly ImageRepository $imageRepository,
         private readonly ReportManager $reportManager,
         private readonly OAuth2ClientAccessRepository $clientAccessRepository,

--- a/src/Controller/Api/User/Admin/UserApplicationApi.php
+++ b/src/Controller/Api/User/Admin/UserApplicationApi.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Api\User\Admin;
+
+use App\Controller\Api\User\UserBaseApi;
+use App\DTO\UserResponseDto;
+use App\Entity\User;
+use App\Factory\UserFactory;
+use App\Schema\Errors\ForbiddenErrorSchema;
+use App\Schema\Errors\NotFoundErrorSchema;
+use App\Schema\Errors\TooManyRequestsErrorSchema;
+use App\Schema\Errors\UnauthorizedErrorSchema;
+use App\Schema\PaginationSchema;
+use Nelmio\ApiDocBundle\Annotation\Model;
+use Nelmio\ApiDocBundle\Annotation\Security;
+use OpenApi\Attributes as OA;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+class UserApplicationApi extends UserBaseApi
+{
+    #[OA\Response(
+        response: 200,
+        description: 'Returns a paginated list of users that are awaiting admin approval',
+        headers: [
+            new OA\Header(header: 'X-RateLimit-Remaining', description: 'Number of requests left until you will be rate limited', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Retry-After', description: 'Unix timestamp to retry the request after', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Limit', description: 'Number of requests available', schema: new OA\Schema(type: 'integer')),
+        ],
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(
+                    property: 'items',
+                    type: 'array',
+                    items: new OA\Items(ref: new Model(type: UserResponseDto::class))
+                ),
+                new OA\Property(
+                    property: 'pagination',
+                    ref: new Model(type: PaginationSchema::class)
+                ),
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'Permission denied due to missing or expired token',
+        content: new OA\JsonContent(ref: new Model(type: UnauthorizedErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 403,
+        description: 'You are not authorized to view users waiting for approval',
+        content: new OA\JsonContent(ref: new Model(type: ForbiddenErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 429,
+        description: 'You are being rate limited',
+        headers: [
+            new OA\Header(header: 'X-RateLimit-Remaining', description: 'Number of requests left until you will be rate limited', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Retry-After', description: 'Unix timestamp to retry the request after', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Limit', description: 'Number of requests available', schema: new OA\Schema(type: 'integer')),
+        ],
+        content: new OA\JsonContent(ref: new Model(type: TooManyRequestsErrorSchema::class))
+    )]
+    #[OA\Parameter(
+        name: 'p',
+        description: 'Page of users to retrieve',
+        in: 'query',
+        schema: new OA\Schema(type: 'integer', default: 1, minimum: 1)
+    )]
+    #[OA\Tag(name: 'admin/user')]
+    #[IsGranted('ROLE_ADMIN')]
+    #[Security(name: 'oauth2', scopes: ['admin:user:application'])]
+    #[IsGranted('ROLE_OAUTH2_ADMIN:USER:APPLICATION')]
+    /** Retrieve users waiting for admin approval */
+    public function retrieve(
+        UserFactory $userFactory,
+        RateLimiterFactory $apiReadLimiter,
+        RateLimiterFactory $anonymousApiReadLimiter,
+        #[MapQueryParameter] int $p = 1,
+    ): JsonResponse {
+        $headers = $this->rateLimit($apiReadLimiter, $anonymousApiReadLimiter);
+        $users = $this->userRepository->findAllSignupRequestsPaginated($p);
+
+        $dtos = [];
+        foreach ($users->getCurrentPageResults() as $value) {
+            \assert($value instanceof User);
+            $dtos[] = $this->serializeUser($userFactory->createDto($value));
+        }
+
+        return new JsonResponse(
+            $this->serializePaginated($dtos, $users),
+            headers: $headers
+        );
+    }
+
+    #[OA\Response(
+        response: 200,
+        description: 'Returns nothing on success',
+        headers: [
+            new OA\Header(header: 'X-RateLimit-Remaining', description: 'Number of requests left until you will be rate limited', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Retry-After', description: 'Unix timestamp to retry the request after', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Limit', description: 'Number of requests available', schema: new OA\Schema(type: 'integer')),
+        ],
+        content: null
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'Permission denied due to missing or expired token',
+        content: new OA\JsonContent(ref: new Model(type: UnauthorizedErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 403,
+        description: 'You are not authorized to verify this user',
+        content: new OA\JsonContent(ref: new Model(type: ForbiddenErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 404,
+        description: 'User not found',
+        content: new OA\JsonContent(ref: new Model(type: NotFoundErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 429,
+        description: 'You are being rate limited',
+        headers: [
+            new OA\Header(header: 'X-RateLimit-Remaining', description: 'Number of requests left until you will be rate limited', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Retry-After', description: 'Unix timestamp to retry the request after', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Limit', description: 'Number of requests available', schema: new OA\Schema(type: 'integer')),
+        ],
+        content: new OA\JsonContent(ref: new Model(type: TooManyRequestsErrorSchema::class))
+    )]
+    #[OA\Parameter(
+        name: 'user_id',
+        description: 'The user to approve',
+        in: 'path',
+        schema: new OA\Schema(type: 'integer', minimum: 1)
+    )]
+    #[OA\Tag(name: 'admin/user')]
+    #[IsGranted('ROLE_ADMIN')]
+    #[Security(name: 'oauth2', scopes: ['admin:user:application'])]
+    #[IsGranted('ROLE_OAUTH2_ADMIN:USER:APPLICATION')]
+    public function approve(
+        RateLimiterFactory $apiReadLimiter,
+        RateLimiterFactory $anonymousApiReadLimiter,
+        #[MapEntity(id: 'user_id')] User $user,
+    ): JsonResponse {
+        $headers = $this->rateLimit($apiReadLimiter, $anonymousApiReadLimiter);
+        $this->userManager->approveUserApplication($user);
+
+        return new JsonResponse(null, headers: $headers);
+    }
+
+    #[OA\Response(
+        response: 200,
+        description: 'Returns nothing on success',
+        headers: [
+            new OA\Header(header: 'X-RateLimit-Remaining', description: 'Number of requests left until you will be rate limited', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Retry-After', description: 'Unix timestamp to retry the request after', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Limit', description: 'Number of requests available', schema: new OA\Schema(type: 'integer')),
+        ],
+        content: null
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'Permission denied due to missing or expired token',
+        content: new OA\JsonContent(ref: new Model(type: UnauthorizedErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 403,
+        description: 'You are not authorized to verify this user',
+        content: new OA\JsonContent(ref: new Model(type: ForbiddenErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 404,
+        description: 'User not found',
+        content: new OA\JsonContent(ref: new Model(type: NotFoundErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 429,
+        description: 'You are being rate limited',
+        headers: [
+            new OA\Header(header: 'X-RateLimit-Remaining', description: 'Number of requests left until you will be rate limited', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Retry-After', description: 'Unix timestamp to retry the request after', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Limit', description: 'Number of requests available', schema: new OA\Schema(type: 'integer')),
+        ],
+        content: new OA\JsonContent(ref: new Model(type: TooManyRequestsErrorSchema::class))
+    )]
+    #[OA\Parameter(
+        name: 'user_id',
+        description: 'The user to reject',
+        in: 'path',
+        schema: new OA\Schema(type: 'integer', minimum: 1)
+    )]
+    #[OA\Tag(name: 'admin/user')]
+    #[IsGranted('ROLE_ADMIN')]
+    #[Security(name: 'oauth2', scopes: ['admin:user:application'])]
+    #[IsGranted('ROLE_OAUTH2_ADMIN:USER:APPLICATION')]
+    public function reject(
+        RateLimiterFactory $apiReadLimiter,
+        RateLimiterFactory $anonymousApiReadLimiter,
+        #[MapEntity(id: 'user_id')] User $user,
+    ): JsonResponse {
+        $headers = $this->rateLimit($apiReadLimiter, $anonymousApiReadLimiter);
+        $this->userManager->rejectUserApplication($user);
+
+        return new JsonResponse(null, headers: $headers);
+    }
+}

--- a/src/Controller/Security/RegisterController.php
+++ b/src/Controller/Security/RegisterController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller\Security;
 
 use App\Controller\AbstractController;
+use App\DTO\UserDto;
 use App\Form\UserRegisterType;
 use App\Service\IpResolver;
 use App\Service\SettingsManager;
@@ -39,6 +40,7 @@ class RegisterController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            /** @var UserDto $dto */
             $dto = $form->getData();
             $dto->ip = $this->ipResolver->resolve();
 
@@ -49,7 +51,14 @@ class RegisterController extends AbstractController
                 'flash_register_success'
             );
 
-            return $this->redirectToRoute('front');
+            if ($this->settingsManager->getNewUsersNeedApproval()) {
+                $this->addFlash(
+                    'success',
+                    'flash_application_info'
+                );
+            }
+
+            return $this->redirectToRoute('app_login');
         } elseif ($form->isSubmitted() && !$form->isValid()) {
             $this->logger->error('Registration form submission was invalid.', [
                 'errors' => $form->getErrors(true, false),

--- a/src/Controller/Security/ResendActivationEmailController.php
+++ b/src/Controller/Security/ResendActivationEmailController.php
@@ -9,13 +9,15 @@ use App\Entity\User;
 use App\Form\ResendEmailActivationFormType;
 use App\MessageHandler\SentUserConfirmationEmailHandler;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class ResendActivationEmailController extends AbstractController
 {
     public function __construct(
-        private readonly EntityManagerInterface $entityManager
+        private readonly EntityManagerInterface $entityManager,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -43,6 +45,7 @@ class ResendActivationEmailController extends AbstractController
 
                 return $this->redirectToRoute('app_resend_email_activation');
             } catch (\Exception $e) {
+                $this->logger->error('There was an exception trying to re-send the activation email to: {u} - {mail}: {e} - {msg}', ['u' => $user->username, 'mail' => $user->email, 'e' => \get_class($e), 'msg' => $e->getMessage()]);
                 $this->addFlash('error', 'resend_account_activation_email_error');
 
                 return $this->redirectToRoute('app_resend_email_activation');

--- a/src/Controller/User/UserFrontController.php
+++ b/src/Controller/User/UserFrontController.php
@@ -40,6 +40,10 @@ class UserFrontController extends AbstractController
         $requestedByUser = $this->getUser();
         $hideAdult = (!$requestedByUser || $requestedByUser->hideAdult);
 
+        if (!$user->isApproved || $user->isRejected) {
+            throw $this->createNotFoundException();
+        }
+
         if ($user->isDeleted && (!$requestedByUser || (!$requestedByUser->isAdmin() && !$requestedByUser->isModerator()) || null === $user->markedForDeletionAt)) {
             throw $this->createNotFoundException();
         }

--- a/src/Controller/User/UserFrontController.php
+++ b/src/Controller/User/UserFrontController.php
@@ -6,6 +6,7 @@ namespace App\Controller\User;
 
 use App\Controller\AbstractController;
 use App\Entity\User;
+use App\Enums\EApplicationStatus;
 use App\PageView\EntryCommentPageView;
 use App\PageView\EntryPageView;
 use App\PageView\MagazinePageView;
@@ -40,7 +41,7 @@ class UserFrontController extends AbstractController
         $requestedByUser = $this->getUser();
         $hideAdult = (!$requestedByUser || $requestedByUser->hideAdult);
 
-        if (!$user->isApproved || $user->isRejected) {
+        if (EApplicationStatus::Approved !== $user->getApplicationStatus()) {
             throw $this->createNotFoundException();
         }
 

--- a/src/DTO/SettingsDto.php
+++ b/src/DTO/SettingsDto.php
@@ -38,6 +38,7 @@ class SettingsDto implements \JsonSerializable
         public bool $MBIN_SSO_SHOW_FIRST,
         public int $MAX_IMAGE_BYTES,
         public string $MBIN_DOWNVOTES_MODE,
+        public bool $MBIN_NEW_USERS_NEED_APPROVAL,
     ) {
     }
 
@@ -70,6 +71,7 @@ class SettingsDto implements \JsonSerializable
         $dto->MBIN_SSO_SHOW_FIRST = $this->MBIN_SSO_SHOW_FIRST ?? $dto->MBIN_SSO_SHOW_FIRST;
         $dto->MAX_IMAGE_BYTES = $this->MAX_IMAGE_BYTES ?? $dto->MAX_IMAGE_BYTES;
         $dto->MBIN_DOWNVOTES_MODE = $this->MBIN_DOWNVOTES_MODE ?? $dto->MBIN_DOWNVOTES_MODE;
+        $dto->MBIN_NEW_USERS_NEED_APPROVAL = $this->MBIN_NEW_USERS_NEED_APPROVAL ?? $dto->MBIN_NEW_USERS_NEED_APPROVAL;
 
         return $dto;
     }
@@ -104,6 +106,7 @@ class SettingsDto implements \JsonSerializable
             'MBIN_SSO_SHOW_FIRST' => $this->MBIN_SSO_SHOW_FIRST,
             'MAX_IMAGE_BYTES' => $this->MAX_IMAGE_BYTES,
             'MBIN_DOWNVOTES_MODE' => $this->MBIN_DOWNVOTES_MODE,
+            'MBIN_NEW_USERS_NEED_APPROVAL' => $this->MBIN_NEW_USERS_NEED_APPROVAL,
         ];
     }
 }

--- a/src/DTO/UserDto.php
+++ b/src/DTO/UserDto.php
@@ -49,6 +49,7 @@ class UserDto implements UserDtoInterface
     public ?string $totpSecret = null;
     public ?string $serverSoftware = null;
     public ?string $serverSoftwareVersion = null;
+    public ?string $applicationText = null;
 
     #[Assert\Callback]
     public function validate(
@@ -91,6 +92,7 @@ class UserDto implements UserDtoInterface
         ?bool $isBot = null,
         ?bool $isAdmin = null,
         ?bool $isGlobalModerator = null,
+        ?string $applicationText = null,
     ): self {
         $dto = new UserDto();
         $dto->id = $id;
@@ -107,6 +109,7 @@ class UserDto implements UserDtoInterface
         $dto->isBot = $isBot;
         $dto->isAdmin = $isAdmin;
         $dto->isGlobalModerator = $isGlobalModerator;
+        $dto->applicationText = $applicationText;
 
         return $dto;
     }

--- a/src/DoctrineExtensions/DBAL/Types/EnumApplicationStatus.php
+++ b/src/DoctrineExtensions/DBAL/Types/EnumApplicationStatus.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DoctrineExtensions\DBAL\Types;
+
+use App\Enums\EApplicationStatus;
+
+class EnumApplicationStatus extends EnumType
+{
+    public function getName(): string
+    {
+        return 'EnumApplicationStatus';
+    }
+
+    public function getValues(): array
+    {
+        return EApplicationStatus::getValues();
+    }
+}

--- a/src/DoctrineExtensions/DBAL/Types/EnumType.php
+++ b/src/DoctrineExtensions/DBAL/Types/EnumType.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DoctrineExtensions\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * See example by doctrine: https://www.doctrine-project.org/projects/doctrine-orm/en/2.20/cookbook/mysql-enums.html#solution-2-defining-a-type.
+ */
+abstract class EnumType extends Type
+{
+    abstract public function getName(): string;
+
+    /**
+     * @return string[]
+     */
+    abstract public function getValues(): array;
+
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        $values = array_map(function ($val) { return "'".$val."'"; }, $this->getValues());
+
+        return 'ENUM('.implode(', ', $values).')';
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        return $value;
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if (!\in_array($value, $this->getValues())) {
+            throw new \InvalidArgumentException("Invalid '".$this->getName()."' value.");
+        }
+
+        return $value;
+    }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -240,13 +240,24 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Visibil
     #[Column(type: 'string', nullable: false, options: ['default' => self::USER_TYPE_PERSON])]
     public string $type;
 
+    #[Column(type: 'string', nullable: true)]
+    public string $applicationText;
+
+    #[Column(type: 'boolean', nullable: false, options: ['default' => true])]
+    public bool $isApproved;
+
+    #[Column(type: 'boolean', nullable: false, options: ['default' => false])]
+    public bool $isRejected = false;
+
     public function __construct(
         string $email,
         string $username,
         string $password,
         string $type,
         ?string $apProfileId = null,
-        ?string $apId = null
+        ?string $apId = null,
+        bool $isApproved = true,
+        ?string $applicationText = null,
     ) {
         $this->email = $email;
         $this->password = $password;
@@ -280,6 +291,8 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Visibil
         $this->lastActive = new \DateTime();
         $this->createdAtTraitConstruct();
         $this->oAuth2UserConsents = new ArrayCollection();
+        $this->isApproved = $isApproved;
+        $this->applicationText = $applicationText;
     }
 
     public function getId(): int

--- a/src/Enums/EApplicationStatus.php
+++ b/src/Enums/EApplicationStatus.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum EApplicationStatus: string
+{
+    case Approved = 'Approved';
+    case Rejected = 'Rejected';
+    case Pending = 'Pending';
+
+    public static function getFromString(string $value): ?EApplicationStatus
+    {
+        return match ($value) {
+            self::Approved->value => self::Approved,
+            self::Rejected->value => self::Rejected,
+            self::Pending->value => self::Pending,
+            default => null,
+        };
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getValues(): array
+    {
+        return [
+            EApplicationStatus::Approved->value,
+            EApplicationStatus::Rejected->value,
+            EApplicationStatus::Pending->value,
+        ];
+    }
+}

--- a/src/Event/User/UserApplicationApprovedEvent.php
+++ b/src/Event/User/UserApplicationApprovedEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Event\User;
+
+use App\Entity\User;
+
+class UserApplicationApprovedEvent
+{
+    public function __construct(
+        public readonly User $user,
+    ) {
+    }
+}

--- a/src/Event/User/UserApplicationRejectedEvent.php
+++ b/src/Event/User/UserApplicationRejectedEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Event\User;
+
+use App\Entity\User;
+
+class UserApplicationRejectedEvent
+{
+    public function __construct(
+        public readonly User $user,
+    ) {
+    }
+}

--- a/src/EventSubscriber/User/UserApplicationSubscriber.php
+++ b/src/EventSubscriber/User/UserApplicationSubscriber.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber\User;
+
+use App\Event\User\UserApplicationApprovedEvent;
+use App\Event\User\UserApplicationRejectedEvent;
+use App\Message\UserApplicationAnswerMessage;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class UserApplicationSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly MessageBusInterface $bus,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            UserApplicationRejectedEvent::class => 'onUserApplicationRejected',
+            UserApplicationApprovedEvent::class => 'onUserApplicationApproved',
+        ];
+    }
+
+    public function onUserApplicationApproved(UserApplicationApprovedEvent $event): void
+    {
+        $this->logger->debug('Got a UserApplicationApprovedEvent for {u}', ['u' => $event->user->username]);
+        $this->bus->dispatch(new UserApplicationAnswerMessage($event->user->getId(), approved: true));
+    }
+
+    public function onUserApplicationRejected(UserApplicationRejectedEvent $event): void
+    {
+        $this->logger->debug('Got a UserApplicationRejectedEvent for {u}', ['u' => $event->user->username]);
+        $this->bus->dispatch(new UserApplicationAnswerMessage($event->user->getId(), approved: false));
+    }
+}

--- a/src/Form/SettingsType.php
+++ b/src/Form/SettingsType.php
@@ -59,6 +59,7 @@ class SettingsType extends AbstractType
                     $dto->MBIN_DOWNVOTES_MODE => ['checked' => true],
                 ],
             ])
+            ->add('MBIN_NEW_USERS_NEED_APPROVAL', CheckboxType::class, ['required' => false])
             ->add('submit', SubmitType::class);
     }
 

--- a/src/Form/UserRegisterType.php
+++ b/src/Form/UserRegisterType.php
@@ -9,12 +9,14 @@ use App\Form\EventListener\AddFieldsOnUserEdit;
 use App\Form\EventListener\CaptchaListener;
 use App\Form\EventListener\DisableFieldsOnUserEdit;
 use App\Form\EventListener\ImageListener;
+use App\Service\SettingsManager;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -25,6 +27,7 @@ class UserRegisterType extends AbstractType
         private readonly AddFieldsOnUserEdit $addAvatarFieldOnUserEdit,
         private readonly DisableFieldsOnUserEdit $disableUsernameFieldOnUserEdit,
         private readonly CaptchaListener $captchaListener,
+        private readonly SettingsManager $settingsManager,
     ) {
     }
 
@@ -63,6 +66,11 @@ class UserRegisterType extends AbstractType
                 ]
             )
             ->add('submit', SubmitType::class);
+
+        if ($this->settingsManager->getNewUsersNeedApproval()) {
+            $builder
+                ->add('applicationText', TextareaType::class, ['required' => true]);
+        }
 
         $builder->addEventSubscriber($this->disableUsernameFieldOnUserEdit);
         $builder->addEventSubscriber($this->captchaListener);

--- a/src/Message/UserApplicationAnswerMessage.php
+++ b/src/Message/UserApplicationAnswerMessage.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+use App\Message\Contracts\AsyncMessageInterface;
+
+class UserApplicationAnswerMessage implements AsyncMessageInterface
+{
+    public function __construct(
+        public readonly int $userId,
+        public readonly bool $approved,
+    ) {
+    }
+}

--- a/src/MessageHandler/DeleteUserHandler.php
+++ b/src/MessageHandler/DeleteUserHandler.php
@@ -94,7 +94,7 @@ class DeleteUserHandler extends MbinMessageHandler
         $this->entityManager->flush();
 
         // recreate a user with the same name, so this handle is blocked
-        $user = $this->userManager->create($userDto, verifyUserEmail: false, rateLimit: false);
+        $user = $this->userManager->create($userDto, verifyUserEmail: false, rateLimit: false, preApprove: true);
         $user->isDeleted = true;
         $user->markedForDeletionAt = null;
         $user->isVerified = false;

--- a/src/MessageHandler/SendApplicationAnswerMailHandler.php
+++ b/src/MessageHandler/SendApplicationAnswerMailHandler.php
@@ -6,40 +6,40 @@ namespace App\MessageHandler;
 
 use App\Entity\User;
 use App\Message\Contracts\MessageInterface;
-use App\Message\Contracts\SendConfirmationEmailInterface;
+use App\Message\UserApplicationAnswerMessage;
 use App\Repository\UserRepository;
-use App\Security\EmailVerifier;
 use App\Service\SettingsManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Mime\Address;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[AsMessageHandler]
-class SentUserConfirmationEmailHandler extends MbinMessageHandler
+class SendApplicationAnswerMailHandler extends MbinMessageHandler
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly SettingsManager $settingsManager,
-        private readonly EmailVerifier $emailVerifier,
         private readonly UserRepository $repository,
         private readonly ParameterBagInterface $params,
-        private readonly TranslatorInterface $translator
+        private readonly TranslatorInterface $translator,
+        private readonly MailerInterface $mailer,
     ) {
         parent::__construct($this->entityManager);
     }
 
-    public function __invoke(SendConfirmationEmailInterface $message): void
+    public function __invoke(UserApplicationAnswerMessage $message): void
     {
         $this->workWrapper($message);
     }
 
     public function doWork(MessageInterface $message): void
     {
-        if (!($message instanceof SendConfirmationEmailInterface)) {
+        if (!($message instanceof UserApplicationAnswerMessage)) {
             throw new \LogicException();
         }
         $user = $this->repository->find($message->userId);
@@ -47,31 +47,26 @@ class SentUserConfirmationEmailHandler extends MbinMessageHandler
             throw new UnrecoverableMessageHandlingException('User not found');
         }
 
-        $this->sendConfirmationEmail($user);
+        $this->sendAnswerMail($user, $message->approved);
     }
 
-    /**
-     * @param User $user user that will be sent the confirmation email
-     *
-     * @throws \Exception
-     */
-    public function sendConfirmationEmail(User $user): void
+    public function sendAnswerMail(User $user, bool $approved): void
     {
-        try {
-            $this->emailVerifier->sendEmailConfirmation(
-                'app_verify_email',
-                $user,
-                (new TemplatedEmail())
-                    ->from(
-                        new Address($this->settingsManager->get('KBIN_SENDER_EMAIL'), $this->params->get('kbin_domain'))
-                    )
-                    ->to($user->email)
-                    ->subject($this->translator->trans('email_confirm_title'))
-                    ->htmlTemplate('_email/confirmation_email.html.twig')
-                    ->context(['user' => $user])
-            );
-        } catch (\Exception $e) {
-            throw $e;
+        $mail = (new TemplatedEmail())
+            ->from(
+                new Address($this->settingsManager->get('KBIN_SENDER_EMAIL'), $this->params->get('kbin_domain'))
+            )
+            ->to($user->email);
+
+        if ($approved) {
+            $mail->subject($this->translator->trans('email_application_approved_title'))
+                ->htmlTemplate('_email/application_approved.html.twig')
+                ->context(['user' => $user]);
+        } else {
+            $mail->subject($this->translator->trans('email_application_rejected_title'))
+                ->htmlTemplate('_email/application_rejected.html.twig')
+                ->context(['user' => $user]);
         }
+        $this->mailer->send($mail);
     }
 }

--- a/src/Security/UserChecker.php
+++ b/src/Security/UserChecker.php
@@ -40,6 +40,10 @@ class UserChecker implements UserCheckerInterface
             }
         }
 
+        if (!$user->isApproved) {
+            throw new CustomUserMessageAccountStatusException($this->translator->trans('your_account_is_not_yet_approved'));
+        }
+
         if (!$user->isVerified) {
             $resendEmailActivationUrl = $this->urlGenerator->generate('app_resend_email_activation');
             throw new CustomUserMessageAccountStatusException($this->translator->trans('your_account_is_not_active', ['%link_target%' => $resendEmailActivationUrl]));

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -315,7 +315,8 @@ class ActivityPubManager
         $this->userManager->create(
             $this->userFactory->createDtoFromAp($actorUrl, $webfinger->getHandle()),
             false,
-            false
+            false,
+            preApprove: true,
         );
 
         return $this->updateUser($actorUrl);

--- a/src/Service/SettingsManager.php
+++ b/src/Service/SettingsManager.php
@@ -39,6 +39,7 @@ class SettingsManager
         private readonly bool $mbinSsoOnlyMode,
         private readonly int $maxImageBytes,
         private readonly DownvotesMode $mbinDownvotesMode,
+        private readonly bool $mbinNewUsersNeedApproval,
     ) {
         if (!self::$dto) {
             $results = $this->repository->findAll();
@@ -46,6 +47,13 @@ class SettingsManager
             $maxImageBytesEdited = $this->find($results, 'MAX_IMAGE_BYTES', FILTER_VALIDATE_INT);
             if (null === $maxImageBytesEdited || 0 === $maxImageBytesEdited) {
                 $maxImageBytesEdited = $this->maxImageBytes;
+            }
+
+            $newUsersNeedApprovalEdited = $this->find($results, 'MBIN_NEW_USERS_NEED_APPROVAL');
+            if ('true' === $newUsersNeedApprovalEdited) {
+                $newUsersNeedApprovalEdited = true;
+            } elseif (null === $newUsersNeedApprovalEdited) {
+                $newUsersNeedApprovalEdited = $this->mbinNewUsersNeedApproval;
             }
 
             self::$dto = new SettingsDto(
@@ -84,6 +92,7 @@ class SettingsManager
                 $this->find($results, 'MBIN_SSO_SHOW_FIRST', FILTER_VALIDATE_BOOLEAN) ?? false,
                 $maxImageBytesEdited,
                 $this->find($results, 'MBIN_DOWNVOTES_MODE') ?? $this->mbinDownvotesMode->value,
+                $newUsersNeedApprovalEdited,
             );
         }
     }
@@ -161,6 +170,11 @@ class SettingsManager
     public function getDownvotesMode(): DownvotesMode
     {
         return DownvotesMode::from($this->get('MBIN_DOWNVOTES_MODE'));
+    }
+
+    public function getNewUsersNeedApproval(): bool
+    {
+        return $this->get('MBIN_NEW_USERS_NEED_APPROVAL');
     }
 
     public function set(string $name, $value): void

--- a/src/Service/SettingsManager.php
+++ b/src/Service/SettingsManager.php
@@ -49,10 +49,12 @@ class SettingsManager
                 $maxImageBytesEdited = $this->maxImageBytes;
             }
 
-            $newUsersNeedApprovalEdited = $this->find($results, 'MBIN_NEW_USERS_NEED_APPROVAL');
-            if ('true' === $newUsersNeedApprovalEdited) {
+            $newUsersNeedApprovalDb = $this->find($results, 'MBIN_NEW_USERS_NEED_APPROVAL');
+            if ('true' === $newUsersNeedApprovalDb) {
                 $newUsersNeedApprovalEdited = true;
-            } elseif (null === $newUsersNeedApprovalEdited) {
+            } elseif ('false' === $newUsersNeedApprovalDb) {
+                $newUsersNeedApprovalEdited = false;
+            } else {
                 $newUsersNeedApprovalEdited = $this->mbinNewUsersNeedApproval;
             }
 

--- a/src/Twig/Extension/AdminExtension.php
+++ b/src/Twig/Extension/AdminExtension.php
@@ -15,6 +15,7 @@ final class AdminExtension extends AbstractExtension
         return [
             new TwigFunction('is_admin_panel_page', [AdminExtensionRuntime::class, 'isAdminPanelPage']),
             new TwigFunction('is_tag_banned', [AdminExtensionRuntime::class, 'isTagBanned']),
+            new TwigFunction('do_new_users_need_approval', [AdminExtensionRuntime::class, 'doNewUsersNeedApproval']),
         ];
     }
 }

--- a/src/Twig/Runtime/AdminExtensionRuntime.php
+++ b/src/Twig/Runtime/AdminExtensionRuntime.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Twig\Runtime;
 
 use App\Repository\TagRepository;
+use App\Service\SettingsManager;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Twig\Extension\RuntimeExtensionInterface;
@@ -14,6 +15,7 @@ readonly class AdminExtensionRuntime implements RuntimeExtensionInterface
     public function __construct(
         private Security $security,
         private TagRepository $tagRepository,
+        private SettingsManager $settingsManager,
     ) {
     }
 
@@ -29,5 +31,10 @@ readonly class AdminExtensionRuntime implements RuntimeExtensionInterface
         }
 
         return $hashtag->banned;
+    }
+
+    public function doNewUsersNeedApproval(): bool
+    {
+        return $this->settingsManager->getNewUsersNeedApproval();
     }
 }

--- a/src/Twig/Runtime/AdminExtensionRuntime.php
+++ b/src/Twig/Runtime/AdminExtensionRuntime.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Twig\Runtime;
 
 use App\Repository\TagRepository;
+use App\Repository\UserRepository;
 use App\Service\SettingsManager;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -16,6 +17,7 @@ readonly class AdminExtensionRuntime implements RuntimeExtensionInterface
         private Security $security,
         private TagRepository $tagRepository,
         private SettingsManager $settingsManager,
+        private UserRepository $userRepository,
     ) {
     }
 
@@ -35,6 +37,7 @@ readonly class AdminExtensionRuntime implements RuntimeExtensionInterface
 
     public function doNewUsersNeedApproval(): bool
     {
-        return $this->settingsManager->getNewUsersNeedApproval();
+        // show the signup requests page even if they are deactivated if there are any remaining
+        return $this->settingsManager->getNewUsersNeedApproval() || $this->userRepository->findAllSignupRequestsPaginated()->count() > 0;
     }
 }

--- a/templates/_email/application_approved.html.twig
+++ b/templates/_email/application_approved.html.twig
@@ -1,0 +1,19 @@
+{% extends '_email/email_base.html.twig' %}
+
+{%- block title -%}
+    {{- 'email_application_approved_title'|trans }}
+{%- endblock -%}
+
+{% block body %}
+    <p>
+        {{ 'email_application_approved_body'|trans({
+            '%link%': url('app_login'),
+            '%siteName%': kbin_domain(),
+        })|raw }}
+    </p>
+    {% if user.isVerified is same as false %}
+        <p>
+            {{ 'email_verification_pending'|trans }}
+        </p>
+    {% endif %}
+{% endblock %}

--- a/templates/_email/application_rejected.html.twig
+++ b/templates/_email/application_rejected.html.twig
@@ -1,0 +1,11 @@
+{% extends '_email/email_base.html.twig' %}
+
+{%- block title -%}
+    {{- 'email_application_rejected_title'|trans }}
+{%- endblock -%}
+
+{% block body %}
+    <p>
+        {{ 'email_application_rejected_body'|trans }}
+    </p>
+{% endblock %}

--- a/templates/_email/confirmation_email.html.twig
+++ b/templates/_email/confirmation_email.html.twig
@@ -10,6 +10,11 @@
     <p>
         <a class="btn btn__primary" href="{{ signedUrl|raw }}">{{ 'email_verify'|trans }}</a>
     </p>
+    {% if user.isApproved is same as false %}
+        <p>
+            {{ 'email_application_pending'|trans }}
+        </p>
+    {% endif %}
     <p>{{ 'email_confirm_expire'|trans }}</p>
     <p>Cheers!</p>
 {% endblock %}

--- a/templates/_email/confirmation_email.html.twig
+++ b/templates/_email/confirmation_email.html.twig
@@ -10,7 +10,7 @@
     <p>
         <a class="btn btn__primary" href="{{ signedUrl|raw }}">{{ 'email_verify'|trans }}</a>
     </p>
-    {% if user.isApproved is same as false %}
+    {% if user.getApplicationStatus() is not same as enum('App\\Enums\\EApplicationStatus').Approved %}
         <p>
             {{ 'email_application_pending'|trans }}
         </p>

--- a/templates/admin/_options.html.twig
+++ b/templates/admin/_options.html.twig
@@ -45,7 +45,7 @@
             <li>
                 <a href="{{ path('admin_signup_requests', { page: 1 }) }}"
                    class="{{ html_classes({'active': is_route_name('admin_signup_requests') }) }}">
-                    {{ 'applications'|trans }}
+                    {{ 'signup_requests'|trans }}
                 </a>
             </li>
         {% endif %}

--- a/templates/admin/_options.html.twig
+++ b/templates/admin/_options.html.twig
@@ -41,6 +41,14 @@
                 {{ 'ownership_requests'|trans }}
             </a>
         </li>
+        {% if do_new_users_need_approval() %}
+            <li>
+                <a href="{{ path('admin_signup_requests', { page: 1 }) }}"
+                   class="{{ html_classes({'active': is_route_name('admin_signup_requests') }) }}">
+                    {{ 'applications'|trans }}
+                </a>
+            </li>
+        {% endif %}
         <li>
             <a href="{{ path('admin_pages', {page: 'announcement'}) }}"
                class="{{ html_classes({'active': is_route_name('admin_pages')}) }}">

--- a/templates/admin/settings.html.twig
+++ b/templates/admin/settings.html.twig
@@ -91,6 +91,10 @@
                 {{ form_label(form.MBIN_SSO_SHOW_FIRST, 'sso_show_first') }}
                 {{ form_widget(form.MBIN_SSO_SHOW_FIRST) }}
             </div>
+            <div class="checkbox">
+                {{ form_label(form.MBIN_NEW_USERS_NEED_APPROVAL, 'new_users_need_approval') }}
+                {{ form_widget(form.MBIN_NEW_USERS_NEED_APPROVAL) }}
+            </div>
             <div class="row actions">
                 {{ form_row(form.submit, {label: 'save', attr: {class: 'btn btn__primary'}}) }}
             </div>

--- a/templates/admin/signup_requests.html.twig
+++ b/templates/admin/signup_requests.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 
 {%- block title -%}
-    {{- 'applications'|trans }} - {{ parent() -}}
+    {{- 'signup_requests'|trans }} - {{ parent() -}}
 {%- endblock -%}
 
 {% block mainClass %}page-admin-federation{% endblock %}
@@ -16,6 +16,7 @@
     {% include 'admin/_options.html.twig' %}
     <div class="section">
         <h3>{{ 'signup_requests_header'|trans }}</h3>
+        <p>{{ 'signup_requests_paragraph'|trans }}</p>
     </div>
     {% if requests|length %}
         {% for request in requests %}

--- a/templates/admin/signup_requests.html.twig
+++ b/templates/admin/signup_requests.html.twig
@@ -1,0 +1,51 @@
+{% extends 'base.html.twig' %}
+
+{%- block title -%}
+    {{- 'applications'|trans }} - {{ parent() -}}
+{%- endblock -%}
+
+{% block mainClass %}page-admin-federation{% endblock %}
+
+{% block header_nav %}
+{% endblock %}
+
+{% block sidebar_top %}
+{% endblock %}
+
+{% block body %}
+    {% include 'admin/_options.html.twig' %}
+    <div class="section">
+        <h3>{{ 'signup_requests_header'|trans }}</h3>
+    </div>
+    {% if requests|length %}
+        {% for request in requests %}
+            <div class="section">
+                <div>
+                    <small class="meta">{{ component('user_inline', {user: request}) }},
+                        {{ component('date', {date: request.createdAt}) }}</small>
+                </div>
+                <div>
+                    {{ request.applicationText }}
+                </div>
+                <div class="actions">
+                    <form method="post"
+                          action="{{ path('admin_signup_requests_reject', { page: page, id: request.id }) }}"
+                          data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
+                        <input type="hidden" name="token" value="{{ csrf_token('application_deny') }}">
+                        <button type="submit" class="btn btn__secondary">{{ 'reject'|trans }}</button>
+                    </form>
+                    <form method="post"
+                          action="{{ path('admin_signup_requests_approve', { page: page, id: request.id }) }}"
+                          data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
+                        <input type="hidden" name="token" value="{{ csrf_token('application_approve') }}">
+                        <button type="submit" class="btn btn__secondary">{{ 'approve'|trans }}</button>
+                    </form>
+                </div>
+            </div>
+        {% endfor %}
+    {% else %}
+        <aside class="section section--muted">
+            <p>{{ 'empty'|trans }}</p>
+        </aside>
+    {% endif %}
+{% endblock %}

--- a/templates/user/register.html.twig
+++ b/templates/user/register.html.twig
@@ -27,6 +27,11 @@
                 {{ form_row(form.username, {
                     label: 'username',
                 }) }}
+                {% if do_new_users_need_approval() %}
+                    {{ form_row(form.applicationText, {
+                        label: 'application_text',
+                    }) }}
+                {% endif %}
                 {{ form_row(form.email, {
                     label: 'email'
                 }) }}

--- a/tests/FactoryTrait.php
+++ b/tests/FactoryTrait.php
@@ -185,7 +185,7 @@ trait FactoryTrait
         $userDto->email = 'test@kbin.test';
         $userDto->plainPassword = hash('sha512', random_bytes(32));
         $userDto->isBot = true;
-        $user = $userManager->create($userDto, false, false);
+        $user = $userManager->create($userDto, false, false, true);
         $client->setUser($user);
 
         $client->setDescription('An OAuth2 client for testing purposes');

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -437,6 +437,8 @@ your_account_is_not_active: Your account has not been activated. Please check yo
   email for account activation instructions or <a href="%link_target%">request a new
   account activation email.</a>
 your_account_has_been_banned: Your account has been banned
+your_account_is_not_yet_approved: Your account has not been approved, yet.
+  We will send you an email as soon as the admins have processed your application.
 toolbar.bold: Bold
 toolbar.italic: Italic
 toolbar.strikethrough: Strikethrough
@@ -919,3 +921,15 @@ search_type_all: Threads + Microblogs
 search_type_entry: Threads
 search_type_post: Microblogs
 select_user: Choose a user
+new_users_need_approval: New users have to be approved by an admin before they can log in.
+applications: Applications
+application_text: Application text
+signup_requests_header: These users would like to join your server. They cannot log in until you've approved their application
+flash_application_info: Your admin needs to approve your account before you can log in.
+  You will receive an email when they processed your application.
+email_application_approved_title: Your application was approved
+email_application_approved_body: Your signup application was approved by the admins. You can log into the server at <a href="%link%">%siteName%</a>.
+email_application_rejected_title: Your application was rejected
+email_application_rejected_body: Your signup application was rejected by the admins
+email_application_pending: Your admin needs to approve your account before you can log in.
+email_verification_pending: You have to verify your email address before you can log in.

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -437,7 +437,7 @@ your_account_is_not_active: Your account has not been activated. Please check yo
   email for account activation instructions or <a href="%link_target%">request a new
   account activation email.</a>
 your_account_has_been_banned: Your account has been banned
-your_account_is_not_yet_approved: Your account has not been approved, yet.
+your_account_is_not_yet_approved: Your account has not been approved yet.
   We will send you an email as soon as the admins have processed your application.
 toolbar.bold: Bold
 toolbar.italic: Italic
@@ -925,11 +925,11 @@ new_users_need_approval: New users have to be approved by an admin before they c
 applications: Applications
 application_text: Application text
 signup_requests_header: These users would like to join your server. They cannot log in until you've approved their application
-flash_application_info: Your admin needs to approve your account before you can log in.
+flash_application_info: An admin needs to approve your account before you can log in.
   You will receive an email when they processed your application.
 email_application_approved_title: Your application was approved
 email_application_approved_body: Your signup application was approved by the admins. You can log into the server at <a href="%link%">%siteName%</a>.
-email_application_rejected_title: Your application was rejected
+email_application_rejected_title: Your application has been rejected
 email_application_rejected_body: Your signup application was rejected by the admins
 email_application_pending: Your admin needs to approve your account before you can log in.
 email_verification_pending: You have to verify your email address before you can log in.

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -922,9 +922,10 @@ search_type_entry: Threads
 search_type_post: Microblogs
 select_user: Choose a user
 new_users_need_approval: New users have to be approved by an admin before they can log in.
-applications: Signup requests
+signup_requests: Signup requests
 application_text: Application text
-signup_requests_header: These users would like to join your server. They cannot log in until you've approved their signup request
+signup_requests_header: Signup Requests
+signup_requests_paragraph: These users would like to join your server. They cannot log in until you've approved their signup request.
 flash_application_info: An admin needs to approve your account before you can log in.
   You will receive an email when they processed your signup request.
 email_application_approved_title: Your signup request was approved

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -438,7 +438,7 @@ your_account_is_not_active: Your account has not been activated. Please check yo
   account activation email.</a>
 your_account_has_been_banned: Your account has been banned
 your_account_is_not_yet_approved: Your account has not been approved yet.
-  We will send you an email as soon as the admins have processed your application.
+  We will send you an email as soon as the admins have processed your signup request.
 toolbar.bold: Bold
 toolbar.italic: Italic
 toolbar.strikethrough: Strikethrough
@@ -922,14 +922,14 @@ search_type_entry: Threads
 search_type_post: Microblogs
 select_user: Choose a user
 new_users_need_approval: New users have to be approved by an admin before they can log in.
-applications: Applications
+applications: Signup requests
 application_text: Application text
-signup_requests_header: These users would like to join your server. They cannot log in until you've approved their application
+signup_requests_header: These users would like to join your server. They cannot log in until you've approved their signup request
 flash_application_info: An admin needs to approve your account before you can log in.
-  You will receive an email when they processed your application.
-email_application_approved_title: Your application was approved
-email_application_approved_body: Your signup application was approved by the admins. You can log into the server at <a href="%link%">%siteName%</a>.
-email_application_rejected_title: Your application has been rejected
-email_application_rejected_body: Your signup application was rejected by the admins
-email_application_pending: Your admin needs to approve your account before you can log in.
+  You will receive an email when they processed your signup request.
+email_application_approved_title: Your signup request was approved
+email_application_approved_body: Your signup request was approved by the admins. You can log into the server at <a href="%link%">%siteName%</a>.
+email_application_rejected_title: Your signup request was declined
+email_application_rejected_body: Thank you for your interest, but we regret to inform you that your signup request has been declined.
+email_application_pending: Your account requires admin approval before you can log in.
 email_verification_pending: You have to verify your email address before you can log in.


### PR DESCRIPTION
- admins can now decide to turn a mandatory approval on in the admin settings
- a new tab will appear labelled "Applications" where new users that are not yet approved will appear
- when the setting is enabled a new input will be displayed on the register page: "Application Text"
- This behavior will be apparent on registering with an added flash message informing the user about it
- Users will receive an email when they are accepted or rejected
- when a user is not approved they cannot log in and an appropriate message will be displayed
- the register site now redirects to the login page instead of the front page

## Tasks

- [x] API implemented
- [x] Updated Docs
- [x] Included Images
- [x] Implemented mails
- [x] Refine email texts (I am definitely not qualified to do that)
- [x] Refine Admin application page

# Pictures

## Register Page

![Register page](https://github.com/user-attachments/assets/3cbd73b1-979c-44d7-9059-ba4e72a186f1)
![After registration](https://github.com/user-attachments/assets/1c30b690-877a-414d-9108-9c62f6027497)

## Admin application view

![Admin application view](https://github.com/user-attachments/assets/cd222988-5f25-4a44-9cca-b9416d3d3d2a)

## Mails

![Approved email](https://github.com/user-attachments/assets/a4240b75-814a-47c6-95f0-870842dc065d)

![Rejected email](https://github.com/user-attachments/assets/7e2afc6d-4d79-4400-a303-0857a7edfe8b)



Closing #722 