### PR TITLE
Remove DMs and ban sender users command

### DIFF
--- a/src/Command/RemoveDMAndBanCommand.php
+++ b/src/Command/RemoveDMAndBanCommand.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Repository\UserRepository;
+use App\Service\UserManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'mbin:messages:remove_and_ban',
+    description: 'Removes found direct messages on body search and ban senders.',
+)]
+class RemoveDMAndBanCommand extends Command
+{
+    private string $bodySearch;
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly UserRepository $repository,
+        private readonly UserManager $manager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('body', InputArgument::REQUIRED, 'Search query for direct message body.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $this->bodySearch = (string) $input->getArgument('body');
+
+        try {
+            // Search and display messages
+            $this->searchMessages($io);
+
+            // Confirm?
+            if (!$io->confirm('Do you want to remove *all* found messages and ban sender users? This action is irreversible !!!', false)) {
+                // If not confirmed, exit
+                return Command::FAILURE;
+            }
+
+            // Ban sender users
+            $io->note('Banning sender users...');
+            $this->banSenders();
+
+            // Remove messages
+            $io->note('Removing direct messages...');
+            $this->removeMessages();
+            // Ban sender user
+        } catch (\Exception $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Search for direct messages matching the search query.
+     */
+    private function searchMessages(SymfonyStyle $io): void
+    {
+        $resultSet = $this->entityManager->getConnection()->executeQuery('
+            select m.id ,u.username, m.body
+            FROM message m
+            JOIN public.user u ON m.sender_id = u.id
+            WHERE body LIKE :body', ['body' => '%'.$this->bodySearch.'%']);
+        $results = $resultSet->fetchAllAssociative();
+
+        if (0 === \count($results)) {
+            throw new \Exception('No direct messages found.');
+        }
+
+        $io->text('Found '.\count($results).' direct messages.');
+
+        // Display results
+        $table = new Table(new ConsoleOutput());
+        $table
+            ->setHeaders(['DM ID', 'Sender username', 'Body direct message'])
+            ->setRows(array_map(fn ($item) => [
+                $item['id'],
+                $item['username'],
+                wordwrap(str_replace(["\r\n", "\r", "\n"], " ", $item['body']), 60, PHP_EOL, true),
+            ], $results));
+        $table->render();
+    }
+
+    /**
+     * Ban sender users based on the found messages.
+     */
+    private function banSenders(): void
+    {
+        $this->entityManager->getConnection()->executeQuery('
+            UPDATE public.user
+            SET is_banned = TRUE
+            WHERE id IN (
+                SELECT DISTINCT m.sender_id
+                FROM message m
+                JOIN public.user u ON m.sender_id = u.id
+                WHERE body LIKE :body
+            )', ['body' => '%'.$this->bodySearch.'%']);
+    }
+
+    /**
+     * Remove messages by removing message threads (message_thread table).
+     *
+     * Which will automatically do a cascade delete on the messages table and
+     * the message participants table.
+     */
+    private function removeMessages(): void
+    {
+        $this->entityManager->getConnection()->executeQuery('
+            DELETE FROM message_thread
+            WHERE id IN (
+                SELECT DISTINCT thread_id 
+                FROM message 
+                WHERE body LIKE :body
+            )', ['body' => '%'.$this->bodySearch.'%']);
+    }
+}

--- a/src/Command/RemoveDMAndBanCommand.php
+++ b/src/Command/RemoveDMAndBanCommand.php
@@ -96,7 +96,7 @@ class RemoveDMAndBanCommand extends Command
             ->setRows(array_map(fn ($item) => [
                 $item['id'],
                 $item['username'],
-                wordwrap(str_replace(["\r\n", "\r", "\n"], " ", $item['body']), 60, PHP_EOL, true),
+                wordwrap(str_replace(["\r\n", "\r", "\n"], ' ', $item['body']), 60, PHP_EOL, true),
             ], $results));
         $table->render();
     }

--- a/src/Command/RemoveDMAndBanCommand.php
+++ b/src/Command/RemoveDMAndBanCommand.php
@@ -59,6 +59,8 @@ class RemoveDMAndBanCommand extends Command
             // Remove messages
             $io->note('Removing direct messages...');
             $this->removeMessages();
+
+            $io->success('Done!');
             // Ban sender user
         } catch (\Exception $e) {
             $io->error($e->getMessage());


### PR DESCRIPTION
Reducing spam messages (like the infamous fediverse chick) by introducing a command. Meaning admins no longer need to use manual DB queries. Its just simpler.

This new command (`./bin/console mbin:messages:remove_and_ban`), allows you to easily search on direct messages. And remove all the matched messages and ban the senders user from the instance.

Hint: If you want to search on strings with spaces its just a shell script basically, so use quotes around the body query in those cases and it will work fine:

```sh
./bin/console mbin:messages:remove_and_ban "Fediverse Chick"
```

----

1. Search query is executed. And displayed in a very nice ASCII table:
![image](https://github.com/user-attachments/assets/a0a5790c-135d-4268-90fb-c619ada3e018)
2. User input requested to continue: 
![image](https://github.com/user-attachments/assets/817423fb-fa6f-4b97-8cfe-12b0d2622f42)
3. If y(es), then we continue with banning the users and removing the direct messages.