### PR TITLE
Inline all content previews

### DIFF
--- a/assets/styles/components/_inline_md.scss
+++ b/assets/styles/components/_inline_md.scss
@@ -2,6 +2,7 @@
 .entry-comment-inline,
 .post-inline,
 .post-comment-inline {
+  display: inline-block;
   font-weight: bold;
   border: var(--kbin-section-border);
   padding: .25em;

--- a/src/Repository/ApActivityRepository.php
+++ b/src/Repository/ApActivityRepository.php
@@ -95,6 +95,10 @@ class ApActivityRepository extends ServiceEntityRepository
                         'type' => Post::class,
                     ];
                 } else {
+                    if (0 === $id) {
+                        return null;
+                    }
+
                     return [
                         'id' => $id,
                         'type' => PostComment::class,
@@ -108,7 +112,17 @@ class ApActivityRepository extends ServiceEntityRepository
                         'id' => $id,
                         'type' => Entry::class,
                     ];
+                } elseif (5 === \count($exploded)) {
+                    // entry url with slug (non-ap route)
+                    return [
+                        'id' => \intval($exploded[4]),
+                        'type' => Entry::class,
+                    ];
                 } else {
+                    if (0 === $id) {
+                        return null;
+                    }
+
                     return [
                         'id' => $id,
                         'type' => EntryComment::class,

--- a/src/Repository/ApActivityRepository.php
+++ b/src/Repository/ApActivityRepository.php
@@ -95,6 +95,7 @@ class ApActivityRepository extends ServiceEntityRepository
                         'type' => Post::class,
                     ];
                 } else {
+                    // since the id is just the intval of the last part in the url it will be 0 if that was not a number
                     if (0 === $id) {
                         return null;
                     }
@@ -119,6 +120,7 @@ class ApActivityRepository extends ServiceEntityRepository
                         'type' => Entry::class,
                     ];
                 } else {
+                    // since the id is just the intval of the last part in the url it will be 0 if that was not a number
                     if (0 === $id) {
                         return null;
                     }

--- a/src/Repository/ApActivityRepository.php
+++ b/src/Repository/ApActivityRepository.php
@@ -94,6 +94,12 @@ class ApActivityRepository extends ServiceEntityRepository
                         'id' => $id,
                         'type' => Post::class,
                     ];
