### PR TITLE
Fix data action kbin -> mbin rename

### DIFF
--- a/assets/controllers/mbin_controller.js
+++ b/assets/controllers/mbin_controller.js
@@ -60,6 +60,6 @@ export default class extends ApplicationController {
     }
 
     changeLang(event) {
-        window.location.href = '/settings/theme/kbin_lang/' + event.target.value;
+        window.location.href = '/settings/theme/mbin_lang/' + event.target.value;
     }
 }

--- a/assets/styles/components/_header.scss
+++ b/assets/styles/components/_header.scss
@@ -43,7 +43,7 @@
     }
   }
 
-  .kbin-container {
+  .mbin-container {
     display: grid;
     grid-template-areas: 'sr-nav brand magazine nav menu';
     grid-template-columns: min-content max-content max-content auto max-content;

--- a/assets/styles/components/_sidebar-subscriptions.scss
+++ b/assets/styles/components/_sidebar-subscriptions.scss
@@ -2,7 +2,7 @@
   border-radius: 0.5rem;
 }
 
-.kbin-container.width--fixed {
+.mbin-container.width--fixed {
   .sidebar-subscriptions:not(.inline) .subscription-list .subscription a {
     max-width: calc(max(305px, 1360px / 6) - 3rem);
   }
@@ -12,7 +12,7 @@
   }
 }
 
-.kbin-container.width--auto {
+.mbin-container.width--auto {
   .sidebar-subscriptions:not(.inline) .subscription-list .subscription a {
     max-width: calc(max(305px, 85vw / 6) - 3rem);
   }
@@ -22,7 +22,7 @@
   }
 }
 
-.kbin-container.width--max {
+.mbin-container.width--max {
   .sidebar-subscriptions:not(.inline) .subscription-list .subscription a {
     max-width: calc(max(305px, 100vw / 6) - 3rem);
   }

--- a/assets/styles/layout/_layout.scss
+++ b/assets/styles/layout/_layout.scss
@@ -7,7 +7,7 @@ body {
   fill: red
 }
 
-.kbin-container {
+.mbin-container {
   margin: 0 auto;
   max-width: 1360px;
 
@@ -27,7 +27,7 @@ body {
   z-index: 5;
   position: relative;
 
-  .kbin-container {
+  .mbin-container {
     display: grid;
     grid-template-areas: 'main sidebar';
     grid-template-columns: 3fr 1fr;

--- a/src/Controller/User/ThemeSettingsController.php
+++ b/src/Controller/User/ThemeSettingsController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ThemeSettingsController extends AbstractController
 {
-    public const KBIN_LANG = 'kbin_lang';
+    public const MBIN_LANG = 'mbin_lang';
     public const ENTRIES_VIEW = 'entries_view';
     public const ENTRY_COMMENTS_VIEW = 'entry_comments_view';
     public const POST_COMMENTS_VIEW = 'post_comments_view';
@@ -93,7 +93,7 @@ class ThemeSettingsController extends AbstractController
         self::KBIN_POSTS_SHOW_PREVIEW,
         self::KBIN_POSTS_SHOW_USERS_AVATARS,
         self::KBIN_GENERAL_DYNAMIC_LISTS,
-        self::KBIN_LANG,
+        self::MBIN_LANG,
         self::KBIN_COMMENTS_SHOW_USER_AVATAR,
         self::KBIN_COMMENTS_REPLY_POSITION,
         self::KBIN_SUBSCRIPTIONS_SHOW,
@@ -149,8 +149,8 @@ class ThemeSettingsController extends AbstractController
             $response->headers->setCookie(new Cookie($key, $value, strtotime('+1 year')));
         }
 
-        if (self::KBIN_LANG === $key) {
-            $response->headers->setCookie(new Cookie(self::KBIN_LANG, $value, strtotime('+1 year')));
+        if (self::MBIN_LANG === $key) {
+            $response->headers->setCookie(new Cookie(self::MBIN_LANG, $value, strtotime('+1 year')));
         }
 
         if ($request->isXmlHttpRequest()) {

--- a/src/EventListener/LanguageListener.php
+++ b/src/EventListener/LanguageListener.php
@@ -16,8 +16,8 @@ class LanguageListener
     {
         $request = $event->getRequest();
 
-        if ($request->cookies->has('kbin_lang')) {
-            $request->setLocale($request->cookies->get('kbin_lang'));
+        if ($request->cookies->has('mbin_lang')) {
+            $request->setLocale($request->cookies->get('mbin_lang'));
 
             return;
         }

--- a/src/Service/SettingsManager.php
+++ b/src/Service/SettingsManager.php
@@ -185,7 +185,7 @@ class SettingsManager
     {
         $request = $this->requestStack->getCurrentRequest();
 
-        return $request->cookies->get('kbin_lang') ?? $request->getLocale() ?? $this->get('KBIN_DEFAULT_LANG');
+        return $request->cookies->get('mbin_lang') ?? $request->getLocale() ?? $this->get('KBIN_DEFAULT_LANG');
     }
 
     public function getMaxImageByteString(): string

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -61,7 +61,7 @@
         'subs-show': app.user is defined and app.user is not same as null and SUBSCRIPTIONS_SHOW is not same as V_FALSE and SUBSCRIPTIONS_SEPARATE is same as V_TRUE,
         'sidebars-same-side': app.user is defined and app.user is not same as null and SUBSCRIPTIONS_SEPARATE is same as V_TRUE and SUBSCRIPTIONS_SAME_SIDE is same as V_TRUE,
     }) }}"
-        data-controller="kbin notifications"
+        data-controller="mbin notifications"
         data-notifications-endpoint-value="{{ kbin_mercure_enabled() ? 'https://'~kbin_domain()~'/.well-known/mercure' : null }}"
         data-notifications-user-value="{{ app.user ? app.user.id : null }}"
         data-notifications-magazine-value="{{ magazine is defined and magazine ? magazine.id : null }}"

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -71,7 +71,7 @@
 {% include 'layout/_header.html.twig' with {header_nav: block('header_nav')} %}
 {{ component('announcement') }}
 <div id="middle" class="{%- block mainClass -%}page{%- endblock %}">
-    <div class="kbin-container {{ html_classes('width--'~PAGE_WIDTH) }}">
+    <div class="mbin-container {{ html_classes('width--'~PAGE_WIDTH) }}">
         <main id="main"
               data-controller="lightbox timeago confirmation"
               class="{{ html_classes({'view-compact': COMPACT is same as V_TRUE}) }}">

--- a/templates/bundles/NelmioApiDocBundle/SwaggerUi/index.html.twig
+++ b/templates/bundles/NelmioApiDocBundle/SwaggerUi/index.html.twig
@@ -16,6 +16,9 @@
         padding: inherit;
         overflow: inherit;
     }
+    header #logo {
+        position: inherit;
+    }
     </style>
 {% endblock %}
 

--- a/templates/bundles/NelmioApiDocBundle/SwaggerUi/index.html.twig
+++ b/templates/bundles/NelmioApiDocBundle/SwaggerUi/index.html.twig
@@ -25,7 +25,7 @@
 
 {% block header_block %}
     <header id="header" class="header">
-        <div class="kbin-container">
+        <div class="mbin-container">
             <nav class="head-nav">
                 <div class="brand">
                     <a href="{{ '/' }}">

--- a/templates/bundles/NelmioApiDocBundle/SwaggerUi/index.html.twig
+++ b/templates/bundles/NelmioApiDocBundle/SwaggerUi/index.html.twig
@@ -18,6 +18,7 @@
     }
     header #logo {
         position: inherit;
+        transform: unset;
     }
     </style>
 {% endblock %}

--- a/templates/bundles/NelmioApiDocBundle/SwaggerUi/index.html.twig
+++ b/templates/bundles/NelmioApiDocBundle/SwaggerUi/index.html.twig
@@ -22,7 +22,7 @@
 {% block header_block %}
     <header id="header" class="header">
         <div class="kbin-container">
-            <nav class="head-nav"  data-action="click->kbin#toggleNav">
+            <nav class="head-nav">
                 <div class="brand">
                     <a href="{{ '/' }}">
                         {% if kbin_header_logo() %}

--- a/templates/layout/_header.html.twig
+++ b/templates/layout/_header.html.twig
@@ -1,6 +1,6 @@
 {%- set STATUS_PENDING = constant('App\\Entity\\Report::STATUS_PENDING') -%}
 <header id="header" class="header">
-    <div class="kbin-container
+    <div class="mbin-container
           {{ html_classes(app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH'))
             ? 'width--'~app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_PAGE_WIDTH'))
             : '') }}">

--- a/templates/layout/_header.html.twig
+++ b/templates/layout/_header.html.twig
@@ -11,7 +11,7 @@
         </div>
         <nav class="head-nav">
             <div class="brand">
-                <div id="nav-toggle" data-action="click->kbin#handleNavToggleClick" aria-label="{{ 'menu'|trans }}"><i class="fa-solid fa-bars" aria-hidden="true"></i></div>
+                <div id="nav-toggle" data-action="click->mbin#handleNavToggleClick" aria-label="{{ 'menu'|trans }}"><i class="fa-solid fa-bars" aria-hidden="true"></i></div>
                 <a href="/">
                     {% if kbin_header_logo() %}
                         <img id="logo" src="{{ asset('mbin_logo.svg') }}" alt="{{ 'homepage'|trans }}" title="{{ 'homepage'|trans}}">

--- a/templates/layout/_sidebar.html.twig
+++ b/templates/layout/_sidebar.html.twig
@@ -159,7 +159,7 @@
                 : null %}
             {% set current = app.request.cookies.get('kbin_lang') ?? header_accept_language ?? kbin_default_lang() %}
             <li>
-                <select data-action="kbin#changeLang">
+                <select data-action="mbin#changeLang">
                     {% for code in ['bg', 'da', 'de', 'el', 'en', 'eo', 'es', 'fil', 'fr', 'gl', 'it', 'ja', 'nl', 'pl', 'pt', 'pt_BR', 'ru', 'tr', 'uk', 'zh_TW'] %}
                         <option value="{{ code }}" {{ code is same as current ? 'selected' : '' }}>{{ code|language_name(code) }}</option>
                     {% endfor %}

--- a/templates/layout/_sidebar.html.twig
+++ b/templates/layout/_sidebar.html.twig
@@ -157,7 +157,7 @@
             {% set header_accept_language = app.request.headers.has('accept_language')
                 ? app.request.headers.get('accept_language')|slice(0,2)
                 : null %}
-            {% set current = app.request.cookies.get('kbin_lang') ?? header_accept_language ?? kbin_default_lang() %}
+            {% set current = app.request.cookies.get('mbin_lang') ?? header_accept_language ?? kbin_default_lang() %}
             <li>
                 <select data-action="mbin#changeLang">
                     {% for code in ['bg', 'da', 'de', 'el', 'en', 'eo', 'es', 'fil', 'fr', 'gl', 'it', 'ja', 'nl', 'pl', 'pt', 'pt_BR', 'ru', 'tr', 'uk', 'zh_TW'] %}


### PR DESCRIPTION
- I renamed `kbin_controller.js` to `mbin_controller.js`, however then you apparently **ALSO need to update the `data-controller` as well with this name. So Stimulus would load the controller.**
- Then I also did the rename on the `data-action` to `mbin#` (which is required after you renamed the data-controller).
- In the swagger template (by NelmioApiDocBundle), we don't even use this navigation menu. This should be removed, because this is dead-code there.
   -  While I was at here, I also improved the CSS in the Swagger template, so the logo actually is better displayed now within the SwaggerUI template.
- Also update `kbin_lang` to `mbin_lang` while I found it anyways how it works now.
- ALso rename `kbin-container` to `mbin-container`, while I'm here now.

Regression of: https://github.com/MbinOrg/mbin/pull/1256
