### PR TITLE
Add header bread crumb for mobile

### DIFF
--- a/assets/styles/components/_header.scss
+++ b/assets/styles/components/_header.scss
@@ -329,6 +329,10 @@
       li a.active {
         background: var(--kbin-header-link-active-bg);
       }
+
+      &__mobile-menu {
+        display: none;
+      }
     }
   }
 }

--- a/templates/layout/_header.html.twig
+++ b/templates/layout/_header.html.twig
@@ -26,6 +26,11 @@
                 </li>
                 {% include 'layout/_header_nav.html.twig' %}
             </menu>
+            <menu class="head-nav__mobile-menu">
+                <li>
+                    {% include 'layout/_header_bread.html.twig' %}
+                </li>
+            </menu>
         </nav>
         <menu>
             <li>


### PR DESCRIPTION
Exactly what the title says, just add the already existing header bread crumb for mobile
![grafik](https://github.com/user-attachments/assets/a4d5c974-27c0-43d9-a2a4-19007411e8a8)
