### PR TITLE
Fix DeleteHandler and add tests

### DIFF
--- a/src/EventSubscriber/PostComment/PostCommentDeleteSubscriber.php
+++ b/src/EventSubscriber/PostComment/PostCommentDeleteSubscriber.php
@@ -9,10 +9,8 @@ use App\Entity\User;
 use App\Event\PostComment\PostCommentBeforeDeletedEvent;
 use App\Event\PostComment\PostCommentBeforePurgeEvent;
 use App\Event\PostComment\PostCommentDeletedEvent;
-use App\Message\ActivityPub\Outbox\DeleteMessage;
 use App\Message\Notification\PostCommentDeletedNotificationMessage;
-use App\Service\ActivityPub\ActivityJsonBuilder;
-use App\Service\ActivityPub\Wrapper\DeleteWrapper;
+use App\Service\ActivityPub\DeleteService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Contracts\Cache\CacheInterface;
@@ -22,8 +20,7 @@ class PostCommentDeleteSubscriber implements EventSubscriberInterface
     public function __construct(
         private readonly CacheInterface $cache,
         private readonly MessageBusInterface $bus,
-        private readonly DeleteWrapper $deleteWrapper,
-        private readonly ActivityJsonBuilder $activityJsonBuilder,
+        private readonly DeleteService $deleteService,
     ) {
     }
 
@@ -64,11 +61,6 @@ class PostCommentDeleteSubscriber implements EventSubscriberInterface
         ]);
 
         $this->bus->dispatch(new PostCommentDeletedNotificationMessage($comment->getId()));
-
-        if (!$comment->apId || !$comment->magazine->apId || (null !== $user && $comment->magazine->userIsModerator($user))) {
-            $activity = $this->deleteWrapper->adjustDeletePayload($user, $comment);
-            $payload = $this->activityJsonBuilder->buildActivityJson($activity);
-            $this->bus->dispatch(new DeleteMessage($payload, $comment->user->getId(), $comment->magazine->getId()));
-        }
+        $this->deleteService->announceIfNecessary($user, $comment);
     }
 }

--- a/src/MessageHandler/ActivityPub/Inbox/DeleteHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/DeleteHandler.php
@@ -13,6 +13,7 @@ use App\Message\ActivityPub\Inbox\DeleteMessage;
 use App\Message\Contracts\MessageInterface;
 use App\Message\DeleteUserMessage;
 use App\MessageHandler\MbinMessageHandler;
+use App\Repository\ActivityRepository;
 use App\Repository\ApActivityRepository;
 use App\Repository\UserRepository;
 use App\Service\ActivityPubManager;
@@ -39,6 +40,7 @@ class DeleteHandler extends MbinMessageHandler
         private readonly EntryCommentManager $entryCommentManager,
         private readonly PostManager $postManager,
         private readonly PostCommentManager $postCommentManager,
+        private readonly ActivityRepository $activityRepository,
     ) {
         parent::__construct($this->entityManager, $this->kernel);
     }
@@ -75,6 +77,13 @@ class DeleteHandler extends MbinMessageHandler
         }
 
         $entity = $this->entityManager->getRepository($object['type'])->find((int) $object['id']);
+
+        if ($entity instanceof Entry || $entity instanceof EntryComment || $entity instanceof Post || $entity instanceof PostComment) {
+            if (!$entity->magazine->apId || ($actor->apId && !$entity->user->apId)) {
+                // local magazine or remote actor for a local users content -> need to announce it later
+                $this->activityRepository->createForRemoteActivity($message->payload, $entity);
+            }
+        }
 
         if ($entity instanceof Entry) {
             $this->deleteEntry($entity, $actor);

--- a/src/Service/ActivityPub/DeleteService.php
+++ b/src/Service/ActivityPub/DeleteService.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\ActivityPub;
+
+use App\Entity\Entry;
+use App\Entity\EntryComment;
+use App\Entity\Post;
+use App\Entity\PostComment;
+use App\Entity\User;
+use App\Message\ActivityPub\Outbox\DeleteMessage;
+use App\Repository\ActivityRepository;
+use App\Service\ActivityPub\Wrapper\AnnounceWrapper;
+use App\Service\ActivityPub\Wrapper\DeleteWrapper;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class DeleteService
+{
+    public function __construct(
+        private readonly MessageBusInterface $bus,
+        private readonly AnnounceWrapper $announceWrapper,
+        private readonly DeleteWrapper $deleteWrapper,
+        private readonly ActivityJsonBuilder $activityJsonBuilder,
+        private readonly ActivityRepository $activityRepository,
+    ) {
+    }
+
+    public function announceIfNecessary(?User $deletingUser, Entry|EntryComment|Post|PostComment $content): void
+    {
+        if (null !== $deletingUser && (!$content->apId || !$content->magazine->apId || !$deletingUser->apId) && ($content->magazine->userIsModerator($deletingUser) || $content->magazine->hasSameHostAsUser($deletingUser))) {
+            if ($deletingUser->apId) {
+                $deleteActivity = $this->activityRepository->findFirstActivitiesByTypeAndObject('Delete', $content);
+                if (!$deleteActivity) {
+                    throw new \Exception('Cannot announce an activity that is not in the DB');
+                }
+                if (!$content->apId) {
+                    // local content, but remote actor ->
+                    // this activity should be just forwarded to the inbox of the accounts following the author,
+                    // but we do not have anything for that, yet, so instead we just announce it as the user
+                    $activity = $this->announceWrapper->build($content->user, $deleteActivity);
+                } elseif (!$content->magazine->apId) {
+                    // local magazine, but remote actor -> announce
+                    $activity = $this->announceWrapper->build($content->magazine, $deleteActivity);
+                }
+            } else {
+                $activity = $this->deleteWrapper->build($content, $deletingUser);
+            }
+            $payload = $this->activityJsonBuilder->buildActivityJson($activity);
+            $this->bus->dispatch(new DeleteMessage($payload, $content->user->getId(), $content->magazine->getId()));
+        }
+    }
+}

--- a/src/Service/ActivityPub/Wrapper/DeleteWrapper.php
+++ b/src/Service/ActivityPub/Wrapper/DeleteWrapper.php
@@ -12,6 +12,7 @@ use App\Entity\Post;
 use App\Entity\PostComment;
 use App\Entity\User;
 use App\Factory\ActivityPub\ActivityFactory;
+use App\Service\ActivityPub\ActivityJsonBuilder;
 use App\Service\ActivityPub\ContextsProvider;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -24,6 +25,7 @@ class DeleteWrapper
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly EntityManagerInterface $entityManager,
         private readonly ContextsProvider $contextsProvider,
+        private readonly ActivityJsonBuilder $activityJsonBuilder,
     ) {
     }
 
