### PR TITLE
Rename 3rd party dev - > App developers

### DIFF
--- a/docs/04-app_developers/README.md
+++ b/docs/04-app_developers/README.md
@@ -1,4 +1,12 @@
-# 3rd Party Developer
+# App Developers
+
+If you wish to develop an app that uses the Mbin API end-points, that is possible by using the OAuth2.
+
+## API Endpoints
+
+For all the API endpoints go to the [API documentation page](https://docs.joinmbin.org/api/).
+
+Or use the Swagger documentation on an existing Mbin instance: `https://mbin_site.com/api/docs`. Assuming you setup the server and the API correctly.
 
 ## OAuth2 Guide
 
@@ -18,10 +26,6 @@
 3. `refresh_token`
    - [documentation here](https://www.oauth.com/oauth2-servers/making-authenticated-requests/refreshing-an-access-token/)
    - Refresh tokens are used with the `authorization_code` grant type to reduce the number of times the user must log in.
-
-### Endpoints
-
-For all the API endpoints go to the swagger documentation page, which is: `https://your_domain.com/api/docs`. Assuming you setup the server and the API correctly.
 
 ### Obtaining OAuth2 credentials from a new server
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 We split up the documentation for:
 
-- [Users](01-user/README.md)
-- [Admins](02-admin/README.md)
-- [Contributing](03-contributing/README.md)
-- and [3rd party developers](04-3rd_party_developer/README.md), meaning API documentation.
+- [Users](01-user/README.md) - User guide
+- [Admins](02-admin/README.md) - How-to guides for admins
+- [Contributing](03-contributing/README.md) - How to contribute to the project
+- [App developers](04-app_developers/README.md) - How to use Mbin API


### PR DESCRIPTION
- Renaming 3rd party developer to App developers
- Improve top-level README
- Improved app developers docs