### PR TITLE
Improve Markdown inline twig rendering

### DIFF
--- a/src/Markdown/CommonMark/CommunityLinkParser.php
+++ b/src/Markdown/CommonMark/CommunityLinkParser.php
@@ -16,6 +16,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class CommunityLinkParser implements InlineParserInterface
 {
+    public const COMMUNITY_REGEX = '\B!(\w{1,30})(?:@)?((?:[\pL\pN\pS\pM\-\_]++\.)+[\pL\pN\pM]++|[a-z0-9\-\_]++)?';
+
     public function __construct(
         private readonly MagazineRepository $magazineRepository,
         private readonly SettingsManager $settingsManager,
@@ -25,7 +27,7 @@ class CommunityLinkParser implements InlineParserInterface
 
     public function getMatchDefinition(): InlineParserMatch
     {
-        return InlineParserMatch::regex('\B!(\w{1,30})(?:@)?((?:[\pL\pN\pS\pM\-\_]++\.)+[\pL\pN\pM]++|[a-z0-9\-\_]++)?');
+        return InlineParserMatch::regex(self::COMMUNITY_REGEX);
     }
 
     public function parse(InlineParserContext $ctx): bool

--- a/src/Utils/UrlUtils.php
+++ b/src/Utils/UrlUtils.php
@@ -21,8 +21,22 @@ class UrlUtils
 
     public static function getCacheKeyForMarkdownUrl(string $url): string
     {
-        $key = preg_replace('/[(){}\/:]/', '_', $url);
+        $key = preg_replace('/[(){}\/:@]/', '_', $url);
 
         return "markdown_url_$key";
+    }
+
+    public static function getCacheKeyForMarkdownUserMention(string $url): string
+    {
+        $key = preg_replace('/[(){}\/:@]/', '_', $url);
+
+        return "markdown_user_mention_$key";
+    }
+
+    public static function getCacheKeyForMarkdownMagazineMention(string $url): string
+    {
+        $key = preg_replace('/[(){}\/:@]/', '_', $url);
+
+        return "markdown_magazine_mention_$key";
     }
 }


### PR DESCRIPTION
- do not render inline twig components if a link contains a title
- add cache tagging and clearing for user and magazine handles

Closes #1434 