### PR TITLE
Expose instance admins and moderators

### DIFF
--- a/config/mbin_routes/user_api.yaml
+++ b/config/mbin_routes/user_api.yaml
@@ -4,6 +4,18 @@ api_users_collection:
   methods: [ GET ]
   format: json
 
+api_admins_collection:
+  controller: App\Controller\Api\User\UserRetrieveApi::admins
+  path: /api/users/admins
+  methods: [ GET ]
+  format: json
+
+api_moderators_collection:
+    controller: App\Controller\Api\User\UserRetrieveApi::moderators
+    path: /api/users/moderators
+    methods: [ GET ]
+    format: json
+
 api_user_blocked:
   controller: App\Controller\Api\User\UserRetrieveApi::blocked
   path: /api/users/blocked

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -129,6 +129,8 @@ security:
         - { path: ^/api/federated, roles: PUBLIC_ACCESS }
         - { path: ^/api/defederated, roles: PUBLIC_ACCESS }
         - { path: ^/api/dead, roles: PUBLIC_ACCESS }
+        - { path: ^/api/users/admins, role: PUBLIC_ACCESS }
+        - { path: ^/api/users/moderators, role: PUBLIC_ACCESS }
         - { path: ^/, roles: PUBLIC_ACCESS_UNLESS_PRIVATE_INSTANCE }
 
     role_hierarchy:

--- a/src/Controller/Api/User/UserRetrieveApi.php
+++ b/src/Controller/Api/User/UserRetrieveApi.php
@@ -765,4 +765,106 @@ class UserRetrieveApi extends UserBaseApi
             headers: $headers
         );
     }
+
+    #[OA\Response(
+        response: 200,
+        description: 'Returns all instance admins',
+        headers: [
+            new OA\Header(header: 'X-RateLimit-Remaining', description: 'Number of requests left until you will be rate limited', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Retry-After', description: 'Unix timestamp to retry the request after', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Limit', description: 'Number of requests available', schema: new OA\Schema(type: 'integer')),
+        ],
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'items', type: 'array', items: new OA\Items(ref: new Model(type: UserResponseDto::class))),
+                new OA\Property(property: 'pagination', ref: new Model(type: PaginationSchema::class)),
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'Permission denied due to missing or expired token',
+        content: new OA\JsonContent(ref: new Model(type: \App\Schema\Errors\UnauthorizedErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 429,
+        description: 'You are being rate limited',
+        headers: [
+            new OA\Header(header: 'X-RateLimit-Remaining', description: 'Number of requests left until you will be rate limited', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Retry-After', description: 'Unix timestamp to retry the request after', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Limit', description: 'Number of requests available', schema: new OA\Schema(type: 'integer')),
+        ],
+        content: new OA\JsonContent(ref: new Model(type: \App\Schema\Errors\TooManyRequestsErrorSchema::class))
+    )]
+    #[OA\Tag(name: 'instance')]
+    public function admins(
+        UserRepository $repository,
+        UserFactory $factory,
+        RateLimiterFactory $apiReadLimiter,
+        RateLimiterFactory $anonymousApiReadLimiter,
+    ): JsonResponse {
+        $headers = $this->rateLimit($apiReadLimiter, $anonymousApiReadLimiter);
+
+        $users = $repository->findAllAdmins();
+
+        $dtos = [];
+        foreach ($users as $value) {
+            \assert($value instanceof User);
+            $dtos[] = $this->serializeUser($factory->createDto($value));
+        }
+
+        return new JsonResponse(['items' => $dtos], headers: $headers);
+    }
+
+    #[OA\Response(
+        response: 200,
+        description: 'Returns all instance moderators',
+        headers: [
+            new OA\Header(header: 'X-RateLimit-Remaining', description: 'Number of requests left until you will be rate limited', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Retry-After', description: 'Unix timestamp to retry the request after', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Limit', description: 'Number of requests available', schema: new OA\Schema(type: 'integer')),
+        ],
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'items', type: 'array', items: new OA\Items(ref: new Model(type: UserResponseDto::class))),
+                new OA\Property(property: 'pagination', ref: new Model(type: PaginationSchema::class)),
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'Permission denied due to missing or expired token',
+        content: new OA\JsonContent(ref: new Model(type: \App\Schema\Errors\UnauthorizedErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 429,
+        description: 'You are being rate limited',
+        headers: [
+            new OA\Header(header: 'X-RateLimit-Remaining', description: 'Number of requests left until you will be rate limited', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Retry-After', description: 'Unix timestamp to retry the request after', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Limit', description: 'Number of requests available', schema: new OA\Schema(type: 'integer')),
+        ],
+        content: new OA\JsonContent(ref: new Model(type: \App\Schema\Errors\TooManyRequestsErrorSchema::class))
+    )]
+    #[OA\Tag(name: 'instance')]
+    public function moderators(
+        UserRepository $repository,
+        UserFactory $factory,
+        RateLimiterFactory $apiReadLimiter,
+        RateLimiterFactory $anonymousApiReadLimiter,
+    ): JsonResponse {
+        $headers = $this->rateLimit($apiReadLimiter, $anonymousApiReadLimiter);
+
+        $users = $repository->findAllModerators();
+
+        $dtos = [];
+        foreach ($users as $value) {
+            \assert($value instanceof User);
+            $dtos[] = $this->serializeUser($factory->createDto($value));
+        }
+
+        return new JsonResponse(['items' => $dtos], headers: $headers);
+    }
 }

