### PR TITLE
Sort and filter comment replies the same as root comments

### DIFF
--- a/src/Controller/Api/Entry/Comments/DomainEntryCommentsRetrieveApi.php
+++ b/src/Controller/Api/Entry/Comments/DomainEntryCommentsRetrieveApi.php
@@ -158,7 +158,7 @@ class DomainEntryCommentsRetrieveApi extends EntriesBaseApi
         foreach ($comments->getCurrentPageResults() as $value) {
             try {
                 $this->handlePrivateContent($value);
-                array_push($dtos, $this->serializeCommentTree($value));
+                $dtos[] = $this->serializeCommentTree($value, $criteria);
             } catch (\Exception $e) {
                 continue;
             }

--- a/src/Controller/Api/Entry/Comments/EntryCommentsRetrieveApi.php
+++ b/src/Controller/Api/Entry/Comments/EntryCommentsRetrieveApi.php
@@ -153,6 +153,9 @@ class EntryCommentsRetrieveApi extends EntriesBaseApi
 
         $comments = $commentsRepository->findByCriteria($criteria);
 
+        $commentsRepository->hydrate(...$comments);
+        $commentsRepository->hydrateChildren(...$comments);
+
         $dtos = [];
         foreach ($comments->getCurrentPageResults() as $value) {
             try {

--- a/src/Controller/Api/Entry/Comments/EntryCommentsUpdateApi.php
+++ b/src/Controller/Api/Entry/Comments/EntryCommentsUpdateApi.php
@@ -10,11 +10,13 @@ use App\DTO\EntryCommentRequestDto;
 use App\DTO\EntryCommentResponseDto;
 use App\Entity\EntryComment;
 use App\Factory\EntryCommentFactory;
+use App\PageView\EntryCommentPageView;
 use App\Service\EntryCommentManager;
 use Nelmio\ApiDocBundle\Attribute\Model;
 use Nelmio\ApiDocBundle\Attribute\Security;
 use OpenApi\Attributes as OA;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Bundle\SecurityBundle\Security as SymfonySecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -92,6 +94,7 @@ class EntryCommentsUpdateApi extends EntriesBaseApi
         EntryCommentFactory $factory,
         ValidatorInterface $validator,
         RateLimiterFactory $apiUpdateLimiter,
+        SymfonySecurity $security,
     ): JsonResponse {
         $headers = $this->rateLimit($apiUpdateLimiter);
 
@@ -108,7 +111,7 @@ class EntryCommentsUpdateApi extends EntriesBaseApi
         $comment = $manager->edit($comment, $dto, $this->getUserOrThrow());
 
         return new JsonResponse(
-            $this->serializeCommentTree($comment),
+            $this->serializeCommentTree($comment, new EntryCommentPageView(0, $security)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Entry/Comments/UserEntryCommentsRetrieveApi.php
+++ b/src/Controller/Api/Entry/Comments/UserEntryCommentsRetrieveApi.php
@@ -157,7 +157,7 @@ class UserEntryCommentsRetrieveApi extends EntriesBaseApi
         foreach ($comments->getCurrentPageResults() as $value) {
             try {
                 $this->handlePrivateContent($value);
-                array_push($dtos, $this->serializeCommentTree($value));
+                $dtos[] = $this->serializeCommentTree($value, $criteria);
             } catch (\Exception $e) {
                 continue;
             }

--- a/src/Controller/Api/Entry/EntriesBaseApi.php
+++ b/src/Controller/Api/Entry/EntriesBaseApi.php
@@ -17,6 +17,7 @@ use App\Entity\EntryComment;
 use App\Entity\Magazine;
 use App\Enums\ENotificationStatus;
 use App\Factory\EntryCommentFactory;
+use App\PageView\EntryCommentPageView;
 use App\Service\EntryManager;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -173,7 +174,7 @@ class EntriesBaseApi extends BaseApi
      *
      * @return array An associative array representation of the comment's hierarchy, to be used as JSON
      */
-    protected function serializeCommentTree(?EntryComment $comment, ?int $depth = null): array
+    protected function serializeCommentTree(?EntryComment $comment, EntryCommentPageView $commentPageView, ?int $depth = null): array
     {
         if (null === $comment) {
             return [];
@@ -187,7 +188,7 @@ class EntriesBaseApi extends BaseApi
             $canModerate = $comment->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
         }
 
-        $commentTree = $this->commentsFactory->createResponseTree($comment, $depth, $canModerate);
+        $commentTree = $this->commentsFactory->createResponseTree($comment, $commentPageView, $depth, $canModerate);
         $commentTree->canAuthUserModerate = $canModerate;
 
         return $commentTree->jsonSerialize();

--- a/src/Controller/Api/Post/Comments/PostCommentsRetrieveApi.php
+++ b/src/Controller/Api/Post/Comments/PostCommentsRetrieveApi.php
@@ -73,13 +73,15 @@ class PostCommentsRetrieveApi extends PostsBaseApi
         PostCommentRepository $repository,
         RateLimiterFactory $apiReadLimiter,
         RateLimiterFactory $anonymousApiReadLimiter,
+        Security $security,
     ): JsonResponse {
         $headers = $this->rateLimit($apiReadLimiter, $anonymousApiReadLimiter);
 
         $this->handlePrivateContent($comment);
+        $criteria = new PostCommentPageView(0, $security);
 
         return new JsonResponse(
-            $this->serializePostCommentTree($comment),
+            $this->serializePostCommentTree($comment, $criteria),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Post/Comments/PostCommentsRetrieveApi.php
+++ b/src/Controller/Api/Post/Comments/PostCommentsRetrieveApi.php
@@ -78,8 +78,6 @@ class PostCommentsRetrieveApi extends PostsBaseApi
 
         $this->handlePrivateContent($comment);
 
-        $repository->hydrate($comment);
-
         return new JsonResponse(
             $this->serializePostCommentTree($comment),
             headers: $headers
@@ -204,7 +202,7 @@ class PostCommentsRetrieveApi extends PostsBaseApi
             \assert($value instanceof PostComment);
             try {
                 $this->handlePrivateContent($value);
-                array_push($dtos, $this->serializePostCommentTree($value));
+                $dtos[] = $this->serializePostCommentTree($value, $criteria);
             } catch (\Exception $e) {
                 continue;
             }

--- a/src/Controller/Api/Post/Comments/PostCommentsRetrieveApi.php
+++ b/src/Controller/Api/Post/Comments/PostCommentsRetrieveApi.php
@@ -80,6 +80,8 @@ class PostCommentsRetrieveApi extends PostsBaseApi
         $this->handlePrivateContent($comment);
         $criteria = new PostCommentPageView(0, $security);
 
+        $repository->hydrate($comment);
+
         return new JsonResponse(
             $this->serializePostCommentTree($comment, $criteria),
             headers: $headers

--- a/src/Controller/Api/Post/Comments/PostCommentsUpdateApi.php
+++ b/src/Controller/Api/Post/Comments/PostCommentsUpdateApi.php
@@ -10,11 +10,13 @@ use App\DTO\PostCommentRequestDto;
 use App\DTO\PostCommentResponseDto;
 use App\Entity\PostComment;
 use App\Factory\PostCommentFactory;
+use App\PageView\PostCommentPageView;
 use App\Service\PostCommentManager;
 use Nelmio\ApiDocBundle\Attribute\Model;
 use Nelmio\ApiDocBundle\Attribute\Security;
 use OpenApi\Attributes as OA;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Bundle\SecurityBundle\Security as SymfonySecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -92,6 +94,7 @@ class PostCommentsUpdateApi extends PostsBaseApi
         PostCommentFactory $factory,
         ValidatorInterface $validator,
         RateLimiterFactory $apiUpdateLimiter,
+        SymfonySecurity $security,
     ): JsonResponse {
         $headers = $this->rateLimit($apiUpdateLimiter);
 
@@ -106,9 +109,10 @@ class PostCommentsUpdateApi extends PostsBaseApi
         }
 
         $comment = $manager->edit($comment, $dto, $this->getUserOrThrow());
+        $criteria = new PostCommentPageView(0, $security);
 
         return new JsonResponse(
-            $this->serializePostCommentTree($comment),
+            $this->serializePostCommentTree($comment, $criteria),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Post/Comments/UserPostCommentsRetrieveApi.php
+++ b/src/Controller/Api/Post/Comments/UserPostCommentsRetrieveApi.php
@@ -148,7 +148,7 @@ class UserPostCommentsRetrieveApi extends PostsBaseApi
             \assert($value instanceof PostComment);
             try {
                 $this->handlePrivateContent($value);
-                array_push($dtos, $this->serializePostCommentTree($value));
+                $dtos[] = $this->serializePostCommentTree($value, $criteria);
             } catch (\Exception $e) {
                 continue;
             }

--- a/src/Controller/Api/Post/PostsBaseApi.php
+++ b/src/Controller/Api/Post/PostsBaseApi.php
@@ -13,6 +13,7 @@ use App\DTO\PostRequestDto;
 use App\DTO\PostResponseDto;
 use App\Entity\PostComment;
 use App\Enums\ENotificationStatus;
+use App\PageView\PostCommentPageView;
 
 class PostsBaseApi extends BaseApi
 {
@@ -148,7 +149,7 @@ class PostsBaseApi extends BaseApi
      *
      * @return array An associative array representation of the comment's hierarchy, to be used as JSON
      */
-    protected function serializePostCommentTree(?PostComment $comment, ?int $depth = null): array
+    protected function serializePostCommentTree(?PostComment $comment, PostCommentPageView $commentPageView, ?int $depth = null): array
     {
         if (null === $comment) {
             return [];
@@ -163,7 +164,7 @@ class PostsBaseApi extends BaseApi
             $canModerate = $comment->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
         }
 
-        $commentTree = $this->postCommentFactory->createResponseTree($comment, $depth, $canModerate);
+        $commentTree = $this->postCommentFactory->createResponseTree($comment, $commentPageView, $depth, $canModerate);
         $commentTree->canAuthUserModerate = $canModerate;
 
         return $commentTree->jsonSerialize();

--- a/src/Controller/Entry/Comment/EntryCommentViewController.php
+++ b/src/Controller/Entry/Comment/EntryCommentViewController.php
@@ -10,8 +10,10 @@ use App\Entity\Entry;
 use App\Entity\EntryComment;
 use App\Entity\Magazine;
 use App\Event\Entry\EntryHasBeenSeenEvent;
+use App\PageView\EntryCommentPageView;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -34,6 +36,7 @@ class EntryCommentViewController extends AbstractController
         #[MapEntity(id: 'comment_id')]
         ?EntryComment $comment,
         Request $request,
+        Security $security,
     ): Response {
         $this->handlePrivateContent($entry);
 
@@ -41,12 +44,15 @@ class EntryCommentViewController extends AbstractController
         // it should be added so one comment view does not mark all as read in the same entry
         $this->dispatcher->dispatch(new EntryHasBeenSeenEvent($entry));
 
+        $criteria = new EntryCommentPageView(1, $security);
+
         return $this->render(
             'entry/comment/view.html.twig',
             [
                 'magazine' => $magazine,
                 'entry' => $entry,
                 'comment' => $comment,
+                'criteria' => $criteria,
             ]
         );
     }

--- a/src/Controller/Entry/EntrySingleController.php
+++ b/src/Controller/Entry/EntrySingleController.php
@@ -69,7 +69,9 @@ class EntrySingleController extends AbstractController
 
         $comments = $repository->findByCriteria($criteria);
 
-        $repository->hydrate(...$comments->getCurrentPageResults());
+        $commentObjects = [...$comments->getCurrentPageResults()];
+        $repository->hydrate(...$commentObjects);
+        $repository->hydrateChildren(...$commentObjects);
 
         $dispatcher->dispatch(new EntryHasBeenSeenEvent($entry));
 

--- a/src/Controller/Entry/EntrySingleController.php
+++ b/src/Controller/Entry/EntrySingleController.php
@@ -69,6 +69,8 @@ class EntrySingleController extends AbstractController
 
         $comments = $repository->findByCriteria($criteria);
 
+        $repository->hydrate(...$comments->getCurrentPageResults());
+
         $dispatcher->dispatch(new EntryHasBeenSeenEvent($entry));
 
         if ($request->isXmlHttpRequest()) {

--- a/src/Controller/Post/PostSingleController.php
+++ b/src/Controller/Post/PostSingleController.php
@@ -70,6 +70,7 @@ class PostSingleController extends AbstractController
         }
 
         $comments = $repository->findByCriteria($criteria);
+        $repository->hydrate(...$comments->getCurrentPageResults());
 
         $dispatcher->dispatch(new PostHasBeenSeenEvent($post));
 

--- a/src/Controller/Post/PostSingleController.php
+++ b/src/Controller/Post/PostSingleController.php
@@ -70,7 +70,10 @@ class PostSingleController extends AbstractController
         }
 
         $comments = $repository->findByCriteria($criteria);
-        $repository->hydrate(...$comments->getCurrentPageResults());
+
+        $commentObjects = [...$comments->getCurrentPageResults()];
+        $repository->hydrate(...$commentObjects);
+        $repository->hydrateChildren(...$commentObjects);
 
         $dispatcher->dispatch(new PostHasBeenSeenEvent($post));
 

--- a/src/Controller/User/UserFrontController.php
+++ b/src/Controller/User/UserFrontController.php
@@ -120,6 +120,7 @@ class UserFrontController extends AbstractController
             [
                 'user' => $user,
                 'comments' => $comments,
+                'criteria' => new EntryCommentPageView(0, $this->security),
             ],
             $response
         );

--- a/src/Entity/EntryComment.php
+++ b/src/Entity/EntryComment.php
@@ -15,10 +15,12 @@ use App\Entity\Traits\CreatedAtTrait;
 use App\Entity\Traits\EditedAtTrait;
 use App\Entity\Traits\VisibilityTrait;
 use App\Entity\Traits\VotableTrait;
+use App\Repository\Criteria as MbinCriteria;
 use App\Repository\EntryCommentRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Order;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -251,5 +253,57 @@ class EntryComment implements VotableInterface, VisibilityInterface, ReportInter
     public function getParentSubject(): ?ContentInterface
     {
         return $this->entry;
+    }
+
+    public function containsBannedHashtags(): bool
+    {
+        foreach ($this->hashtags as /** @var $hashtag HashtagLink */ $hashtag) {
+            if ($hashtag->hashtag->banned) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function getChildrenByCriteria(MbinCriteria $entryCommentCriteria): Collection
+    {
+        $criteria = Criteria::create();
+
+        if ($entryCommentCriteria->languages) {
+            $criteria->andwhere(Criteria::expr()->in('lang', $entryCommentCriteria->languages));
+        }
+
+        if (MbinCriteria::AP_LOCAL === $entryCommentCriteria->federation) {
+            $criteria->andWhere(Criteria::expr()->isNull('apId'));
+        } elseif (MbinCriteria::AP_FEDERATED === $entryCommentCriteria->federation) {
+            $criteria->andWhere(Criteria::expr()->isNotNull('apId'));
+        }
+
+        if (MbinCriteria::TIME_ALL !== $entryCommentCriteria->time) {
+            $criteria->andWhere(Criteria::expr()->gte('createdAt', $entryCommentCriteria->getSince()));
+        }
+
+        $orderings = [];
+        switch ($entryCommentCriteria->sortOption) {
+            case MbinCriteria::SORT_TOP:
+            case MbinCriteria::SORT_HOT:
+                $orderings['favouriteCount'] = Order::Descending;
+                break;
+            case MbinCriteria::SORT_ACTIVE:
+                $orderings['lastActive'] = Order::Descending;
+                break;
+            default:
+        }
+
+        $criteria->orderBy([
+            ...$orderings,
+            'createdAt' => MbinCriteria::SORT_OLD === $entryCommentCriteria->sortOption ? Order::Ascending : Order::Descending,
+            'id' => Order::Descending,
+        ]);
+
+        return $this->children
+            ->matching($criteria)
+            ->filter(fn (EntryComment $comment) => !$comment->containsBannedHashtags());
     }
 }

--- a/src/Factory/EntryCommentFactory.php
+++ b/src/Factory/EntryCommentFactory.php
@@ -11,6 +11,7 @@ use App\Entity\User;
 use App\PageView\EntryCommentPageView;
 use App\Repository\BookmarkListRepository;
 use App\Repository\TagLinkRepository;
+use App\Service\SettingsManager;
 use Symfony\Bundle\SecurityBundle\Security;
 
 class EntryCommentFactory
@@ -22,6 +23,7 @@ class EntryCommentFactory
         private readonly MagazineFactory $magazineFactory,
         private readonly TagLinkRepository $tagLinkRepository,
         private readonly BookmarkListRepository $bookmarkListRepository,
+        private readonly SettingsManager $settingsManager,
     ) {
     }
 
@@ -78,7 +80,7 @@ class EntryCommentFactory
             return $toReturn;
         }
 
-        foreach ($comment->getChildrenByCriteria($commentPageView) as $childComment) {
+        foreach ($comment->getChildrenByCriteria($commentPageView, $this->settingsManager->getDownvotesMode()) as $childComment) {
             \assert($childComment instanceof EntryComment);
             if (($user = $this->security->getUser()) && $user instanceof User) {
                 if ($user->isBlocked($childComment->user)) {

--- a/src/Repository/EntryCommentRepository.php
+++ b/src/Repository/EntryCommentRepository.php
@@ -17,7 +17,6 @@ use App\Entity\HashtagLink;
 use App\Entity\MagazineBlock;
 use App\Entity\MagazineSubscription;
 use App\Entity\Moderator;
-use App\Entity\User;
 use App\Entity\UserBlock;
 use App\Entity\UserFollow;
 use App\Service\SettingsManager;
@@ -266,85 +265,5 @@ class EntryCommentRepository extends ServiceEntityRepository
         $qb->addOrderBy('c.id', 'DESC');
 
         return $qb;
-    }
-
-    public function hydrateChildren(EntryComment ...$comments): void
-    {
-        $children = $this->createQueryBuilder('c')
-            ->andWhere('c.root IN (:ids)')
-            ->setParameter('ids', $comments)
-            ->getQuery()->getResult();
-
-        $this->hydrate(...$children);
-    }
-
-    public function hydrate(EntryComment ...$comments): void
-    {
-        $this->createQueryBuilder('c')
-            ->select('PARTIAL c.{id}')
-            ->addSelect('u')
-            ->addSelect('e')
-            ->addSelect('v')
-            ->addSelect('em')
-            ->addSelect('f')
-            ->join('c.user', 'u')
-            ->join('c.entry', 'e')
-            ->join('c.votes', 'v')
-            ->leftJoin('c.favourites', 'f')
-            ->join('e.magazine', 'em')
-            ->where('c IN (?1)')
-            ->setParameter(1, $comments)
-            ->getQuery()
-            ->execute();
-
-        $this->createQueryBuilder('c')
-            ->select('PARTIAL c.{id}')
-            ->addSelect('cc')
-            ->addSelect('ccu')
-            ->addSelect('ccua')
-            ->addSelect('ccv')
-            ->addSelect('ccf')
-            ->leftJoin('c.children', 'cc')
-            ->join('cc.user', 'ccu')
-            ->leftJoin('ccu.avatar', 'ccua')
-            ->leftJoin('cc.votes', 'ccv')
-            ->leftJoin('cc.favourites', 'ccf')
-            ->where('c IN (?1)')
-            ->setParameter(1, $comments)
-            ->getQuery()
-            ->execute();
-    }
-
-    public function hydrateParents(EntryComment ...$comments): void
-    {
-        $this->createQueryBuilder('c')
-            ->select('PARTIAL c.{id}')
-            ->addSelect('cp')
-            ->addSelect('cpu')
-            ->addSelect('cpe')
-            ->leftJoin('c.parent', 'cp')
-            ->leftJoin('cp.user', 'cpu')
-            ->leftJoin('cp.entry', 'cpe')
-            ->where('c IN (?1)')
-            ->setParameter(1, $comments)
-            ->getQuery()
-            ->execute();
-    }
-
-    public function findToDelete(User $user, int $limit): array
-    {
-        $query = $this->createQueryBuilder('c')
-            ->where('c.visibility != :visibility')
-            ->andWhere('c.user = :user')
-            ->setParameters(['visibility' => VisibilityInterface::VISIBILITY_SOFT_DELETED, 'user' => $user])
-            ->orderBy('c.id', 'DESC');
-
-        if ($limit) {
-            $query->setMaxResults($limit);
-        }
-
-        return $query
-            ->getQuery()
-            ->getResult();
     }
 }

--- a/src/Repository/EntryCommentRepository.php
+++ b/src/Repository/EntryCommentRepository.php
@@ -266,4 +266,51 @@ class EntryCommentRepository extends ServiceEntityRepository
 
         return $qb;
     }
+
+    public function hydrateChildren(EntryComment ...$comments): void
+    {
+        $children = $this->createQueryBuilder('c')
+            ->andWhere('c.root IN (:ids)')
+            ->setParameter('ids', $comments)
+            ->getQuery()->getResult();
+
+        $this->hydrate(...$children);
+    }
+
+    public function hydrate(EntryComment ...$comments): void
+    {
+        $this->createQueryBuilder('c')
+            ->select('PARTIAL c.{id}')
+            ->addSelect('u')
+            ->addSelect('e')
+            ->addSelect('v')
+            ->addSelect('em')
+            ->addSelect('f')
+            ->join('c.user', 'u')
+            ->join('c.entry', 'e')
+            ->join('c.votes', 'v')
+            ->leftJoin('c.favourites', 'f')
+            ->join('e.magazine', 'em')
+            ->where('c IN (?1)')
+            ->setParameter(1, $comments)
+            ->getQuery()
+            ->execute();
+
+        $this->createQueryBuilder('c')
+            ->select('PARTIAL c.{id}')
+            ->addSelect('cc')
+            ->addSelect('ccu')
+            ->addSelect('ccua')
+            ->addSelect('ccv')
+            ->addSelect('ccf')
+            ->leftJoin('c.children', 'cc')
+            ->join('cc.user', 'ccu')
+            ->leftJoin('ccu.avatar', 'ccua')
+            ->leftJoin('cc.votes', 'ccv')
+            ->leftJoin('cc.favourites', 'ccf')
+            ->where('c IN (?1)')
+            ->setParameter(1, $comments)
+            ->getQuery()
+            ->execute();
+    }
 }

--- a/src/Repository/PostCommentRepository.php
+++ b/src/Repository/PostCommentRepository.php
@@ -190,6 +190,16 @@ class PostCommentRepository extends ServiceEntityRepository
         $qb->addOrderBy('c.id', 'DESC');
     }
 
+    public function hydrateChildren(PostComment ...$comments): void
+    {
+        $children = $this->createQueryBuilder('c')
+            ->andWhere('c.root IN (:ids)')
+            ->setParameter('ids', $comments)
+            ->getQuery()->getResult();
+
+        $this->hydrate(...$children);
+    }
+
     public function hydrate(PostComment ...$comment): void
     {
         $this->_em->createQueryBuilder()

--- a/src/Repository/PostCommentRepository.php
+++ b/src/Repository/PostCommentRepository.php
@@ -191,37 +191,6 @@ class PostCommentRepository extends ServiceEntityRepository
         $qb->addOrderBy('c.id', 'DESC');
     }
 
-    public function hydrate(PostComment ...$comment): void
-    {
-        $this->_em->createQueryBuilder()
-            ->select('PARTIAL c.{id}')
-            ->addSelect('u')
-            ->addSelect('m')
-            ->addSelect('i')
-            ->from(PostComment::class, 'c')
-            ->join('c.user', 'u')
-            ->join('c.magazine', 'm')
-            ->leftJoin('c.image', 'i')
-            ->where('c IN (?1)')
-            ->setParameter(1, $comment)
-            ->getQuery()
-            ->getResult();
-
-        if ($this->security->getUser()) {
-            $this->_em->createQueryBuilder()
-                ->select('PARTIAL c.{id}')
-                ->addSelect('cv')
-                ->addSelect('cf')
-                ->from(PostComment::class, 'c')
-                ->leftJoin('c.votes', 'cv')
-                ->leftJoin('c.favourites', 'cf')
-                ->where('c IN (?1)')
-                ->setParameter(1, $comment)
-                ->getQuery()
-                ->getResult();
-        }
-    }
-
     public function findToDelete(User $user, int $limit): array
     {
         return $this->createQueryBuilder('c')

--- a/src/Twig/Components/EntryCommentComponent.php
+++ b/src/Twig/Components/EntryCommentComponent.php
@@ -7,6 +7,7 @@ namespace App\Twig\Components;
 use App\Controller\User\ThemeSettingsController;
 use App\Entity\Contracts\VisibilityInterface;
 use App\Entity\EntryComment;
+use App\PageView\EntryCommentPageView;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
@@ -27,6 +28,7 @@ final class EntryCommentComponent
     public int $level = 1;
     public bool $canSeeTrash = false;
     public bool $dateAsUrl = true;
+    public EntryCommentPageView $criteria;
 
     public function postMount(array $attr): array
     {

--- a/src/Twig/Components/EntryCommentsNestedComponent.php
+++ b/src/Twig/Components/EntryCommentsNestedComponent.php
@@ -6,6 +6,7 @@ namespace App\Twig\Components;
 
 use App\Controller\User\ThemeSettingsController;
 use App\Entity\EntryComment;
+use App\PageView\EntryCommentPageView;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
 #[AsTwigComponent('entry_comments_nested')]
@@ -14,4 +15,5 @@ final class EntryCommentsNestedComponent
     public EntryComment $comment;
     public int $level;
     public string $view = ThemeSettingsController::TREE;
+    public EntryCommentPageView $criteria;
 }

--- a/src/Twig/Components/PostCommentComponent.php
+++ b/src/Twig/Components/PostCommentComponent.php
@@ -7,6 +7,7 @@ namespace App\Twig\Components;
 use App\Controller\User\ThemeSettingsController;
 use App\Entity\Contracts\VisibilityInterface;
 use App\Entity\PostComment;
+use App\Repository\Criteria;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
@@ -26,6 +27,7 @@ final class PostCommentComponent
     public bool $withPost = false;
     public int $level = 1;
     public bool $canSeeTrash = false;
+    public Criteria $criteria;
 
     public function postMount(array $attr): array
     {

--- a/src/Twig/Components/PostCommentsNestedComponent.php
+++ b/src/Twig/Components/PostCommentsNestedComponent.php
@@ -6,6 +6,7 @@ namespace App\Twig\Components;
 
 use App\Controller\User\ThemeSettingsController;
 use App\Entity\PostComment;
+use App\Repository\Criteria;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
 #[AsTwigComponent('post_comments_nested')]
@@ -14,4 +15,5 @@ final class PostCommentsNestedComponent
     public PostComment $comment;
     public int $level;
     public string $view = ThemeSettingsController::TREE;
+    public Criteria $criteria;
 }

--- a/src/Utils/ArrayUtils.php
+++ b/src/Utils/ArrayUtils.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Utils;
+
+class ArrayUtils
+{
+    public static function numCompareAscending(int $a, int $b): int
+    {
+        if ($a === $b) {
+            return 0;
+        }
+
+        return ($a < $b) ? -1 : 1;
+    }
+
+    public static function numCompareDescending(int $a, int $b): int
+    {
+        if ($a === $b) {
+            return 0;
+        }
+
+        return ($a < $b) ? 1 : -1;
+    }
+}

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -150,7 +150,8 @@
             comment: comment,
             level: level,
             showNested: true,
-            view: VIEW_STYLE
+            view: VIEW_STYLE,
+            criteria: criteria,
         }) }}
     {% endif %}
 {% endif %}

--- a/templates/components/entry_comments_nested.html.twig
+++ b/templates/components/entry_comments_nested.html.twig
@@ -9,13 +9,14 @@
         }) }}
     {% endfor %}
 {% else %}
