### PR TITLE
Fix doctrine weirdness

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -5,7 +5,6 @@ doctrine:
             citext: App\DoctrineExtensions\DBAL\Types\Citext
             enumApplicationStatus: App\DoctrineExtensions\DBAL\Types\EnumApplicationStatus
             enumNotificationStatus: App\DoctrineExtensions\DBAL\Types\EnumNotificationStatus
-            EnumNotificationStatus: App\DoctrineExtensions\DBAL\Types\EnumNotificationStatus
             enumSortOptions: App\DoctrineExtensions\DBAL\Types\EnumSortOptions
         mapping_types:
             user_type: string

--- a/migrations/Version20250204152300.php
+++ b/migrations/Version20250204152300.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20250204152300 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'remove confusing comment on notification_settings.notification_status';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('COMMENT ON COLUMN notification_settings.notification_status IS NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('COMMENT ON COLUMN notification_settings.notification_status IS \'(DC2Type:EnumNotificationStatus)\'');
+    }
+}


### PR DESCRIPTION
- remove an unnecessary mapping type
- remove a column comment that is confusing doctrine

If we only removed the mapping type the `php bin/console doctrine:migrations:diff` command would throw an error because of the comment on the column