### PR TITLE
Fix SSO auth not redirecting to /authorize

### DIFF
--- a/src/Security/AuthentikAuthenticator.php
+++ b/src/Security/AuthentikAuthenticator.php
@@ -18,24 +18,18 @@ use App\Service\UserManager;
 use App\Utils\Slugger;
 use Doctrine\ORM\EntityManagerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
-use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 
-class AuthentikAuthenticator extends OAuth2Authenticator
+class AuthentikAuthenticator extends MbinOAuthAuthenticatorBase
 {
     public function __construct(
         private readonly ClientRegistry $clientRegistry,
-        private readonly RouterInterface $router,
         private readonly EntityManagerInterface $entityManager,
         private readonly UserManager $userManager,
         private readonly ImageManager $imageManager,
@@ -45,7 +39,9 @@ class AuthentikAuthenticator extends OAuth2Authenticator
         private readonly Slugger $slugger,
         private readonly UserRepository $userRepository,
         private readonly SettingsManager $settingsManager,
+        RouterInterface $router,
     ) {
+        parent::__construct($router);
     }
 
     public function supports(Request $request): ?bool
@@ -153,31 +149,5 @@ class AuthentikAuthenticator extends OAuth2Authenticator
         }
 
         return $image ?? null;
-    }
-
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
-    {
-        if ($request->getSession()->get('is_newly_created')) {
-            $targetUrl = $this->router->generate('user_settings_profile');
-            $request->getSession()->remove('is_newly_created');
-        } else {
-            $targetUrl = $this->router->generate('front');
-        }
-
-        return new RedirectResponse($targetUrl);
-    }
-
-    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
-    {
-        $message = strtr($exception->getMessageKey(), $exception->getMessageData());
-
-        if ('MBIN_SSO_REGISTRATIONS_ENABLED' === $message) {
-            $session = $request->getSession();
-            $session->getFlashBag()->add('error', 'sso_registrations_enabled.error');
-
-            return new RedirectResponse($this->router->generate('app_login'));
-        }
-
-        return new Response($message, Response::HTTP_FORBIDDEN);
     }
 }

--- a/src/Security/FacebookAuthenticator.php
+++ b/src/Security/FacebookAuthenticator.php
@@ -16,25 +16,20 @@ use App\Service\UserManager;
 use App\Utils\Slugger;
 use Doctrine\ORM\EntityManagerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
-use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
 use League\OAuth2\Client\Provider\FacebookUser;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 
-class FacebookAuthenticator extends OAuth2Authenticator
+class FacebookAuthenticator extends MbinOAuthAuthenticatorBase
 {
     public function __construct(
         private readonly ClientRegistry $clientRegistry,
-        private readonly RouterInterface $router,
+        RouterInterface $router,
         private readonly EntityManagerInterface $entityManager,
         private readonly UserManager $userManager,
         private readonly ImageManager $imageManager,
@@ -44,6 +39,7 @@ class FacebookAuthenticator extends OAuth2Authenticator
         private readonly Slugger $slugger,
         private readonly SettingsManager $settingsManager,
     ) {
+        parent::__construct($router);
     }
 
     public function supports(Request $request): ?bool
@@ -150,31 +146,5 @@ class FacebookAuthenticator extends OAuth2Authenticator
         }
 
         return $image ?? null;
-    }
-
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
-    {
-        if ($request->getSession()->get('is_newly_created')) {
-            $targetUrl = $this->router->generate('user_settings_profile');
-            $request->getSession()->remove('is_newly_created');
-        } else {
-            $targetUrl = $this->router->generate('front');
-        }
-
-        return new RedirectResponse($targetUrl);
-    }
-
-    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
-    {
-        $message = strtr($exception->getMessageKey(), $exception->getMessageData());
-
-        if ('MBIN_SSO_REGISTRATIONS_ENABLED' === $message) {
-            $session = $request->getSession();
-            $session->getFlashBag()->add('error', 'sso_registrations_enabled.error');
-
-            return new RedirectResponse($this->router->generate('app_login'));
-        }
-
-        return new Response($message, Response::HTTP_FORBIDDEN);
     }
 }

--- a/src/Security/GithubAuthenticator.php
+++ b/src/Security/GithubAuthenticator.php
@@ -11,29 +11,25 @@ use App\Service\UserManager;
 use App\Utils\Slugger;
 use Doctrine\ORM\EntityManagerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
