### PR TITLE
Add testcase for hashtag matching

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -18,7 +18,7 @@ KBIN_DEFAULT_LANG=en
 KBIN_DOMAIN=kbin.test
 ELASTICSEARCH_ENABLED=false
 KBIN_API_ITEMS_PER_PAGE=2
-KBIN_FEDERATION_ENABLED=false
+KBIN_FEDERATION_ENABLED=true
 
 ###> league/oauth2-server-bundle ###
 OAUTH_PRIVATE_KEY=%kernel.project_dir%/config/oauth2/tests/private.pem

--- a/src/Command/ApImportObject.php
+++ b/src/Command/ApImportObject.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Command;
 
 use App\Message\ActivityPub\Inbox\ActivityMessage;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -21,7 +21,7 @@ class ApImportObject extends Command
 {
     public function __construct(
         private readonly MessageBusInterface $bus,
-        private readonly ApHttpClient $client,
+        private readonly ApHttpClientInterface $client,
     ) {
         parent::__construct();
     }

--- a/src/Controller/ActivityPub/WebFingerController.php
+++ b/src/Controller/ActivityPub/WebFingerController.php
@@ -6,19 +6,26 @@ namespace App\Controller\ActivityPub;
 
 use App\ActivityPub\JsonRd;
 use App\Event\ActivityPub\WebfingerResponseEvent;
+use App\Service\ActivityPub\Webfinger\WebFingerParameters;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 class WebFingerController
 {
-    public function __construct(private readonly EventDispatcherInterface $eventDispatcher)
-    {
+    public function __construct(
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly WebFingerParameters $webFingerParameters,
+    ) {
     }
 
     public function __invoke(Request $request): JsonResponse
     {
-        $event = new WebfingerResponseEvent(new JsonRd(), $request);
+        $event = new WebfingerResponseEvent(
+            new JsonRd(),
+            $request->query->get('resource') ?: '',
+            $this->webFingerParameters->getParams($request),
+        );
         $this->eventDispatcher->dispatch($event);
 
         if (!empty($event->jsonRd->getLinks())) {

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -9,7 +9,7 @@ use App\Entity\Magazine;
 use App\Entity\User;
 use App\Message\ActivityPub\Inbox\CreateMessage;
 use App\MessageHandler\ActivityPub\Inbox\CreateHandler;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\ActivityPubManager;
 use App\Service\SearchManager;
 use App\Service\SettingsManager;
@@ -23,7 +23,7 @@ class SearchController extends AbstractController
     public function __construct(
         private readonly SearchManager $manager,
         private readonly ActivityPubManager $activityPubManager,
-        private readonly ApHttpClient $apHttpClient,
+        private readonly ApHttpClientInterface $apHttpClient,
         private readonly SubjectOverviewManager $overviewManager,
         private readonly SettingsManager $settingsManager,
         private readonly LoggerInterface $logger,

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -11,7 +11,7 @@ use App\Entity\Traits\ActivityPubActorTrait;
 use App\Entity\Traits\CreatedAtTrait;
 use App\Entity\Traits\VisibilityTrait;
 use App\Repository\UserRepository;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
@@ -869,7 +869,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Visibil
         return $this->magazineOwnershipRequests->matching($criteria)->count() > 0;
     }
 
-    public function getFollowerUrl(ApHttpClient $client, UrlGeneratorInterface $urlGenerator, bool $isRemote): ?string
+    public function getFollowerUrl(ApHttpClientInterface $client, UrlGeneratorInterface $urlGenerator, bool $isRemote): ?string
     {
         if ($isRemote) {
             $actorObject = $client->getActorObject($this->apProfileId);

--- a/src/Event/ActivityPub/WebfingerResponseEvent.php
+++ b/src/Event/ActivityPub/WebfingerResponseEvent.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace App\Event\ActivityPub;
 
 use App\ActivityPub\JsonRd;
-use Symfony\Component\HttpFoundation\Request;
 
 class WebfingerResponseEvent
 {
     public function __construct(
         public JsonRd $jsonRd,
-        public Request $request,
+        public string $subject,
+        public array $params,
     ) {
     }
 }

--- a/src/EventSubscriber/ActivityPub/GroupWebFingerProfileSubscriber.php
+++ b/src/EventSubscriber/ActivityPub/GroupWebFingerProfileSubscriber.php
@@ -16,7 +16,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class GroupWebFingerProfileSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly WebFingerParameters $webfingerParameters,
         private readonly MagazineRepository $magazineRepository,
         private readonly UrlGeneratorInterface $urlGenerator,
     ) {
@@ -32,7 +31,7 @@ class GroupWebFingerProfileSubscriber implements EventSubscriberInterface
 
     public function buildResponse(WebfingerResponseEvent $event): void
     {
-        $params = $this->webfingerParameters->getParams($event->request);
+        $params = $event->params;
         $jsonRd = $event->jsonRd;
 
         if (

--- a/src/EventSubscriber/ActivityPub/GroupWebFingerSubscriber.php
+++ b/src/EventSubscriber/ActivityPub/GroupWebFingerSubscriber.php
@@ -16,7 +16,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class GroupWebFingerSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly WebFingerParameters $webfingerParameters,
         private readonly MagazineRepository $magazineRepository,
         private readonly UrlGeneratorInterface $urlGenerator,
     ) {
@@ -32,11 +31,10 @@ class GroupWebFingerSubscriber implements EventSubscriberInterface
 
     public function buildResponse(WebfingerResponseEvent $event): void
     {
-        $request = $event->request;
-        $params = $this->webfingerParameters->getParams($request);
+        $params = $event->params;
         $jsonRd = $event->jsonRd;
 
-        $subject = $request->query->get('resource') ?: '';
+        $subject = $event->subject;
         if (!empty($subject)) {
             $jsonRd->setSubject($subject);
         }

--- a/src/EventSubscriber/ActivityPub/UserWebFingerProfileSubscriber.php
+++ b/src/EventSubscriber/ActivityPub/UserWebFingerProfileSubscriber.php
@@ -19,7 +19,6 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class UserWebFingerProfileSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly WebFingerParameters $webfingerParameters,
         private readonly UserRepository $userRepository,
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly SettingsManager $settingsManager,
@@ -38,7 +37,7 @@ class UserWebFingerProfileSubscriber implements EventSubscriberInterface
 
     public function buildResponse(WebfingerResponseEvent $event): void
     {
-        $params = $this->webfingerParameters->getParams($event->request);
+        $params = $event->params;
         $jsonRd = $event->jsonRd;
 
         if (isset($params[WebFingerParameters::ACCOUNT_KEY_NAME])) {

--- a/src/EventSubscriber/ActivityPub/UserWebFingerSubscriber.php
+++ b/src/EventSubscriber/ActivityPub/UserWebFingerSubscriber.php
@@ -16,7 +16,6 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class UserWebFingerSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly WebFingerParameters $webfingerParameters,
         private readonly UserRepository $userRepository,
         private readonly UrlGeneratorInterface $urlGenerator,
     ) {
@@ -32,11 +31,10 @@ class UserWebFingerSubscriber implements EventSubscriberInterface
 
     public function buildResponse(WebfingerResponseEvent $event): void
     {
-        $request = $event->request;
-        $params = $this->webfingerParameters->getParams($request);
+        $params = $event->params;
         $jsonRd = $event->jsonRd;
 
-        $subject = $request->query->get('resource') ?: '';
+        $subject = $event->subject;
         if (!empty($subject)) {
             $jsonRd->setSubject($subject);
         }

--- a/src/Factory/ActivityPub/EntryCommentNoteFactory.php
+++ b/src/Factory/ActivityPub/EntryCommentNoteFactory.php
@@ -8,7 +8,7 @@ use App\Entity\Contracts\ActivityPubActivityInterface;
 use App\Entity\EntryComment;
 use App\Markdown\MarkdownConverter;
 use App\Markdown\RenderTarget;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\ActivityPub\ContextsProvider;
 use App\Service\ActivityPub\Wrapper\ImageWrapper;
 use App\Service\ActivityPub\Wrapper\MentionsWrapper;
@@ -28,7 +28,7 @@ class EntryCommentNoteFactory
         private readonly MentionsWrapper $mentionsWrapper,
         private readonly MentionManager $mentionManager,
         private readonly EntryPageFactory $pageFactory,
-        private readonly ApHttpClient $client,
+        private readonly ApHttpClientInterface $client,
         private readonly ActivityPubManager $activityPubManager,
         private readonly MarkdownConverter $markdownConverter,
     ) {

--- a/src/Factory/ActivityPub/EntryPageFactory.php
+++ b/src/Factory/ActivityPub/EntryPageFactory.php
@@ -8,7 +8,7 @@ use App\Entity\Contracts\ActivityPubActivityInterface;
 use App\Entity\Entry;
 use App\Markdown\MarkdownConverter;
 use App\Markdown\RenderTarget;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\ActivityPub\ContextsProvider;
 use App\Service\ActivityPub\Wrapper\ImageWrapper;
 use App\Service\ActivityPub\Wrapper\MentionsWrapper;
@@ -27,7 +27,7 @@ class EntryPageFactory
         private readonly ImageWrapper $imageWrapper,
         private readonly TagsWrapper $tagsWrapper,
         private readonly MentionsWrapper $mentionsWrapper,
-        private readonly ApHttpClient $client,
+        private readonly ApHttpClientInterface $client,
         private readonly ActivityPubManager $activityPubManager,
         private readonly MarkdownConverter $markdownConverter,
     ) {

--- a/src/Factory/ActivityPub/InstanceFactory.php
+++ b/src/Factory/ActivityPub/InstanceFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Factory\ActivityPub;
 
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\ActivityPub\ContextsProvider;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -12,7 +12,7 @@ class InstanceFactory
 {
     public function __construct(
         private string $kbinDomain,
-        private readonly ApHttpClient $client,
+        private readonly ApHttpClientInterface $client,
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly ContextsProvider $contextProvider,
     ) {

--- a/src/Factory/ActivityPub/PostCommentNoteFactory.php
+++ b/src/Factory/ActivityPub/PostCommentNoteFactory.php
@@ -8,7 +8,7 @@ use App\Entity\Contracts\ActivityPubActivityInterface;
 use App\Entity\PostComment;
 use App\Markdown\MarkdownConverter;
 use App\Markdown\RenderTarget;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\ActivityPub\ContextsProvider;
 use App\Service\ActivityPub\Wrapper\ImageWrapper;
 use App\Service\ActivityPub\Wrapper\MentionsWrapper;
@@ -28,7 +28,7 @@ class PostCommentNoteFactory
         private readonly TagsWrapper $tagsWrapper,
         private readonly MentionsWrapper $mentionsWrapper,
         private readonly MentionManager $mentionManager,
-        private readonly ApHttpClient $client,
+        private readonly ApHttpClientInterface $client,
         private readonly ActivityPubManager $activityPubManager,
         private readonly MarkdownConverter $markdownConverter,
     ) {

--- a/src/Factory/ActivityPub/PostNoteFactory.php
+++ b/src/Factory/ActivityPub/PostNoteFactory.php
@@ -8,7 +8,7 @@ use App\Entity\Contracts\ActivityPubActivityInterface;
 use App\Entity\Post;
 use App\Markdown\MarkdownConverter;
 use App\Markdown\RenderTarget;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\ActivityPub\ContextsProvider;
 use App\Service\ActivityPub\Wrapper\ImageWrapper;
 use App\Service\ActivityPub\Wrapper\MentionsWrapper;
@@ -27,7 +27,7 @@ class PostNoteFactory
         private readonly ImageWrapper $imageWrapper,
         private readonly TagsWrapper $tagsWrapper,
         private readonly MentionsWrapper $mentionsWrapper,
-        private readonly ApHttpClient $client,
+        private readonly ApHttpClientInterface $client,
         private readonly ActivityPubManager $activityPubManager,
         private readonly MentionManager $mentionManager,
         private readonly TagExtractor $tagExtractor,

--- a/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
@@ -23,7 +23,7 @@ use App\Message\ActivityPub\Inbox\UpdateMessage;
 use App\Message\Contracts\MessageInterface;
 use App\MessageHandler\MbinMessageHandler;
 use App\Repository\InstanceRepository;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\ActivityPub\SignatureValidator;
 use App\Service\ActivityPubManager;
 use App\Service\RemoteInstanceManager;
@@ -45,7 +45,7 @@ class ActivityHandler extends MbinMessageHandler
         private readonly SettingsManager $settingsManager,
         private readonly MessageBusInterface $bus,
         private readonly ActivityPubManager $activityPubManager,
-        private readonly ApHttpClient $apHttpClient,
+        private readonly ApHttpClientInterface $apHttpClient,
         private readonly InstanceRepository $instanceRepository,
         private readonly RemoteInstanceManager $remoteInstanceManager,
         private readonly LoggerInterface $logger,

--- a/src/MessageHandler/ActivityPub/Inbox/AddHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/AddHandler.php
@@ -15,7 +15,7 @@ use App\MessageHandler\MbinMessageHandler;
 use App\Repository\ApActivityRepository;
 use App\Repository\EntryRepository;
 use App\Repository\MagazineRepository;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\ActivityPubManager;
 use App\Service\EntryManager;
 use App\Service\MagazineManager;
@@ -33,7 +33,7 @@ class AddHandler extends MbinMessageHandler
         private readonly EntityManagerInterface $entityManager,
         private readonly KernelInterface $kernel,
         private readonly ActivityPubManager $activityPubManager,
-        private readonly ApHttpClient $apHttpClient,
+        private readonly ApHttpClientInterface $apHttpClient,
         private readonly ApActivityRepository $apActivityRepository,
         private readonly MagazineRepository $magazineRepository,
         private readonly MagazineManager $magazineManager,

--- a/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
@@ -20,7 +20,7 @@ use App\Message\ActivityPub\Inbox\LikeMessage;
 use App\Message\Contracts\MessageInterface;
 use App\MessageHandler\MbinMessageHandler;
 use App\Repository\ApActivityRepository;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\ActivityPub\Note;
 use App\Service\ActivityPub\Page;
 use App\Service\SettingsManager;
@@ -37,7 +37,7 @@ class ChainActivityHandler extends MbinMessageHandler
         private readonly EntityManagerInterface $entityManager,
         private readonly KernelInterface $kernel,
         private readonly LoggerInterface $logger,
-        private readonly ApHttpClient $client,
+        private readonly ApHttpClientInterface $client,
         private readonly MessageBusInterface $bus,
         private readonly ApActivityRepository $repository,
         private readonly Note $note,

--- a/src/MessageHandler/ActivityPub/Inbox/FollowHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/FollowHandler.php
@@ -9,7 +9,7 @@ use App\Entity\User;
 use App\Message\ActivityPub\Inbox\FollowMessage;
 use App\Message\Contracts\MessageInterface;
 use App\MessageHandler\MbinMessageHandler;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\ActivityPub\Wrapper\FollowResponseWrapper;
 use App\Service\ActivityPubManager;
 use App\Service\MagazineManager;
@@ -28,7 +28,7 @@ class FollowHandler extends MbinMessageHandler
         private readonly ActivityPubManager $activityPubManager,
         private readonly UserManager $userManager,
         private readonly MagazineManager $magazineManager,
-        private readonly ApHttpClient $client,
+        private readonly ApHttpClientInterface $client,
         private readonly LoggerInterface $logger,
         private readonly FollowResponseWrapper $followResponseWrapper,
     ) {

--- a/src/MessageHandler/ActivityPub/Outbox/DeliverHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/DeliverHandler.php
@@ -12,7 +12,7 @@ use App\Message\ActivityPub\Outbox\DeliverMessage;
 use App\Message\Contracts\MessageInterface;
 use App\MessageHandler\MbinMessageHandler;
 use App\Repository\InstanceRepository;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\ActivityPubManager;
 use App\Service\SettingsManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -32,7 +32,7 @@ class DeliverHandler extends MbinMessageHandler
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly KernelInterface $kernel,
-        private readonly ApHttpClient $client,
+        private readonly ApHttpClientInterface $client,
         private readonly ActivityPubManager $activityPubManager,
         private readonly SettingsManager $settingsManager,
         private readonly LoggerInterface $logger,

--- a/src/MessageHandler/ActivityPub/Outbox/FollowHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/FollowHandler.php
@@ -9,7 +9,7 @@ use App\Message\Contracts\MessageInterface;
 use App\MessageHandler\MbinMessageHandler;
 use App\Repository\MagazineRepository;
 use App\Repository\UserRepository;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\ActivityPub\Wrapper\FollowWrapper;
 use App\Service\ActivityPub\Wrapper\UndoWrapper;
 use App\Service\ActivityPubManager;
@@ -30,7 +30,7 @@ class FollowHandler extends MbinMessageHandler
         private readonly ActivityPubManager $activityPubManager,
         private readonly FollowWrapper $followWrapper,
         private readonly UndoWrapper $undoWrapper,
-        private readonly ApHttpClient $apHttpClient,
+        private readonly ApHttpClientInterface $apHttpClient,
         private readonly SettingsManager $settingsManager,
         private readonly DeliverManager $deliverManager,
     ) {

--- a/src/MessageHandler/ActivityPub/UpdateActorHandler.php
+++ b/src/MessageHandler/ActivityPub/UpdateActorHandler.php
@@ -9,7 +9,7 @@ use App\Message\Contracts\MessageInterface;
 use App\MessageHandler\MbinMessageHandler;
 use App\Repository\MagazineRepository;
 use App\Repository\UserRepository;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\ActivityPubManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -24,7 +24,7 @@ class UpdateActorHandler extends MbinMessageHandler
         private readonly EntityManagerInterface $entityManager,
         private readonly KernelInterface $kernel,
         private readonly ActivityPubManager $activityPubManager,
-        private readonly ApHttpClient $apHttpClient,
+        private readonly ApHttpClientInterface $apHttpClient,
         private readonly LockFactory $lockFactory,
         private readonly UserRepository $userRepository,
         private readonly MagazineRepository $magazineRepository,

--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -41,7 +41,7 @@ enum ApRequestType
     case NodeInfo;
 }
 
-class ApHttpClient
+class ApHttpClient implements ApHttpClientInterface
 {
     public const TIMEOUT = 8;
     public const MAX_DURATION = 15;

--- a/src/Service/ActivityPub/ApHttpClientInterface.php
+++ b/src/Service/ActivityPub/ApHttpClientInterface.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\ActivityPub;
+
+use App\Entity\Magazine;
+use App\Entity\User;
+use App\Exception\InvalidApPostException;
+use App\Exception\InvalidWebfingerException;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+interface ApHttpClientInterface
+{
+    /**
+     * Retrieve a remote activity object from an URL. And cache the result.
+     *
+     * @param bool $decoded (optional)
+     *
+     * @return array|string|null JSON Response body (as PHP Object)
+     */
+    public function getActivityObject(string $url, bool $decoded = true): array|string|null;
+
+    public function getActivityObjectCacheKey(string $url): string;
+
+    /**
+     * Retrieve AP actor object (could be a user or magazine).
+     *
+     * @return string return the inbox URL of the actor
+     *
+     * @throws \LogicException|InvalidApPostException if the AP actor object cannot be found
+     */
+    public function getInboxUrl(string $apProfileId): string;
+
+    /**
+     * Execute a webfinger request according to RFC 7033 (https://tools.ietf.org/html/rfc7033).
+     *
+     * @param string $url the URL of the user/magazine to get the webfinger object for
+     *
+     * @return array|null The webfinger object (as PHP Object)
+     *
+     * @throws InvalidWebfingerException|InvalidArgumentException
+     */
+    public function getWebfingerObject(string $url): ?array;
+
+    /**
+     * Retrieve AP actor object (could be a user or magazine).
+     *
+     * @return array|null key/value array of actor response body (as PHP Object)
+     *
+     * @throws InvalidApPostException|InvalidArgumentException
+     */
+    public function getActorObject(string $apProfileId): ?array;
+
+    /**
+     * Remove actor object from cache.
+     *
+     * @param string $apProfileId AP profile ID to remove from cache
+     */
+    public function invalidateActorObjectCache(string $apProfileId): void;
+
+    /**
+     * Remove collection object from cache.
+     *
+     * @param string $apAddress AP address to remove from cache
+     */
+    public function invalidateCollectionObjectCache(string $apAddress): void;
+
+    /**
+     * Retrieve AP collection object. First look in cache, then try to retrieve from AP server.
+     * And finally, save the response to cache.
+     *
+     * @return array|null JSON Response body (as PHP Object)
+     *
+     * @throws InvalidArgumentException
+     */
+    public function getCollectionObject(string $apAddress): ?array;
+
+    /**
+     * Sends a POST request to the specified URL with optional request body and caching mechanism.
+     *
+     * @param string        $url   the URL to which the POST request will be sent
+     * @param User|Magazine $actor The actor initiating the request, either a User or Magazine object
+     * @param array|null    $body  (Optional) The body of the POST request. Defaults to null.
+     *
+     * @throws InvalidApPostException      if the POST request fails with a non-2xx response status code
+     * @throws TransportExceptionInterface
+     */
+    public function post(string $url, User|Magazine $actor, ?array $body = null): void;
+
+    public function fetchInstanceNodeInfoEndpoints(string $domain, bool $decoded = true): array|string|null;
+
+    public function fetchInstanceNodeInfo(string $url, bool $decoded = true): array|string|null;
+
+    public function getInstancePublicKey(): string;
+}

--- a/src/Service/ActivityPub/SignatureValidator.php
+++ b/src/Service/ActivityPub/SignatureValidator.php
@@ -18,7 +18,7 @@ readonly class SignatureValidator
 {
     public function __construct(
         private ActivityPubManager $activityPubManager,
-        private ApHttpClient $client,
+        private ApHttpClientInterface $client,
         private LoggerInterface $logger,
     ) {
     }

--- a/src/Service/ActivityPub/Webfinger/WebFingerFactory.php
+++ b/src/Service/ActivityPub/Webfinger/WebFingerFactory.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace App\Service\ActivityPub\Webfinger;
 
 use App\ActivityPub\ActorHandle;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 
 /**
  * A simple WebFinger discoverer tool.
@@ -23,7 +23,7 @@ class WebFingerFactory
 {
     public const WEBFINGER_URL = '%s://%s%s/.well-known/webfinger?resource=acct:%s';
 
-    public function __construct(private readonly ApHttpClient $client)
+    public function __construct(private readonly ApHttpClientInterface $client)
     {
     }
 

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -34,7 +34,7 @@ use App\Repository\ImageRepository;
 use App\Repository\InstanceRepository;
 use App\Repository\MagazineRepository;
 use App\Repository\UserRepository;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\ActivityPub\ApObjectExtractor;
 use App\Service\ActivityPub\Webfinger\WebFinger;
 use App\Service\ActivityPub\Webfinger\WebFingerFactory;
@@ -57,7 +57,7 @@ class ActivityPubManager
         private readonly MagazineManager $magazineManager,
         private readonly MagazineFactory $magazineFactory,
         private readonly MagazineRepository $magazineRepository,
-        private readonly ApHttpClient $apHttpClient,
+        private readonly ApHttpClientInterface $apHttpClient,
         private readonly ImageRepository $imageRepository,
         private readonly ImageManager $imageManager,
         private readonly EntityManagerInterface $entityManager,

--- a/src/Service/EntryManager.php
+++ b/src/Service/EntryManager.php
@@ -26,7 +26,7 @@ use App\Message\DeleteImageMessage;
 use App\Message\EntryEmbedMessage;
 use App\Repository\EntryRepository;
 use App\Repository\ImageRepository;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\Contracts\ContentManagerInterface;
 use App\Utils\Slugger;
 use App\Utils\UrlCleaner;
@@ -61,7 +61,7 @@ class EntryManager implements ContentManagerInterface
         private readonly EntityManagerInterface $entityManager,
         private readonly EntryRepository $entryRepository,
         private readonly ImageRepository $imageRepository,
-        private readonly ApHttpClient $apHttpClient,
+        private readonly ApHttpClientInterface $apHttpClient,
         private readonly CacheInterface $cache,
     ) {
     }

--- a/src/Service/PostManager.php
+++ b/src/Service/PostManager.php
@@ -21,7 +21,7 @@ use App\Factory\PostFactory;
 use App\Message\DeleteImageMessage;
 use App\Repository\ImageRepository;
 use App\Repository\PostRepository;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\Contracts\ContentManagerInterface;
 use App\Utils\Slugger;
 use Doctrine\Common\Collections\Criteria;
@@ -52,7 +52,7 @@ class PostManager implements ContentManagerInterface
         private readonly EntityManagerInterface $entityManager,
         private readonly PostRepository $postRepository,
         private readonly ImageRepository $imageRepository,
-        private readonly ApHttpClient $apHttpClient,
+        private readonly ApHttpClientInterface $apHttpClient,
         private readonly SettingsManager $settingsManager,
         private readonly CacheInterface $cache,
     ) {

--- a/src/Service/RemoteInstanceManager.php
+++ b/src/Service/RemoteInstanceManager.php
@@ -8,7 +8,7 @@ use App\Controller\ActivityPub\NodeInfoController;
 use App\Entity\Instance;
 use App\Payloads\NodeInfo\NodeInfo;
 use App\Payloads\NodeInfo\WellKnownNodeInfo;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\PropertyInfo\Extractor\ConstructorExtractor;
@@ -24,7 +24,7 @@ class RemoteInstanceManager
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
-        private readonly ApHttpClient $client,
+        private readonly ApHttpClientInterface $client,
         private readonly LoggerInterface $logger,
     ) {
     }

--- a/src/Service/SearchManager.php
+++ b/src/Service/SearchManager.php
@@ -10,7 +10,7 @@ use App\Message\ActivityPub\Inbox\ActivityMessage;
 use App\Repository\DomainRepository;
 use App\Repository\MagazineRepository;
 use App\Repository\SearchRepository;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Utils\RegPatterns;
 use Pagerfanta\Adapter\ArrayAdapter;
 use Pagerfanta\Pagerfanta;
@@ -25,7 +25,7 @@ class SearchManager
         private readonly DomainRepository $domainRepository,
         private readonly ActivityPubManager $activityPubManager,
         private readonly MessageBusInterface $bus,
-        private readonly ApHttpClient $apHttpClient,
+        private readonly ApHttpClientInterface $apHttpClient,
     ) {
     }
 

--- a/tests/FactoryTrait.php
+++ b/tests/FactoryTrait.php
@@ -272,6 +272,7 @@ trait FactoryTrait
         $this->entityManager->persist($newMod);
 
         $magazine = $this->magazineManager->create($dto, $newMod);
+        $this->entityManager->persist($magazine);
 
         $this->magazines->add($magazine);
 

--- a/tests/Functional/Controller/Api/Search/SearchApiTest.php
+++ b/tests/Functional/Controller/Api/Search/SearchApiTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Functional\Controller\Api\Search;
 
 use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\SettingsManager;
 use App\Tests\WebTestCase;
 use phpseclib3\Crypt\RSA;
@@ -395,6 +396,6 @@ class SearchApiTest extends WebTestCase
             $this->siteRepository,
             $this->projectInfoService,
         );
-        self::getContainer()->set(ApHttpClient::class, $apHttpClient);
+        self::getContainer()->set(ApHttpClientInterface::class, $apHttpClient);
     }
 }

--- a/tests/TestingApHttpClient.php
+++ b/tests/TestingApHttpClient.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests;
+
+use App\Entity\Magazine;
+use App\Entity\User;
+use App\Service\ActivityPub\ApHttpClientInterface;
+
+class TestingApHttpClient implements ApHttpClientInterface
+{
+    /**
+     * @phpstan-var array<string, array> $activityObjects
+     */
+    public array $activityObjects = [];
+
+    /**
+     * @phpstan-var array<string, array> $collectionObjects
+     */
+    public array $collectionObjects = [];
+
+    /**
+     * @phpstan-var array<string, array> $webfingerObjects
+     */
+    public array $webfingerObjects = [];
+
+    /**
+     * @phpstan-var array<string, array> $actorObjects
+     */
+    public array $actorObjects = [];
+
+    /**
+     * @var array<int, array{inboxUrl: string, payload: array, actor: User|Magazine}>
+     */
+    private array $postedObjects = [];
+
+    public function getActivityObject(string $url, bool $decoded = true): array|string|null
+    {
+        if (\array_key_exists($url, $this->activityObjects)) {
+            return $this->activityObjects[$url];
+        }
+
+        return null;
+    }
+
+    public function getCollectionObject(string $apAddress): ?array
+    {
+        if (\array_key_exists($apAddress, $this->collectionObjects)) {
+            return $this->collectionObjects[$apAddress];
+        }
+
+        return null;
+    }
+
+    public function getActorObject(string $apProfileId): ?array
+    {
+        if (\array_key_exists($apProfileId, $this->actorObjects)) {
+            return $this->actorObjects[$apProfileId];
+        }
+
+        return null;
+    }
+
+    public function getWebfingerObject(string $url): ?array
+    {
+        if (\array_key_exists($url, $this->webfingerObjects)) {
+            return $this->webfingerObjects[$url];
+        }
+
+        return null;
+    }
+
+    public function fetchInstanceNodeInfoEndpoints(string $domain, bool $decoded = true): array|string|null
+    {
+        return null;
+    }
+
+    public function fetchInstanceNodeInfo(string $url, bool $decoded = true): array|string|null
+    {
+        return null;
+    }
+
+    public function post(string $url, Magazine|User $actor, ?array $body = null): void
+    {
+        $this->postedObjects[] = [
+            'inboxUrl' => $url,
+            'actor' => $actor,
+            'payload' => $body,
+        ];
+    }
+
+    /**
+     * @return array<int, array{inboxUrl: string, payload: array, actor: User|Magazine}>
+     */
+    public function getPostedObjects(): array
+    {
+        return $this->postedObjects;
+    }
+
+    public function getActivityObjectCacheKey(string $url): string
+    {
+        return 'SOME_TESTING_CACHE_KEY';
+    }
+
+    public function getInboxUrl(string $apProfileId): string
+    {
+        $actor = $this->getActorObject($apProfileId);
+        if (!empty($actor)) {
+            return $actor['endpoints']['sharedInbox'] ?? $actor['inbox'];
+        } else {
+            throw new \LogicException("Unable to find AP actor (user or magazine) with URL: $apProfileId");
+        }
+    }
+
+    public function invalidateActorObjectCache(string $apProfileId): void
+    {
+    }
+
+    public function invalidateCollectionObjectCache(string $apAddress): void
+    {
+    }
+
+    public function getInstancePublicKey(): string
+    {
+        return 'TESTING PUBLIC KEY';
+    }
+}

--- a/tests/Unit/ActivityPub/TagMatchTest.php
+++ b/tests/Unit/ActivityPub/TagMatchTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\ActivityPub;
+
+use App\ActivityPub\JsonRd;
+use App\Event\ActivityPub\WebfingerResponseEvent;
+use App\Message\ActivityPub\Inbox\CreateMessage;
+use App\Service\ActivityPub\Webfinger\WebFingerFactory;
+use App\Tests\WebTestCase;
+use Doctrine\Common\Collections\ArrayCollection;
+
+class TagMatchTest extends WebTestCase
+{
+    private array $domains = [
+        'mbin1.tld',
+        'mbin2.tld',
+        'mbin3.tld',
+        'mbin4.tld',
+        'mbin5.tld',
+        'mbin6.tld',
+        'mbin7.tld',
+        'mbin8.tld',
+        'mbin9.tld',
+        'mbin10.tld',
+    ];
+
+    private array $remoteUsers = [];
+
+    private array $remoteMagazines = [];
+
+    /**
+     * Create 10 remote users ('user1'...'user10') and 10 remote magazines (all called mbin) with their webfingers
+     * and 1 entry in each of the magazines.
+     */
+    public function createMockedRemoteObjects(): void
+    {
+        $prevDomain = $this->settingsManager->get('KBIN_DOMAIN');
+
+        foreach ($this->domains as $domain) {
+            $this->settingsManager->set('KBIN_DOMAIN', $domain);
+            $context = $this->router->getContext();
+            $context->setHost($domain);
+
+            $username = 'user';
+            $user = $this->getUserByUsername($username);
+            $json = $this->personFactory->create($user);
+            $this->testingApHttpClient->actorObjects[$json['id']] = $json;
+
+            $userEvent = new WebfingerResponseEvent(new JsonRd(), "$username@$domain", ['account' => $username]);
+            $this->eventDispatcher->dispatch($userEvent);
+            $realDomain = \sprintf(WebFingerFactory::WEBFINGER_URL, 'https', $domain, '', "$username@$domain");
+            $this->testingApHttpClient->webfingerObjects[$realDomain] = $userEvent->jsonRd->toArray();
+
+            $magazineName = 'mbin';
+            $magazine = $this->getMagazineByName($magazineName, user: $user);
+            $json = $this->groupFactory->create($magazine);
+            $this->testingApHttpClient->actorObjects[$json['id']] = $json;
+
+            $magazineEvent = new WebfingerResponseEvent(new JsonRd(), "$magazineName@$domain", ['account' => $magazineName]);
+            $this->eventDispatcher->dispatch($magazineEvent);
+            $realDomain = \sprintf(WebFingerFactory::WEBFINGER_URL, 'https', $domain, '', "$magazineName@$domain");
+            $this->testingApHttpClient->webfingerObjects[$realDomain] = $magazineEvent->jsonRd->toArray();
+
+            $entry = $this->getEntryByTitle("test from $domain", magazine: $magazine, user: $user);
+            $json = $this->pageFactory->create($entry, $this->tagLinkRepository->getTagsOfEntry($entry));
+            $this->testingApHttpClient->activityObjects[$json['id']] = $json;
+
+            $create = $this->createWrapper->build($entry);
+            $this->testingApHttpClient->activityObjects[$create['id']] = $create;
+
+            $this->entryManager->purge($user, $entry);
+            $this->magazineManager->purge($magazine);
+            $this->entityManager->remove($user);
+
+            $this->entries = new ArrayCollection();
+            $this->magazines = new ArrayCollection();
+            $this->users = new ArrayCollection();
+        }
+
+        $this->settingsManager->set('KBIN_DOMAIN', $prevDomain);
+        $context = $this->router->getContext();
+        $context->setHost($prevDomain);
+
+        $this->testingApHttpClient->actorObjects[$this->mastodonUser['id']] = $this->mastodonUser;
+        $this->testingApHttpClient->activityObjects[$this->mastodonPost['id']] = $this->mastodonPost;
+        $this->testingApHttpClient->webfingerObjects[\sprintf(WebFingerFactory::WEBFINGER_URL, 'https', 'masto.don', '', 'User@masto.don')] = $this->mastodonWebfinger;
+    }
+
+    public function setUp(): void
+    {
+        sort($this->domains);
+        parent::setUp();
+
+        $admin = $this->getUserByUsername('admin', isAdmin: true);
+        $this->getMagazineByName('random', user: $admin);
+
+        $this->createMockedRemoteObjects();
+        $user = $this->getUserByUsername('user');
+        $magazine = $this->getMagazineByName('matching_mbin', user: $user);
+        $magazine->title = 'Matching Mbin';
+        $magazine->tags = ['mbin'];
+        $this->entityManager->persist($magazine);
+        $this->entityManager->flush();
+
+        foreach ($this->domains as $domain) {
+            $this->remoteUsers[] = $this->activityPubManager->findActorOrCreate("user@$domain");
+            $this->remoteMagazines[] = $this->activityPubManager->findActorOrCreate("mbin@$domain");
+        }
+
+        foreach ($this->remoteUsers as $remoteUser) {
+            $this->magazineManager->subscribe($magazine, $remoteUser);
+        }
+
+        foreach ($this->remoteMagazines as $remoteMagazine) {
+            $this->magazineManager->subscribe($remoteMagazine, $user);
+        }
+    }
+
+    public function testMatching(): void
+    {
+        self::assertEquals(\sizeof($this->domains), \sizeof(array_filter($this->remoteMagazines)));
+        self::assertEquals(\sizeof($this->domains), \sizeof(array_filter($this->remoteUsers)));
+
+        // pull in the 10 prepared remote entries
+        foreach (array_filter($this->testingApHttpClient->activityObjects, fn ($item) => 'Page' === $item['type']) as $apObject) {
+            $this->bus->dispatch(new CreateMessage($apObject));
+            $entry = $this->entryRepository->findOneBy(['apId' => $apObject['id']]);
+            self::assertNotNull($entry);
+        }
+
+        $this->bus->dispatch(new CreateMessage($this->mastodonPost));
+        $postedObjects = $this->testingApHttpClient->getPostedObjects();
+        $postedAnnounces = array_filter($postedObjects, fn ($item) => 'Announce' === $item['payload']['type']);
+        $targetInboxes = array_map(fn ($item) => parse_url($item['inboxUrl'], PHP_URL_HOST), $postedAnnounces);
+        sort($targetInboxes);
+        self::assertArrayIsEqualToArrayIgnoringListOfKeys($this->domains, $targetInboxes, []);
+    }
+
+    private array $mastodonUser = [
+        'id' => 'https://masto.don/users/User',
+        'type' => 'Person',
+        'following' => 'https://masto.don/users/User/following',
+        'followers' => 'https://masto.don/users/User/followers',
+        'inbox' => 'https://masto.don/users/User/inbox',
+        'outbox' => 'https://masto.don/users/User/outbox',
+        'featured' => 'https://masto.don/users/User/collections/featured',
+        'featuredTags' => 'https://masto.don/users/User/collections/tags',
+        'preferredUsername' => 'User',
+        'name' => 'User',
+        'summary' => '<p>Some summary</p>',
+        'url' => 'https://masto.don/@User',
+        'manuallyApprovesFollowers' => false,
+        'discoverable' => true,
+        'indexable' => true,
+        'published' => '2025-01-01T00:00:00Z',
+        'memorial' => false,
+        'publicKey' => [
+            'id' => 'https://masto.don/users/User#main-key',
+            'owner' => 'https://masto.don/users/User',
+            'publicKeyPem' => "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAujdiYalTtr7R1CJIVBIy\nP50V+/JX+P15o0Cz0LUOhKvJIVyeV6szQGHj6Idu74x9e3+xf9jzQRCH6eq8ASAH\nHAKwdnHfhSmKbCQaTEI5V8497/4yU9z9Zn7uJ+C1rrKVIEoGGkpt8bK8fynfR/hb\n17FctW6EnrVrvNHyW+WwbyEbyqAxwbcOYd78PhdftWEdP6D+t4+XUoF9N1XGpsGO\nrixJDzMwNqkg9Gg9l/mnCmxV367xgh8qHC0SNmwaMbWv6AV/07dHWlr0N1pXmHqo\n9YkOEy7XuH1hovBzHWEf++P1Ew4bstwdfyS/m5bcakmSe+dR3WDylW336nO88vAF\nCQIDAQAB\n-----END PUBLIC KEY-----\n",
+        ],
+        'tag' => [],
+        'attachment' => [],
+        'endpoints' => [
+            'sharedInbox' => 'https://masto.don/inbox',
+        ],
+    ];
+
+    private array $mastodonPost = [
+        'id' => 'https://masto.don/users/User/statuses/110226274955756643',
+        'type' => 'Note',
+        'summary' => null,
+        'inReplyTo' => null,
+        'published' => '2025-01-01T15:51:18Z',
+        'url' => 'https://masto.don/@User/110226274955756643',
+        'attributedTo' => 'https://masto.don/users/User',
+        'to' => [
+            'https://www.w3.org/ns/activitystreams#Public',
+        ],
+        'cc' => [
+            'https://masto.don/users/User/followers',
+        ],
+        'sensitive' => false,
+        'atomUri' => 'https://masto.don/users/User/statuses/110226274955756643',
+        'inReplyToAtomUri' => null,
+        'conversation' => 'tag:masto.don,2025-01-01:objectId=399588:objectType=Conversation',
+        'content' => '<p>I am very excited about <a href="https://masto.don/tags/mbin" class="mention hashtag" rel="tag">#<span>mbin</span></a></p>',
+        'contentMap' => [
+            'de' => '<p>I am very excited about <a href="https://masto.don/tags/mbin" class="mention hashtag" rel="tag">#<span>mbin</span></a></p>',
+        ],
+        'attachment' => [],
+        'tag' => [
+            [
+                'type' => 'Hashtag',
+                'href' => 'https://masto.don/tags/mbin',
+                'name' => '#mbin',
+            ],
+        ],
+        'replies' => [
+            'id' => 'https://masto.don/users/User/statuses/110226274955756643/replies',
+            'type' => 'Collection',
+            'first' => [
+                'type' => 'CollectionPage',
+                'next' => 'https://masto.don/users/User/statuses/110226274955756643/replies?min_id=110226283102047096&page=true',
+                'partOf' => 'https://masto.don/users/User/statuses/110226274955756643/replies',
+                'items' => [
+                    'https://masto.don/users/User/statuses/110226283102047096',
+                ],
+            ],
+        ],
+        'likes' => [
+            'id' => 'https://masto.don/users/User/statuses/110226274955756643/likes',
+            'type' => 'Collection',
+            'totalItems' => 0,
+        ],
+        'shares' => [
+            'id' => 'https://masto.don/users/User/statuses/110226274955756643/shares',
+            'type' => 'Collection',
+            'totalItems' => 0,
+        ],
+    ];
+
+    private array $mastodonWebfinger = [
+        'subject' => 'acct:User@masto.don',
+        'aliases' => [
+            'https://masto.don/@User',
+            'https://masto.don/users/User',
+        ],
+        'links' => [
+            [
+                'rel' => 'http://webfinger.net/rel/profile-page',
+                'type' => 'text/html',
+                'href' => 'https://masto.don/@User',
+            ],
+            [
+                'rel' => 'self',
+                'type' => 'application/activity+json',
+                'href' => 'https://masto.don/users/User',
+            ],
+            [
+                'rel' => 'http://ostatus.org/schema/1.0/subscribe',
+                'template' => 'https://masto.don/authorize_interaction?uri=[uri]',
+            ],
+        ],
+    ];
+}

--- a/tests/Unit/Service/ActivityPub/SignatureValidatorTest.php
+++ b/tests/Unit/Service/ActivityPub/SignatureValidatorTest.php
@@ -6,7 +6,7 @@ namespace App\Tests\Unit\Service\ActivityPub;
 
 use App\Entity\Magazine;
 use App\Exception\InvalidApSignatureException;
-use App\Service\ActivityPub\ApHttpClient;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\ActivityPub\SignatureValidator;
 use App\Service\ActivityPubManager;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
@@ -97,7 +97,7 @@ class SignatureValidatorTest extends TestCase
         $apManager->method('findActorOrCreate')
             ->willReturn($stubMagazine);
 
-        $apHttpClient = $this->createStub(ApHttpClient::class);
+        $apHttpClient = $this->createStub(ApHttpClientInterface::class);
         $apHttpClient->method('getActorObject')
             ->willReturn(
                 [
@@ -128,7 +128,7 @@ class SignatureValidatorTest extends TestCase
         $apManager->method('findActorOrCreate')
             ->willReturn($stubMagazine);
 
-        $apHttpClient = $this->createStub(ApHttpClient::class);
+        $apHttpClient = $this->createStub(ApHttpClientInterface::class);
         $apHttpClient->method('getActorObject')
             ->willReturn(
                 [
@@ -158,7 +158,7 @@ class SignatureValidatorTest extends TestCase
         $apManager->method('findActorOrCreate')
             ->willReturn($stubMagazine);
 
-        $apHttpClient = $this->createStub(ApHttpClient::class);
+        $apHttpClient = $this->createStub(ApHttpClientInterface::class);
         $apHttpClient->method('getActorObject')
             ->willReturn(
                 [
@@ -192,7 +192,7 @@ class SignatureValidatorTest extends TestCase
         $this->headers['signature'][0] = \sprintf($this->headers['signature'][0], 'https://kbin.localhost/m/group');
 
         $apManager = $this->createStub(ActivityPubManager::class);
-        $apHttpClient = $this->createStub(ApHttpClient::class);
+        $apHttpClient = $this->createStub(ApHttpClientInterface::class);
 
         $logger = $this->createStub(LoggerInterface::class);
 
@@ -218,7 +218,7 @@ class SignatureValidatorTest extends TestCase
         $this->headers['signature'][0] = \sprintf($this->headers['signature'][0], 'http://kbin.localhost/m/group');
 
         $apManager = $this->createStub(ActivityPubManager::class);
-        $apHttpClient = $this->createStub(ApHttpClient::class);
+        $apHttpClient = $this->createStub(ApHttpClientInterface::class);
 
         $logger = $this->createStub(LoggerInterface::class);
 


### PR DESCRIPTION
This commit contains a lot of prep work for testing activity pub code functionally:
- create a test only `ApHttpClient` and create an interface for DI
- the webfinger code no longer passes a `Request` object in the event, so we can test it easily

The actual test creates 10 remote users and 10 remote magazines with 1 entry each. Then it creates a local magazine that uses the `mbin` hashtag to get posts. Then the 10 remote entries are pulled in each containing the `mbin` hashtag as well, because their magazines are named that way. Afterwards a mastodon style payload is created with an `mbin` hashtag. If all the posts and entries are created correctly then there are exactly 10 announces as the 10 remote users are subscribed to the local magazine