### PR TITLE
Enable option help + missing text for various options

### DIFF
--- a/assets/styles/components/_settings_row.scss
+++ b/assets/styles/components/_settings_row.scss
@@ -32,10 +32,6 @@
     margin-left: .375rem;
   }
 
-  .help {
-    display: none;
-  }
-
   .value-container {
     display: flex;
     justify-content: end;

--- a/templates/components/_settings_row_enum.html.twig
+++ b/templates/components/_settings_row_enum.html.twig
@@ -1,6 +1,5 @@
 <div class="settings-row {{ class }}" data-controller="settings-row-enum">
-    <span class="label" id="settings-row-label-{{ settingsKey }}">{{ label }}</span>
-    <span class="help" id="settings-row-help-{{ settingsKey }}">{{ help }}</span>
+    <span class="label" title="{{ help }}" id="settings-row-label-{{ settingsKey }}">{{ label }}</span>
     <div class="value-container">
         <div class="enum" role="radiogroup" aria-labelledby="settings-row-label-{{ settingsKey }}"
              aria-describedby="settings-row-help-{{ settingsKey }}">

--- a/templates/components/_settings_row_switch.html.twig
+++ b/templates/components/_settings_row_switch.html.twig
@@ -1,6 +1,5 @@
 <div class="settings-row" data-controller="settings-row-switch">
-    <span class="label" id="settings-row-label-{{ settingsKey }}">{{ label }}</span>
-    <span class="help" id="settings-row-help-{{ settingsKey }}">{{ help }}</span>
+    <span class="label" title="{{ help }}" id="settings-row-label-{{ settingsKey }}">{{ label }}</span>
     <div class="value-container">
         <label class="switch" role="switch">
             <input type="checkbox"

--- a/templates/layout/_options_appearance.html.twig
+++ b/templates/layout/_options_appearance.html.twig
@@ -42,16 +42,16 @@
     <strong>{{ 'threads'|trans }}</strong>
     <div class="settings-section">
         {{ component('settings_row_switch', {label: 'auto_preview'|trans, help: 'auto_preview_help'|trans,  settingsKey: 'KBIN_ENTRIES_SHOW_PREVIEW'}) }}
-        {{ component('settings_row_switch', {label: 'compact_view'|trans, settingsKey: 'KBIN_ENTRIES_COMPACT'}) }}
-        {{ component('settings_row_switch', {label: 'show_users_avatars'|trans, settingsKey: 'KBIN_ENTRIES_SHOW_USERS_AVATARS', defaultValue: true}) }}
-        {{ component('settings_row_switch', {label: 'show_magazines_icons'|trans, settingsKey: 'KBIN_ENTRIES_SHOW_MAGAZINES_ICONS', defaultValue: true}) }}
-        {{ component('settings_row_switch', {label: 'show_thumbnails'|trans, settingsKey: 'KBIN_ENTRIES_SHOW_THUMBNAILS', defaultValue: true}) }}
-        {{ component('settings_row_switch', {label: 'image_lightbox_in_list'|trans, settingsKey: 'MBIN_LIST_IMAGE_LIGHTBOX', defaultValue: true}) }}
+        {{ component('settings_row_switch', {label: 'compact_view'|trans, help: 'compact_view_help'|trans, settingsKey: 'KBIN_ENTRIES_COMPACT'}) }}
+        {{ component('settings_row_switch', {label: 'show_users_avatars'|trans, help: 'show_users_avatars_help'|trans, settingsKey: 'KBIN_ENTRIES_SHOW_USERS_AVATARS', defaultValue: true}) }}
+        {{ component('settings_row_switch', {label: 'show_magazines_icons'|trans, help: 'show_magazines_icons_help'|trans, settingsKey: 'KBIN_ENTRIES_SHOW_MAGAZINES_ICONS', defaultValue: true}) }}
+        {{ component('settings_row_switch', {label: 'show_thumbnails'|trans, help: 'show_thumbnails_help'|trans, settingsKey: 'KBIN_ENTRIES_SHOW_THUMBNAILS', defaultValue: true}) }}
+        {{ component('settings_row_switch', {label: 'image_lightbox_in_list'|trans, help: 'image_lightbox_in_list_help'|trans, settingsKey: 'MBIN_LIST_IMAGE_LIGHTBOX', defaultValue: true}) }}
     </div>
     <strong>{{ 'microblog'|trans }}</strong>
     <div class="settings-section">
         {{ component('settings_row_switch', {label: 'auto_preview'|trans, help: 'auto_preview_help'|trans,  settingsKey: 'KBIN_POSTS_SHOW_PREVIEW'}) }}
-        {{ component('settings_row_switch', {label: 'show_users_avatars'|trans, settingsKey: 'KBIN_POSTS_SHOW_USERS_AVATARS', defaultValue: true}) }}
+        {{ component('settings_row_switch', {label: 'show_users_avatars'|trans, help: 'show_users_avatars_help'|trans, settingsKey: 'KBIN_POSTS_SHOW_USERS_AVATARS', defaultValue: true}) }}
     </div>
     <strong>{{ 'single_settings'|trans }}</strong>
     <div class="settings-section">
@@ -60,7 +60,7 @@
     </div>
     <strong>{{ 'mod_log'|trans }}</strong>
     <div class="settings-section">
-        {{ component('settings_row_switch', {label: 'show_users_avatars'|trans, settingsKey: 'MBIN_MODERATION_LOG_SHOW_USER_AVATARS', defaultValue: false}) }}
-        {{ component('settings_row_switch', {label: 'show_magazines_icons'|trans, settingsKey: 'MBIN_MODERATION_LOG_SHOW_MAGAZINE_ICONS', defaultValue: false}) }}
+        {{ component('settings_row_switch', {label: 'show_users_avatars'|trans, help: 'show_users_avatars_help'|trans, settingsKey: 'MBIN_MODERATION_LOG_SHOW_USER_AVATARS', defaultValue: false}) }}
+        {{ component('settings_row_switch', {label: 'show_magazines_icons'|trans, help: 'show_magazines_icons_help'|trans, settingsKey: 'MBIN_MODERATION_LOG_SHOW_MAGAZINE_ICONS', defaultValue: false}) }}
     </div>
 </div>

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -962,4 +962,10 @@ by: by
 front_default_sort: Frontpage default sort
 comment_default_sort: Comment default sort
 open_signup_request: Open signup request
-image_lightbox_in_list: List thumbs opens full screen
+image_lightbox_in_list: Thread thumbnails opens full screen
+auto_preview_help: Show the media (photo, video) in a larger size below the content.
+compact_view_help: A compact view with less margins, where the media is moved to the right side.
+show_users_avatars_help: Display the user avatar image.
+show_magazines_icons_help: Display the magazine icon.
+show_thumbnails_help: Show the thumbnail images.
+image_lightbox_in_list_help: When checked, clicking the thumbnail shows a modal image box window. When unchecked, clicking the thumbnail will open the thread.

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -413,7 +413,7 @@ preferred_languages: Filter languages of threads and posts
 infinite_scroll_help: Automatically load more content when you reach the bottom of
   the page.
 sticky_navbar_help: The navbar will stick to the top of the page when you scroll down.
-auto_preview_help: Automatically expand media previews.
+auto_preview_help: Show the media (photo, video) previews in a larger size below the content.
 reload_to_apply: Reload page to apply changes
 filter.origin.label: Choose origin
 filter.fields.label: Choose which fields to search

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -963,7 +963,6 @@ front_default_sort: Frontpage default sort
 comment_default_sort: Comment default sort
 open_signup_request: Open signup request
 image_lightbox_in_list: Thread thumbnails opens full screen
-auto_preview_help: Show the media (photo, video) in a larger size below the content.
 compact_view_help: A compact view with less margins, where the media is moved to the right side.
 show_users_avatars_help: Display the user avatar image.
 show_magazines_icons_help: Display the magazine icon.


### PR DESCRIPTION
- Since commit https://github.com/MbinOrg/mbin/commit/0d9711fee7de4bd1589042587b25109a1c4cfda0, the help text seems to be fully **disabled** (put to hidden) in the option settings sidebar
- This PR refactor the help section, and show the help text again but as a mouse-over `title` attribute on the HTML `span` element.
- Apply the `title` improvement to both the `enum` and `switch` settings row.
- Add missing help text for various options, which allows us to better explain the settings towards the user. In more detail and not limited to any length of text.