### PR TITLE
Reduce the number of db calls on the login page

### DIFF
--- a/templates/layout/_sidebar.html.twig
+++ b/templates/layout/_sidebar.html.twig
@@ -97,18 +97,20 @@
 {% if tag is defined and tag %}
     {% include 'tag/_panel.html.twig' %}
 {% endif %}
-{% if show_related_magazines is not same as V_FALSE %}
-    {{ component('related_magazines', {magazine: magazine is defined and magazine ? magazine.name : null, tag: tag is defined and tag ? tag : null}) }}
+{% if not is_route_name_contains('login') %}
+    {% if show_related_magazines is not same as V_FALSE %}
+        {{ component('related_magazines', {magazine: magazine is defined and magazine ? magazine.name : null, tag: tag is defined and tag ? tag : null}) }}
+    {% endif %}
+    {% if not is_route_name_contains('people') and show_active_users is not same as V_FALSE %}
+        {{ component('active_users', {magazine: magazine is defined and magazine ? magazine : null}) }}
+    {% endif %}
+    {% if show_related_posts is not same as V_FALSE %}
+        {{ component('related_posts', {magazine: magazine is defined and magazine ? magazine.name : null, tag: tag is defined and tag ? tag : null}) }}
+    {% endif%}
+    {% if show_related_entries is not same as V_FALSE %}
+        {{ component('related_entries', {magazine: magazine is defined and magazine ? magazine.name : null, tag: tag is defined and tag ? tag : null}) }}
+    {% endif%}
 {% endif %}
-{% if not is_route_name_contains('people') and show_active_users is not same as V_FALSE %}
-    {{ component('active_users', {magazine: magazine is defined and magazine ? magazine : null}) }}
-{% endif %}
-{% if show_related_posts is not same as V_FALSE %}
-    {{ component('related_posts', {magazine: magazine is defined and magazine ? magazine.name : null, tag: tag is defined and tag ? tag : null}) }}
-{% endif%}
-{% if show_related_entries is not same as V_FALSE %}
-    {{ component('related_entries', {magazine: magazine is defined and magazine ? magazine.name : null, tag: tag is defined and tag ? tag : null}) }}
-{% endif%}
 <section class="about section">
     <h3>{{ kbin_domain() }}</h3>
     <div class="container">

--- a/templates/layout/_topbar.html.twig
+++ b/templates/layout/_topbar.html.twig
@@ -1,24 +1,28 @@
-<div id="topbar">
-    <menu>
-        <li class="{{ html_classes({'active': (is_route_name('front') and not criteria.subscribed and not criteria.moderated and not criteria.favourite) or (is_route_name('root') and not criteria.subscribed and not criteria.moderated and not criteria.favourite) or is_route_name('posts_front') or is_route_name('people_front')}) }}">
-            <a class="stretched-link" href="/all">{{ 'all'|trans }}</a>
-        </li>
-        <li class="{{ html_classes({'active': (is_route_name('front') and criteria.subscribed) or (is_route_name('root') and criteria.subscribed) }) }}">
-            <a class="stretched-link" href="/sub/">{{ 'subscribed'|trans }}</a>
-        </li>
-        <li class="{{ html_classes({'active': (is_route_name('front') and criteria.moderated) or (is_route_name('root') and criteria.moderated) }) }}">
-            <a class="stretched-link" href="/mod/">{{ 'moderated'|trans }}</a>
-        </li>
-        <li class="{{ html_classes({'active': (is_route_name('front') and criteria.favourite) or (is_route_name('root') and criteria.favourite) }) }}">
-            <a class="stretched-link" href="/fav/">{{ 'favourites'|trans }}</a>
-        </li>
-        <li>
-            <a class="stretched-link" href="#">•</a>
-        </li>
-    </menu>
-    {{ component('featured_magazines', {magazine: magazine is defined and magazine ? magazine : null}) }}
-    <menu>
-        <li class="{{ html_classes({'active': is_route_name('magazine_list_all')}) }}">
-            <a class="stretched-link" href="{{ path('magazine_list_all') }}">{{ 'all_magazines'|trans }}</a></li>
-    </menu>
-</div>
+{% set show_topbar = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_GENERAL_TOPBAR')) %}
+{% set V_TRUE = constant('App\\Controller\\User\\ThemeSettingsController::TRUE') %}
+{% if show_topbar is same as V_TRUE %}
+    <div id="topbar">
+        <menu>
+            <li class="{{ html_classes({'active': (is_route_name('front') and not criteria.subscribed and not criteria.moderated and not criteria.favourite) or (is_route_name('root') and not criteria.subscribed and not criteria.moderated and not criteria.favourite) or is_route_name('posts_front') or is_route_name('people_front')}) }}">
+                <a class="stretched-link" href="/all">{{ 'all'|trans }}</a>
+            </li>
+            <li class="{{ html_classes({'active': (is_route_name('front') and criteria.subscribed) or (is_route_name('root') and criteria.subscribed) }) }}">
+                <a class="stretched-link" href="/sub/">{{ 'subscribed'|trans }}</a>
+            </li>
+            <li class="{{ html_classes({'active': (is_route_name('front') and criteria.moderated) or (is_route_name('root') and criteria.moderated) }) }}">
+                <a class="stretched-link" href="/mod/">{{ 'moderated'|trans }}</a>
+            </li>
+            <li class="{{ html_classes({'active': (is_route_name('front') and criteria.favourite) or (is_route_name('root') and criteria.favourite) }) }}">
+                <a class="stretched-link" href="/fav/">{{ 'favourites'|trans }}</a>
+            </li>
+            <li>
+                <a class="stretched-link" href="#">•</a>
+            </li>
+        </menu>
+        {{ component('featured_magazines', {magazine: magazine is defined and magazine ? magazine : null}) }}
+        <menu>
+            <li class="{{ html_classes({'active': is_route_name('magazine_list_all')}) }}">
+                <a class="stretched-link" href="{{ path('magazine_list_all') }}">{{ 'all_magazines'|trans }}</a></li>
+        </menu>
+    </div>
+{% endif %}


### PR DESCRIPTION
All the widgets like the topbar, active users, random threads, posts and magazines were rendered, but hidden on the login page, so this commits just prevents the rendering which also removes the db calls. It is down from 6 to one (according to the symfony debug tool)