-use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
 use League\OAuth2\Client\Provider\GithubResourceOwner;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 
-class GithubAuthenticator extends OAuth2Authenticator
+class GithubAuthenticator extends MbinOAuthAuthenticatorBase
 {
     public function __construct(
         private readonly ClientRegistry $clientRegistry,
-        private readonly RouterInterface $router,
+        RouterInterface $router,
         private readonly EntityManagerInterface $entityManager,
         private readonly UserManager $userManager,
         private readonly Slugger $slugger,
         private readonly SettingsManager $settingsManager,
     ) {
+        parent::__construct($router);
     }
 
     public function supports(Request $request): ?bool
@@ -97,31 +93,5 @@ class GithubAuthenticator extends OAuth2Authenticator
                 return $user;
             })
         );
-    }
-
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
-    {
-        if ($request->getSession()->get('is_newly_created')) {
-            $targetUrl = $this->router->generate('user_settings_profile');
-            $request->getSession()->remove('is_newly_created');
-        } else {
-            $targetUrl = $this->router->generate('front');
-        }
-
-        return new RedirectResponse($targetUrl);
-    }
-
-    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
-    {
-        $message = strtr($exception->getMessageKey(), $exception->getMessageData());
-
-        if ('MBIN_SSO_REGISTRATIONS_ENABLED' === $message) {
-            $session = $request->getSession();
-            $session->getFlashBag()->add('error', 'sso_registrations_enabled.error');
-
-            return new RedirectResponse($this->router->generate('app_login'));
-        }
-
-        return new Response($message, Response::HTTP_FORBIDDEN);
     }
 }

--- a/src/Security/GoogleAuthenticator.php
+++ b/src/Security/GoogleAuthenticator.php
@@ -16,26 +16,21 @@ use App\Service\UserManager;
 use App\Utils\Slugger;
 use Doctrine\ORM\EntityManagerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
-use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
 use League\OAuth2\Client\Provider\GoogleUser;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 
-class GoogleAuthenticator extends OAuth2Authenticator
+class GoogleAuthenticator extends MbinOAuthAuthenticatorBase
 {
     public function __construct(
         private readonly ClientRegistry $clientRegistry,
-        private readonly RouterInterface $router,
+        RouterInterface $router,
         private readonly EntityManagerInterface $entityManager,
         private readonly UserManager $userManager,
         private readonly ImageManager $imageManager,
@@ -46,6 +41,7 @@ class GoogleAuthenticator extends OAuth2Authenticator
         private readonly Slugger $slugger,
         private readonly SettingsManager $settingsManager,
     ) {
+        parent::__construct($router);
     }
 
     public function supports(Request $request): ?bool
@@ -153,31 +149,5 @@ class GoogleAuthenticator extends OAuth2Authenticator
         }
 
         return $image ?? null;
-    }
-
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
-    {
-        if ($request->getSession()->get('is_newly_created')) {
-            $targetUrl = $this->router->generate('user_settings_profile');
-            $request->getSession()->remove('is_newly_created');
-        } else {
-            $targetUrl = $this->router->generate('front');
-        }
-
-        return new RedirectResponse($targetUrl);
-    }
-
-    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
-    {
-        $message = strtr($exception->getMessageKey(), $exception->getMessageData());
-
-        if ('MBIN_SSO_REGISTRATIONS_ENABLED' === $message) {
-            $session = $request->getSession();
-            $session->getFlashBag()->add('error', 'sso_registrations_enabled.error');
-
-            return new RedirectResponse($this->router->generate('app_login'));
-        }
-
-        return new Response($message, Response::HTTP_FORBIDDEN);
     }
 }

--- a/src/Security/KeycloakAuthenticator.php
+++ b/src/Security/KeycloakAuthenticator.php
@@ -13,25 +13,20 @@ use App\Service\UserManager;
 use App\Utils\Slugger;
 use Doctrine\ORM\EntityManagerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
-use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
 use Stevenmaguire\OAuth2\Client\Provider\KeycloakResourceOwner;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 
