### PR TITLE
Fix period in remote usernames

### DIFF
--- a/src/Service/MentionManager.php
+++ b/src/Service/MentionManager.php
@@ -83,6 +83,7 @@ class MentionManager
      *
      * @param val Body input string
      * @param type Type of mentions to extract (ALL, LOCAL only or REMOTE only)
+     *
      * @return string[]
      */
     public function extract(?string $body, $type = self::ALL): ?array
@@ -106,6 +107,7 @@ class MentionManager
      * Remote activitypub prefix, like @username@domain.tld.
      *
      * @param value Input string
+     *
      * @return string[]
      */
     private function byApPrefix(string $value): array
@@ -123,6 +125,7 @@ class MentionManager
      * Local username prefix, like @username.
      *
      * @param value Input string
+     *
      * @return string[]
      */
     private function byPrefix(string $value): array

--- a/src/Service/MentionManager.php
+++ b/src/Service/MentionManager.php
@@ -78,16 +78,23 @@ class MentionManager
         );
     }
 
-    public function extract(?string $val, $type = self::ALL): ?array
+    /**
+     * Try to extract mentions from the body (eg. @username@domain.tld).
+     *
+     * @param val Body input string
+     * @param type Type of mentions to extract (ALL, LOCAL only or REMOTE only)
+     * @return string[]
+     */
+    public function extract(?string $body, $type = self::ALL): ?array
     {
-        if (!$val) {
+        if (!$body) {
             return null;
         }
 
         $result = match ($type) {
-            self::ALL => array_merge($this->byApPrefix($val), $this->byPrefix($val)),
-            self::LOCAL => $this->byPrefix($val),
-            self::REMOTE => $this->byApPrefix($val),
+            self::ALL => array_merge($this->byApPrefix($body), $this->byPrefix($body)),
+            self::LOCAL => $this->byPrefix($body),
+            self::REMOTE => $this->byApPrefix($body),
         };
 
         $result = array_map(fn ($val) => trim($val), $result);
@@ -95,10 +102,16 @@ class MentionManager
         return \count($result) ? array_unique($result) : null;
     }
 
+    /**
+     * Remote activitypub prefix, like @username@domain.tld.
+     *
+     * @param value Input string
+     * @return string[]
+     */
     private function byApPrefix(string $value): array
     {
         preg_match_all(
-            '/(?<!\/)\B@(\w{1,30})(@)(([\pL\pN\pS\pM\-\_]++\.)+[\pL\pN\pM]++|[a-z0-9\-\_]++)/u',
+            '/(?<!\/)\B@([a-zA-Z0-9._-]+@?)(@)(([\pL\pN\pS\pM\-\_]++\.)+[\pL\pN\pM]++|[a-z0-9\-\_]++)/u',
             $value,
             $matches
         );
@@ -106,6 +119,12 @@ class MentionManager
         return \count($matches[0]) ? array_unique(array_values($matches[0])) : [];
     }
 
+    /**
+     * Local username prefix, like @username.
+     *
+     * @param value Input string
+     * @return string[]
+     */
     private function byPrefix(string $value): array
     {
         preg_match_all('/(?<!\/)\B@([a-zA-Z0-9_-]{1,30}@?)/u', $value, $matches);


### PR DESCRIPTION
- Fix period in remote usernames (`\w` for word, will not cut it), since some Fediverse software allows `@user.name`, for example, as a valid username)
- Removing the arbitrary 30 char limit as well
- Add code documentation

I tested it regex again with https://regex101.com/