### PR TITLE
Fix missing `Update` activity add cover and avatar removal

### DIFF
--- a/src/Controller/Api/User/UserDeleteImagesApi.php
+++ b/src/Controller/Api/User/UserDeleteImagesApi.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller\Api\User;
 
 use App\DTO\UserResponseDto;
+use App\Event\User\UserEditedEvent;
 use App\Factory\UserFactory;
 use App\Service\UserManager;
 use Nelmio\ApiDocBundle\Attribute\Model;
@@ -51,7 +52,12 @@ class UserDeleteImagesApi extends UserBaseApi
     ): JsonResponse {
         $headers = $this->rateLimit($apiImageLimiter);
 
-        $manager->detachAvatar($this->getUserOrThrow());
+        $user = $this->getUserOrThrow();
+        $manager->detachAvatar($user);
+        /*
+         * Call edit so the @see UserEditedEvent is triggered and the changes are federated
+         */
+        $manager->edit($user, $manager->createDto($user));
 
         return new JsonResponse(
             $this->serializeUser($factory->createDto($this->getUserOrThrow())),
@@ -94,7 +100,12 @@ class UserDeleteImagesApi extends UserBaseApi
     ): JsonResponse {
         $headers = $this->rateLimit($apiImageLimiter);
 
-        $manager->detachCover($this->getUserOrThrow());
+        $user = $this->getUserOrThrow();
+        $manager->detachCover($user);
+        /*
+         * Call edit so the @see UserEditedEvent is triggered and the changes are federated
+         */
+        $manager->edit($user, $manager->createDto($user));
 
         return new JsonResponse(
             $this->serializeUser($factory->createDto($this->getUserOrThrow())),

--- a/src/Controller/User/Profile/UserEditController.php
+++ b/src/Controller/User/Profile/UserEditController.php
@@ -6,9 +6,11 @@ namespace App\Controller\User\Profile;
 
 use App\Controller\AbstractController;
 use App\DTO\UserDto;
+use App\Exception\ImageDownloadTooLargeException;
 use App\Form\UserBasicType;
 use App\Form\UserEmailType;
 use App\Form\UserPasswordType;
+use App\Service\SettingsManager;
 use App\Service\UserManager;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\FormError;
@@ -27,6 +29,7 @@ class UserEditController extends AbstractController
         private readonly UserPasswordHasherInterface $userPasswordHasher,
         private readonly TranslatorInterface $translator,
         private readonly Security $security,
+        private readonly SettingsManager $settingsManager,
     ) {
     }
 
@@ -176,6 +179,10 @@ class UserEditController extends AbstractController
             }
 
             return $form;
+        } catch (ImageDownloadTooLargeException $e) {
+            $this->addFlash('error', $this->translator->trans('flash_image_download_too_large_error', ['%bytes%' => $this->settingsManager->getMaxImageByteString()]));
+
+            return null;
         } catch (\Exception $e) {
             return null;
         }

