### PR TITLE
Fix signup notification links when approvals are enabled

### DIFF
--- a/src/Controller/Admin/AdminSignupRequestsController.php
+++ b/src/Controller/Admin/AdminSignupRequestsController.php
@@ -22,13 +22,21 @@ class AdminSignupRequestsController extends AbstractController
     }
 
     #[IsGranted('ROLE_ADMIN')]
-    public function requests(#[MapQueryParameter] int $page): Response
+    public function requests(#[MapQueryParameter] ?int $page = 1, #[MapQueryParameter] ?string $username = null): Response
     {
-        $requests = $this->repository->findAllSignupRequestsPaginated($page);
+        if (null === $username) {
+            $requests = $this->repository->findAllSignupRequestsPaginated($page);
+        } else {
+            $requests = [];
+            if ($signupRequest = $this->repository->findSignupRequest($username)) {
+                $requests[] = $signupRequest;
+            }
+        }
 
         return $this->render('admin/signup_requests.html.twig', [
             'requests' => $requests,
             'page' => $page,
+            'username' => $username,
         ]);
     }
 

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -800,4 +800,18 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
 
         return $fanta;
     }
+
+    public function findSignupRequest(string $username): ?User
+    {
+        return $this->createQueryBuilder('u')
+            ->where('u.applicationStatus = :status')
+            ->andWhere('u.apId IS NULL')
+            ->andWhere('u.isDeleted = false')
+            ->andWhere('u.markedForDeletionAt IS NULL')
+            ->andWhere('u.username = :username')
+            ->setParameter('status', EApplicationStatus::Pending->value)
+            ->setParameter('username', $username)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
 }

--- a/templates/admin/_options.html.twig
+++ b/templates/admin/_options.html.twig
@@ -43,7 +43,7 @@
         </li>
         {% if do_new_users_need_approval() %}
             <li>
-                <a href="{{ path('admin_signup_requests', { page: 1 }) }}"
+                <a href="{{ path('admin_signup_requests') }}"
                    class="{{ html_classes({'active': is_route_name('admin_signup_requests') }) }}">
                     {{ 'signup_requests'|trans }}
                 </a>

--- a/templates/admin/signup_requests.html.twig
+++ b/templates/admin/signup_requests.html.twig
@@ -18,6 +18,12 @@
         <h3>{{ 'signup_requests_header'|trans }}</h3>
         <p>{{ 'signup_requests_paragraph'|trans }}</p>
     </div>
+    {% if username is defined and username is not same as null %}
+        <div class="alert alert__info">
+            <p>{{ 'viewing_one_signup_request'|trans({'%username%': username}) }}</p>
+            <p><a href="{{ path('admin_signup_requests') }}"><i class="fa-solid fa-arrow-left" aria-hidden="true"></i> {{ 'return'|trans }}</a></p>
+        </div>
+    {% endif %}
     {% if requests|length %}
         {% for request in requests %}
             <div class="section">

--- a/templates/notifications/_blocks.html.twig
+++ b/templates/notifications/_blocks.html.twig
@@ -160,4 +160,11 @@
 {% block new_signup %}
     {{ 'notification_title_new_signup'|trans }}<br />
     {{ component('user_inline', { user: notification.newUser } ) }}
+    {% if do_new_users_need_approval() and notification.newUser.applicationStatus is not same as enum('App\\Enums\\EApplicationStatus').Approved %}
+        <div>
+            <a href="{{ path('admin_signup_requests') }}?username={{ notification.newUser.username }}">
+                {{ 'open_signup_request'|trans }}
+            </a>
+        </div>
+    {% endif %}
 {% endblock %}

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -403,6 +403,7 @@ captcha_enabled: Captcha enabled
 header_logo: Header logo
 browsing_one_thread: You are only browsing one thread in the discussion! All comments
   are available on the post page.
+viewing_one_signup_request: You are only viewing one signup request by %username%
 return: Return
 boost: Boost
 mercure_enabled: Mercure enabled
@@ -944,3 +945,4 @@ answered: answered
 by: by
 front_default_sort: Frontpage default sort
 comment_default_sort: Comment default sort
+open_signup_request: Open signup request


### PR DESCRIPTION
- when the server has approvals enabled the links from the user inline component are quite useless, because you'll just get a 404. This adds a link to the signup requests page for the specific user to that notification
- add optional query parameter `username` to the `AdminSignupRequestsController`

![grafik](https://github.com/user-attachments/assets/ba200e4e-a863-4bb8-9679-3bd9eaf20305)

![Bildschirmfoto vom 2025-01-31 19-01-18](https://github.com/user-attachments/assets/abaea4d6-2b44-44c3-8174-50c10c3036fb)
