### PR TITLE
Limit touch click detection to the content div

### DIFF
--- a/assets/controllers/subject_controller.js
+++ b/assets/controllers/subject_controller.js
@@ -39,7 +39,7 @@ export default class extends Controller {
 
         // if in a list and the click is made via touch, open the post
         if (!this.element.classList.contains('isSingle')) {
-            this.element.addEventListener('click', (e) => {
+            this.element.querySelector('.content').addEventListener('click', (e) => {
                 if (e.defaultPrevented) {
                     return
                 }
@@ -423,6 +423,7 @@ export default class extends Controller {
                 e.target.previousSibling.scrollIntoView();
                 this.isExpandedValue = false;
             }
+            e.preventDefault();
         });
     }
 


### PR DESCRIPTION
- only open a post when clicking the content section (solves opening the post when trying to click the "more" dropdown or clicking reply)
- `preventDefault()` when clicking the expand content button