### PR TITLE
Fix generated markdown search link not prefilling the query field

### DIFF
--- a/src/Markdown/CommonMark/MentionLinkParser.php
+++ b/src/Markdown/CommonMark/MentionLinkParser.php
@@ -148,7 +148,7 @@ class MentionLinkParser implements InlineParserInterface
             MentionType::Magazine => ['route' => 'front_magazine', 'param' => 'name'],
             MentionType::RemoteMagazine => ['route' => 'front_magazine', 'param' => 'name'],
             MentionType::RemoteUser => ['route' => 'user_overview',  'param' => 'username'],
-            MentionType::Search => ['route' => 'search',         'param' => 'q'],
+            MentionType::Search => ['route' => 'search',         'param' => 'search[q]'],
             MentionType::User => ['route' => 'user_overview',  'param' => 'username'],
         };
     }


### PR DESCRIPTION
- When improving the search the field name for the query also changed. Adapt the markdown parser to use the new field name so the query field can be prefilled when searching for user handles