### PR TITLE
Add new html to markdown converter for strikethrough support

### DIFF
--- a/src/Service/ActivityPub/MarkdownConverter.php
+++ b/src/Service/ActivityPub/MarkdownConverter.php
@@ -23,6 +23,7 @@ class MarkdownConverter
     {
         $converter = new HtmlConverter(['strip_tags' => true]);
         $converter->getEnvironment()->addConverter(new TableConverter());
+        $converter->getEnvironment()->addConverter(new StrikethroughConverter());
         $value = stripslashes($converter->convert($value));
 
         preg_match_all('/\[([^]]*)\] *\(([^)]*)\)/i', $value, $matches, PREG_SET_ORDER);

--- a/src/Service/ActivityPub/StrikethroughConverter.php
+++ b/src/Service/ActivityPub/StrikethroughConverter.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\ActivityPub;
+
+use League\HTMLToMarkdown\Configuration;
+use League\HTMLToMarkdown\ConfigurationAwareInterface;
+use League\HTMLToMarkdown\Converter\ConverterInterface;
+use League\HTMLToMarkdown\ElementInterface;
+
+/**
+ * Inspired by https://github.com/thephpleague/html-to-markdown/blob/master/src/Converter/EmphasisConverter.php.
+ */
+class StrikethroughConverter implements ConverterInterface, ConfigurationAwareInterface
+{
+    protected Configuration $config;
+
+    public function getSupportedTags(): array
+    {
+        return ['del', 'strike'];
+    }
+
+    public function setConfig(Configuration $config): void
+    {
+        $this->config = $config;
+    }
+
+    public function convert(ElementInterface $element): string
+    {
+        $value = $element->getValue();
+        if (!trim($value)) {
+            return $value;
+        }
+
+        $prefix = ltrim($value) !== $value ? ' ' : '';
+        $suffix = rtrim($value) !== $value ? ' ' : '';
+
+        /* If this node is immediately preceded or followed by one of the same type don't emit
+         * the start or end $style, respectively. This prevents <del>foo</del><del>bar</del> from
+         * being converted to ~~foo~~~~bar~~ which is incorrect. We want ~~foobar~~ instead.
+         */
+        $preStyle = \in_array($element->getPreviousSibling()?->getTagName(), $this->getSupportedTags()) ? '' : '~~';
+        $postStyle = \in_array($element->getNextSibling()?->getTagName(), $this->getSupportedTags()) ? '' : '~~';
+
+        return $prefix.$preStyle.trim($value).$postStyle.$suffix;
+    }
+}


### PR DESCRIPTION
Strikethroughs are now properly converted to markdown:
![grafik](https://github.com/user-attachments/assets/93d93693-44f8-4e45-b204-730f2edad38b)

Related PR for the future: thephpleague/html-to-markdown#257
Closes #1189 