### PR TITLE
Move from dotenv to ini codeblocks

### DIFF
--- a/docs/02-admin/02-configuration/02-nginx.md
+++ b/docs/02-admin/02-configuration/02-nginx.md
@@ -332,14 +332,14 @@ nano /var/www/mbin/.env
 
 You can configure a single IP address and/or a range of IP addresses (this configuration should be sufficient if you are running Nginx yourself):
 
-```dotenv
+```ini
 # Change the IP range if needed, this is just an example
 TRUSTED_PROXIES=127.0.0.1,192.168.1.0/24
 ```
 
 Or if the IP address is dynamic, you can set the `REMOTE_ADDR` string which will be replaced at runtime by `$_SERVER['REMOTE_ADDR']`:
 
-```dotenv
+```ini
 TRUSTED_PROXIES=127.0.0.1,REMOTE_ADDR
 ```
 
@@ -360,13 +360,13 @@ More detailed info can be found at: [Symfony Trusted Proxies docs](https://symfo
 
 we suggest that you do not use this configuration:
 
-```dotenv
+```ini
 KBIN_STORAGE_URL=https://mbin.domain.tld/media
 ```
 
 Instead we suggest to use a subdomain for serving your media files:
 
-```dotenv
+```ini
 KBIN_STORAGE_URL=https://media.mbin.domain.tld
 ```
 

--- a/docs/02-admin/03-optional-features/02-sso.md
+++ b/docs/02-admin/03-optional-features/02-sso.md
@@ -24,7 +24,7 @@ in the `.env`|`.env.local` file
 
 https://developers.google.com/
 
-```dotenv
+```ini
 OAUTH_GOOGLE_ID=AS2easdioh912 # your client ID
 OAUTH_GOOGLE_SECRET=sdfpsajh329ura39ßseaoßjf30u # your client secret
 ```
@@ -33,7 +33,7 @@ OAUTH_GOOGLE_SECRET=sdfpsajh329ura39ßseaoßjf30u # your client secret
 
 https://developers.facebook.com
 
-```dotenv
+```ini
 OAUTH_FACEBOOK_ID=AS2easdioh912 # your client ID
 OAUTH_FACEBOOK_SECRET=sdfpsajh329ura39ßseaoßjf30u # your client secret
 ```
@@ -51,7 +51,7 @@ You need a GitHub account, if you do no have one, yet, go and create one: https:
 7. Click "Generate a new client secret"
 8. Insert the "Client ID" and the generated client secret into the `.env` file:
 
-```dotenv
+```ini
 OAUTH_GITHUB_ID=AS2easdioh912 # your client ID
 OAUTH_GITHUB_SECRET=sdfpsajh329ura39ßseaoßjf30u # your client secret
 ```
@@ -60,7 +60,7 @@ OAUTH_GITHUB_SECRET=sdfpsajh329ura39ßseaoßjf30u # your client secret
 
 Self-hosted, https://www.keycloak.org/
 
-```dotenv
+```ini
 OAUTH_KEYCLOAK_ID=AS2easdioh912 # your client ID
 OAUTH_KEYCLOAK_SECRET=sdfpsajh329ura39ßseaoßjf30u # your client secret
 OAUTH_KEYCLOAK_URI=
@@ -72,7 +72,7 @@ OAUTH_KEYCLOAK_VERSION=
 
 Self-hosted, https://zitadel.com/
 
-```dotenv
+```ini
 OAUTH_ZITADEL_ID=AS2easdioh912 # your client ID
 OAUTH_ZITADEL_SECRET=sdfpsajh329ura39ßseaoßjf30u # your client secret
 OAUTH_ZITADEL_BASE_URL=
@@ -89,7 +89,7 @@ You need a SimpleLogin account, if you do not have one, yet, go and create one: 
 5. Insert the client ID ("AppID / OAuth2 Client ID") and the client secret ("AppSecret / OAuth2 Client Secret")
    in your `.env` file
 
-```dotenv
+```ini
 OAUTH_SIMPLELOGIN_ID=gehirneimer.de-vycjfiaznc # your client ID
 OAUTH_SIMPLELOGIN_SECRET=fdiuasdfusdfsdfpsdagofweopf # your client secret
 ```
@@ -105,7 +105,7 @@ You need a Discord account, if you do not have one, yet, go and create one: http
 3. Under "Client information" click "Reset Secret"
 4. The newly generated secret and the "Client ID" need to go in our `.env` file:
 
-```dotenv
+```ini
 OAUTH_DISCORD_ID=3245498543 # your client ID
 OAUTH_DISCORD_SECRET=xJHGApsadOPUIAsdoih # your client secret
 ```
@@ -119,7 +119,7 @@ OAUTH_DISCORD_SECRET=xJHGApsadOPUIAsdoih # your client secret
 
 Self-hosted, https://goauthentik.io/
 
-```dotenv
+```ini
 OAUTH_AUTHENTIK_ID=3245498543 # your client ID
 OAUTH_AUTHENTIK_SECRET=xJHGApsadOPUIAsdoih # your client secret
 OAUTH_AUTHENTIK_BASE_URL=
@@ -129,7 +129,7 @@ OAUTH_AUTHENTIK_BASE_URL=
 
 https://privacyportal.org
 
-```dotenv
+```ini
 OAUTH_PRIVACYPORTAL_ID=3245498543 # your client ID
 OAUTH_PRIVACYPORTAL_SECRET=xJHGApsadOPUIAsdoih # your client secret
 ```
@@ -138,7 +138,7 @@ OAUTH_PRIVACYPORTAL_SECRET=xJHGApsadOPUIAsdoih # your client secret
 
 https://login.microsoftonline.com
 
-```dotenv
+```ini
 OAUTH_AZURE_ID=3245498543 # your client ID
 OAUTH_AZURE_SECRET=xJHGApsadOPUIAsdoih # your client secret
 OAUTH_AZURE_TENANT=

--- a/docs/02-admin/03-optional-features/user_application.md
+++ b/docs/02-admin/03-optional-features/user_application.md
@@ -2,7 +2,7 @@
 
 If you want to manually approve users before they can log into your server, 
 you can either tick the checkbox in the admin settings put this in the `.env` file:
-```dotenv
+```ini
 MBIN_NEW_USERS_NEED_APPROVAL=true
 ```
 


### PR DESCRIPTION
- prismjs which we use to highlight our codeblocks does not support `dotenv` as a language, so move to ini (which was already used in a lot of places)