### PR TITLE
Fix error during missing magazine parsing

### DIFF
--- a/src/Markdown/Listener/CacheMarkdownListener.php
+++ b/src/Markdown/Listener/CacheMarkdownListener.php
@@ -146,6 +146,7 @@ final class CacheMarkdownListener implements EventSubscriberInterface
     /** @return string[] */
     private function getMissingMagazineMentions(string $markdown): array
     {
+        // No-break space is causing issues with word splitting. So replace a no-break (0xc2 0xa0) by a normal space first.
         $words = preg_split('/[ \n\[\]()]/', str_replace(\chr(194).\chr(160), '&nbsp;', $markdown));
         $missingCommunityMentions = [];
         foreach ($words as $word) {

--- a/src/Markdown/Listener/CacheMarkdownListener.php
+++ b/src/Markdown/Listener/CacheMarkdownListener.php
@@ -146,15 +146,21 @@ final class CacheMarkdownListener implements EventSubscriberInterface
     /** @return string[] */
     private function getMissingMagazineMentions(string $markdown): array
     {
-        $words = preg_split('/[ \n\[\]()]/', $markdown);
+        $words = preg_split('/[ \n\[\]()]/', str_replace(chr(194).chr(160), "&nbsp;", $markdown));
         $missingCommunityMentions = [];
         foreach ($words as $word) {
             $matches = null;
-            if (preg_match('/'.CommunityLinkParser::COMMUNITY_REGEX.'/', $word, $matches)) {
+            $word2 = preg_replace('/[[:cntrl:]]/', '', $word);
+            if (preg_match('/'.CommunityLinkParser::COMMUNITY_REGEX.'/', $word2, $matches)) {
                 $apId = "$matches[1]@$matches[2]";
-                $magazine = $this->magazineRepository->findOneBy(['apId' => $apId]);
-                if (!$magazine) {
-                    $missingCommunityMentions[] = $apId;
+                $this->logger->debug("searching for magazine '{m}', original word: '{w}', word without cntrl: '{w2}'", ['m' => $apId, 'w' => $word, 'w2' => $word2]);
+                try {
+                    $magazine = $this->magazineRepository->findOneBy(['apId' => $apId]);
+                    if (!$magazine) {
+                        $missingCommunityMentions[] = $apId;
+                    }
+                } catch (\Exception $e) {
+                    $this->logger->error('An error occurred while looking for magazine "{m}": {t} - {msg}', ['m' => $apId, 't'=> get_class($e), 'msg' => $e->getMessage()]);
                 }
             }
         }

--- a/src/Markdown/Listener/CacheMarkdownListener.php
+++ b/src/Markdown/Listener/CacheMarkdownListener.php
@@ -146,7 +146,7 @@ final class CacheMarkdownListener implements EventSubscriberInterface
     /** @return string[] */
     private function getMissingMagazineMentions(string $markdown): array
     {
-        $words = preg_split('/[ \n\[\]()]/', str_replace(chr(194).chr(160), "&nbsp;", $markdown));
+        $words = preg_split('/[ \n\[\]()]/', str_replace(\chr(194).\chr(160), '&nbsp;', $markdown));
         $missingCommunityMentions = [];
         foreach ($words as $word) {
             $matches = null;
@@ -161,7 +161,7 @@ final class CacheMarkdownListener implements EventSubscriberInterface
                         $missingCommunityMentions[] = $apId;
                     }
                 } catch (\Exception $e) {
-                    $this->logger->error('An error occurred while looking for magazine "{m}": {t} - {msg}', ['m' => $apId, 't'=> get_class($e), 'msg' => $e->getMessage()]);
+                    $this->logger->error('An error occurred while looking for magazine "{m}": {t} - {msg}', ['m' => $apId, 't' => \get_class($e), 'msg' => $e->getMessage()]);
                 }
             }
         }

--- a/src/Markdown/Listener/CacheMarkdownListener.php
+++ b/src/Markdown/Listener/CacheMarkdownListener.php
@@ -150,6 +150,7 @@ final class CacheMarkdownListener implements EventSubscriberInterface
         $missingCommunityMentions = [];
         foreach ($words as $word) {
             $matches = null;
+            // Remove newline (\n), tab (\t), carriage return (\r), etc.
             $word2 = preg_replace('/[[:cntrl:]]/', '', $word);
             if (preg_match('/'.CommunityLinkParser::COMMUNITY_REGEX.'/', $word2, $matches)) {
                 $apId = "$matches[1]@$matches[2]";


### PR DESCRIPTION
When using `0xc2` `0xa0` (no-break space) it tripped up our word splitting and searching for it in the db which then threw an error. Add a try/catch so it will not cause a crash and also fix the parsing