-    {% for reply in comment.children %}
+    {% for reply in comment.getChildrenByCriteria(criteria) %}
         {{ component('entry_comment', {
             comment: reply,
             showNested: true,
             level: level + 1,
             showEntryTitle: false,
-            showMagazineName: false
+            showMagazineName: false,
+            criteria: criteria,
         }) }}
     {% endfor %}
 {% endif %}

--- a/templates/components/entry_comments_nested.html.twig
+++ b/templates/components/entry_comments_nested.html.twig
@@ -9,7 +9,7 @@
         }) }}
     {% endfor %}
 {% else %}
-    {% for reply in comment.getChildrenByCriteria(criteria) %}
+    {% for reply in comment.getChildrenByCriteria(criteria, mbin_downvotes_mode()) %}
         {{ component('entry_comment', {
             comment: reply,
             showNested: true,

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -153,7 +153,8 @@
             comment: comment,
             level: level,
             showNested: true,
-            view: VIEW_STYLE
+            view: VIEW_STYLE,
+            criteria: criteria,
         }) }}
     {% endif %}
 {% endif %}

--- a/templates/components/post_comments_nested.html.twig
+++ b/templates/components/post_comments_nested.html.twig
@@ -7,11 +7,12 @@
         }) }}
     {% endfor %}
 {% else %}
