### PR TITLE
Fix the if statement for $content variable in ApHttpClient.php

### DIFF
--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -394,7 +394,7 @@ class ApHttpClient implements ApHttpClientInterface
             'body' => substr($requestBody ?? 'No body provided', 0, 200),
         ]);
         // And only log the full content in debug log mode
-        if ($content) {
+        if (isset($content)) {
             $this->logger->debug('[ApHttpClient::logRequestException] Full response body content: {content}', [
                 'content' => $content,
             ]);


### PR DESCRIPTION
Fixing log pollution with incorrect checking on the `$content` variable, causing errors in the log like this:

```json
{"message":"Warning: Undefined variable $content","context":{"exception":{"class":"ErrorException","message":"Warning: Undefined variable $content","code":0,"file":"/var/www/kbin.melroy.org/html/src/Service/ActivityPub/ApHttpClient.php:397"}},"level":400,"level_name":"ERROR","channel":"php","datetime":"2025-07-16T20:19:35.057663+00:00","extra":{}}
```

This PR should solve that by using `isset()`