### PR TITLE
Fix min length issues for magazine description and rules

### DIFF
--- a/src/DTO/MagazineDto.php
+++ b/src/DTO/MagazineDto.php
@@ -27,9 +27,9 @@ class MagazineDto
     #[Assert\NotBlank]
     #[Assert\Length(min: 3, max: self::MAX_TITLE_LENGTH)]
     public ?string $title = null;
-    #[Assert\Length(min: 3, max: Magazine::MAX_DESCRIPTION_LENGTH)]
+    #[Assert\Length(min: 0, max: Magazine::MAX_DESCRIPTION_LENGTH)]
     public ?string $description = null;
-    #[Assert\Length(min: 3, max: Magazine::MAX_RULES_LENGTH)]
+    #[Assert\Length(min: 0, max: Magazine::MAX_RULES_LENGTH)]
     public ?string $rules = null;
     public ?string $visibility = null;
     public int $subscriptionsCount = 0;


### PR DESCRIPTION
- lower the min length for the magazine description and rules from 3 to 0

Fixes the mentioned issue in #1001 