### PR TITLE
Add `federation` query parameter to the post and entry retrieve API

### DIFF
--- a/src/Controller/Api/Entry/EntriesRetrieveApi.php
+++ b/src/Controller/Api/Entry/EntriesRetrieveApi.php
@@ -21,6 +21,7 @@ use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\SecurityBundle\Security as SymfonySecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -173,6 +174,12 @@ class EntriesRetrieveApi extends EntriesBaseApi
         in: 'query',
         schema: new OA\Schema(type: 'boolean', default: false),
     )]
+    #[OA\Parameter(
+        name: 'federation',
+        description: 'What type of federated entries to retrieve',
+        in: 'query',
+        schema: new OA\Schema(type: 'string', default: Criteria::AP_ALL, enum: Criteria::AP_OPTIONS)
+    )]
     #[OA\Tag(name: 'entry')]
     public function collection(
         EntryRepository $repository,
@@ -181,6 +188,7 @@ class EntriesRetrieveApi extends EntriesBaseApi
         RateLimiterFactory $apiReadLimiter,
         RateLimiterFactory $anonymousApiReadLimiter,
         SymfonySecurity $security,
+        #[MapQueryParameter] ?string $federation,
     ): JsonResponse {
         $headers = $this->rateLimit($apiReadLimiter, $anonymousApiReadLimiter);
 
@@ -189,6 +197,7 @@ class EntriesRetrieveApi extends EntriesBaseApi
         $criteria->time = $criteria->resolveTime(
             $request->getCurrentRequest()->get('time', Criteria::TIME_ALL)
         );
+        $criteria->setFederation($federation ?? Criteria::AP_ALL);
         $this->handleLanguageCriteria($criteria);
 
         $entries = $repository->findByCriteria($criteria);
@@ -278,6 +287,12 @@ class EntriesRetrieveApi extends EntriesBaseApi
         in: 'query',
         schema: new OA\Schema(type: 'integer', default: EntryRepository::PER_PAGE, minimum: self::MIN_PER_PAGE, maximum: self::MAX_PER_PAGE)
     )]
+    #[OA\Parameter(
+        name: 'federation',
+        description: 'What type of federated entries to retrieve',
+        in: 'query',
+        schema: new OA\Schema(type: 'string', default: Criteria::AP_ALL, enum: Criteria::AP_OPTIONS)
+    )]
     #[OA\Tag(name: 'entry')]
     #[Security(name: 'oauth2', scopes: ['read'])]
     #[IsGranted('ROLE_OAUTH2_READ')]
@@ -287,6 +302,7 @@ class EntriesRetrieveApi extends EntriesBaseApi
         RequestStack $request,
         RateLimiterFactory $apiReadLimiter,
         SymfonySecurity $security,
+        #[MapQueryParameter] ?string $federation,
     ): JsonResponse {
         $headers = $this->rateLimit($apiReadLimiter);
 
@@ -295,6 +311,7 @@ class EntriesRetrieveApi extends EntriesBaseApi
         $criteria->time = $criteria->resolveTime(
             $request->getCurrentRequest()->get('time', Criteria::TIME_ALL)
         );
+        $criteria->setFederation($federation ?? Criteria::AP_ALL);
 
         $criteria->subscribed = true;
 
@@ -385,6 +402,12 @@ class EntriesRetrieveApi extends EntriesBaseApi
         in: 'query',
         schema: new OA\Schema(type: 'integer', default: EntryRepository::PER_PAGE, minimum: self::MIN_PER_PAGE, maximum: self::MAX_PER_PAGE)
     )]
+    #[OA\Parameter(
+        name: 'federation',
+        description: 'What type of federated entries to retrieve',
+        in: 'query',
+        schema: new OA\Schema(type: 'string', default: Criteria::AP_ALL, enum: Criteria::AP_OPTIONS)
+    )]
     #[OA\Tag(name: 'entry')]
     #[Security(name: 'oauth2', scopes: ['moderate:entry'])]
     #[IsGranted('ROLE_OAUTH2_MODERATE:ENTRY')]
@@ -394,6 +417,7 @@ class EntriesRetrieveApi extends EntriesBaseApi
         RequestStack $request,
         RateLimiterFactory $apiReadLimiter,
         SymfonySecurity $security,
+        #[MapQueryParameter] ?string $federation,
     ): JsonResponse {
         $headers = $this->rateLimit($apiReadLimiter);
 
@@ -402,6 +426,7 @@ class EntriesRetrieveApi extends EntriesBaseApi
         $criteria->time = $criteria->resolveTime(
             $request->getCurrentRequest()->get('time', Criteria::TIME_ALL)
         );
+        $criteria->setFederation($federation ?? Criteria::AP_ALL);
 
         $criteria->moderated = true;
 
@@ -492,6 +517,12 @@ class EntriesRetrieveApi extends EntriesBaseApi
         in: 'query',
         schema: new OA\Schema(type: 'integer', default: EntryRepository::PER_PAGE, minimum: self::MIN_PER_PAGE, maximum: self::MAX_PER_PAGE)
     )]
