### PR TITLE
Left-over 'v' in front of our docker tags

### DIFF
--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -101,12 +101,12 @@ else
 # Customizations to the docker compose should be added here.
 # Hint: If you want to combine multiple configurations, be sure to only define the services once (php & messenger).
 
-# Uncomment the following to pin Mbin image docker tag to a specific release (example: 1.8.2).
+# Uncomment the following to pin Mbin image docker tag to a specific release (example: v1.8.2).
 # services:
 #   php:
-#     image: ghcr.io/mbinorg/mbin:1.8.2
+#     image: ghcr.io/mbinorg/mbin:v1.8.2
 #   messenger:
-#     image: ghcr.io/mbinorg/mbin:1.8.2
+#     image: ghcr.io/mbinorg/mbin:v1.8.2
 
 # Uncomment the following to build the Mbin image locally.
 # services:

--- a/docs/02-admin/01-installation/02-docker.md
+++ b/docs/02-admin/01-installation/02-docker.md
@@ -125,7 +125,7 @@ Use the Mbin provided Docker image (default) _OR_ build the docker image locally
 The default is to use our prebuilt images from [ghcr.io](https://github.com/MbinOrg/mbin/pkgs/container/mbin). Reference the next section if you'd like to build the Docker image locally instead.
 
 > [!IMPORTANT]
-> In **production** a recommended practice is to pin the image tag to a specific release (example: 1.8.2) _instead_ of using `latest`.
+> In **production** a recommended practice is to pin the image tag to a specific release (example: v1.8.2) _instead_ of using `latest`.
 >
 
 Pinning the docker image version can be done by editing the `compose.override.yaml` file and uncommenting the following lines
@@ -134,9 +134,9 @@ Pinning the docker image version can be done by editing the `compose.override.ya
 ```yaml
 services:
   php:
-    image: ghcr.io/mbinorg/mbin:1.8.2
+    image: ghcr.io/mbinorg/mbin:v1.8.2
   messenger:
-    image: ghcr.io/mbinorg/mbin:1.8.2
+    image: ghcr.io/mbinorg/mbin:v1.8.2
 ```
 
 #### Build your own image


### PR DESCRIPTION
Apparently, we use a `v` in our tags: https://github.com/MbinOrg/mbin/tags 😆 

So let's fix that, since the git tag is also used one-on-one with the docker tags: https://github.com/MbinOrg/mbin/pkgs/container/mbin