### PR TITLE
Leverage GitHub Actons concurrency groups

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -12,6 +12,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   php-security-scan:
     runs-on: ubuntu-latest
@@ -22,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Psalm Security Scan by Mbin
         uses: docker://ghcr.io/mbinorg/psalm-security-scan


### PR DESCRIPTION
- Cancel the old workflow on pull requests, in case a new commit is pushed to the same branch
- For both the Mbin workflow and psalm workflow
- Update `checkout` action to version: `v4` in psalm