### PR TITLE
Include last receive in the formula for dead instances

### DIFF
--- a/src/Entity/Instance.php
+++ b/src/Entity/Instance.php
@@ -101,6 +101,7 @@ class Instance
     public function isDead(): bool
     {
         return ($this->getLastSuccessfulDeliver() < self::getDateBeforeDead() || null === $this->getLastSuccessfulDeliver())
+            && ($this->getLastSuccessfulReceive() < self::getDateBeforeDead() || null === $this->getLastSuccessfulReceive())
             && $this->getFailedDelivers() >= self::NUMBER_OF_FAILED_DELIVERS_UNTIL_DEAD;
     }
 }

--- a/src/Repository/InstanceRepository.php
+++ b/src/Repository/InstanceRepository.php
@@ -85,6 +85,7 @@ class InstanceRepository extends ServiceEntityRepository
         return $this->createQueryBuilder('i')
             ->where('i.failedDelivers >= :numToDead')
             ->andWhere('i.lastSuccessfulDeliver < :dateBeforeDead OR i.lastSuccessfulDeliver IS NULL')
+            ->andWhere('i.lastSuccessfulReceive < :dateBeforeDead OR i.lastSuccessfulReceive IS NULL')
             ->setParameter('numToDead', Instance::NUMBER_OF_FAILED_DELIVERS_UNTIL_DEAD)
             ->setParameter('dateBeforeDead', Instance::getDateBeforeDead())
             ->orderBy('i.id')

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -454,7 +454,7 @@ federation_page_allowed_description: Known instances we federate with
 federation_page_disallowed_description: Instances we do not federate with
 federation_page_dead_title: Dead instances
 federation_page_dead_description: Instances that we could not deliver at least 10
-  activities in a row and where the last successful deliver was more than a week ago
+  activities in a row and where the last successful deliver and -receive were more than a week ago
 federated_search_only_loggedin: Federated search limited if not logged in
 sidebar_sections_local_only: Restrict "Random X" and "Active People" sections to local
   only


### PR DESCRIPTION
An instance now counts as dead only if last successful deliver AND last successful receive are older than a week and there were 10 failed delivers in a row

This is of course open for discussion, but imo we have to include the receive in the formula. I looked at my instances and at fedia and there were just far too many instances that don't belong there