### PR TITLE
Fix reading the wrong `magazine` property

### DIFF
--- a/src/Service/EntryCommentManager.php
+++ b/src/Service/EntryCommentManager.php
@@ -71,7 +71,7 @@ class EntryCommentManager implements ContentManagerInterface
             throw new TagBannedException();
         }
 
-        if (null !== $dto->magazine->apId && $this->settingsManager->isBannedInstance($dto->magazine->apInboxUrl)) {
+        if (null !== $dto->entry->magazine->apId && $this->settingsManager->isBannedInstance($dto->entry->magazine->apInboxUrl)) {
             throw new InstanceBannedException();
         }
 


### PR DESCRIPTION
`$dto->magazine` seems to be null relatively often, so switch to the already used `$dto->entry->magazine` 

Fixes this error:
>ERROR: php: Warning: Attempt to read property "apId" on null

Introduced in #1636