### PR TITLE
Add missing $logger in ApActivityRepository + init $apActivity with null

### DIFF
--- a/src/Markdown/CommonMark/ExternalLinkRenderer.php
+++ b/src/Markdown/CommonMark/ExternalLinkRenderer.php
@@ -128,6 +128,7 @@ final class ExternalLinkRenderer implements NodeRendererInterface, Configuration
         $url = $node->getUrl();
         $apLink = null;
         if (filter_var($url, FILTER_VALIDATE_URL)) {
+            $apActivity = null;
             try {
                 $apActivity = $this->activityRepository->findByObjectId($url);
             } catch (\Error|\Exception $e) {

--- a/src/Repository/ApActivityRepository.php
+++ b/src/Repository/ApActivityRepository.php
@@ -15,6 +15,7 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\Exception;
 use Doctrine\Persistence\ManagerRegistry;
 use JetBrains\PhpStorm\ArrayShape;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -30,6 +31,7 @@ class ApActivityRepository extends ServiceEntityRepository
         ManagerRegistry $registry,
         private readonly SettingsManager $settingsManager,
         private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly LoggerInterface $logger,
     ) {
         parent::__construct($registry, ApActivity::class);
     }


### PR DESCRIPTION
Causing warnings/errors like:

```sh
{"message":"Warning: Undefined property: App\\Repository\\ApActivityRepository::$logger","context":{"exception":{"class":"ErrorException","message":"Warning: Undefined property: App\\Repository\\ApActivityRepository::$logger","code":0,"file":"/var/www/kbin.melroy.org/html/vendor/doctrine/doctrine-bundle/src/Repository/LazyServiceEntityRepository.php:54"}},"level":400,"level_name":"ERROR","channel":"php","datetime":"2025-04-13T14:30:19.618482+02:00","extra":{}}
```

And:

```sh
{"message":"Warning: Undefined variable $apActivity","context":{"exception":{"class":"ErrorException","message":"Warning: Undefined variable $apActivity","code":0,"file":"/var/www/kbin.melroy.org/html/src/Markdown/CommonMark/ExternalLinkRenderer.php:136"}},"level":400,"level_name":"ERROR","channel":"php","datetime":"2025-04-13T14:30:19.618693+02:00","extra":{}}
```

This PR solved both these warnings.
