### PR TITLE
Render lemmy community links as preview

### DIFF
--- a/src/Markdown/CommonMark/CommunityLinkParser.php
+++ b/src/Markdown/CommonMark/CommunityLinkParser.php
@@ -97,7 +97,7 @@ class CommunityLinkParser implements InlineParserInterface
         if ('[' === $prev && ']' === $next && '(' === $nextNext) {
             $closing = null;
             $link = '';
-            for ($i = 2; $char = $cursor->peek($i); ++$i) {
+            for ($i = 2; null !== ($char = $cursor->peek($i)); ++$i) {
                 if (')' === $char) {
                     $closing = $i;
                     break;

--- a/src/Markdown/CommonMark/CommunityLinkParser.php
+++ b/src/Markdown/CommonMark/CommunityLinkParser.php
@@ -43,6 +43,8 @@ class CommunityLinkParser implements InlineParserInterface
         $isRemote = $this->isRemoteCommunity($domain);
         $magazine = $this->magazineRepository->findOneByName($isRemote ? $fullHandle : $handle);
 
+        $this->removeSurroundingLink($ctx, $handle, $domain);
+
         if ($magazine) {
             $ctx->getContainer()->appendChild(
                 new CommunityLink(
@@ -61,7 +63,7 @@ class CommunityLinkParser implements InlineParserInterface
             $ctx->getContainer()->appendChild(
                 new ActorSearchLink(
                     $this->urlGenerator->generate('search', ['search[q]' => $fullHandle], UrlGeneratorInterface::ABSOLUTE_URL),
-                    '!'.$handle,
+                    '!'.$fullHandle,
                     '!'.$fullHandle,
                 )
             );
@@ -78,5 +80,41 @@ class CommunityLinkParser implements InlineParserInterface
     private function isRemoteCommunity(?string $domain): bool
     {
         return $domain !== $this->settingsManager->get('KBIN_DOMAIN');
+    }
+
+    /**
+     * Removes a surrounding link from the parsing container if the link contains $handle and $domain.
+     *
+     * @param string $handle the user handle in [!@]handle@domain
+     * @param string $domain the domain in [!@]handle@domain
+     */
+    public static function removeSurroundingLink(InlineParserContext $ctx, string $handle, string $domain): void
+    {
+        $cursor = $ctx->getCursor();
+        $prev = $cursor->peek(-1 - $ctx->getFullMatchLength());
+        $next = $cursor->peek(0);
+        $nextNext = $cursor->peek(1);
+        if ('[' === $prev && ']' === $next && '(' === $nextNext) {
+            $closing = null;
+            $link = '';
+            for ($i = 2; $char = $cursor->peek($i); ++$i) {
+                if (')' === $char) {
+                    $closing = $i;
+                    break;
+                }
+                $link .= $char;
+            }
+            if (null !== $closing && str_contains($link, $handle) && str_contains($link, $domain)) {
+                // this is probably a lemmy community link a lá [!magazine@domain.tld](https://domain.tld/c/magazine]
+                $container = $ctx->getContainer();
+                $prev = $container->lastChild();
+                if ('[' === $prev->getLiteral()) {
+                    $prev->detach();
+                }
+                $ctx->getDelimiterStack()->removeBracket();
+                $cursor->advanceBy($closing + 1);
+                $current = $cursor->peek(0);
+            }
+        }
     }
 }

--- a/src/Markdown/CommonMark/ExternalLinkRenderer.php
+++ b/src/Markdown/CommonMark/ExternalLinkRenderer.php
@@ -26,7 +26,6 @@ use App\Repository\EmbedRepository;
 use App\Repository\MagazineRepository;
 use App\Repository\UserRepository;
 use App\Service\ImageManager;
-use App\Service\MentionManager;
 use App\Service\SettingsManager;
 use App\Utils\Embed;
 use App\Utils\UrlUtils;
@@ -62,7 +61,6 @@ final class ExternalLinkRenderer implements NodeRendererInterface, Configuration
         private readonly RequestStack $requestStack,
         private readonly ApActivityRepository $activityRepository,
         private readonly EntityManagerInterface $entityManager,
-        private readonly MentionManager $mentionManager,
     ) {
     }
 
@@ -140,44 +138,6 @@ final class ExternalLinkRenderer implements NodeRendererInterface, Configuration
                     $this->logger->warning('[ExternalLinkRenderer::render] Could not find an entity for type {t} with id {id} from url {url}', ['t' => $apActivity['type'], 'id' => $apActivity['id'], 'url' => $url]);
 
                     return new HtmlElement('div');
-                }
-            } elseif (!$isApRequest && null === $apActivity) {
-                if ($user = $this->userRepository->findOneBy(['apProfileId' => $url])) {
-                    $this->logger->debug('found user for URL {u}', ['u' => $url]);
-                    // @admin@mbin.tld
-                    $name = $user->username;
-                    // admin
-                    $name2 = $this->mentionManager->getUsername($user->username);
-                    // @admin
-                    $name3 = '@'.$this->mentionManager->getUsername($user->username);
-                    // we need that whole checking here because we do not just get the raw text of the link, but instead only the first half
-                    // so if the raw text is [@admin@mbin.tld](https://mbin.tld/u/admin) we get "admin"
-                    if ($childContent === $name || $childContent === $name2 || $childContent === $name3) {
-                        return new HtmlElement('span', contents: $this->renderUser($user));
-                    } else {
-                        $this->logger->debug('found user for URL {u}, but the link text "{t}" is not the same as the username "{name}" or "{name2}" or "{name3}"', ['u' => $url, 't' => $childContent, 'name' => $name, 'name2' => $name2, 'name3' => $name3]);
-                    }
-                } elseif ($magazine = $this->magazineRepository->findOneBy(['apProfileId' => $url])) {
-                    $this->logger->debug('found magazine for URL {u}', ['u' => $url]);
-                    // technology@lemmy.world
-                    $name = $magazine->name;
-                    if (!str_starts_with($name, '@') && !str_starts_with($name, '!')) {
-                        // @technology@lemmy.world
-                        $name = "@$name";
-                    }
-                    // technology
-                    $name2 = $this->mentionManager->getUsername($name);
-                    // !technology
-                    $name3 = '!'.$this->mentionManager->getUsername($name);
-                    // we need that whole checking here because we do not just get the raw text of the link, but instead only the first half
-                    // so if the raw text is [!technology@lemmy.world](https://lemmy.world/c/technology) we get "technology"
-                    if ($childContent === $magazine->name || $childContent === $name2 || $childContent === $name3) {
-                        return new HtmlElement('span', contents: $this->renderMagazine($magazine));
-                    } else {
-                        $this->logger->debug('found magazine for URL {u}, but the link text "{t}" is not the same as the name "{name}" or "{name2}" or "{name3}"', ['u' => $url, 't' => $childContent, 'name' => $name, 'name2' => $name2, 'name3' => $name3]);
-                    }
-                } else {
-                    $this->logger->debug("Didn't find any AP object for url {u}", ['u' => $url]);
                 }
             }
         } else {

--- a/src/Markdown/CommonMark/MentionLinkParser.php
+++ b/src/Markdown/CommonMark/MentionLinkParser.php
@@ -45,6 +45,8 @@ class MentionLinkParser implements InlineParserInterface
 
         $fullUsername = $username.'@'.$domain;
 
+        CommunityLinkParser::removeSurroundingLink($ctx, $username, $domain);
+
         [$type, $data] = $this->resolveType($username, $domain);
 
         if ($data instanceof User && $data->apPublicUrl) {

--- a/tests/Unit/Utils/MarkdownTest.php
+++ b/tests/Unit/Utils/MarkdownTest.php
@@ -23,6 +23,19 @@ class MarkdownTest extends WebTestCase
         self::assertStringNotContainsString('https://kbin.test2', $markdown);
     }
 
+    public function testMagazineLinks2(): void
+    {
+        $text = 'Lots of activity on [!fedibridge@lemmy.dbzer0.com](https://lemmy.dbzer0.com/c/fedibridge) following Reddit paywall announcements';
+        $markdown = $this->markdownConverter->convertToHtml($text, [MarkdownConverter::RENDER_TARGET => RenderTarget::Page]);
+        // assert that this community does not exist, and we get a search link for it that does not link to the external instance
+        self::assertStringContainsString('search', $markdown);
+        self::assertStringNotContainsString('(', $markdown);
+        self::assertStringNotContainsString(')', $markdown);
+        self::assertStringNotContainsString('[', $markdown);
+        self::assertStringNotContainsString(']', $markdown);
+        self::assertStringNotContainsString('https://lemmy.dbzer0.com', $markdown);
+    }
+
     public function testLemmyMagazineLinks(): void
     {
         $text = 'This should belong to [!magazine@kbin.test2](https://kbin.test2/m/magazine)';

--- a/tests/Unit/Utils/MarkdownTest.php
+++ b/tests/Unit/Utils/MarkdownTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Utils;
+
+use App\Markdown\MarkdownConverter;
+use App\Markdown\RenderTarget;
+use App\Tests\WebTestCase;
+
+class MarkdownTest extends WebTestCase
+{
+    public function testMagazineLinks(): void
+    {
+        $text = 'This should belong to !magazine@kbin.test2';
+        $markdown = $this->markdownConverter->convertToHtml($text, [MarkdownConverter::RENDER_TARGET => RenderTarget::Page]);
+        // assert that this community does not exist, and we get a search link for it that does not link to the external instance
+        self::assertStringContainsString('search', $markdown);
+        self::assertStringNotContainsString('(', $markdown);
+        self::assertStringNotContainsString(')', $markdown);
+        self::assertStringNotContainsString('[', $markdown);
+        self::assertStringNotContainsString(']', $markdown);
+        self::assertStringNotContainsString('https://kbin.test2', $markdown);
+    }
+
+    public function testLemmyMagazineLinks(): void
+    {
+        $text = 'This should belong to [!magazine@kbin.test2](https://kbin.test2/m/magazine)';
+        $markdown = $this->markdownConverter->convertToHtml($text, [MarkdownConverter::RENDER_TARGET => RenderTarget::Page]);
+        // assert that this community does not exist, and we get a search link for it that does not link to the external instance
+        self::assertStringContainsString('search', $markdown);
+        self::assertStringNotContainsString('(', $markdown);
+        self::assertStringNotContainsString(')', $markdown);
+        self::assertStringNotContainsString('[', $markdown);
+        self::assertStringNotContainsString(']', $markdown);
+        self::assertStringNotContainsString('https://kbin.test2', $markdown);
+    }
+
+    public function testExternalMagazineLinks(): void
+    {
+        $text = 'This should belong to [this magazine](https://kbin.test2/m/magazine)';
+        $markdown = $this->markdownConverter->convertToHtml($text, [MarkdownConverter::RENDER_TARGET => RenderTarget::Page]);
+        self::assertStringContainsString('https://kbin.test2', $markdown);
+    }
+
+    public function testMentionLink(): void
+    {
+        $text = 'Hi @admin@kbin.test2';
+        $markdown = $this->markdownConverter->convertToHtml($text, [MarkdownConverter::RENDER_TARGET => RenderTarget::Page]);
+        // assert that this community does not exist, and we get a search link for it that does not link to the external instance
+        self::assertStringContainsString('search', $markdown);
+        self::assertStringNotContainsString('(', $markdown);
+        self::assertStringNotContainsString(')', $markdown);
+        self::assertStringNotContainsString('[', $markdown);
+        self::assertStringNotContainsString(']', $markdown);
+        self::assertStringNotContainsString('https://kbin.test2', $markdown);
+    }
+
+    public function testNestedMentionLink(): void
+    {
+        $text = 'Hi [@admin@kbin.test2](https://kbin.test2/u/admin)';
+        $markdown = $this->markdownConverter->convertToHtml($text, [MarkdownConverter::RENDER_TARGET => RenderTarget::Page]);
+        // assert that this community does not exist, and we get a search link for it that does not link to the external instance
+        self::assertStringContainsString('search', $markdown);
+        self::assertStringNotContainsString('(', $markdown);
+        self::assertStringNotContainsString(')', $markdown);
+        self::assertStringNotContainsString('[', $markdown);
+        self::assertStringNotContainsString(']', $markdown);
+        self::assertStringNotContainsString('https://kbin.test2', $markdown);
+    }
+
+    public function testExternalMentionLink(): void
+    {
+        $text = 'You should really talk to your [instance admin](https://kbin.test2/u/admin)';
+        $markdown = $this->markdownConverter->convertToHtml($text, [MarkdownConverter::RENDER_TARGET => RenderTarget::Page]);
+        // assert that this community does not exist, and we get a search link for it that does not link to the external instance
+        self::assertStringContainsString('https://kbin.test2', $markdown);
+    }
+}

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -10,6 +10,7 @@ use App\Factory\ActivityPub\PersonFactory;
 use App\Factory\ActivityPub\TombstoneFactory;
 use App\Factory\ImageFactory;
 use App\Factory\MagazineFactory;
+use App\Markdown\MarkdownConverter;
 use App\MessageHandler\ActivityPub\Outbox\DeliverHandler;
 use App\Repository\BookmarkListRepository;
 use App\Repository\BookmarkRepository;
@@ -111,6 +112,7 @@ abstract class WebTestCase extends BaseWebTestCase
     protected MentionManager $mentionManager;
     protected ActivityPubManager $activityPubManager;
     protected BookmarkManager $bookmarkManager;
+    protected MarkdownConverter $markdownConverter;
 
     protected MagazineRepository $magazineRepository;
     protected EntryRepository $entryRepository;
@@ -181,6 +183,7 @@ abstract class WebTestCase extends BaseWebTestCase
         $this->notificationManager = $this->getService(NotificationManager::class);
         $this->activityPubManager = $this->getService(ActivityPubManager::class);
         $this->bookmarkManager = $this->getService(BookmarkManager::class);
+        $this->markdownConverter = $this->getService(MarkdownConverter::class);
 
         $this->magazineRepository = $this->getService(MagazineRepository::class);
         $this->entryRepository = $this->getService(EntryRepository::class);


### PR DESCRIPTION
A lemmy community link often looks like: `[!community@domain.tld](https://domain.tld/c/community)` which is just rendered as a link at the moment, render such links as the new inline preview