@@ -98,7 +100,8 @@ class DeleteWrapper
         }
 
         if (null !== $actor?->apId) {
-            $json = $this->announceWrapper->build($content->magazine, $payload);
+            $announceActivity = $this->announceWrapper->build($content->magazine, $payload);
+            $json = $this->activityJsonBuilder->buildActivityJson($announceActivity);
         }
 
         $payload->activityJson = json_encode($json);

--- a/tests/Functional/ActivityPub/Inbox/DeleteHandlerTest.php
+++ b/tests/Functional/ActivityPub/Inbox/DeleteHandlerTest.php
@@ -1,0 +1,426 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\ActivityPub\Inbox;
+
+use App\DTO\ModeratorDto;
+use App\Entity\Entry;
+use App\Entity\EntryComment;
+use App\Entity\Magazine;
+use App\Entity\Post;
+use App\Entity\PostComment;
+use App\Entity\User;
+use App\Message\ActivityPub\Inbox\ActivityMessage;
+use App\Tests\Functional\ActivityPub\ActivityPubFunctionalTestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+use function PHPUnit\Framework\assertNotNull;
+
+#[Group(name: 'ActivityPub')]
+#[Group(name: 'NonThreadSafe')]
+class DeleteHandlerTest extends ActivityPubFunctionalTestCase
+{
+    private array $createRemoteEntryInLocalMagazine;
+    private array $deleteRemoteEntryByRemoteModeratorInLocalMagazine;
+    private array $createRemoteEntryInRemoteMagazine;
+    private array $deleteRemoteEntryByRemoteModeratorInRemoteMagazine;
+    private array $createRemoteEntryCommentInLocalMagazine;
+    private array $deleteRemoteEntryCommentByRemoteModeratorInLocalMagazine;
+    private array $createRemoteEntryCommentInRemoteMagazine;
+    private array $deleteRemoteEntryCommentByRemoteModeratorInRemoteMagazine;
+    private array $createRemotePostInLocalMagazine;
+    private array $deleteRemotePostByRemoteModeratorInLocalMagazine;
+    private array $createRemotePostInRemoteMagazine;
+    private array $deleteRemotePostByRemoteModeratorInRemoteMagazine;
+    private array $createRemotePostCommentInLocalMagazine;
+    private array $deleteRemotePostCommentByRemoteModeratorInLocalMagazine;
+    private array $createRemotePostCommentInRemoteMagazine;
+    private array $deleteRemotePostCommentByRemoteModeratorInRemoteMagazine;
+
+    private User $remotePoster;
+
+    public function testDeleteLocalEntryInLocalMagazineByRemoteModerator(): void
+    {
+        $obj = $this->createLocalEntryAndCreateDeleteActivity($this->localMagazine, $this->localUser, $this->remoteUser);
+        $activity = $obj['activity'];
+        $entry = $obj['content'];
+        $this->bus->dispatch(new ActivityMessage(json_encode($activity)));
+        $this->entityManager->refresh($entry);
+        self::assertTrue($entry->isTrashed());
+        $this->assertOneSentAnnouncedActivityOfType('Delete', $activity['id']);
+    }
+
+    public function testDeleteLocalEntryInRemoteMagazineByRemoteModerator(): void
+    {
+        $obj = $this->createLocalEntryAndCreateDeleteActivity($this->remoteMagazine, $this->localUser, $this->remoteUser);
+        $activity = $obj['activity'];
+        $entry = $obj['content'];
+        $this->bus->dispatch(new ActivityMessage(json_encode($activity)));
+        $this->entityManager->refresh($entry);
+        self::assertTrue($entry->isTrashed());
+        $this->assertCountOfSentActivitiesOfType(0, 'Delete');
+        $this->assertOneSentAnnouncedActivityOfType('Delete', $activity['id']);
+    }
+
+    public function testDeleteRemoteEntryInLocalMagazineByRemoteModerator(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemoteEntryInLocalMagazine)));
+        $entryApId = $this->createRemoteEntryInLocalMagazine['object']['id'];
+        $entry = $this->entryRepository->findOneBy(['apId' => $entryApId]);
+        self::assertNotNull($entry);
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->deleteRemoteEntryByRemoteModeratorInLocalMagazine)));
+        $entry = $this->entryRepository->findOneBy(['apId' => $entryApId]);
+        self::assertTrue($entry->isTrashed());
+        $this->assertOneSentAnnouncedActivityOfType('Delete', $this->deleteRemoteEntryByRemoteModeratorInLocalMagazine['id']);
+    }
+
+    public function testDeleteRemoteEntryInRemoteMagazineByRemoteModerator(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemoteEntryInRemoteMagazine)));
+        $entryApId = $this->createRemoteEntryInRemoteMagazine['object']['object']['id'];
+        $entry = $this->entryRepository->findOneBy(['apId' => $entryApId]);
+        self::assertNotNull($entry);
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->deleteRemoteEntryByRemoteModeratorInRemoteMagazine)));
+        $entry = $this->entryRepository->findOneBy(['apId' => $entryApId]);
+        self::assertTrue($entry->isTrashed());
+        $this->assertCountOfSentActivitiesOfType(0, 'Delete');
+        $this->assertCountOfSentActivitiesOfType(0, 'Announce');
+        $deleteActivities = $this->activityRepository->findBy(['type' => 'Delete']);
+        self::assertEmpty($deleteActivities);
+    }
+
+    public function testDeleteLocalEntryCommentInLocalMagazineByRemoteModerator(): void
+    {
+        $obj = $this->createLocalEntryCommentAndCreateDeleteActivity($this->localMagazine, $this->localUser, $this->remoteUser);
+        $activity = $obj['activity'];
+        $entryComment = $obj['content'];
+        $this->bus->dispatch(new ActivityMessage(json_encode($activity)));
+        $this->entityManager->refresh($entryComment);
+        self::assertTrue($entryComment->isTrashed());
+        $this->assertOneSentAnnouncedActivityOfType('Delete', $activity['id']);
+    }
+
+    public function testDeleteLocalEntryCommentInRemoteMagazineByRemoteModerator(): void
+    {
+        $obj = $this->createLocalEntryCommentAndCreateDeleteActivity($this->remoteMagazine, $this->localUser, $this->remoteUser);
+        $activity = $obj['activity'];
+        $entryComment = $obj['content'];
+        $this->bus->dispatch(new ActivityMessage(json_encode($activity)));
+        $this->entityManager->refresh($entryComment);
+        self::assertTrue($entryComment->isTrashed());
+        $this->assertCountOfSentActivitiesOfType(0, 'Delete');
+        $this->assertOneSentAnnouncedActivityOfType('Delete', $activity['id']);
+    }
+
+    public function testDeleteRemoteEntryCommentInLocalMagazineByRemoteModerator(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemoteEntryInLocalMagazine)));
+        $entryApId = $this->createRemoteEntryInLocalMagazine['object']['id'];
+        $entry = $this->entryRepository->findOneBy(['apId' => $entryApId]);
+        assertNotNull($entry);
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemoteEntryCommentInLocalMagazine)));
+        $entryCommentApId = $this->createRemoteEntryCommentInLocalMagazine['object']['id'];
+        $entryComment = $this->entryCommentRepository->findOneBy(['apId' => $entryCommentApId]);
+        self::assertNotNull($entryComment);
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->deleteRemoteEntryCommentByRemoteModeratorInLocalMagazine)));
+        $entryComment = $this->entryCommentRepository->findOneBy(['apId' => $entryCommentApId]);
+        self::assertTrue($entryComment->isTrashed());
+        $this->assertOneSentAnnouncedActivityOfType('Delete', $this->deleteRemoteEntryCommentByRemoteModeratorInLocalMagazine['id']);
+    }
+
+    public function testDeleteRemoteEntryCommentInRemoteMagazineByRemoteModerator(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemoteEntryInRemoteMagazine)));
+        $entryApId = $this->createRemoteEntryInRemoteMagazine['object']['object']['id'];
+        $entry = $this->entryRepository->findOneBy(['apId' => $entryApId]);
+        self::assertNotNull($entry);
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemoteEntryCommentInRemoteMagazine)));
+        $entryCommentApId = $this->createRemoteEntryCommentInRemoteMagazine['object']['object']['id'];
+        $entryComment = $this->entryCommentRepository->findOneBy(['apId' => $entryCommentApId]);
+        self::assertNotNull($entryComment);
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->deleteRemoteEntryCommentByRemoteModeratorInRemoteMagazine)));
+        $entryComment = $this->entryCommentRepository->findOneBy(['apId' => $entryCommentApId]);
+        self::assertTrue($entryComment->isTrashed());
+        $this->assertCountOfSentActivitiesOfType(0, 'Delete');
+        $this->assertCountOfSentActivitiesOfType(0, 'Announce');
+        $deleteActivities = $this->activityRepository->findBy(['type' => 'Delete']);
+        self::assertEmpty($deleteActivities);
+    }
+
+    public function testDeleteLocalPostInLocalMagazineByRemoteModerator(): void
+    {
+        $obj = $this->createLocalPostAndCreateDeleteActivity($this->localMagazine, $this->localUser, $this->remoteUser);
+        $activity = $obj['activity'];
+        $post = $obj['content'];
+        $this->bus->dispatch(new ActivityMessage(json_encode($activity)));
+        $this->entityManager->refresh($post);
+        self::assertTrue($post->isTrashed());
+        $this->assertOneSentAnnouncedActivityOfType('Delete', $activity['id']);
+    }
+
+    public function testDeleteLocalPostInRemoteMagazineByRemoteModerator(): void
+    {
+        $obj = $this->createLocalPostAndCreateDeleteActivity($this->remoteMagazine, $this->localUser, $this->remoteUser);
+        $activity = $obj['activity'];
+        $post = $obj['content'];
+        $this->bus->dispatch(new ActivityMessage(json_encode($activity)));
+        $this->entityManager->refresh($post);
+        self::assertTrue($post->isTrashed());
+        $this->assertCountOfSentActivitiesOfType(0, 'Delete');
+        $this->assertOneSentAnnouncedActivityOfType('Delete', $activity['id']);
+    }
+
+    public function testDeleteRemotePostInLocalMagazineByRemoteModerator(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemotePostInLocalMagazine)));
+        $postApId = $this->createRemotePostInLocalMagazine['object']['id'];
+        $post = $this->postRepository->findOneBy(['apId' => $postApId]);
+        self::assertNotNull($post);
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->deleteRemotePostByRemoteModeratorInLocalMagazine)));
+        $post = $this->postRepository->findOneBy(['apId' => $postApId]);
+        self::assertTrue($post->isTrashed());
+        $this->assertOneSentAnnouncedActivityOfType('Delete', $this->deleteRemotePostByRemoteModeratorInLocalMagazine['id']);
+    }
+
+    public function testDeleteRemotePostInRemoteMagazineByRemoteModerator(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemotePostInRemoteMagazine)));
+        $postApId = $this->createRemotePostInRemoteMagazine['object']['object']['id'];
+        $post = $this->postRepository->findOneBy(['apId' => $postApId]);
+        self::assertNotNull($post);
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->deleteRemotePostByRemoteModeratorInRemoteMagazine)));
+        $post = $this->postRepository->findOneBy(['apId' => $postApId]);
+        self::assertTrue($post->isTrashed());
+        $this->assertCountOfSentActivitiesOfType(0, 'Delete');
+        $this->assertCountOfSentActivitiesOfType(0, 'Announce');
+        $deleteActivities = $this->activityRepository->findBy(['type' => 'Delete']);
+        self::assertEmpty($deleteActivities);
+    }
+
+    public function testDeleteLocalPostCommentInLocalMagazineByRemoteModerator(): void
+    {
+        $obj = $this->createLocalPostCommentAndCreateDeleteActivity($this->localMagazine, $this->localUser, $this->remoteUser);
+        $activity = $obj['activity'];
+        $PostComment = $obj['content'];
+        $this->bus->dispatch(new ActivityMessage(json_encode($activity)));
+        $this->entityManager->refresh($PostComment);
+        self::assertTrue($PostComment->isTrashed());
+        $this->assertOneSentAnnouncedActivityOfType('Delete', $activity['id']);
+    }
+
+    public function testDeleteLocalPostCommentInRemoteMagazineByRemoteModerator(): void
+    {
+        $obj = $this->createLocalPostCommentAndCreateDeleteActivity($this->remoteMagazine, $this->localUser, $this->remoteUser);
+        $activity = $obj['activity'];
+        $postComment = $obj['content'];
+        $this->bus->dispatch(new ActivityMessage(json_encode($activity)));
+        $this->entityManager->refresh($postComment);
+        self::assertTrue($postComment->isTrashed());
+        $this->assertCountOfSentActivitiesOfType(0, 'Delete');
+        $this->assertOneSentAnnouncedActivityOfType('Delete', $activity['id']);
+    }
+
+    public function testDeleteRemotePostCommentInLocalMagazineByRemoteModerator(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemotePostInLocalMagazine)));
+        $postApId = $this->createRemotePostInLocalMagazine['object']['id'];
+        $post = $this->postRepository->findOneBy(['apId' => $postApId]);
+        self::assertNotNull($post);
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemotePostCommentInLocalMagazine)));
+        $postCommentApId = $this->createRemotePostCommentInLocalMagazine['object']['id'];
+        $postComment = $this->postCommentRepository->findOneBy(['apId' => $postCommentApId]);
+        self::assertNotNull($postComment);
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->deleteRemotePostCommentByRemoteModeratorInLocalMagazine)));
+        $postComment = $this->postCommentRepository->findOneBy(['apId' => $postCommentApId]);
+        self::assertTrue($postComment->isTrashed());
+        $this->assertOneSentAnnouncedActivityOfType('Delete', $this->deleteRemotePostCommentByRemoteModeratorInLocalMagazine['id']);
+    }
+
+    public function testDeleteRemotePostCommentInRemoteMagazineByRemoteModerator(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemotePostInRemoteMagazine)));
+        $postApId = $this->createRemotePostInRemoteMagazine['object']['object']['id'];
+        $post = $this->postRepository->findOneBy(['apId' => $postApId]);
+        self::assertNotNull($post);
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemotePostCommentInRemoteMagazine)));
+        $postCommentApId = $this->createRemotePostCommentInRemoteMagazine['object']['object']['id'];
+        $postComment = $this->postCommentRepository->findOneBy(['apId' => $postCommentApId]);
+        self::assertNotNull($postComment);
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->deleteRemotePostCommentByRemoteModeratorInRemoteMagazine)));
+        $postComment = $this->postCommentRepository->findOneBy(['apId' => $postCommentApId]);
+        self::assertTrue($postComment->isTrashed());
+        $this->assertCountOfSentActivitiesOfType(0, 'Delete');
+        $this->assertCountOfSentActivitiesOfType(0, 'Announce');
+        $deleteActivities = $this->activityRepository->findBy(['type' => 'Delete']);
+        self::assertEmpty($deleteActivities);
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->magazineManager->addModerator(new ModeratorDto($this->remoteMagazine, $this->remoteUser));
+        $this->magazineManager->addModerator(new ModeratorDto($this->remoteMagazine, $this->localUser));
+        $this->magazineManager->addModerator(new ModeratorDto($this->localMagazine, $this->remoteUser, $this->localMagazine->getOwner()));
+        $this->magazineManager->subscribe($this->remoteMagazine, $this->remoteSubscriber);
+    }
+
+    protected function setUpRemoteActors(): void
+    {
+        parent::setUpRemoteActors();
+        $username = 'remotePoster';
+        $domain = $this->remoteDomain;
+        $this->remotePoster = $this->getUserByUsername($username, addImage: false);
+        $this->registerActor($this->remotePoster, $domain, true);
+    }
+
+    public function setUpRemoteEntities(): void
+    {
+        $this->createRemoteEntryInRemoteMagazine = $this->createRemoteEntryInRemoteMagazine($this->remoteMagazine, $this->remotePoster, fn ($entry) => $this->createDeletesFromRemoteEntryInRemoteMagazine($entry));
+        $this->createRemoteEntryCommentInRemoteMagazine = $this->createRemoteEntryCommentInRemoteMagazine($this->remoteMagazine, $this->remotePoster, fn ($entryComment) => $this->createDeletesFromRemoteEntryCommentInRemoteMagazine($entryComment));
+        $this->createRemotePostInRemoteMagazine = $this->createRemotePostInRemoteMagazine($this->remoteMagazine, $this->remotePoster, fn ($post) => $this->createDeletesFromRemotePostInRemoteMagazine($post));
+        $this->createRemotePostCommentInRemoteMagazine = $this->createRemotePostCommentInRemoteMagazine($this->remoteMagazine, $this->remotePoster, fn ($comment) => $this->createDeletesFromRemotePostCommentInRemoteMagazine($comment));
+        $this->createRemoteEntryInLocalMagazine = $this->createRemoteEntryInLocalMagazine($this->localMagazine, $this->remotePoster, fn ($entry) => $this->createDeletesFromRemoteEntryInLocalMagazine($entry));
+        $this->createRemoteEntryCommentInLocalMagazine = $this->createRemoteEntryCommentInLocalMagazine($this->localMagazine, $this->remotePoster, fn ($entryComment) => $this->createDeletesFromRemoteEntryCommentInLocalMagazine($entryComment));
+        $this->createRemotePostInLocalMagazine = $this->createRemotePostInLocalMagazine($this->localMagazine, $this->remotePoster, fn ($post) => $this->createDeletesFromRemotePostInLocalMagazine($post));
+        $this->createRemotePostCommentInLocalMagazine = $this->createRemotePostCommentInLocalMagazine($this->localMagazine, $this->remotePoster, fn ($comment) => $this->createDeletesFromRemotePostCommentInLocalMagazine($comment));
+    }
+
+    private function createDeletesFromRemoteEntryInRemoteMagazine(Entry $createdEntry): void
+    {
+        $this->deleteRemoteEntryByRemoteModeratorInRemoteMagazine = $this->createDeleteForContent($createdEntry);
+    }
+
+    private function createDeletesFromRemoteEntryInLocalMagazine(Entry $createdEntry): void
+    {
+        $this->deleteRemoteEntryByRemoteModeratorInLocalMagazine = $this->createDeleteForContent($createdEntry);
+    }
+
+    private function createDeletesFromRemoteEntryCommentInRemoteMagazine(EntryComment $comment): void
+    {
+        $this->deleteRemoteEntryCommentByRemoteModeratorInRemoteMagazine = $this->createDeleteForContent($comment);
+    }
+
+    private function createDeletesFromRemoteEntryCommentInLocalMagazine(EntryComment $comment): void
+    {
+        $this->deleteRemoteEntryCommentByRemoteModeratorInLocalMagazine = $this->createDeleteForContent($comment);
+    }
+
+    private function createDeletesFromRemotePostInRemoteMagazine(Post $post): void
+    {
+        $this->deleteRemotePostByRemoteModeratorInRemoteMagazine = $this->createDeleteForContent($post);
+    }
+
+    private function createDeletesFromRemotePostInLocalMagazine(Post $ost): void
+    {
+        $this->deleteRemotePostByRemoteModeratorInLocalMagazine = $this->createDeleteForContent($ost);
+    }
+
+    private function createDeletesFromRemotePostCommentInRemoteMagazine(PostComment $comment): void
+    {
+        $this->deleteRemotePostCommentByRemoteModeratorInRemoteMagazine = $this->createDeleteForContent($comment);
+    }
+
+    private function createDeletesFromRemotePostCommentInLocalMagazine(PostComment $comment): void
+    {
+        $this->deleteRemotePostCommentByRemoteModeratorInLocalMagazine = $this->createDeleteForContent($comment);
+    }
+
+    private function createDeleteForContent(Entry|EntryComment|Post|PostComment $content): array
+    {
+        $activity = $this->deleteWrapper->build($content, $this->remoteUser);
+        $json = $this->activityJsonBuilder->buildActivityJson($activity);
+        $json['summary'] = ' ';
+
+        $this->testingApHttpClient->activityObjects[$json['id']] = $json;
+        $this->entitiesToRemoveAfterSetup[] = $activity;
+
+        return $json;
+    }
+
+    /**
+     * @return array{entry:Entry, activity: array}
+     */
+    private function createLocalEntryAndCreateDeleteActivity(Magazine $magazine, User $author, User $deletingUser): array
+    {
+        $entry = $this->getEntryByTitle('localEntry', magazine: $magazine, user: $author);
+        $entryJson = $this->pageFactory->create($entry, [], false);
+        $this->switchToRemoteDomain($this->remoteDomain);
+        $activity = $this->deleteWrapper->build($entry, $deletingUser);
+        $activityJson = $this->activityJsonBuilder->buildActivityJson($activity);
+        $activityJson['object'] = $entryJson;
+        $this->switchToLocalDomain();
+
+        $this->entityManager->remove($activity);
+
+        return [
+            'activity' => $activityJson,
+            'content' => $entry,
+        ];
+    }
+
+    /**
+     * @return array{content:EntryComment, activity: array}
+     */
+    private function createLocalEntryCommentAndCreateDeleteActivity(Magazine $magazine, User $author, User $deletingUser): array
+    {
+        $parent = $this->getEntryByTitle('localEntry', magazine: $magazine, user: $author);
+        $comment = $this->createEntryComment('localEntryComment', entry: $parent, user: $author);
+        $commentJson = $this->entryCommentNoteFactory->create($comment, []);
+        $this->switchToRemoteDomain($this->remoteDomain);
+        $activity = $this->deleteWrapper->build($comment, $deletingUser);
+        $activityJson = $this->activityJsonBuilder->buildActivityJson($activity);
+        $activityJson['object'] = $commentJson;
+        $this->switchToLocalDomain();
+
+        $this->entityManager->remove($activity);
+
+        return [
+            'activity' => $activityJson,
+            'content' => $comment,
+        ];
+    }
+
+    /**
+     * @return array{content:EntryComment, activity: array}
+     */
+    private function createLocalPostAndCreateDeleteActivity(Magazine $magazine, User $author, User $deletingUser): array
+    {
+        $post = $this->createPost('localPost', magazine: $magazine, user: $author);
+        $postJson = $this->postNoteFactory->create($post, []);
+        $this->switchToRemoteDomain($this->remoteDomain);
+        $activity = $this->deleteWrapper->build($post, $deletingUser);
+        $activityJson = $this->activityJsonBuilder->buildActivityJson($activity);
+        $activityJson['object'] = $postJson;
+        $this->switchToLocalDomain();
+
+        $this->entityManager->remove($activity);
+
+        return [
+            'activity' => $activityJson,
+            'content' => $post,
+        ];
+    }
+
+    /**
+     * @return array{content:EntryComment, activity: array}
+     */
+    private function createLocalPostCommentAndCreateDeleteActivity(Magazine $magazine, User $author, User $deletingUser): array
+    {
+        $parent = $this->createPost('localPost', magazine: $magazine, user: $author);
+        $postComment = $this->createPostComment('localPost', post: $parent, user: $author);
+        $commentJson = $this->postCommentNoteFactory->create($postComment, []);
+        $this->switchToRemoteDomain($this->remoteDomain);
+        $activity = $this->deleteWrapper->build($postComment, $deletingUser);
+        $activityJson = $this->activityJsonBuilder->buildActivityJson($activity);
+        $activityJson['object'] = $commentJson;
+        $this->switchToLocalDomain();
+
+        $this->entityManager->remove($activity);
+
+        return [
+            'activity' => $activityJson,
+            'content' => $postComment,
+        ];
+    }
+}

