### PR TITLE
Add two stage Nginx rate limit

### DIFF
--- a/docs/02-admin/02-configuration/02-nginx.md
+++ b/docs/02-admin/02-configuration/02-nginx.md
@@ -192,7 +192,7 @@ server {
     client_max_body_size 20M; # Max size of a file that a user can upload
 
     # Two stage rate limit
-    limit_req zone=mbin_limit burst=400 delay=200;
+    limit_req zone=mbin_limit burst=300 delay=200;
 
     # Error log
     error_log /var/log/nginx/mbin_error.log;

--- a/docs/02-admin/02-configuration/02-nginx.md
+++ b/docs/02-admin/02-configuration/02-nginx.md
@@ -152,8 +152,8 @@ map $regularRequest $mbin_limit_key {
     1 $binary_remote_addr;
 }
 
-# Two stage rate limit (10 MB zone): 2 requests/sec limit (=second stage)
-limit_req_zone $mbin_limit_key zone=mbin_limit:10m rate=2r/s;
+# Two stage rate limit (10 MB zone): 5 requests/second limit (=second stage)
+limit_req_zone $mbin_limit_key zone=mbin_limit:10m rate=5r/s;
 
 # Redirect HTTP to HTTPS
 server {


### PR DESCRIPTION
`delay=200` means it will allow the first 200 requests without any delay. After 200 requests you will hit the delaying of the requests, which is set to 5 requests/second. If the client keep requesting requests these will still get queued. However, after 300 requests in the buffer (`bust=300`), Nginx will start rejecting requests. 

- Setup two stage rate limiter in Nginx
- Only rate limit based on the "Regular requests"
- These rejection requests will be put to the error log: `/var/log/nginx/mbin_error.log`.

See also: https://blog.nginx.org/blog/rate-limiting-nginx

---

 If you use Fail2Ban this error log will be matched as `nginx_error_log` variable. You could use the error log to actually ban bots/users who are exceeding the rate limit (this ban is triggered if there are 50 rejected requests, default is only 3, in the past 10 minutes dedicated for the same IP):

```conf
[nginx-limit-req]
enabled  = true
port     = http,https
action   = %(action_)s
logpath  = %(nginx_error_log)s
findtime = 10m
maxretry = 50
bantime  = 1w
```

I will later document Fail2Ban config in a different markdown file / docs.