-class KeycloakAuthenticator extends OAuth2Authenticator
+class KeycloakAuthenticator extends MbinOAuthAuthenticatorBase
 {
     public function __construct(
         private readonly ClientRegistry $clientRegistry,
-        private readonly RouterInterface $router,
+        RouterInterface $router,
         private readonly EntityManagerInterface $entityManager,
         private readonly UserManager $userManager,
         private readonly IpResolver $ipResolver,
@@ -39,6 +34,7 @@ class KeycloakAuthenticator extends OAuth2Authenticator
         private readonly UserRepository $userRepository,
         private readonly SettingsManager $settingsManager,
     ) {
+        parent::__construct($router);
     }
 
     public function supports(Request $request): ?bool
@@ -116,31 +112,5 @@ class KeycloakAuthenticator extends OAuth2Authenticator
                 $rememberBadge,
             ]
         );
-    }
-
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
-    {
-        if ($request->getSession()->get('is_newly_created')) {
-            $targetUrl = $this->router->generate('user_settings_profile');
-            $request->getSession()->remove('is_newly_created');
-        } else {
-            $targetUrl = $this->router->generate('front');
-        }
-
-        return new RedirectResponse($targetUrl);
-    }
-
-    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
-    {
-        $message = strtr($exception->getMessageKey(), $exception->getMessageData());
-
-        if ('MBIN_SSO_REGISTRATIONS_ENABLED' === $message) {
-            $session = $request->getSession();
-            $session->getFlashBag()->add('error', 'sso_registrations_enabled.error');
-
-            return new RedirectResponse($this->router->generate('app_login'));
-        }
-
-        return new Response($message, Response::HTTP_FORBIDDEN);
     }
 }

--- a/src/Security/MbinOAuthAuthenticatorBase.php
+++ b/src/Security/MbinOAuthAuthenticatorBase.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+abstract class MbinOAuthAuthenticatorBase extends OAuth2Authenticator
+{
+    public function __construct(
+        protected readonly RouterInterface $router,
+    ) {
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        $session = $request->getSession();
+        if ($url = $session->get('_security.main.target_path')) {
+            $targetUrl = $url;
+        } elseif ($session->get('is_newly_created')) {
+            $targetUrl = $this->router->generate('user_settings_profile');
+            $session->remove('is_newly_created');
+        } else {
+            $targetUrl = $this->router->generate('front');
+        }
+
+        return new RedirectResponse($targetUrl);
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        $message = strtr($exception->getMessageKey(), $exception->getMessageData());
+
+        if ('MBIN_SSO_REGISTRATIONS_ENABLED' === $message) {
+            $session = $request->getSession();
+            $session->getFlashBag()->add('error', 'sso_registrations_enabled.error');
+
+            return new RedirectResponse($this->router->generate('app_login'));
+        }
+
+        return new Response($message, Response::HTTP_FORBIDDEN);
+    }
+}

--- a/src/Security/PrivacyPortalAuthenticator.php
+++ b/src/Security/PrivacyPortalAuthenticator.php
@@ -13,24 +13,19 @@ use App\Service\UserManager;
 use App\Utils\Slugger;
 use Doctrine\ORM\EntityManagerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
-use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
 use League\OAuth2\Client\Provider\PrivacyPortalResourceOwner;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 
-class PrivacyPortalAuthenticator extends OAuth2Authenticator
+class PrivacyPortalAuthenticator extends MbinOAuthAuthenticatorBase
 {
     public function __construct(
         private readonly ClientRegistry $clientRegistry,
-        private readonly RouterInterface $router,
+        RouterInterface $router,
         private readonly EntityManagerInterface $entityManager,
         private readonly UserManager $userManager,
         private readonly SettingsManager $settingsManager,
@@ -38,6 +33,7 @@ class PrivacyPortalAuthenticator extends OAuth2Authenticator
         private readonly IpResolver $ipResolver,
         private readonly Slugger $slugger,
     ) {
+        parent::__construct($router);
     }
 
     public function supports(Request $request): ?bool
@@ -105,24 +101,5 @@ class PrivacyPortalAuthenticator extends OAuth2Authenticator
                 return $user;
             })
         );
-    }
-
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
-    {
-        if ($request->getSession()->get('is_newly_created')) {
-            $targetUrl = $this->router->generate('user_settings_profile');
-            $request->getSession()->remove('is_newly_created');
-        } else {
-            $targetUrl = $this->router->generate('front');
-        }
-
-        return new RedirectResponse($targetUrl);
-    }
-
-    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
-    {
-        $message = strtr($exception->getMessageKey(), $exception->getMessageData());
-
-        return new Response($message, Response::HTTP_FORBIDDEN);
     }
 }