+                } elseif (5 === \count($exploded)) {
+                    // post url with slug (non-ap route)
+                    return [
+                        'id' => \intval($exploded[4]),
+                        'type' => Post::class,
+                    ];
                 } else {
                     // since the id is just the intval of the last part in the url it will be 0 if that was not a number
                     if (0 === $id) {

--- a/templates/components/entry_comment_inline_md.html.twig
+++ b/templates/components/entry_comment_inline_md.html.twig
@@ -1,4 +1,4 @@
-<div class="entry-comment-inline">
+<span class="entry-comment-inline">
     {{ component('user_inline', {user: comment.user, fullName: userFullName, showNewIcon: true}) }}:
     <a href="{{ path('entry_comment_view', {magazine_name: comment.magazine.name, entry_id: comment.entry.id, comment_id: comment.id, slug: comment.entry.slug|length ? comment.entry.slug : '-'}) }}">
         {% if comment.image is not same as null %}
@@ -27,4 +27,4 @@
         {{ 'in'|trans }}
         {{ component('magazine_inline', {magazine: comment.magazine, fullName: magazineFullName, showNewIcon: true}) }}
     {% endif %}
-</div>
+</span>

--- a/templates/components/entry_inline_md.html.twig
+++ b/templates/components/entry_inline_md.html.twig
@@ -1,4 +1,4 @@
-<div class="entry-inline">
+<span class="entry-inline">
     {{ component('user_inline', {user: entry.user, fullName: userFullName, showNewIcon: true}) }}:
     <a href="{{ path('entry_single', {magazine_name: entry.magazine.name, entry_id: entry.id, slug: entry.slug|length ? entry.slug : '-'}) }}">
         {% if entry.image is not same as null %}
@@ -10,4 +10,4 @@
         {{ 'in'|trans }}
         {{ component('magazine_inline', {magazine: entry.magazine, fullName: magazineFullName, showNewIcon: true}) }}
     {% endif %}
-</div>
+</span>

--- a/templates/components/post_comment_inline_md.html.twig
+++ b/templates/components/post_comment_inline_md.html.twig
@@ -1,4 +1,4 @@
-<div class="post-comment-inline">
+<span class="post-comment-inline">
     {{ component('user_inline', {user: comment.user, fullName: userFullName, showNewIcon: true}) }}:
     <a href="{{ path('post_single', {magazine_name: comment.magazine.name, post_id: comment.post.id, slug: comment.post.slug|length ? comment.post.slug : '-'}) }}#post-comment-{{ comment.id }}">
         {% if comment.image is not same as null %}
@@ -27,4 +27,4 @@
         {{ 'in'|trans }}
         {{ component('magazine_inline', {magazine: comment.magazine, fullName: magazineFullName, showNewIcon: true}) }}
     {% endif %}
-</div>
+</span>

--- a/templates/components/post_inline_md.html.twig
+++ b/templates/components/post_inline_md.html.twig
@@ -1,4 +1,4 @@
-<div class="post-inline">
+<span class="post-inline">
     {{ component('user_inline', {user: post.user, fullName: userFullName, showNewIcon: true}) }}:
     <a href="{{ path('post_single', {magazine_name: post.magazine.name, post_id: post.id, slug: post.slug|length ? post.slug : '-'}) }}">
         {% if post.image is not same as null %}
@@ -10,4 +10,4 @@
         {{ 'in'|trans }}
         {{ component('magazine_inline', {magazine: post.magazine, fullName: magazineFullName}) }}
     {% endif %}
-</div>
+</span>

--- a/tests/Unit/Utils/MarkdownTest.php
+++ b/tests/Unit/Utils/MarkdownTest.php
@@ -122,4 +122,19 @@ class MarkdownTest extends WebTestCase
         $markdown = $this->markdownConverter->convertToHtml($text, [MarkdownConverter::RENDER_TARGET => RenderTarget::Page]);
         assertStringContainsString("https://kbin.test/m/test@kbin.test2/t/{$entry->getId()}/some-slug/votes", $markdown);
     }
+
+    public function testBracketsInLinkTitle(): void
+    {
+        $m = new Magazine('test@kbin.test2', 'test', null, null, null, false, false, null);
+        $m->apId = 'test@kbin.test2';
+        $m->apInboxUrl = 'https://kbin.test2/inbox';
+        $m->apPublicUrl = 'https://kbin.test2/m/test';
+        $m->apProfileId = 'https://kbin.test2/m/test';
+        $this->entityManager->persist($m);
+        $entry = $this->getEntryByTitle('test', magazine: $m);
+        $this->entityManager->flush();
+        $text = "[Look at my post (or not, your choice)](https://kbin.test/m/test@kbin.test2/t/{$entry->getId()}/some-slug/favourites)";
+        $markdown = $this->markdownConverter->convertToHtml($text, [MarkdownConverter::RENDER_TARGET => RenderTarget::Page]);
+        assertStringContainsString("https://kbin.test/m/test@kbin.test2/t/{$entry->getId()}/some-slug/favourites", $markdown);
+    }
 }

--- a/tests/Unit/Utils/MarkdownTest.php
+++ b/tests/Unit/Utils/MarkdownTest.php
@@ -93,7 +93,7 @@ class MarkdownTest extends WebTestCase
         self::assertStringContainsString('https://kbin.test2', $markdown);
     }
 
