### PR TITLE
Introducing the mbin:images:delete command

### DIFF
--- a/docs/02-admin/04-running-mbin/05-cli.md
+++ b/docs/02-admin/04-running-mbin/05-cli.md
@@ -243,7 +243,7 @@ php bin/console mbin:posts:magazines
 
 ## Activity Pub
 
-### Actor-Update
+### Actor update
 
 > [!NOTE]
 > This command will trigger **asynchronous** updates of remote users or magazines
@@ -263,7 +263,7 @@ Options:
 - `--users`: if this options is provided up to 10,000 remote users ordered by their last update time will be updated
 - `--magazines`: if this options is provided up to 10,000 remote magazines ordered by their last update time will be updated
 
-### AP-Import
+### ActivityPub resource import
 
 > [!NOTE]
 > This command will trigger an **asynchronous** import
@@ -279,9 +279,33 @@ php bin/console mbin:ap:import <url>
 Arguments:
 - `url`: the "id" of the ActivityPub object to import
 
-## Miscellaneous
+## Images
 
-### Cache-Build
+### Remove old federated images
+
+This command allows you to remove old federated images, without removing the content.  
+The image delete command works in batches, by default it will remove 800 images for each type.
+
+The image(s) will be removed from the database as well as from disk / storage.
+
+> [!WARNING]
+> This action cannot be undone!
+
+Usage:
+
+```bash
+php bin/console mbin:images:delete
+```
+
+Arguments:
+- `type`: type of images that will get deleted, either: `all` (except for user images), `threads`, `thread_comments`, `posts`, `post_comments` or `users`. (default: `all`)
+- `monthsAgo`: Delete images older than given months are getting deleted (default: `12`)
+
+Options:
+- `--noActivity`: delete images that doesn't have recorded activity. Like comments, updates and/or boosts. (default: `false`)
+- `--batchSize`: the number of images to delete for each type at a time. (default: `800`)
+
+### Rebuild image cache
 
 This command allows you to rebuild image thumbnail cache.
 It executes the `liip:imagine:cache:resolve` command for every user- and magazine-avatar and linked image in entries and posts.
@@ -294,6 +318,8 @@ Usage:
 ```bash
 php bin/console mbin:cache:build
 ```
+
+## Miscellaneous
 
 ### Users-Remove-Marked-For-Deletion
 

--- a/src/Command/RemoveOldImagesCommand.php
+++ b/src/Command/RemoveOldImagesCommand.php
@@ -91,6 +91,8 @@ class RemoveOldImagesCommand extends Command
 
     /**
      * Call all delete methods below, _except_ for the delete users images.
+     * Since users on the instance can be several years old and not getting fetched,
+     * however we shouldn't remove their avatar/cover images just like that.
      */
     private function deleteAllImages($output): void
     {
@@ -251,7 +253,7 @@ class RemoveOldImagesCommand extends Command
     }
 
     /**
-     * Delete user avatar and user cover images.
+     * Delete user avatar and user cover images. Check ap_fetched_at column for the age.
      * Limit by batch size.
      */
     private function deleteUsersImages(OutputInterface $output)

--- a/src/Command/RemoveOldImagesCommand.php
+++ b/src/Command/RemoveOldImagesCommand.php
@@ -86,7 +86,7 @@ class RemoveOldImagesCommand extends Command
 
         $this->entityManager->clear();
 
-        $output->writeln(\sprintf('Total images deleted during this run: %d', $nrDeletedImages));
+        $output->writeln(\sprintf('\nTotal images deleted during this run: %d', $nrDeletedImages));
 
         return Command::SUCCESS;
     }

--- a/src/Command/RemoveOldImagesCommand.php
+++ b/src/Command/RemoveOldImagesCommand.php
@@ -87,7 +87,7 @@ class RemoveOldImagesCommand extends Command
         $this->entityManager->clear();
 
         $output->writeln(''); // New line
-        $output->writeln(\sprintf('\nTotal images deleted during this run: %d', $nrDeletedImages));
+        $output->writeln(\sprintf('Total images deleted during this run: %d', $nrDeletedImages));
 
         return Command::SUCCESS;
     }

