### PR TITLE
Docs: Remove dev setup from production guide + contribute improvements

### DIFF
--- a/docs/02-admin/01-installation/01-bare_metal.md
+++ b/docs/02-admin/01-installation/01-bare_metal.md
@@ -44,7 +44,7 @@ sudo dpkg -i /tmp/debsuryorg-archive-keyring.deb
 sudo sh -c 'echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 ```
 
-Install _PHP 8.3_ with PHP extensions:
+Install _PHP 8.3_ (or install _PHP 8.4_ if you wish) with PHP extensions:
 
 ```bash
 sudo apt-get update
@@ -53,6 +53,9 @@ sudo apt-get install php8.3 php8.3-common php8.3-fpm php8.3-cli php8.3-amqp php8
 
 > [!NOTE]
 > If you are upgrading to PHP 8.3 from an older version, please re-review the [PHP configuration](#php) section of this guide as existing `ini` settings are NOT automatically copied to new versions. Additionally review which php-fpm version is configured in your nginx site.
+
+> [!IMPORTANT]
+> **Never** even install `xdebug` PHP extension in production environments. Even if you didn't enabled it but only installed `xdebug` can give massive performance issues.
 
 Install Composer:
 
@@ -317,9 +320,7 @@ sudo systemctl restart php8.3-fpm.service
 
 ### Composer
 
-Choose either production or developer (not both).
-
-#### Composer Production
+Setup composer in production mode:
 
 ```bash
 composer install --no-dev
@@ -328,21 +329,10 @@ APP_ENV=prod APP_DEBUG=0 php bin/console cache:clear
 composer clear-cache
 ```
 
-#### Composer Development
-
-If you run production already then _skip the steps below_.
-
 > [!CAUTION]
-> When running in development mode your instance will make _sensitive information_ available,
-> such as database credentials, via the debug toolbar and/or stack traces.
-> **DO NOT** expose your development instance to the Internet or you will have a bad time.
-
-```bash
-composer install
-composer dump-env dev
-APP_ENV=dev APP_DEBUG=1 php bin/console cache:clear
-composer clear-cache
-```
+> When running Symfony in _development mode_, your instance may _expose sensitive information_ to the public,
+> including database credentials, through the debug toolbar and stack traces.
+> **NEVER** expose your development instance to the Internet — doing so can lead to serious security risks.
 
 ### Caching
 

--- a/docs/03-contributing/01-getting_started.md
+++ b/docs/03-contributing/01-getting_started.md
@@ -57,7 +57,7 @@ sudo apt install php8.3 php8.3-common php8.3-fpm php8.3-cli php8.3-amqp php8.3-b
 max_execution_time = 120
 ```
 
-- Increase/set max_nesting_level in `/etc/php/8.3/fpm/conf.d/20-xdebug.ini`:
+- _Optional:_ Increase/set max_nesting_level in `/etc/php/8.3/fpm/conf.d/20-xdebug.ini` (in case you have the `xdebug` extension installed):
 
 ```ini
 xdebug.max_nesting_level=512
@@ -177,7 +177,8 @@ Prepare the server:
 2. Install dependencies: `composer install`
 3. Dump `.env` into `.env.local.php` via: `composer dump-env dev`
 4. _Optionally:_ Increase verbosity log level in: `config/packages/monolog.yaml` in the `when@dev` section: `level: debug` (instead of `level: info`),
-5. Clear cache: `APP_ENV=dev APP_DEBUG=1 php bin/console cache:clear -n`
+5. **Important:** clear Symfony cache: `APP_ENV=dev APP_DEBUG=1 php bin/console cache:clear -n`
+6. _Optionally:_ clear the Composer cache: `composer clear-cache`
 
 Start the development server:
 
@@ -188,7 +189,7 @@ You might want to also follow the [Mbin first setup](../02-admin/04-running-mbin
 
 This will give you a minimal working frontend with PostgreSQL setup. Keep in mind: this will _not_ start federating.
 
-_Optionally:_ If you want to start federating, you will also need to messenger jobs + RabbitMQ and host your server behind a reverse proxy with valid SSL certificate.
+_Optionally:_ If you want to start federating, you will also need to messenger jobs + RabbitMQ and host your server behind a reverse proxy with valid SSL certificate. Generally speaking, it's **not** required to setup federation for development purposes.
 
 More info: [Contributing guide](https://github.com/MbinOrg/mbin/blob/main/CONTRIBUTING.md), [Admin guide](../02-admin/README.md) and [Symfony Local Web Server](https://symfony.com/doc/current/setup/symfony_server.html)
 
@@ -210,7 +211,7 @@ For more info read: [Symfony Testing guide](https://symfony.com/doc/current/test
 max_execution_time = 120
 ```
 
-2. Increase/set max_nesting_level in `/etc/php/8.3/fpm/conf.d/20-xdebug.ini`:
+2. _Optional:_ Increase/set max_nesting_level in `/etc/php/8.3/fpm/conf.d/20-xdebug.ini` (in case you have the `xdebug` extension installed):
 
 ```ini
 xdebug.max_nesting_level=512


### PR DESCRIPTION
- Remove composer development setup from production setup (avoid that people will run symfony in dev mode)
- Improve contribute - getting started guide (which is meant for development)
- Keep the warning about development mode in production guide
- Also explain to NOT use `xdebug` in production
- Extend contributing page