### PR TITLE
Throw UnrecoverableMessageHandlingException on 4xx

### DIFF
--- a/src/Exception/InvalidApPostException.php
+++ b/src/Exception/InvalidApPostException.php
@@ -6,4 +6,23 @@ namespace App\Exception;
 
 final class InvalidApPostException extends \Exception
 {
+    public function __construct(public ?string $messageStart = '', public ?string $url = null, public ?int $responseCode = null, public ?array $payload = null, int $code = 0, ?\Throwable $previous = null)
+    {
+        $message = $this->messageStart;
+        $additions = [];
+        if ($url) {
+            $additions[] = $url;
+        }
+        if ($responseCode) {
+            $additions[] = "status code: $responseCode";
+        }
+        if ($payload) {
+            $jsonPayload = json_encode($this->payload);
+            $additions[] = $jsonPayload;
+        }
+        if (0 < \sizeof($additions)) {
+            $message .= ': '.implode(', ', $additions);
+        }
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -102,7 +102,7 @@ class ApHttpClient
             // Accepted status code are 2xx or 410 (used Tombstone types)
             if (!str_starts_with((string) $statusCode, '2') && 410 !== $statusCode) {
                 // Do NOT include the response content in the error message, this will be often a full HTML page
-                throw new InvalidApPostException("Invalid status code while getting: $url, status code: $statusCode");
+                throw new InvalidApPostException('Invalid status code while getting', $url, $statusCode);
             }
 
             // Read also non-OK responses (like 410) by passing 'false'
@@ -318,7 +318,7 @@ class ApHttpClient
             // Accepted status code are 2xx or 410 (used Tombstone types)
             if (!str_starts_with((string) $statusCode, '2') && 410 !== $statusCode) {
                 // Do NOT include the response content in the error message, this will be often a full HTML page
-                throw new InvalidApPostException("Invalid status code while getting: $apAddress, status code: $statusCode");
+                throw new InvalidApPostException('Invalid status code while getting', $apAddress, $statusCode);
             }
         } catch (\Exception $e) {
             $this->logRequestException($response, $apAddress, 'ApHttpClient:getCollectionObject', $e);
@@ -374,7 +374,8 @@ class ApHttpClient
      * @param User|Magazine $actor The actor initiating the request, either a User or Magazine object
      * @param array|null    $body  (Optional) The body of the POST request. Defaults to null.
      *
-     * @throws InvalidApPostException if the POST request fails with a non-2xx response status code
+     * @throws InvalidApPostException      if the POST request fails with a non-2xx response status code
+     * @throws TransportExceptionInterface
      */
     public function post(string $url, User|Magazine $actor, ?array $body = null): void
     {
@@ -407,7 +408,7 @@ class ApHttpClient
             $statusCode = $response->getStatusCode();
             if (!str_starts_with((string) $statusCode, '2')) {
                 // Do NOT include the response content in the error message, this will be often a full HTML page
-                throw new InvalidApPostException("Post failed: $url, status code: $statusCode, request body: $jsonBody");
+                throw new InvalidApPostException('Post failed', $url, $statusCode, $body);
             }
         } catch (\Exception $e) {
             $this->logRequestException($response, $url, 'ApHttpClient:post', $e);


### PR DESCRIPTION
When we try to deliver an activity to an inbox and receive a 4xx status code other than the 429 for rate limiting we now discard that message, so it will not get retried. This also doesn't count as a failed delivery to the instance anymore, because the instance is up, it just didn't accept the activity. TransportExceptions are now caught as well, since those are the ones we get when an instance is down