### PR TITLE
Remove using the AP id as the URL

### DIFF
--- a/src/Factory/ActivityPub/EntryPageFactory.php
+++ b/src/Factory/ActivityPub/EntryPageFactory.php
@@ -131,6 +131,6 @@ class EntryPageFactory
             return $this->imageManager->getUrl($entry->image);
         }
 
-        return $entry->url ?? $this->getActivityPubId($entry);
+        return $entry->url;
     }
 }


### PR DESCRIPTION
Entries exposed their AP id as their URL if no URL was set. This commit removes that

As far as I can tell this is only relevant for `Article` AP types, so only the entries. Mastodon posts have their id as the url, so I'd keep it for `Note` AP types (posts and comments)

On Articles it had the effect that mbin instances had domains for each other mbin instance, but also the mbin logo on each mbin article when it didn't have an image attached or pointed to a link. That behaviour has annoyed me forever, so here it gets removed