### PR TITLE
Upgraded Caddy image to v2.9.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ RUN chown -R $USER:$GROUP /usr/local/etc/php-fpm.d
 
 ####################
 
-FROM caddy:2.8.4-builder-alpine AS builder-caddy
+FROM caddy:2.9.1-builder-alpine AS builder-caddy
 
 # Build Caddy with the Mercure and Vulcain and brotil cache modules
 RUN xcaddy build \


### PR DESCRIPTION
Update the Caddy docker image to [2.9.1-builder-alpine](https://hub.docker.com/layers/library/caddy/2.9.1-builder-alpine/images/sha256-db250d8ac333dbfb36d2082ae73b39f21d1316e42d441199f8fdef60aa578773)

Hopefully, this should fix the Docker build issue (we're seeing on the main branch).