+    #[OA\Parameter(
+        name: 'federation',
+        description: 'What type of federated entries to retrieve',
+        in: 'query',
+        schema: new OA\Schema(type: 'string', default: Criteria::AP_ALL, enum: Criteria::AP_OPTIONS)
+    )]
     #[OA\Tag(name: 'entry')]
     #[Security(name: 'oauth2', scopes: ['entry:vote'])]
     #[IsGranted('ROLE_OAUTH2_ENTRY:VOTE')]
@@ -501,6 +532,7 @@ class EntriesRetrieveApi extends EntriesBaseApi
         RequestStack $request,
         RateLimiterFactory $apiReadLimiter,
         SymfonySecurity $security,
+        #[MapQueryParameter] ?string $federation,
     ): JsonResponse {
         $headers = $this->rateLimit($apiReadLimiter);
 
@@ -509,6 +541,7 @@ class EntriesRetrieveApi extends EntriesBaseApi
         $criteria->time = $criteria->resolveTime(
             $request->getCurrentRequest()->get('time', Criteria::TIME_ALL)
         );
+        $criteria->setFederation($federation ?? Criteria::AP_ALL);
 
         $criteria->favourite = true;
 

--- a/src/Controller/Api/Post/PostsRetrieveApi.php
+++ b/src/Controller/Api/Post/PostsRetrieveApi.php
@@ -22,6 +22,7 @@ use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\SecurityBundle\Security as SymfonySecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -167,6 +168,12 @@ class PostsRetrieveApi extends PostsBaseApi
         in: 'query',
         schema: new OA\Schema(type: 'boolean', default: false),
     )]
+    #[OA\Parameter(
+        name: 'federation',
+        description: 'What type of federated entries to retrieve',
+        in: 'query',
+        schema: new OA\Schema(type: 'string', default: Criteria::AP_ALL, enum: Criteria::AP_OPTIONS)
+    )]
     #[OA\Tag(name: 'post')]
     public function collection(
         PostRepository $repository,
@@ -175,6 +182,7 @@ class PostsRetrieveApi extends PostsBaseApi
         RateLimiterFactory $apiReadLimiter,
         RateLimiterFactory $anonymousApiReadLimiter,
         SymfonySecurity $security,
+        #[MapQueryParameter] ?string $federation,
     ): JsonResponse {
         $headers = $this->rateLimit($apiReadLimiter, $anonymousApiReadLimiter);
 
@@ -184,6 +192,7 @@ class PostsRetrieveApi extends PostsBaseApi
             $request->getCurrentRequest()->get('time', Criteria::TIME_ALL)
         );
         $criteria->perPage = self::constrainPerPage($request->getCurrentRequest()->get('perPage', PostRepository::PER_PAGE));
+        $criteria->setFederation($federation ?? Criteria::AP_ALL);
 
         $this->handleLanguageCriteria($criteria);
 
@@ -285,6 +294,12 @@ class PostsRetrieveApi extends PostsBaseApi
         in: 'query',
         schema: new OA\Schema(type: 'boolean', default: false),
     )]
+    #[OA\Parameter(
+        name: 'federation',
+        description: 'What type of federated entries to retrieve',
+        in: 'query',
+        schema: new OA\Schema(type: 'string', default: Criteria::AP_ALL, enum: Criteria::AP_OPTIONS)
+    )]
     #[OA\Tag(name: 'post')]
     #[Security(name: 'oauth2', scopes: ['read'])]
     #[IsGranted('ROLE_OAUTH2_READ')]
@@ -295,6 +310,7 @@ class PostsRetrieveApi extends PostsBaseApi
         RateLimiterFactory $apiReadLimiter,
         RateLimiterFactory $anonymousApiReadLimiter,
         SymfonySecurity $security,
+        #[MapQueryParameter] ?string $federation,
     ): JsonResponse {
         $headers = $this->rateLimit($apiReadLimiter, $anonymousApiReadLimiter);
 
@@ -304,6 +320,7 @@ class PostsRetrieveApi extends PostsBaseApi
             $request->getCurrentRequest()->get('time', Criteria::TIME_ALL)
         );
         $criteria->perPage = self::constrainPerPage($request->getCurrentRequest()->get('perPage', PostRepository::PER_PAGE));
+        $criteria->setFederation($federation ?? Criteria::AP_ALL);
         $criteria->subscribed = true;
 
         $this->handleLanguageCriteria($criteria);
@@ -394,6 +411,12 @@ class PostsRetrieveApi extends PostsBaseApi
         in: 'query',
         schema: new OA\Schema(type: 'string', default: Criteria::TIME_ALL, enum: Criteria::TIME_ROUTES_EN)
     )]
+    #[OA\Parameter(
+        name: 'federation',
+        description: 'What type of federated entries to retrieve',
+        in: 'query',
+        schema: new OA\Schema(type: 'string', default: Criteria::AP_ALL, enum: Criteria::AP_OPTIONS)
+    )]
     #[OA\Tag(name: 'post')]
     #[Security(name: 'oauth2', scopes: ['moderate:post'])]
     #[IsGranted('ROLE_OAUTH2_MODERATE:POST')]