--- a/src/Command/RemoveOldImagesCommand.php
+++ b/src/Command/RemoveOldImagesCommand.php
@@ -67,7 +67,7 @@ class RemoveOldImagesCommand extends Command
         $this->batchSize = (int) $input->getOption('batchSize');
 
         if ('all' === $type) {
-            $this->deleteAllImages($output); // Except for user images
+            $this->deleteAllImages($output); // Except for user avatars and covers
         } elseif ('threads' === $type) {
             $this->deleteThreadsImages($output);
         } elseif ('thread_comments' === $type) {

--- a/src/Command/RemoveOldImagesCommand.php
+++ b/src/Command/RemoveOldImagesCommand.php
@@ -309,8 +309,12 @@ class RemoveOldImagesCommand extends Command
 
         foreach ($users as $user) {
             $output->writeln(\sprintf('Deleting image from username: %s', $user->getUsername()));
-            $this->userManager->detachCover($user);
-            $this->userManager->detachAvatar($user);
+            if (null !== $user->cover) {
+                $this->userManager->detachCover($user);
+            }
+            if (null !== $user->avatar) {
+                $this->userManager->detachAvatar($user);
+            }
         }
 
         // Return total number of elements deleted

--- a/src/Command/RemoveOldImagesCommand.php
+++ b/src/Command/RemoveOldImagesCommand.php
@@ -53,6 +53,9 @@ class RemoveOldImagesCommand extends Command
             ->addOption('batchSize', null, InputOption::VALUE_OPTIONAL, 'Number of images to delete at a time (for each type)', $this->batchSize);
     }
 
+    /**
+     * Starting point, switch what image will get deleted based on the type input arg.
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
@@ -87,7 +90,7 @@ class RemoveOldImagesCommand extends Command
     }
 
     /**
-     * Delete all delete methods below, _except_ for the delete users images.
+     * Call all delete methods below, _except_ for the delete users images.
      */
     private function deleteAllImages($output): void
     {
@@ -97,6 +100,10 @@ class RemoveOldImagesCommand extends Command
         $this->deletePostCommentsImages($output);
     }
 
+    /**
+     * Delete thread images, check on created_at database column for the age.
+     * Limit by batch size.
+     */
     private function deleteThreadsImages(OutputInterface $output): void
     {
         $queryBuilder = $this->entityManager->createQueryBuilder();
@@ -131,6 +138,10 @@ class RemoveOldImagesCommand extends Command
         }
     }
 
+    /**
+     * Delete thread comment images, check on created_at database column for the age.
+     * Limit by batch size.
+     */
     private function deleteThreadCommentsImages(OutputInterface $output): void
     {
         $queryBuilder = $this->entityManager->createQueryBuilder();
@@ -164,6 +175,10 @@ class RemoveOldImagesCommand extends Command
         }
     }
 
+    /**
+     * Delete post images, check on created_at database column for the age.
+     * Limit by batch size.
+     */
     private function deletePostsImages(OutputInterface $output): void
     {
         $queryBuilder = $this->entityManager->createQueryBuilder();
@@ -198,6 +213,10 @@ class RemoveOldImagesCommand extends Command
         }
     }
 
+    /**
+     * Delete post comment images, check on created_at database column for the age.
+     * Limit by batch size.
+     */
     private function deletePostCommentsImages(OutputInterface $output): void
     {
         $queryBuilder = $this->entityManager->createQueryBuilder();
@@ -231,6 +250,10 @@ class RemoveOldImagesCommand extends Command
         }
     }
 
+    /**
+     * Delete user avatar and user cover images.
+     * Limit by batch size.
+     */
     private function deleteUsersImages(OutputInterface $output)
     {
         $queryBuilder = $this->entityManager->createQueryBuilder();

--- a/src/Command/RemoveOldImagesCommand.php
+++ b/src/Command/RemoveOldImagesCommand.php
@@ -314,6 +314,6 @@ class RemoveOldImagesCommand extends Command
         }
 
         // Return total number of elements deleted
-        return \count($users * 2);
+        return \count($users) * 2;
     }
 }

--- a/src/Command/RemoveOldImagesCommand.php
+++ b/src/Command/RemoveOldImagesCommand.php
@@ -86,6 +86,7 @@ class RemoveOldImagesCommand extends Command
 
         $this->entityManager->clear();
 
+        $output->writeln(''); // New line
         $output->writeln(\sprintf('\nTotal images deleted during this run: %d', $nrDeletedImages));
 
         return Command::SUCCESS;


### PR DESCRIPTION
- As the title says; introducing a new command for removing old images from your instance.
- By default will try to delete old federated images from threads, thread comments, posts and post comments.
- By default the `monthsAgo` arg is set to 12 months (1 year)
- By default the `type` arg is set to "all", meaning delete all images from threads, threads comments, posts and post comments, with the exceptions of users. Since I believe users can still be activate after 12 months, right ;)..
- Extended the docs

---

In my case, each time running `./bin/console mbin:images:delete`, will delete around 1GB of data from my media directory. Just for info.