--- a/tests/FactoryTrait.php
+++ b/tests/FactoryTrait.php
@@ -219,7 +219,7 @@ trait FactoryTrait
         ];
     }
 
-    protected function getUserByUsername(string $username, bool $isAdmin = false, bool $hideAdult = true, ?string $about = null, bool $active = true): User
+    protected function getUserByUsername(string $username, bool $isAdmin = false, bool $hideAdult = true, ?string $about = null, bool $active = true, bool $isModerator = false): User
     {
         $user = $this->users->filter(fn (User $user) => $user->getUsername() === $username)->first();
 
@@ -231,6 +231,8 @@ trait FactoryTrait
 
         if ($isAdmin) {
             $user->roles = ['ROLE_ADMIN'];
+        } elseif ($isModerator) {
+            $user->roles = ['ROLE_MODERATOR'];
         }
 
         $this->entityManager->persist($user);

--- a/tests/Functional/Controller/Api/Instance/InstanceRetrieveInfoApiTest.php
+++ b/tests/Functional/Controller/Api/Instance/InstanceRetrieveInfoApiTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Controller\Api\Instance;
+
+use App\Tests\WebTestCase;
+
+class InstanceRetrieveInfoApiTest extends WebTestCase
+{
+    public const INFO_KEYS = [
+        'softwareName',
+        'softwareVersion',
+        'softwareRepository',
+        'websiteDomain',
+        'websiteContactEmail',
+        'websiteTitle',
+        'websiteOpenRegistrations',
+        'websiteFederationEnabled',
+        'websiteDefaultLang',
+        'instanceModerators',
+        'instanceAdmins',
+    ];
+
+    public const AP_USER_DEFAULT_KEYS = [
+        'id',
+        'type',
+        'name',
+        'preferredUsername',
+        'inbox',
+        'outbox',
+        'url',
+        'manuallyApprovesFollowers',
+        'published',
+        'following',
+        'followers',
+        'publicKey',
+        'endpoints',
+        'icon',
+    ];
+
+    public function testCanRetrieveInfoAnonymous(): void
+    {
+        $this->getUserByUsername('admin', isAdmin: true);
+        $this->getUserByUsername('moderator', isModerator: true);
+        $this->client->request('GET', '/api/info');
+
+        self::assertResponseIsSuccessful();
+
+        $jsonData = self::getJsonResponse($this->client);
+        self::assertArrayKeysMatch(self::INFO_KEYS, $jsonData);
+        self::assertIsString($jsonData['softwareName']);
+        self::assertIsString($jsonData['softwareVersion']);
+        self::assertIsString($jsonData['softwareRepository']);
+        self::assertIsString($jsonData['websiteDomain']);
+        self::assertIsString($jsonData['websiteContactEmail']);
+        self::assertIsString($jsonData['websiteTitle']);
+        self::assertIsBool($jsonData['websiteOpenRegistrations']);
+        self::assertIsBool($jsonData['websiteFederationEnabled']);
+        self::assertIsString($jsonData['websiteDefaultLang']);
+        self::assertIsArray($jsonData['instanceAdmins']);
+        self::assertIsArray($jsonData['instanceModerators']);
+        self::assertNotEmpty($jsonData['instanceAdmins']);
+        self::assertNotEmpty($jsonData['instanceModerators']);
+        self::assertArrayKeysMatch(self::AP_USER_DEFAULT_KEYS, $jsonData['instanceAdmins'][0]);
+        self::assertArrayKeysMatch(self::AP_USER_DEFAULT_KEYS, $jsonData['instanceModerators'][0]);
+    }
+}

--- a/tests/Functional/Controller/Api/User/UserRetrieveApiTest.php
+++ b/tests/Functional/Controller/Api/User/UserRetrieveApiTest.php
@@ -61,6 +61,40 @@ class UserRetrieveApiTest extends WebTestCase
         self::assertSame(self::NUM_USERS, \count($jsonData['items']));
     }
 
+    public function testApiCanRetrieveAdminsAnonymous(): void
+    {
+        $users = [];
+        for ($i = 0; $i < self::NUM_USERS; ++$i) {
+            $users[] = $this->getUserByUsername('admin'.(string) ($i + 1), isAdmin: true);
+        }
+
+        $this->client->request('GET', '/api/users/admins');
+        self::assertResponseIsSuccessful();
+
+        $jsonData = self::getJsonResponse($this->client);
+
+        self::assertIsArray($jsonData);
+        self::assertIsArray($jsonData['items']);
+        self::assertSame(self::NUM_USERS, \count($jsonData['items']));
+    }
+
+    public function testApiCanRetrieveModeratorsAnonymous(): void
+    {
+        $users = [];
+        for ($i = 0; $i < self::NUM_USERS; ++$i) {
+            $users[] = $this->getUserByUsername('moderator'.(string) ($i + 1), isModerator: true);
+        }
+
+        $this->client->request('GET', '/api/users/moderators');
+        self::assertResponseIsSuccessful();
+
+        $jsonData = self::getJsonResponse($this->client);
+
+        self::assertIsArray($jsonData);
+        self::assertIsArray($jsonData['items']);
+        self::assertSame(self::NUM_USERS, \count($jsonData['items']));
+    }
+
     public function testApiCanRetrieveUsersWithAbout(): void
     {
         self::createOAuth2AuthCodeClient();


### PR DESCRIPTION
- add instance admins and moderators in their ActivityPub representation to the `/api/info` endpoint
- add a new endpoint to retrieve all instance admins
- add a new endpoint to retrieve all instance moderators

Closes #1589