--- a/tests/Functional/ActivityPub/Outbox/DeleteHandlerTest.php
+++ b/tests/Functional/ActivityPub/Outbox/DeleteHandlerTest.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\ActivityPub\Outbox;
+
+use App\DTO\ModeratorDto;
+use App\Entity\Contracts\ActivityPubActivityInterface;
+use App\Entity\Contracts\ActivityPubActorInterface;
+use App\Entity\User;
+use App\Message\ActivityPub\Inbox\ActivityMessage;
+use App\Tests\Functional\ActivityPub\ActivityPubFunctionalTestCase;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+#[Group(name: 'ActivityPub')]
+#[Group(name: 'NonThreadSafe')]
+class DeleteHandlerTest extends ActivityPubFunctionalTestCase
+{
+    private array $createRemoteEntryInLocalMagazine;
+    private array $createRemoteEntryInRemoteMagazine;
+    private array $createRemoteEntryCommentInLocalMagazine;
+    private array $createRemoteEntryCommentInRemoteMagazine;
+    private array $createRemotePostInLocalMagazine;
+    private array $createRemotePostInRemoteMagazine;
+    private array $createRemotePostCommentInLocalMagazine;
+    private array $createRemotePostCommentInRemoteMagazine;
+
+    private User $remotePoster;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->magazineManager->addModerator(new ModeratorDto($this->remoteMagazine, $this->localUser));
+    }
+
+    public function setUpRemoteEntities(): void
+    {
+        $this->createRemoteEntryInRemoteMagazine = $this->createRemoteEntryInRemoteMagazine($this->remoteMagazine, $this->remotePoster);
+        $this->createRemoteEntryCommentInRemoteMagazine = $this->createRemoteEntryCommentInRemoteMagazine($this->remoteMagazine, $this->remotePoster);
+        $this->createRemotePostInRemoteMagazine = $this->createRemotePostInRemoteMagazine($this->remoteMagazine, $this->remotePoster);
+        $this->createRemotePostCommentInRemoteMagazine = $this->createRemotePostCommentInRemoteMagazine($this->remoteMagazine, $this->remotePoster);
+        $this->createRemoteEntryInLocalMagazine = $this->createRemoteEntryInLocalMagazine($this->localMagazine, $this->remotePoster);
+        $this->createRemoteEntryCommentInLocalMagazine = $this->createRemoteEntryCommentInLocalMagazine($this->localMagazine, $this->remotePoster);
+        $this->createRemotePostInLocalMagazine = $this->createRemotePostInLocalMagazine($this->localMagazine, $this->remotePoster);
+        $this->createRemotePostCommentInLocalMagazine = $this->createRemotePostCommentInLocalMagazine($this->localMagazine, $this->remotePoster);
+    }
+
+    protected function setUpRemoteActors(): void
+    {
+        parent::setUpRemoteActors();
+        $username = 'remotePoster';
+        $domain = $this->remoteDomain;
+        $this->remotePoster = $this->getUserByUsername($username, addImage: false);
+        $this->registerActor($this->remotePoster, $domain, true);
+    }
+
+    public function testDeleteLocalEntryInLocalMagazineByLocalModerator(): void
+    {
+        $entry = $this->getEntryByTitle(title: 'test entry', magazine: $this->localMagazine, user: $this->localUser);
+        $this->entryManager->delete($this->localUser, $entry);
+        $this->assertOneSentActivityOfType('Delete');
+    }
+
+    public function testDeleteLocalEntryInRemoteMagazineByLocalModerator(): void
+    {
+        $entry = $this->getEntryByTitle(title: 'test entry', magazine: $this->remoteMagazine, user: $this->localUser);
+        $this->entryManager->delete($this->localUser, $entry);
+        $this->assertOneSentActivityOfType('Delete');
+    }
+
+    public function testDeleteRemoteEntryInLocalMagazineByLocalModerator(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemoteEntryInLocalMagazine)));
+        $entryApId = $this->createRemoteEntryInLocalMagazine['object']['id'];
+        $entry = $this->entryRepository->findOneBy(['apId' => $entryApId]);
+        self::assertNotNull($entry);
+        $this->entryManager->delete($this->localUser, $entry);
+        $entry = $this->entryRepository->findOneBy(['apId' => $entryApId]);
+        self::assertTrue($entry->isTrashed());
+        $this->assertOneSentActivityOfType('Delete');
+    }
+
+    public function testDeleteRemoteEntryInRemoteMagazineByLocalModerator(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemoteEntryInRemoteMagazine)));
+        $entryApId = $this->createRemoteEntryInRemoteMagazine['object']['object']['id'];
+        $entry = $this->entryRepository->findOneBy(['apId' => $entryApId]);
+        self::assertNotNull($entry);
+        $this->entryManager->purge($this->localUser, $entry);
+        $entry = $this->entryRepository->findOneBy(['apId' => $entryApId]);
+        self::assertNull($entry);
+        self::assertNotEmpty($this->testingApHttpClient->getPostedObjects());
+        $deleteActivity = $this->activityRepository->findOneBy(['type' => 'Delete']);
+        self::assertNotNull($deleteActivity);
+        $activityId = $this->urlGenerator->generate('ap_object', ['id' => $deleteActivity->uuid], UrlGeneratorInterface::ABSOLUTE_URL);
+        $this->assertOneSentActivityOfType('Delete', $activityId);
+    }
+
+    public function testDeleteLocalEntryCommentInLocalMagazineByLocalModerator(): void
+    {
+        $entry = $this->getEntryByTitle(title: 'test entry', magazine: $this->localMagazine, user: $this->localUser);
+        $comment = $this->createEntryComment('test entry comment', entry: $entry, user: $this->localUser);
+        $this->removeActivitiesWithObject($comment);
+        $this->entryCommentManager->delete($this->localUser, $comment);
+        $this->assertOneSentActivityOfType('Delete');
+    }
+
+    public function testDeleteLocalEntryCommentInRemoteMagazineByLocalModerator(): void
+    {
+        $entry = $this->getEntryByTitle(title: 'test entry', magazine: $this->remoteMagazine, user: $this->localUser);
+        $comment = $this->createEntryComment('test entry comment', entry: $entry, user: $this->localUser);
+        $this->removeActivitiesWithObject($comment);
+        $this->entryCommentManager->delete($this->localUser, $comment);
+        $this->assertOneSentActivityOfType('Delete');
+    }
+
+    public function testDeleteRemoteEntryCommentInLocalMagazineByLocalModerator(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemoteEntryInLocalMagazine)));
+        $entryApId = $this->createRemoteEntryInLocalMagazine['object']['id'];
+        $entry = $this->entryRepository->findOneBy(['apId' => $entryApId]);
+        self::assertNotNull($entry);
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemoteEntryCommentInLocalMagazine)));
+        $entryCommentApId = $this->createRemoteEntryCommentInLocalMagazine['object']['id'];
+        $entryComment = $this->entryCommentRepository->findOneBy(['apId' => $entryCommentApId]);
+        self::assertNotNull($entryComment);
+        $this->entryCommentManager->delete($this->localUser, $entryComment);
+        $entryComment = $this->entryCommentRepository->findOneBy(['apId' => $entryCommentApId]);
+        self::assertTrue($entryComment->isTrashed());
+        // 2 subs -> 2 delete activities
+        $this->assertCountOfSentActivitiesOfType(2, 'Delete');
+    }
+
+    public function testDeleteRemoteEntryCommentInRemoteMagazineByLocalModerator(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemoteEntryInRemoteMagazine)));
+        $entryApId = $this->createRemoteEntryInRemoteMagazine['object']['object']['id'];
+        $entry = $this->entryRepository->findOneBy(['apId' => $entryApId]);
+        self::assertNotNull($entry);
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemoteEntryCommentInRemoteMagazine)));
+        $entryCommentApId = $this->createRemoteEntryCommentInRemoteMagazine['object']['object']['id'];
+        $entryComment = $this->entryCommentRepository->findOneBy(['apId' => $entryCommentApId]);
+        self::assertNotNull($entryComment);
+        $this->entryCommentManager->purge($this->localUser, $entryComment);
+        $entryComment = $this->entryCommentRepository->findOneBy(['apId' => $entryCommentApId]);
+        self::assertNull($entryComment);
+        self::assertNotEmpty($this->testingApHttpClient->getPostedObjects());
+        $deleteActivity = $this->activityRepository->findOneBy(['type' => 'Delete']);
+        self::assertNotNull($deleteActivity);
+        $activityId = $this->urlGenerator->generate('ap_object', ['id' => $deleteActivity->uuid], UrlGeneratorInterface::ABSOLUTE_URL);
+        $this->assertOneSentActivityOfType('Delete', $activityId);
+    }
+
+    public function testDeleteLocalPostInLocalMagazineByLocalModerator(): void
+    {
+        $post = $this->createPost(body: 'test post', magazine: $this->localMagazine, user: $this->localUser);
+        $this->postManager->delete($this->localUser, $post);
+        $this->assertOneSentActivityOfType('Delete');
+    }
+
+    public function testDeleteLocalPostInRemoteMagazineByLocalModerator(): void
+    {
+        $post = $this->createPost(body: 'test post', magazine: $this->remoteMagazine, user: $this->localUser);
+        $this->postManager->delete($this->localUser, $post);
+        $this->assertOneSentActivityOfType('Delete');
+    }
+
+    public function testDeleteRemotePostInLocalMagazineByLocalModerator(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemotePostInLocalMagazine)));
+        $postApId = $this->createRemotePostInLocalMagazine['object']['id'];
+        $post = $this->postRepository->findOneBy(['apId' => $postApId]);
+        self::assertNotNull($post);
+        $this->postManager->delete($this->localUser, $post);
+        $post = $this->postRepository->findOneBy(['apId' => $postApId]);
+        self::assertTrue($post->isTrashed());
+        $this->assertOneSentActivityOfType('Delete');
+    }
+
+    public function testDeleteRemotePostInRemoteMagazineByLocalModerator(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemotePostInRemoteMagazine)));
+        $postApId = $this->createRemotePostInRemoteMagazine['object']['object']['id'];
+        $post = $this->postRepository->findOneBy(['apId' => $postApId]);
+        self::assertNotNull($post);
+        $this->postManager->purge($this->localUser, $post);
+        $post = $this->postRepository->findOneBy(['apId' => $postApId]);
+        self::assertNull($post);
+        self::assertNotEmpty($this->testingApHttpClient->getPostedObjects());
+        $deleteActivity = $this->activityRepository->findOneBy(['type' => 'Delete']);
+        self::assertNotNull($deleteActivity);
+        $activityId = $this->urlGenerator->generate('ap_object', ['id' => $deleteActivity->uuid], UrlGeneratorInterface::ABSOLUTE_URL);
+        $this->assertOneSentActivityOfType('Delete', $activityId);
+    }
+
+    public function testDeleteLocalPostCommentInLocalMagazineByLocalModerator(): void
+    {
+        $post = $this->createPost(body: 'test post', magazine: $this->localMagazine, user: $this->localUser);
+        $comment = $this->createPostComment('test post comment', post: $post, user: $this->localUser);
+        $this->removeActivitiesWithObject($comment);
+        $this->postCommentManager->delete($this->localUser, $comment);
+        $this->assertOneSentActivityOfType('Delete');
+    }
+
+    public function testDeleteLocalPostCommentInRemoteMagazineByLocalModerator(): void
+    {
+        $post = $this->createPost(body: 'test post', magazine: $this->remoteMagazine, user: $this->localUser);
+        $comment = $this->createPostComment('test post comment', post: $post, user: $this->localUser);
+        $this->removeActivitiesWithObject($comment);
+        $this->postCommentManager->delete($this->localUser, $comment);
+        $this->assertOneSentActivityOfType('Delete');
+    }
+
+    public function testDeleteRemotePostCommentInLocalMagazineByLocalModerator(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemotePostInLocalMagazine)));
+        $postApId = $this->createRemotePostInLocalMagazine['object']['id'];
+        $post = $this->postRepository->findOneBy(['apId' => $postApId]);
+        self::assertNotNull($post);
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemotePostCommentInLocalMagazine)));
+        $postCommentApId = $this->createRemotePostCommentInLocalMagazine['object']['id'];
+        $postComment = $this->postCommentRepository->findOneBy(['apId' => $postCommentApId]);
+        self::assertNotNull($postComment);
+        $this->postCommentManager->delete($this->localUser, $postComment);
+        $postComment = $this->postCommentRepository->findOneBy(['apId' => $postCommentApId]);
+        self::assertTrue($postComment->isTrashed());
+        // 2 subs -> 2 delete activities
+        $this->assertCountOfSentActivitiesOfType(2, 'Delete');
+    }
+
+    public function testDeleteRemotePostCommentInRemoteMagazineByLocalModerator(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemotePostInRemoteMagazine)));
+        $postApId = $this->createRemotePostInRemoteMagazine['object']['object']['id'];
+        $post = $this->postRepository->findOneBy(['apId' => $postApId]);
+        self::assertNotNull($post);
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createRemotePostCommentInRemoteMagazine)));
+        $postCommentApId = $this->createRemotePostCommentInRemoteMagazine['object']['object']['id'];
+        $postComment = $this->postCommentRepository->findOneBy(['apId' => $postCommentApId]);
+        self::assertNotNull($postComment);
+        $this->postCommentManager->purge($this->localUser, $postComment);
+        $postComment = $this->postCommentRepository->findOneBy(['apId' => $postCommentApId]);
+        self::assertNull($postComment);
+        self::assertNotEmpty($this->testingApHttpClient->getPostedObjects());
+        $deleteActivity = $this->activityRepository->findOneBy(['type' => 'Delete']);
+        self::assertNotNull($deleteActivity);
+        $activityId = $this->urlGenerator->generate('ap_object', ['id' => $deleteActivity->uuid], UrlGeneratorInterface::ABSOLUTE_URL);
+        $this->assertOneSentActivityOfType('Delete', $activityId);
+    }
+
+    public function removeActivitiesWithObject(ActivityPubActivityInterface|ActivityPubActorInterface $object): void
+    {
+        $activities = $this->activityRepository->findAllActivitiesByObject($object);
+        foreach ($activities as $activity) {
+            $this->entityManager->remove($activity);
+        }
+    }
+}

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -12,6 +12,7 @@ use App\Factory\ImageFactory;
 use App\Factory\MagazineFactory;
 use App\Markdown\MarkdownConverter;
 use App\MessageHandler\ActivityPub\Outbox\DeliverHandler;
