### PR TITLE
Enable multi-core parallel PHP CS Fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -13,6 +13,7 @@ $finder = (new PhpCsFixer\Finder())
 ;
 
 return (new PhpCsFixer\Config())
+    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setRules([
         '@Symfony' => true,
 


### PR DESCRIPTION
Enable the parallel config, which auto-detect the cores on the system and run PHP CS Fixer in parallel. See also:

https://cs.symfony.com/doc/usage.html

Tested and works perfectly fine! Especially on my new threadripper system :)