### PR TITLE
Add missing colons to GitHub Issues template for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,14 +31,14 @@ If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
  - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Browser Version [e.g. 123]
+ - Browser: [e.g. chrome, safari]
+ - Browser Version: [e.g. 123]
 
 **Smartphone (please complete the following information):**
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Browser Version [e.g. 123]
+ - Browser: [e.g. stock browser, safari]
+ - Browser Version: [e.g. 123]
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
The GitHub Issues template for bug reports is inconsistent with its usage of colons. This looks like it wasn't intentional (?) so I added colons to the points missing it.