+use App\Repository\ActivityRepository;
 use App\Repository\BookmarkListRepository;
 use App\Repository\BookmarkRepository;
 use App\Repository\EntryCommentRepository;
@@ -134,6 +135,7 @@ abstract class WebTestCase extends BaseWebTestCase
     protected BookmarkListRepository $bookmarkListRepository;
     protected UserFollowRepository $userFollowRepository;
     protected MagazineSubscriptionRepository $magazineSubscriptionRepository;
+    protected ActivityRepository $activityRepository;
 
     protected ImageFactory $imageFactory;
     protected MagazineFactory $magazineFactory;
@@ -209,6 +211,7 @@ abstract class WebTestCase extends BaseWebTestCase
         $this->bookmarkListRepository = $this->getService(BookmarkListRepository::class);
         $this->userFollowRepository = $this->getService(UserFollowRepository::class);
         $this->magazineSubscriptionRepository = $this->getService(MagazineSubscriptionRepository::class);
+        $this->activityRepository = $this->getService(ActivityRepository::class);
 
         $this->imageFactory = $this->getService(ImageFactory::class);
         $this->personFactory = $this->getService(PersonFactory::class);


### PR DESCRIPTION
- add inbox and outbox tests for the `DeleteHandler`s
- fix some problems with announcing deletes:
  - it did not check for the moderator to be local, so everytime a "Delete" was received from an actual moderator (regardless of the source instance) an "Announce" activity was created for those. This is not a huge problem, as it would result in the `DeliverHandler` to throw an exception, because it cannot sign headers for remote magazines
  - the `DeleteWrapper` just json-encoded the activity object when it wrapped the activity to announce it, which is just stupid -> properly build the json of the activity using the `ActivityJsonBuilder` as it should be
  - consolidate the code of the deletion event subscribers to a new `DeleteService`