@@ -404,6 +427,7 @@ class PostsRetrieveApi extends PostsBaseApi
         RateLimiterFactory $apiReadLimiter,
         RateLimiterFactory $anonymousApiReadLimiter,
         SymfonySecurity $security,
+        #[MapQueryParameter] ?string $federation,
     ): JsonResponse {
         $headers = $this->rateLimit($apiReadLimiter, $anonymousApiReadLimiter);
 
@@ -413,6 +437,7 @@ class PostsRetrieveApi extends PostsBaseApi
             $request->getCurrentRequest()->get('time', Criteria::TIME_ALL)
         );
         $criteria->perPage = self::constrainPerPage($request->getCurrentRequest()->get('perPage', PostRepository::PER_PAGE));
+        $criteria->setFederation($federation ?? Criteria::AP_ALL);
         $criteria->moderated = true;
 
         $posts = $repository->findByCriteria($criteria);
@@ -496,6 +521,12 @@ class PostsRetrieveApi extends PostsBaseApi
         in: 'query',
         schema: new OA\Schema(type: 'string', default: Criteria::TIME_ALL, enum: Criteria::TIME_ROUTES_EN)
     )]
+    #[OA\Parameter(
+        name: 'federation',
+        description: 'What type of federated entries to retrieve',
+        in: 'query',
+        schema: new OA\Schema(type: 'string', default: Criteria::AP_ALL, enum: Criteria::AP_OPTIONS)
+    )]
     #[OA\Tag(name: 'post')]
     #[Security(name: 'oauth2', scopes: ['post:vote'])]
     #[IsGranted('ROLE_OAUTH2_POST:VOTE')]
@@ -506,6 +537,7 @@ class PostsRetrieveApi extends PostsBaseApi
         RateLimiterFactory $apiReadLimiter,
         RateLimiterFactory $anonymousApiReadLimiter,
         SymfonySecurity $security,
+        #[MapQueryParameter] ?string $federation,
     ): JsonResponse {
         $headers = $this->rateLimit($apiReadLimiter, $anonymousApiReadLimiter);
 
@@ -515,6 +547,7 @@ class PostsRetrieveApi extends PostsBaseApi
             $request->getCurrentRequest()->get('time', Criteria::TIME_ALL)
         );
         $criteria->perPage = self::constrainPerPage($request->getCurrentRequest()->get('perPage', PostRepository::PER_PAGE));
+        $criteria->setFederation($federation ?? Criteria::AP_ALL);
         $criteria->favourite = true;
 
         $this->logger->debug(var_export($criteria, true));
@@ -628,6 +661,12 @@ class PostsRetrieveApi extends PostsBaseApi
         in: 'query',
         schema: new OA\Schema(type: 'boolean', default: false),
     )]
+    #[OA\Parameter(
+        name: 'federation',
+        description: 'What type of federated entries to retrieve',
+        in: 'query',
+        schema: new OA\Schema(type: 'string', default: Criteria::AP_ALL, enum: Criteria::AP_OPTIONS)
+    )]
     #[OA\Tag(name: 'magazine')]
     public function byMagazine(
         #[MapEntity(id: 'magazine_id')]
@@ -638,6 +677,7 @@ class PostsRetrieveApi extends PostsBaseApi
         RateLimiterFactory $apiReadLimiter,
         RateLimiterFactory $anonymousApiReadLimiter,
         SymfonySecurity $security,
+        #[MapQueryParameter] ?string $federation,
     ): JsonResponse {
         $headers = $this->rateLimit($apiReadLimiter, $anonymousApiReadLimiter);
 
@@ -647,6 +687,7 @@ class PostsRetrieveApi extends PostsBaseApi
             $request->getCurrentRequest()->get('time', Criteria::TIME_ALL)
         );
         $criteria->perPage = self::constrainPerPage($request->getCurrentRequest()->get('perPage', PostRepository::PER_PAGE));
+        $criteria->setFederation($federation ?? Criteria::AP_ALL);
         $criteria->stickiesFirst = true;
 
         $this->handleLanguageCriteria($criteria);

--- a/src/Repository/EntryRepository.php
+++ b/src/Repository/EntryRepository.php
@@ -160,6 +160,8 @@ class EntryRepository extends ServiceEntityRepository
 
         if (Criteria::AP_LOCAL === $criteria->federation) {
             $qb->andWhere('e.apId IS NULL');
+        } elseif (Criteria::AP_FEDERATED === $criteria->federation) {
+            $qb->andWhere('e.apId IS NOT NULL');
         }
 
         if ($criteria->magazine) {

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -150,6 +150,8 @@ class PostRepository extends ServiceEntityRepository
 
         if (Criteria::AP_LOCAL === $criteria->federation) {
             $qb->andWhere('p.apId IS NULL');
+        } elseif (Criteria::AP_FEDERATED === $criteria->federation) {
+            $qb->andWhere('p.apId IS NOT NULL');
         }
 
         if ($criteria->magazine) {


### PR DESCRIPTION
- Add the `federation` query parameter in the `EntryRetrieveApi` and the `PostRetrieveApi` default to `all`
- Add tests for this
- Add the `Criteria::AP_FEDERATED` option to the 2 repositories

Closes #1528 