### PR TITLE
Extend public access roles for three API end-points

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -123,6 +123,7 @@ security:
         - { path: ^/authorize, roles: PUBLIC_ACCESS }
         - { path: ^/token, roles: PUBLIC_ACCESS }
         - { path: ^/api/doc, roles: PUBLIC_ACCESS }
+        - { path: ^/api/client, roles: PUBLIC_ACCESS }
         - { path: ^/api/info, roles: PUBLIC_ACCESS }
         - { path: ^/api/instance, roles: PUBLIC_ACCESS }
         - { path: ^/api/defederate, roles: PUBLIC_ACCESS }

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -123,7 +123,9 @@ security:
         - { path: ^/authorize, roles: PUBLIC_ACCESS }
         - { path: ^/token, roles: PUBLIC_ACCESS }
         - { path: ^/api/doc, roles: PUBLIC_ACCESS }
-        - { path: ^/api/client, roles: PUBLIC_ACCESS }
+        - { path: ^/api/info, roles: PUBLIC_ACCESS }
+        - { path: ^/api/instance, roles: PUBLIC_ACCESS }
+        - { path: ^/api/defederate, roles: PUBLIC_ACCESS }
         - { path: ^/, roles: PUBLIC_ACCESS_UNLESS_PRIVATE_INSTANCE }
 
     role_hierarchy:

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -126,7 +126,9 @@ security:
         - { path: ^/api/client, roles: PUBLIC_ACCESS }
         - { path: ^/api/info, roles: PUBLIC_ACCESS }
         - { path: ^/api/instance, roles: PUBLIC_ACCESS }
+        - { path: ^/api/federated, roles: PUBLIC_ACCESS }
         - { path: ^/api/defederated, roles: PUBLIC_ACCESS }
+        - { path: ^/api/dead, roles: PUBLIC_ACCESS }
         - { path: ^/, roles: PUBLIC_ACCESS_UNLESS_PRIVATE_INSTANCE }
 
     role_hierarchy:

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -126,7 +126,7 @@ security:
         - { path: ^/api/client, roles: PUBLIC_ACCESS }
         - { path: ^/api/info, roles: PUBLIC_ACCESS }
         - { path: ^/api/instance, roles: PUBLIC_ACCESS }
-        - { path: ^/api/defederate, roles: PUBLIC_ACCESS }
+        - { path: ^/api/defederated, roles: PUBLIC_ACCESS }
         - { path: ^/, roles: PUBLIC_ACCESS_UNLESS_PRIVATE_INSTANCE }
 
     role_hierarchy:


### PR DESCRIPTION
When the server is in "Force users to login before they can access any content" mode, still allow the following 3 API end-points to be accessible for requests. Which is also used for: https://joinmbin.org/servers

- `/api/info`
- `/api/instance`
- `/api/defederate`