-    public function testExternalMagazineLocalPostLink(): void
+    public function testExternalMagazineLocalEntryLink(): void
     {
         $m = new Magazine('test@kbin.test2', 'test', null, null, null, false, false, null);
         $m->apId = 'test@kbin.test2';
@@ -106,6 +106,21 @@ class MarkdownTest extends WebTestCase
         $text = "Look at my post at https://kbin.test/m/test@kbin.test2/t/{$entry->getId()}/some-slug";
         $markdown = $this->markdownConverter->convertToHtml($text, [MarkdownConverter::RENDER_TARGET => RenderTarget::Page]);
         assertStringContainsString('entry-inline', $markdown);
+    }
+
+    public function testExternalMagazineLocalPostLink(): void
+    {
+        $m = new Magazine('test@kbin.test2', 'test', null, null, null, false, false, null);
+        $m->apId = 'test@kbin.test2';
+        $m->apInboxUrl = 'https://kbin.test2/inbox';
+        $m->apPublicUrl = 'https://kbin.test2/m/test';
+        $m->apProfileId = 'https://kbin.test2/m/test';
+        $this->entityManager->persist($m);
+        $post = $this->createPost('test', magazine: $m);
+        $this->entityManager->flush();
+        $text = "Look at my post at https://kbin.test/m/test@kbin.test2/p/{$post->getId()}/some-slug";
+        $markdown = $this->markdownConverter->convertToHtml($text, [MarkdownConverter::RENDER_TARGET => RenderTarget::Page]);
+        assertStringContainsString('post-inline', $markdown);
     }
 
     public function testLocalNotMatchingUrl(): void

--- a/tests/Unit/Utils/MarkdownTest.php
+++ b/tests/Unit/Utils/MarkdownTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Utils;
 
+use App\Entity\Magazine;
 use App\Markdown\MarkdownConverter;
 use App\Markdown\RenderTarget;
 use App\Tests\WebTestCase;
+
+use function PHPUnit\Framework\assertStringContainsString;
 
 class MarkdownTest extends WebTestCase
 {
@@ -88,5 +91,35 @@ class MarkdownTest extends WebTestCase
         $markdown = $this->markdownConverter->convertToHtml($text, [MarkdownConverter::RENDER_TARGET => RenderTarget::Page]);
         // assert that this community does not exist, and we get a search link for it that does not link to the external instance
         self::assertStringContainsString('https://kbin.test2', $markdown);
+    }
+
+    public function testExternalMagazineLocalPostLink(): void
+    {
+        $m = new Magazine('test@kbin.test2', 'test', null, null, null, false, false, null);
+        $m->apId = 'test@kbin.test2';
+        $m->apInboxUrl = 'https://kbin.test2/inbox';
+        $m->apPublicUrl = 'https://kbin.test2/m/test';
+        $m->apProfileId = 'https://kbin.test2/m/test';
+        $this->entityManager->persist($m);
+        $entry = $this->getEntryByTitle('test', magazine: $m);
+        $this->entityManager->flush();
+        $text = "Look at my post at https://kbin.test/m/test@kbin.test2/t/{$entry->getId()}/some-slug";
+        $markdown = $this->markdownConverter->convertToHtml($text, [MarkdownConverter::RENDER_TARGET => RenderTarget::Page]);
+        assertStringContainsString('entry-inline', $markdown);
+    }
+
+    public function testLocalNotMatchingUrl(): void
+    {
+        $m = new Magazine('test@kbin.test2', 'test', null, null, null, false, false, null);
+        $m->apId = 'test@kbin.test2';
+        $m->apInboxUrl = 'https://kbin.test2/inbox';
+        $m->apPublicUrl = 'https://kbin.test2/m/test';
+        $m->apProfileId = 'https://kbin.test2/m/test';
+        $this->entityManager->persist($m);
+        $entry = $this->getEntryByTitle('test', magazine: $m);
+        $this->entityManager->flush();
+        $text = "Look at my post at https://kbin.test/m/test@kbin.test2/t/{$entry->getId()}/some-slug/votes";
+        $markdown = $this->markdownConverter->convertToHtml($text, [MarkdownConverter::RENDER_TARGET => RenderTarget::Page]);
+        assertStringContainsString("https://kbin.test/m/test@kbin.test2/t/{$entry->getId()}/some-slug/votes", $markdown);
     }
 }


### PR DESCRIPTION
- make them inline, so when you have `look here (some content link)` it does not get converted to: ``` look here ( some content preview ) ```
- fix links getting completely removed. The cause was the link-matching in the `ApActivityRepository` which sometimes returned an object with `0` as the id which of course does not yield results from the DB. Since that was just not expected we showed an empty div for these links
![grafik](https://github.com/user-attachments/assets/b5de49c7-09dd-437e-9a27-5f2ebedb1758)

Closes #1493