### PR TITLE
Extend zz-docker with process manager config

### DIFF
--- a/docker/php/php-fpm.d/zz-docker.conf
+++ b/docker/php/php-fpm.d/zz-docker.conf
@@ -4,5 +4,13 @@ process_control_timeout = 20
 
 [www]
 listen = 9000
+
+; process manager
+pm = dynamic
+pm.max_children = 100
+pm.start_servers = 12
+pm.min_spare_servers = 5
+pm.max_spare_servers = 15
+
 ping.path = /ping
 ping.response = OK


### PR DESCRIPTION
- Add missing PHP process manager configs in Docker PHP FPM config under `[www]`