--- a/src/Controller/User/UserAvatarDeleteController.php
+++ b/src/Controller/User/UserAvatarDeleteController.php
@@ -22,7 +22,12 @@ class UserAvatarDeleteController extends AbstractController
     {
         $this->denyAccessUnlessGranted('edit_profile', $this->getUserOrThrow());
 
-        $this->userManager->detachAvatar($this->getUserOrThrow());
+        $user = $this->getUserOrThrow();
+        $this->userManager->detachAvatar($user);
+        /*
+         * Call edit so the @see UserEditedEvent is triggered and the changes are federated
+         */
+        $this->userManager->edit($user, $this->userManager->createDto($user));
 
         if ($request->isXmlHttpRequest()) {
             return new JsonResponse(

--- a/src/Controller/User/UserCoverDeleteController.php
+++ b/src/Controller/User/UserCoverDeleteController.php
@@ -22,7 +22,12 @@ class UserCoverDeleteController extends AbstractController
     {
         $this->denyAccessUnlessGranted('edit_profile', $this->getUserOrThrow());
 
-        $this->userManager->detachCover($this->getUserOrThrow());
+        $user = $this->getUserOrThrow();
+        $this->userManager->detachCover($user);
+        /*
+         * Call edit so the @see UserEditedEvent is triggered and the changes are federated
+         */
+        $this->userManager->edit($user, $this->userManager->createDto($user));
 
         if ($request->isXmlHttpRequest()) {
             return new JsonResponse(

--- a/src/MessageHandler/ActivityPub/Outbox/UpdateHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/UpdateHandler.php
@@ -23,6 +23,7 @@ use App\Service\ActivityPubManager;
 use App\Service\DeliverManager;
 use App\Service\SettingsManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -38,6 +39,7 @@ class UpdateHandler extends MbinMessageHandler
         private readonly DeliverManager $deliverManager,
         private readonly UpdateWrapper $updateWrapper,
         private readonly KernelInterface $kernel,
+        private readonly LoggerInterface $logger,
     ) {
         parent::__construct($this->entityManager, $this->kernel);
     }
@@ -88,6 +90,7 @@ class UpdateHandler extends MbinMessageHandler
             $activity = $this->updateWrapper->buildForActor($entity, $editedByUser);
             if ($entity instanceof User) {
                 $inboxes = $this->userRepository->findAudience($entity);
+                $this->logger->debug('[UpdateHandler::doWork] sending update user activity for user {u} to {i}', ['u' => $entity->username, 'i' => join(', ', $inboxes)]);
             } elseif ($entity instanceof Magazine) {
                 if ('random' === $entity->name) {
                     // do not federate the random magazine

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -409,6 +409,9 @@ class ActivityPubManager
                     $this->bus->dispatch(new DeleteImageMessage($user->avatar->getId()));
                 }
                 $user->avatar = $newImage;
+            } elseif (null !== $user->avatar) {
+                $this->bus->dispatch(new DeleteImageMessage($user->avatar->getId()));
+                $user->avatar = null;
             }
 
             // Only update cover if image is set
@@ -421,6 +424,9 @@ class ActivityPubManager
                     $this->bus->dispatch(new DeleteImageMessage($user->cover->getId()));
                 }
                 $user->cover = $newImage;
+            } elseif (null !== $user->cover) {
+                $this->bus->dispatch(new DeleteImageMessage($user->cover->getId()));
+                $user->cover = null;
             }
 
             if (null !== $user->apFollowersUrl) {
@@ -565,6 +571,9 @@ class ActivityPubManager
                     $this->bus->dispatch(new DeleteImageMessage($magazine->icon->getId()));
                 }
                 $magazine->icon = $newImage;
+            } elseif (null !== $magazine->icon) {
+                $this->bus->dispatch(new DeleteImageMessage($magazine->icon->getId()));
+                $magazine->icon = null;
             }
 
             if ($actor['name']) {

--- a/templates/user/settings/profile.html.twig
+++ b/templates/user/settings/profile.html.twig
@@ -29,20 +29,54 @@
             {{ form_start(form) }}
             {{ component('editor_toolbar', {id: 'user_basic_about'}) }}
             {{ form_row(form.about, {label: false, attr: {
-                placeholder: 'about', 
-                'data-controller': 'input-length rich-textarea autogrow', 
+                placeholder: 'about',
+                'data-controller': 'input-length rich-textarea autogrow',
                 'data-entry-link-create-target': 'user_about',
                 'data-action' : 'input-length#updateDisplay',
                 'data-input-length-max-value' : constant('App\\DTO\\UserDto::MAX_ABOUT_LENGTH')
                 }}) }}
             {{ form_row(form.username, {label: 'username', attr: {
-                'data-controller': 'input-length autogrow', 
+                'data-controller': 'input-length autogrow',
                 'data-entry-link-create-target': 'user_about',
                 'data-action' : 'input-length#updateDisplay',
                 'data-input-length-max-value' : constant('App\\DTO\\UserDto::MAX_USERNAME_LENGTH')
             }}) }}
             {{ form_row(form.avatar, {label: 'avatar'}) }}
+            {% if app.user.avatar is not same as null %}
+                <div class="actions">
+                    <ul style="width: 100%">
+                        <img width="40"
+                             height="40"
+                             src="{{ asset(app.user.avatar.filePath)|imagine_filter('entry_thumb') }}"
+                             alt="{{ app.user.avatar.altText }}" />
+                        <button formaction="{{ path('user_settings_avatar_delete') }}"
+                                class="btn-link"
+                                aria-label="{{ 'remove_user_avatar'|trans }}"
+                                title="{{ 'remove_user_avatar'|trans }}"
+                                data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
+                            <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+                        </button>
+                    </ul>
+                </div>
+            {% endif %}
             {{ form_row(form.cover, {label: 'cover'}) }}
+            {% if app.user.cover is not same as null %}
+                <div class="actions">
+                    <ul style="width: 100%">
+                        <img width="40"
+                             height="40"
+                             src="{{ asset(app.user.cover.filePath)|imagine_filter('entry_thumb') }}"
+                             alt="{{ app.user.cover.altText }}" />
+                        <button formaction="{{ path('user_settings_cover_delete') }}"
+                                class="btn-link"
+                                aria-label="{{ 'remove_user_cover'|trans }}"
+                                title="{{ 'remove_user_cover'|trans }}"
+                                data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
+                            <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+                        </button>
+                    </ul>
+                </div>
+            {% endif %}
             <div class="row actions">
                 {{ form_row(form.submit, {label: 'save', attr: {class: 'btn btn__primary'}}) }}
             </div>

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -53,6 +53,8 @@ add_comment: Add comment
 add_post: Add post
 add_media: Add media
 remove_media: Remove media
+remove_user_avatar: Remove avatar
+remove_user_cover: Remove cover
 markdown_howto: How does the editor work?
 enter_your_comment: Enter your comment
 enter_your_post: Enter your post


### PR DESCRIPTION
- add option to remove the user avatar or cover in the profile settings. This uses the same style as the media removal in the entry edit
- fix missing outwards federation when deleting the image through the API
- fix inwards federation when an image was removed, this was previously ignored
- add error message when the user submits an image that is too large

Delete user iamges:
![Bildschirmfoto vom 2025-03-04 16-42-30](https://github.com/user-attachments/assets/56b15f16-ae44-4197-afe0-21afceb2d263)

Error message:
![Bildschirmfoto vom 2025-03-04 16-42-55](https://github.com/user-attachments/assets/5d2b5205-2fa4-4f18-a87a-af24c326df0f)
