### PR TITLE
Ban additional Semrush agents

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,12 +3,10 @@
 # Using: https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/blob/master/robots.txt/robots.txt
 ### Version Information for nginx-ultimate-bad-bot-blocker #
 ###################################################
-### Version: V4.2024.07.4631
-### Updated: Thu Jul 18 22:01:11 UTC 2024
-### Bad Bot Count: 663
+### Version: V4.2025.01.4984
+### Updated: Sun Jan 19 10:06:56 UTC 2025
+### Bad Bot Count: 675
 ###################################################
-### Version Information ##
-
 User-agent: 01h4x.com
 Disallow:/
 User-agent: 360Spider
@@ -96,6 +94,8 @@ Disallow:/
 User-agent: Backlink-Ceck
 Disallow:/
 User-agent: BacklinkCrawler
+Disallow:/
+User-agent: BacklinksExtendedBot
 Disallow:/
 User-agent: Badass
 Disallow:/
@@ -362,8 +362,6 @@ Disallow:/
 User-agent: Go-Ahead-Got-It
 Disallow:/
 User-agent: GoZilla
-Disallow:/
-User-agent: Google-Extended
 Disallow:/
 User-agent: Gotit
 Disallow:/
@@ -813,6 +811,8 @@ User-agent: SEOkicks
 Disallow:/
 User-agent: SEOkicks-Robot
 Disallow:/
+User-agent: SEOlyt
+Disallow:/
 User-agent: SEOlyticsCrawler
 Disallow:/
 User-agent: SEOprofiler
@@ -853,9 +853,21 @@ User-agent: Semrush
 Disallow:/
 User-agent: SemrushBot
 Disallow:/
+User-agent: SemrushBot-BA
+Disallow:/
+User-agent: SemrushBot-FT
+Disallow:/
+User-agent: SemrushBot-OCOB
+Disallow:/
+User-agent: SemrushBot-SI
+Disallow:/
+User-agent: SemrushBot-SWA
+Disallow:/
 User-agent: SentiBot
 Disallow:/
 User-agent: SenutoBot
+Disallow:/
+User-agent: SeoCherryBot
 Disallow:/
 User-agent: SeoSiteCheckup
 Disallow:/
@@ -866,6 +878,8 @@ Disallow:/
 User-agent: Shodan
 Disallow:/
 User-agent: Siphon
+Disallow:/
+User-agent: SiteAuditBot
 Disallow:/
 User-agent: SiteCheckerBotCrawler
 Disallow:/
@@ -915,7 +929,13 @@ User-agent: Spanner
 Disallow:/
 User-agent: Spbot
 Disallow:/
+User-agent: Spider_Bot
+Disallow:/
+User-agent: Spider_Bot/3.0
+Disallow:/
 User-agent: Spinn3r
+Disallow:/
+User-agent: SplitSignalBot
 Disallow:/
 User-agent: SputnikBot
 Disallow:/
@@ -1209,7 +1229,7 @@ User-agent: crawler4j
 Disallow:/
 User-agent: dataforseo.com
 Disallow:/
-User-agent: DataForSeoBot
+User-agent: dataforseobot
 Disallow:/
 User-agent: demandbase-bot
 Disallow:/
@@ -1218,6 +1238,8 @@ Disallow:/
 User-agent: eCatch
 Disallow:/
 User-agent: evc-batch
+Disallow:/
+User-agent: everyfeed-spider
 Disallow:/
 User-agent: facebookscraper
 Disallow:/
@@ -1337,6 +1359,8 @@ User-agent: zgrab
 Disallow:/
 
 # Extra bad bots
+User-agent: Google-Extended
+Disallow: /
 User-agent: PerplexityBot
 Disallow: /
 User-agent: OmigiliBot


### PR DESCRIPTION
Sync with upstream: https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/blob/master/robots.txt/robots.txt

After additional Semrush user-agents were added: https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/pull/615

(Google-Extended UA was removed from that list, so I moved it to our "Extra bad bots" section)