### PR TITLE
Fix checkmarks not being rendered correctly anymore

### DIFF
--- a/assets/styles/layout/_forms.scss
+++ b/assets/styles/layout/_forms.scss
@@ -122,9 +122,12 @@ input[type=radio] {
   align-content: center;
   cursor: pointer;
 
+  @extend %fa-icon;
+  @extend .fa-solid;
+
   &::before {
     font-family: var(--kbin-font-awesome-font-family);
-    content: "\f00c";
+    content: fa-content($fa-var-check);
     transform: scale(0);
     transition: 100ms transform ease-in;
   }


### PR DESCRIPTION
This is a regression from the bookmark PR (https://github.com/MbinOrg/mbin/pull/1095/files#diff-9bd0d44eb1a48bf0f2477fe3f36ced33415d0e85a6542e8931c9c3120e4c6ff6R3) adding the `regular` style font awesome style

| before | after |
| ------ | ----- |
| ![grafik](https://github.com/user-attachments/assets/778fb8c4-f5ad-4248-a18a-d38860206cd0) | ![grafik](https://github.com/user-attachments/assets/fa141b5e-fb6e-41c0-afdf-ef7bb1d59d02) |