### PR TITLE
Add instance actor test and remove url field

### DIFF
--- a/src/Factory/ActivityPub/InstanceFactory.php
+++ b/src/Factory/ActivityPub/InstanceFactory.php
@@ -36,7 +36,6 @@ class InstanceFactory
                 'owner' => $actor,
                 'publicKeyPem' => $this->client->getInstancePublicKey(),
             ],
-            'url' => 'https://'.$this->kbinDomain.'/instance-actor',
         ];
     }
 }

--- a/tests/Functional/Controller/WebfingerControllerTest.php
+++ b/tests/Functional/Controller/WebfingerControllerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Controller;
+
+use App\Tests\WebTestCase;
+
+class WebfingerControllerTest extends WebTestCase
+{
+    public function testInstanceActor(): void
+    {
+        $domain = $this->settingsManager->get('KBIN_DOMAIN');
+        $resource = "acct:$domain@$domain";
+        $resourceUrlEncoded = urlencode($resource);
+        $this->client->request('GET', "https://$domain/.well-known/webfinger?resource=$resourceUrlEncoded");
+        self::assertResponseIsSuccessful();
+        $jsonContent = self::getJsonResponse($this->client);
+        self::assertResponseIsSuccessful();
+
+        self::assertArrayHasKey('subject', $jsonContent);
+        self::assertEquals($resource, $jsonContent['subject']);
+        self::assertArrayHasKey('links', $jsonContent);
+        self::assertNotEmpty($jsonContent['links']);
+        $instanceActor = $jsonContent['links'][0];
+        self::assertArrayKeysMatch(['rel', 'href', 'type'], $instanceActor);
+
+        $this->client->request('GET', $instanceActor['href']);
+
+        self::assertResponseIsSuccessful();
+        $jsonContent = self::getJsonResponse($this->client);
+        self::assertNotNull($jsonContent);
+        $keys = ['id', 'type', 'preferredUsername', 'publicKey', 'name', 'manuallyApprovesFollowers'];
+        foreach ($keys as $key) {
+            self::assertArrayHasKey($key, $jsonContent);
+        }
+        self::assertEquals($instanceActor['href'], $jsonContent['id']);
+        self::assertEquals('Application', $jsonContent['type']);
+        self::assertEquals($domain, $jsonContent['preferredUsername']);
+        self::assertTrue($jsonContent['manuallyApprovesFollowers']);
+        self::assertNotEmpty($jsonContent['publicKey']);
+    }
+}


### PR DESCRIPTION
After observing a 401 error from mastodon like this:
```json
{
    "error":"Verification failed for gehirneimer.de@gehirneimer.de https://gehirneimer.de/i/actor"
}
```

I decided to add a test for the instance actor. I suspect that mastodon actually tried to pull the `url` field of the actor which would result in a 404 causing mastodon to spit out this error. Not 100% sure, but having a pointer to an address we do not serve is pointless, so I removed it