### PR TITLE
Fix reading the wrong magazine property II

### DIFF
--- a/src/Service/PostCommentManager.php
+++ b/src/Service/PostCommentManager.php
@@ -71,7 +71,7 @@ class PostCommentManager implements ContentManagerInterface
             throw new TagBannedException();
         }
 
-        if (null !== $dto->magazine->apId && $this->settingsManager->isBannedInstance($dto->magazine->apInboxUrl)) {
+        if (null !== $dto->post->magazine->apId && $this->settingsManager->isBannedInstance($dto->post->magazine->apInboxUrl)) {
             throw new InstanceBannedException();
         }
 


### PR DESCRIPTION
$dto->magazine seems to be null relatively often, so switch to the already used $dto->post->magazine

Fixes this error:
> ERROR: php: Warning: Attempt to read property "apId" on null

Introduced in #1636

Same as #1666 but for post comments