### PR TITLE
Make touch click open post

### DIFF
--- a/assets/controllers/subject_controller.js
+++ b/assets/controllers/subject_controller.js
@@ -36,6 +36,19 @@ export default class extends Controller {
         }
 
         this.checkHeight();
+
+        // if in a list and the click is made via touch, open the post
+        if (!this.element.classList.contains('isSingle')) {
+            this.element.addEventListener('click', (e) => {
+                if (e.defaultPrevented) {
+                    return
+                }
+                if ("touch" === e.pointerType) {
+                    let link = this.element.querySelector("header a:not(.user-inline)")
+                    document.location.href = link.getAttribute('href')
+                }
+            })
+        }
     }
 
     async getForm(event) {

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -19,7 +19,8 @@
             class: html_classes('entry section subject', {
                 'no-image': SHOW_THUMBNAILS is same as V_FALSE,
                 'own': app.user and entry.isAuthor(app.user),
-                'show-preview': SHOW_PREVIEW is same as V_TRUE and not entry.isAdult
+                'show-preview': SHOW_PREVIEW is same as V_TRUE and not entry.isAdult,
+                'isSingle': isSingle is same as true
             })}).without('id') }}
                 id="entry-{{ entry.id }}"
                 data-controller="subject preview mentions"

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -12,7 +12,8 @@
         <blockquote{{ attributes.defaults({
             class: html_classes('section post subject ', {
                 'own': app.user and post.isAuthor(app.user),
-                'show-preview': SHOW_PREVIEW is same as V_TRUE and not post.isAdult
+                'show-preview': SHOW_PREVIEW is same as V_TRUE and not post.isAdult,
+                'isSingle': isSingle is same as true
             })}).without('id') }}
                 id="post-{{ post.id }}"
                 data-controller="post subject mentions"


### PR DESCRIPTION
When on a touch device the initial though is that clicking on the text of a post the post should be loaded in the single view. This implements exactly that