### PR TITLE
Fix search for URLs

### DIFF
--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -62,7 +62,7 @@ class SearchController extends AbstractController
                     $this->logger->debug('Query is a valid url');
                     $objects = $this->manager->findByApId($query);
                     if (0 === \sizeof($objects)) {
-                        $body = $this->apHttpClient->getActivityObject($query, false);
+                        $body = $this->apHttpClient->getActivityObject($query);
                         // the returned id could be different from the query url.
                         $postId = $body['id'];
                         $objects = $this->manager->findByApId($postId);


### PR DESCRIPTION
- when improving the search the `decoded` option for `getActivityObject` was set to false which leads to a plain json string response. That leads to errors when attempting to read properties, so fix that