### PR TITLE
WHen you enter a space during the search I was getting 500 error

### DIFF
--- a/src/DTO/SearchDto.php
+++ b/src/DTO/SearchDto.php
@@ -9,7 +9,7 @@ use App\Entity\User;
 
 class SearchDto
 {
-    public string $q;
+    public string $q = '';
     public ?string $type = null;
     public ?User $user = null;
     public ?Magazine $magazine = null;


### PR DESCRIPTION
Handle just a simple empty space (or multiple spaces) during a search resulted in 500 error.

Here you can try it: https://gehirneimer.de/search?search%5Bq%5D=+&search%5Bmagazine%5D=&search%5Buser%5D=&search%5Btype%5D=0

Now there is no error displayed at least. Just no results.