-    {% for reply in comment.children %}
+    {% for reply in comment.getChildrenByCriteria(criteria) %}
         {{ component('post_comment', {
             comment: reply,
             showNested: true,
-            level: level + 1
+            level: level + 1,
+            criteria: criteria,
         }) }}
     {% endfor %}
 {% endif %}

--- a/templates/entry/comment/_list.html.twig
+++ b/templates/entry/comment/_list.html.twig
@@ -28,7 +28,8 @@
             showNested: showNested,
             dateAsUrl: dateAsUrl is defined ? dateAsUrl : true,
             showMagazineName: magazine is not defined or not magazine,
-            showEntryTitle: entry is not defined or not entry
+            showEntryTitle: entry is not defined or not entry,
+            criteria: criteria,
         }) }}
     {% endfor %}
     {% if(comments.haveToPaginate is defined and comments.haveToPaginate) %}

--- a/templates/entry/comment/view.html.twig
+++ b/templates/entry/comment/view.html.twig
@@ -53,6 +53,7 @@
                 showEntryTitle: false,
                 showMagazineName: false,
                 showNested: true,
+                criteria: criteria,
             }) }}
         {% else %}
         <div class="section alert alert__danger">

--- a/templates/post/comment/_list.html.twig
+++ b/templates/post/comment/_list.html.twig
@@ -32,7 +32,8 @@
             comment: comment,
             showNested: showNested,
             dateAsUrl: dateAsUrl is defined ? dateAsUrl : true,
-            level: level
+            level: level,
+            criteria: criteria,
         }) }}
     {% endfor %}
     {% if(comments.haveToPaginate is defined and comments.haveToPaginate) %}


### PR DESCRIPTION
- pass the criteria through to match child comments by it
- included criteria:
  - ordering
  - banned hashtag checking
  - preferred languages
  - federation filter (not used with comments, but still included)
  - time filter (also not used for comments atm)
- filter out comments from banned authors

Closes #1397 