### PR TITLE
Use baseData instead

### DIFF
--- a/src/Controller/Entry/EntryFrontController.php
+++ b/src/Controller/Entry/EntryFrontController.php
@@ -234,7 +234,7 @@ class EntryFrontController extends AbstractController
 
         if ($request->isXmlHttpRequest()) {
             return new JsonResponse([
-                'html' => $this->renderView($templatePath.'_list.html.twig', $data),
+                'html' => $this->renderView($templatePath.'_list.html.twig', $baseData),
             ]);
         }
 


### PR DESCRIPTION
Try to use `$baseData` instead of `$data` to pass along to the `renderView` of the `*_list.html.twig` template.