### PR TITLE
Check whether the actor is a User

### DIFF
--- a/src/Service/ActivityPub/Note.php
+++ b/src/Service/ActivityPub/Note.php
@@ -131,7 +131,7 @@ class Note
         }
 
         $actor = $this->activityPubManager->findActorOrCreate($object['attributedTo']);
-        if (!empty($actor)) {
+        if ($actor instanceof User) {
             if ($actor->isBanned) {
                 throw new UserBannedException();
             }
@@ -213,7 +213,7 @@ class Note
         $dto->apId = $object['id'];
 
         $actor = $this->activityPubManager->findActorOrCreate($object['attributedTo']);
-        if (!empty($actor)) {
+        if ($actor instanceof User) {
             if ($actor->isBanned) {
                 throw new UserBannedException();
             }
@@ -277,7 +277,7 @@ class Note
         }
 
         $actor = $this->activityPubManager->findActorOrCreate($object['attributedTo']);
-        if (!empty($actor)) {
+        if ($actor instanceof User) {
             if ($actor->isBanned) {
                 throw new UserBannedException();
             }

--- a/src/Service/ActivityPub/Note.php
+++ b/src/Service/ActivityPub/Note.php
@@ -12,6 +12,7 @@ use App\Entity\Contracts\ActivityPubActivityInterface;
 use App\Entity\Contracts\VisibilityInterface;
 use App\Entity\Entry;
 use App\Entity\EntryComment;
+use App\Entity\Magazine;
 use App\Entity\Post;
 use App\Entity\PostComment;
 use App\Entity\User;
@@ -163,8 +164,10 @@ class Note
             $dto->apShareCount = $this->activityPubManager->extractRemoteShareCount($object);
 
             return $this->entryCommentManager->create($dto, $actor, false);
+        } elseif ($actor instanceof Magazine) {
+            throw new UnrecoverableMessageHandlingException('Actor "'.$object['attributedTo'].'" is not a user, but a magazine for post "'.$dto->apId.'".');
         } else {
-            throw new UnrecoverableMessageHandlingException('Actor could not be found for entry comment.');
+            throw new UnrecoverableMessageHandlingException('Actor "'.$object['attributedTo'].'"could not be found for post "'.$dto->apId.'".');
         }
     }
 
@@ -250,8 +253,10 @@ class Note
             $dto->apShareCount = $this->activityPubManager->extractRemoteShareCount($object);
 
             return $this->postManager->create($dto, $actor, false, $stickyIt);
+        } elseif ($actor instanceof Magazine) {
+            throw new UnrecoverableMessageHandlingException('Actor "'.$object['attributedTo'].'" is not a user, but a magazine for post "'.$dto->apId.'".');
         } else {
-            throw new UnrecoverableMessageHandlingException('Actor could not be found for post.');
+            throw new UnrecoverableMessageHandlingException('Actor "'.$object['attributedTo'].'"could not be found for post "'.$dto->apId.'".');
         }
     }
 
@@ -308,8 +313,10 @@ class Note
             $dto->apShareCount = $this->activityPubManager->extractRemoteShareCount($object);
 
             return $this->postCommentManager->create($dto, $actor, false);
+        } elseif ($actor instanceof Magazine) {
+            throw new UnrecoverableMessageHandlingException('Actor "'.$object['attributedTo'].'" is not a user, but a magazine for post "'.$dto->apId.'".');
         } else {
-            throw new UnrecoverableMessageHandlingException('Actor could not be found for post comment.');
+            throw new UnrecoverableMessageHandlingException('Actor "'.$object['attributedTo'].'"could not be found for post "'.$dto->apId.'".');
         }
     }
 }

--- a/src/Service/ActivityPub/Note.php
+++ b/src/Service/ActivityPub/Note.php
@@ -28,6 +28,7 @@ use App\Service\PostManager;
 use App\Service\SettingsManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
 class Note
 {
@@ -163,7 +164,7 @@ class Note
 
             return $this->entryCommentManager->create($dto, $actor, false);
         } else {
-            throw new \Exception('Actor could not be found for entry comment.');
+            throw new UnrecoverableMessageHandlingException('Actor could not be found for entry comment.');
         }
     }
 
@@ -250,7 +251,7 @@ class Note
 
             return $this->postManager->create($dto, $actor, false, $stickyIt);
         } else {
-            throw new \Exception('Actor could not be found for post.');
+            throw new UnrecoverableMessageHandlingException('Actor could not be found for post.');
         }
     }
 
@@ -308,7 +309,7 @@ class Note
 
             return $this->postCommentManager->create($dto, $actor, false);
         } else {
-            throw new \Exception('Actor could not be found for post comment.');
+            throw new UnrecoverableMessageHandlingException('Actor could not be found for post comment.');
         }
     }
 }


### PR DESCRIPTION
- when creating a post of any kind the actor needs to be a user in the mbin context, so check for that. If the actor is not a user we get a bunch of type errors which severely slow the messengers down

I had this problem with a pleroma post from a group actor. My message rate plummeted: 
![grafik](https://github.com/user-attachments/assets/fdc302b2-a4a2-4b50-bf05-e9c473f4d9a0)

Which lead to me banning the origin instance. I could not check whether this fix worked, but it should. Either way, since we can get a Magazine from `findActorOrCreate` it should be done anyway.
