### PR TITLE
Set the default from the default dto object in case of null

### DIFF
--- a/src/DTO/UserSettingsDto.php
+++ b/src/DTO/UserSettingsDto.php
@@ -79,8 +79,8 @@ class UserSettingsDto implements \JsonSerializable
         $dto->addMentionsEntries = $this->addMentionsEntries ?? $dto->addMentionsEntries;
         $dto->addMentionsPosts = $this->addMentionsPosts ?? $dto->addMentionsPosts;
         $dto->homepage = $this->homepage ?? $dto->homepage;
-        $dto->frontDefaultSort = $this->frontDefaultSort;
-        $dto->commentDefaultSort = $this->commentDefaultSort;
+        $dto->frontDefaultSort = $this->frontDefaultSort ?? $dto->frontDefaultSort;
+        $dto->commentDefaultSort = $this->commentDefaultSort ?? $dto->commentDefaultSort;
         $dto->featuredMagazines = $this->featuredMagazines ?? $dto->featuredMagazines;
         $dto->preferredLanguages = $this->preferredLanguages ?? $dto->preferredLanguages;
         $dto->customCss = $this->customCss ?? $dto->customCss;


### PR DESCRIPTION
- Set the [default (hot) sorting values](https://github.com/MbinOrg/mbin/blob/main/src/Service/UserSettingsManager.php#L17) from the DTO in case `frontDefaultSort` and `commentDefaultSort` are `null`.