--- a/src/Security/SimpleLoginAuthenticator.php
+++ b/src/Security/SimpleLoginAuthenticator.php
@@ -18,24 +18,19 @@ use App\Service\UserManager;
 use App\Utils\Slugger;
 use Doctrine\ORM\EntityManagerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
-use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 
-class SimpleLoginAuthenticator extends OAuth2Authenticator
+class SimpleLoginAuthenticator extends MbinOAuthAuthenticatorBase
 {
     public function __construct(
         private readonly ClientRegistry $clientRegistry,
-        private readonly RouterInterface $router,
+        RouterInterface $router,
         private readonly EntityManagerInterface $entityManager,
         private readonly UserManager $userManager,
         private readonly ImageManager $imageManager,
@@ -46,6 +41,7 @@ class SimpleLoginAuthenticator extends OAuth2Authenticator
         private readonly UserRepository $userRepository,
         private readonly SettingsManager $settingsManager,
     ) {
+        parent::__construct($router);
     }
 
     public function supports(Request $request): ?bool
@@ -161,31 +157,5 @@ class SimpleLoginAuthenticator extends OAuth2Authenticator
         }
 
         return $image ?? null;
-    }
-
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
-    {
-        if ($request->getSession()->get('is_newly_created')) {
-            $targetUrl = $this->router->generate('user_settings_profile');
-            $request->getSession()->remove('is_newly_created');
-        } else {
-            $targetUrl = $this->router->generate('front');
-        }
-
-        return new RedirectResponse($targetUrl);
-    }
-
-    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
-    {
-        $message = strtr($exception->getMessageKey(), $exception->getMessageData());
-
-        if ('MBIN_SSO_REGISTRATIONS_ENABLED' === $message) {
-            $session = $request->getSession();
-            $session->getFlashBag()->add('error', 'sso_registrations_enabled.error');
-
-            return new RedirectResponse($this->router->generate('app_login'));
-        }
-
-        return new Response($message, Response::HTTP_FORBIDDEN);
     }
 }

--- a/src/Security/ZitadelAuthenticator.php
+++ b/src/Security/ZitadelAuthenticator.php
@@ -18,24 +18,19 @@ use App\Service\UserManager;
 use App\Utils\Slugger;
 use Doctrine\ORM\EntityManagerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
-use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 
-class ZitadelAuthenticator extends OAuth2Authenticator
+class ZitadelAuthenticator extends MbinOAuthAuthenticatorBase
 {
     public function __construct(
         private readonly ClientRegistry $clientRegistry,
-        private readonly RouterInterface $router,
+        RouterInterface $router,
         private readonly EntityManagerInterface $entityManager,
         private readonly UserManager $userManager,
         private readonly ImageManager $imageManager,
@@ -46,6 +41,7 @@ class ZitadelAuthenticator extends OAuth2Authenticator
         private readonly UserRepository $userRepository,
         private readonly SettingsManager $settingsManager,
     ) {
+        parent::__construct($router);
     }
 
     public function supports(Request $request): ?bool
@@ -154,31 +150,5 @@ class ZitadelAuthenticator extends OAuth2Authenticator
         }
 
         return $image ?? null;
-    }
-
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
-    {
-        if ($request->getSession()->get('is_newly_created')) {
-            $targetUrl = $this->router->generate('user_settings_profile');
-            $request->getSession()->remove('is_newly_created');
-        } else {
-            $targetUrl = $this->router->generate('front');
-        }
-
-        return new RedirectResponse($targetUrl);
-    }
-
-    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
-    {
-        $message = strtr($exception->getMessageKey(), $exception->getMessageData());
-
-        if ('MBIN_SSO_REGISTRATIONS_ENABLED' === $message) {
-            $session = $request->getSession();
-            $session->getFlashBag()->add('error', 'sso_registrations_enabled.error');
-
-            return new RedirectResponse($this->router->generate('app_login'));
-        }
-
-        return new Response($message, Response::HTTP_FORBIDDEN);
     }
 }


### PR DESCRIPTION
- When an OAuth app requests a login and the user wants to login via SSO it will now properly redirect to the authorize URL
- Refactor the SSO authenticators a bit, so more code is shared

Fixes #1627