### PR TITLE
Fix notification api route methods

### DIFF
--- a/config/mbin_routes/notification_api.yaml
+++ b/config/mbin_routes/notification_api.yaml
@@ -62,5 +62,5 @@ api_notification_push_unregister:
 api_notification_push_test:
     controller: App\Controller\Api\Notification\NotificationPushApi::testSubscription
     path: /api/notification/push/test
-    methods: [ GET ]
+    methods: [ POST ]
     format: json

--- a/config/mbin_routes/notification_settings_api.yaml
+++ b/config/mbin_routes/notification_settings_api.yaml
@@ -4,5 +4,5 @@ api_notification_settings_update:
     requirements:
         targetType: entry|post|magazine|user
         setting: Default|Loud|Muted
-    methods: [ GET ]
+    methods: [ PUT ]
     format: json


### PR DESCRIPTION
I found two more routes that need their methods changed:

- The notification settings route should use `PUT` to indicate that it updates a setting.
- The notification test route should use `POST` to indicate that something happens on the backend (sends a test notification). This route was already released, but I do know both Interstellar and joinmbin.org don't use this route, and I did a quick check through a GitHub search and didn't find anything else, so I think we'll be fine updating this route. I'd say out of all the routes that exist, this is probably one of the least important ones anyway.

---

Just as an aside, for those who don't know, HTTP requests with the `GET` method are not supposed to have side effects. They should exclusively be a read-only operation that returns data from the server (nothing else should happen). For data mutating routes, `POST` is best for a create operation, `PUT` for update, and `DELETE` for deleting a resource.