### PR TITLE
Add test case for liking a hashtag matched post

### DIFF
--- a/src/MessageHandler/ActivityPub/Outbox/AnnounceLikeHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/AnnounceLikeHandler.php
@@ -85,11 +85,10 @@ class AnnounceLikeHandler extends MbinMessageHandler
             $likeActivity
         );
 
-        $inboxes = array_filter(array_unique(array_merge(
-            $this->magazineRepository->findAudience($object->magazine),
-            $this->userRepository->findAudience($user),
-            [$object->user->apInboxUrl]
-        )));
+        // send the announcement only to the subscribers of the magazine
+        $inboxes = array_filter(
+            $this->magazineRepository->findAudience($object->magazine)
+        );
         $this->deliverManager->deliver($inboxes, $activity);
     }
 }

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -26,6 +26,7 @@ use App\Repository\TagLinkRepository;
 use App\Repository\UserRepository;
 use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\ActivityPub\Wrapper\CreateWrapper;
+use App\Service\ActivityPub\Wrapper\LikeWrapper;
 use App\Service\ActivityPubManager;
 use App\Service\BadgeManager;
 use App\Service\DomainManager;
@@ -130,6 +131,7 @@ abstract class WebTestCase extends BaseWebTestCase
     protected TestingApHttpClient $testingApHttpClient;
 
     protected CreateWrapper $createWrapper;
+    protected LikeWrapper $likeWrapper;
 
     protected UrlGeneratorInterface $urlGenerator;
     protected TranslatorInterface $translator;
@@ -194,6 +196,7 @@ abstract class WebTestCase extends BaseWebTestCase
         $this->pageFactory = $this->getService(EntryPageFactory::class);
 
         $this->createWrapper = $this->getService(CreateWrapper::class);
+        $this->likeWrapper = $this->getService(LikeWrapper::class);
 
         $this->urlGenerator = $this->getService(UrlGeneratorInterface::class);
         $this->translator = $this->getService(TranslatorInterface::class);


### PR DESCRIPTION
Add test case for:
- a local user liking a hashtag matched post
- a remote user liking a hashtag matched post

Discovered in this process:
- too many likes were announced by the magazine. These like messages are expected to already be sent to the author of the liked post, so we do not need to announce them to them, only to the subscribers of the magazine