### PR TITLE
Improve entry editing

### DIFF
--- a/src/DTO/EntryDto.php
+++ b/src/DTO/EntryDto.php
@@ -62,11 +62,14 @@ class EntryDto implements ContentVisibilityInterface
         $payload,
     ) {
         if (empty($this->image)) {
-            $image = Request::createFromGlobals()->files->filter('entry_image');
-            if (\is_array($image)) {
-                $image = $image['image'];
-            } else {
-                $image = $context->getValue()->image;
+            $keys = ['entry_image', 'entry_edit'];
+            for ($i = 0; $i < \sizeof($keys) && empty($image); ++$i) {
+                $image = Request::createFromGlobals()->files->filter($keys[$i]);
+                if (\is_array($image)) {
+                    $image = $image['image'];
+                } else {
+                    $image = $context->getValue()->image;
+                }
             }
         } else {
             $image = $this->image;
@@ -81,7 +84,7 @@ class EntryDto implements ContentVisibilityInterface
 
     private function buildViolation(ExecutionContextInterface $context, $path)
     {
-        $context->buildViolation('This value should not be blank.')
+        $context->buildViolation('One of these values should not be blank.')
             ->atPath($path)
             ->addViolation();
     }

--- a/src/Service/EntryManager.php
+++ b/src/Service/EntryManager.php
@@ -194,8 +194,10 @@ class EntryManager implements ContentManagerInterface
         $entry->slug = $this->slugger->slug($dto->title);
         $entry->visibility = $dto->visibility;
         $oldImage = $entry->image;
-        if ($dto->image) {
-            $entry->image = $this->imageRepository->find($dto->image->id);
+        $entry->image = $dto->image ? $this->imageRepository->find($dto->image->id) : null;
+        $this->logger->debug('setting image to {imageId}, dto was {dtoImageId}', ['imageId' => $entry->image?->getId() ?? 'none', 'dtoImageId' => $dto->image?->id ?? 'none']);
+        if ($entry->image && !$entry->image->altText) {
+            $entry->image->altText = $dto->imageAlt;
         }
         $this->tagManager->updateEntryTags($entry, $this->tagManager->getTagsFromEntryDto($dto));
 

--- a/templates/entry/_form_edit.html.twig
+++ b/templates/entry/_form_edit.html.twig
@@ -10,6 +10,7 @@
             </div>
         {% endset %}
         {{ form_label(form.url, label, {'label_html': true}) }}
+        {{ form_errors(form.url) }}
         {{ form_widget(form.url, {attr: {'data-action': 'entry-link-create#fetchLink', 'data-entry-link-create-target': 'url'}}) }}
     </div>
 


### PR DESCRIPTION
- After removing an image from an entry and then re-adding an image with alt-text the alt-text will now get saved
- Form errors on the URL field will now be displayed
- Editing an entry not having a URL or body, just an image, will now work properly

Fixes #1579