### PR TITLE
Also set MESSENGER_TRANSPORT_DSN in .env.test

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -4,6 +4,7 @@ APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999
 PANTHER_APP_ENV=panther
 PANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots
+MESSENGER_TRANSPORT_DSN=sync://
 
 # Mbin variables
 DATABASE_HOST=127.0.0.1
@@ -19,7 +20,6 @@ KBIN_DOMAIN=kbin.test
 ELASTICSEARCH_ENABLED=false
 KBIN_API_ITEMS_PER_PAGE=2
 KBIN_FEDERATION_ENABLED=true
-MESSENGER_TRANSPORT_DSN=sync://
 
 ###> league/oauth2-server-bundle ###
 OAUTH_PRIVATE_KEY=%kernel.project_dir%/config/oauth2/tests/private.pem

--- a/.env.test
+++ b/.env.test
@@ -19,6 +19,7 @@ KBIN_DOMAIN=kbin.test
 ELASTICSEARCH_ENABLED=false
 KBIN_API_ITEMS_PER_PAGE=2
 KBIN_FEDERATION_ENABLED=true
+MESSENGER_TRANSPORT_DSN=sync://
 
 ###> league/oauth2-server-bundle ###
 OAUTH_PRIVATE_KEY=%kernel.project_dir%/config/oauth2/tests/private.pem


### PR DESCRIPTION
Make unit test & integration more robust by changes to the `.env` file, and still have the tests run (using `.env.test`) successfully. 