### PR TITLE
Fix template error on figure

### DIFF
--- a/templates/components/_figure_entry.html.twig
+++ b/templates/components/_figure_entry.html.twig
@@ -36,7 +36,7 @@
         {% endif %}
         <a href="{{ route }}"
            class="{{ html_classes('sensitive-checked--show', {'thumb': is_single_image or LIST_LIGHTBOX is same as V_TRUE}) }}"
-           rel="{{ (type is same as 'link') ? get_rel(route) : '' }}"
+           rel="{{ (type is same as 'link') and route is not same as null ? get_rel(route) : '' }}"
            data-gallery="entry-{{ entry.id }}"
            data-description="{{ is_single_image and image.altText ? '.'~lightbox_alt_id : '' }}">
             <img class="thumb-subject"


### PR DESCRIPTION
Fix "LinkExtensionRuntime::getRel(): Argument #1 ($url) must be of type string, null given"

```json
{
    "message": "Uncaught PHP Exception Twig\\Error\\RuntimeError: \"An exception has been thrown during the rendering of a template (\"App\\Twig\\Runtime\\LinkExtensionRuntime::getRel(): Argument #1 ($url) must be of type string, null given, called in /var/www/kbin/var/cache/prod/twig/b1/b19a01a9a35befa0b64192f6bcd4bc0f.php on line 142\").\" at _figure_entry.html.twig line 39",
    "context": {
        "exception": {
            "class": "Twig\\Error\\RuntimeError",
            "message": "An exception has been thrown during the rendering of a template (\"App\\Twig\\Runtime\\LinkExtensionRuntime::getRel(): Argument #1 ($url) must be of type string, null given, called in /var/www/kbin/var/cache/prod/twig/b1/b19a01a9a35befa0b64192f6bcd4bc0f.php on line 142\").",
            "code": 0,
            "file": "/var/www/kbin/templates/components/_figure_entry.html.twig:39",
            "previous": {
                "class": "TypeError",
                "message": "App\\Twig\\Runtime\\LinkExtensionRuntime::getRel(): Argument #1 ($url) must be of type string, null given, called in /var/www/kbin/var/cache/prod/twig/b1/b19a01a9a35befa0b64192f6bcd4bc0f.php on line 142",
                "code": 0,
                "file": "/var/www/kbin/src/Twig/Runtime/LinkExtensionRuntime.php:20"
            }
        }
    },
    "level": 500,
    "level_name": "CRITICAL",
    "channel": "request",
    "datetime": "2025-07-02T07:17:27.155290+00:00",
    "extra": {}
}
```