### PR TITLE
Federate bans

### DIFF
--- a/migrations/Version20250723183702.php
+++ b/migrations/Version20250723183702.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250723183702 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add magazine ban as an object to the activity table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE activity ADD object_magazine_ban_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE activity ADD CONSTRAINT FK_AC74095AE490E490 FOREIGN KEY (object_magazine_ban_id) REFERENCES magazine_ban (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_AC74095AE490E490 ON activity (object_magazine_ban_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE activity DROP CONSTRAINT FK_AC74095AE490E490');
+        $this->addSql('DROP INDEX IDX_AC74095AE490E490');
+        $this->addSql('ALTER TABLE activity DROP object_magazine_ban_id');
+    }
+}

--- a/migrations/Version20250802102904.php
+++ b/migrations/Version20250802102904.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250802102904 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add column ban_reason to the user table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" ADD ban_reason VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" DROP ban_reason');
+    }
+}

--- a/src/Controller/User/UserBanController.php
+++ b/src/Controller/User/UserBanController.php
@@ -20,7 +20,7 @@ class UserBanController extends AbstractController
     {
         $this->validateCsrf('user_ban', $request->getPayload()->get('token'));
 
-        $manager->ban($user);
+        $manager->ban($user, $this->getUserOrThrow(), reason: null);
 
         if ($request->isXmlHttpRequest()) {
             return new JsonResponse(
@@ -40,7 +40,7 @@ class UserBanController extends AbstractController
     {
         $this->validateCsrf('user_ban', $request->getPayload()->get('token'));
 
-        $manager->unban($user);
+        $manager->unban($user, $this->getUserOrThrow(), reason: null);
 
         if ($request->isXmlHttpRequest()) {
             return new JsonResponse(

--- a/src/Entity/Activity.php
+++ b/src/Entity/Activity.php
@@ -39,7 +39,7 @@ class Activity
     public ?Magazine $magazineActor;
 
     #[ManyToOne, JoinColumn(nullable: true, onDelete: 'CASCADE')]
-    public ?Magazine $audience;
+    public ?Magazine $audience = null;
 
     #[ManyToOne, JoinColumn(referencedColumnName: 'uuid', nullable: true, onDelete: 'CASCADE', options: ['default' => null])]
     public ?Activity $innerActivity = null;
@@ -68,6 +68,9 @@ class Activity
     #[ManyToOne, JoinColumn(nullable: true, onDelete: 'CASCADE')]
     public ?Magazine $objectMagazine = null;
 
+    #[ManyToOne, JoinColumn(nullable: true, onDelete: 'CASCADE')]
+    public ?MagazineBan $objectMagazineBan = null;
+
     #[Column(type: 'text', nullable: true)]
     public ?string $objectGeneric = null;
 
@@ -88,7 +91,7 @@ class Activity
         $this->type = $type;
     }
 
-    public function setObject(ActivityPubActivityInterface|Entry|EntryComment|Post|PostComment|ActivityPubActorInterface|User|Magazine|Activity|array|string $object): void
+    public function setObject(ActivityPubActivityInterface|Entry|EntryComment|Post|PostComment|ActivityPubActorInterface|User|Magazine|MagazineBan|Activity|array|string $object): void
     {
         if ($object instanceof Entry) {
             $this->objectEntry = $object;
@@ -104,6 +107,8 @@ class Activity
             $this->objectUser = $object;
         } elseif ($object instanceof Magazine) {
             $this->objectMagazine = $object;
+        } elseif ($object instanceof MagazineBan) {
+            $this->objectMagazineBan = $object;
         } elseif ($object instanceof Activity) {
             $this->innerActivity = $object;
         } elseif (\is_array($object)) {
@@ -118,9 +123,9 @@ class Activity
         }
     }
 
-    public function getObject(): Post|EntryComment|PostComment|Entry|Message|User|Magazine|array|string|null
+    public function getObject(): Post|EntryComment|PostComment|Entry|Message|User|Magazine|MagazineBan|array|string|null
     {
-        $o = $this->objectEntry ?? $this->objectEntryComment ?? $this->objectPost ?? $this->objectPostComment ?? $this->objectMessage ?? $this->objectUser ?? $this->objectMagazine;
+        $o = $this->objectEntry ?? $this->objectEntryComment ?? $this->objectPost ?? $this->objectPostComment ?? $this->objectMessage ?? $this->objectUser ?? $this->objectMagazine ?? $this->objectMagazineBan;
         if (null !== $o) {
             return $o;
         }

--- a/src/Entity/Magazine.php
+++ b/src/Entity/Magazine.php
@@ -441,7 +441,7 @@ class Magazine implements VisibilityInterface, ActivityPubActorInterface, ApiRes
          * @var MagazineBan $ban
          */
         $ban = $this->bans->matching($criteria)->first();
-        $ban->expiredAt = new \DateTime('+10 seconds');
+        $ban->expiredAt = new \DateTime('-10 seconds');
 
         return $ban;
     }

--- a/src/Entity/MagazineLogBan.php
+++ b/src/Entity/MagazineLogBan.php
@@ -26,7 +26,7 @@ class MagazineLogBan extends MagazineLog
 
         $this->ban = $ban;
 
-        if ($ban->expiredAt < new \DateTime('+10 seconds')) {
+        if (null !== $ban->expiredAt && $ban->expiredAt < new \DateTime()) {
             $this->meta = 'unban';
         }
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -168,6 +168,8 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Visibil
     public bool $addMentionsPosts = true;
     #[Column(type: 'boolean', nullable: false, options: ['default' => false])]
     public bool $isBanned = false;
+    #[Column(type: 'string', nullable: true, options: ['default' => null])]
+    public ?string $banReason = null;
     #[Column(type: 'boolean', nullable: false)]
     public bool $isVerified = false;
     #[Column(type: 'boolean', nullable: false, options: ['default' => false])]

--- a/src/Event/Instance/InstanceBanEvent.php
+++ b/src/Event/Instance/InstanceBanEvent.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Event\Instance;
+
+use App\Entity\User;
+
+class InstanceBanEvent
+{
+    public function __construct(public User $bannedUser, public ?User $bannedByUser, public ?string $reason)
+    {
+    }
+}

--- a/src/EventSubscriber/Instance/InstanceBanSubscriber.php
+++ b/src/EventSubscriber/Instance/InstanceBanSubscriber.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber\Instance;
+
+use App\Event\Instance\InstanceBanEvent;
+use App\Message\ActivityPub\Outbox\BlockMessage;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class InstanceBanSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly MessageBusInterface $bus,
+    ) {
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            InstanceBanEvent::class => 'onInstanceBan',
+        ];
+    }
+
+    public function onInstanceBan(InstanceBanEvent $event): void
+    {
+        if (!$event->bannedUser->apId && !$event->bannedByUser->apId) {
+            // local user banning another local user
+            $this->bus->dispatch(new BlockMessage(magazineBanId: null, bannedUserId: $event->bannedUser->getId(), actor: $event->bannedByUser->getId()));
+        }
+    }
+}

--- a/src/EventSubscriber/Magazine/MagazineBanSubscriber.php
+++ b/src/EventSubscriber/Magazine/MagazineBanSubscriber.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 namespace App\EventSubscriber\Magazine;
 
 use App\Event\Magazine\MagazineBanEvent;
+use App\Message\ActivityPub\Outbox\BlockMessage;
 use App\Message\Notification\MagazineBanNotificationMessage;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 class MagazineBanSubscriber implements EventSubscriberInterface
 {
-    public function __construct(private readonly MessageBusInterface $bus)
-    {
+    public function __construct(
+        private readonly MessageBusInterface $bus,
+        private readonly LoggerInterface $logger,
+    ) {
     }
 
     public static function getSubscribedEvents(): array
@@ -25,5 +29,15 @@ class MagazineBanSubscriber implements EventSubscriberInterface
     public function onBan(MagazineBanEvent $event): void
     {
         $this->bus->dispatch(new MagazineBanNotificationMessage($event->ban->getId()));
+        $this->logger->debug('[MagazineBanSubscriber::onBan] got ban event: banned: {u}, magazine {m}, expires: {e}, bannedBy: {u2}', [
+            'u' => $event->ban->user->username,
+            'm' => $event->ban->magazine->name,
+            'e' => $event->ban->expiredAt,
+            'u2' => $event->ban->bannedBy->username,
+        ]);
+        if (null !== $event->ban->bannedBy && null === $event->ban->bannedBy->apId) {
+            // bannedBy not null and a local user
+            $this->bus->dispatch(new BlockMessage(magazineBanId: $event->ban->getId(), bannedUserId: null, actor: null));
+        }
     }
 }

--- a/src/Factory/ActivityPub/BlockFactory.php
+++ b/src/Factory/ActivityPub/BlockFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory\ActivityPub;
+
+use App\Entity\Activity;
+use App\Entity\MagazineBan;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+
+class BlockFactory
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function createActivityFromMagazineBan(MagazineBan $magazineBan): Activity
+    {
+        $activity = new Activity('Block');
+        $activity->audience = $magazineBan->magazine;
+        $activity->setActor($magazineBan->bannedBy);
+        $activity->setObject($magazineBan);
+
+        $this->entityManager->persist($activity);
+
+        return $activity;
+    }
+
+    public function createActivityFromInstanceBan(User $bannedUser, User $actor): Activity
+    {
+        $activity = new Activity('Block');
+        $activity->setActor($actor);
+        $activity->setObject($bannedUser);
+
+        $this->entityManager->persist($activity);
+
+        return $activity;
+    }
+}

--- a/src/Factory/ActivityPub/InstanceFactory.php
+++ b/src/Factory/ActivityPub/InstanceFactory.php
@@ -39,4 +39,9 @@ class InstanceFactory
             'url' => 'https://'.$this->kbinDomain.'/instance-actor',
         ];
     }
+
+    public function getTargetUrl(): string
+    {
+        return 'https://'.$this->kbinDomain;
+    }
 }

--- a/src/Message/ActivityPub/Inbox/BlockMessage.php
+++ b/src/Message/ActivityPub/Inbox/BlockMessage.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message\ActivityPub\Inbox;
+
+use App\Message\Contracts\ActivityPubInboxInterface;
+
+class BlockMessage implements ActivityPubInboxInterface
+{
+    public function __construct(
+        public array $payload,
+    ) {
+    }
+}

--- a/src/Message/ActivityPub/Outbox/BlockMessage.php
+++ b/src/Message/ActivityPub/Outbox/BlockMessage.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message\ActivityPub\Outbox;
+
+use App\Message\Contracts\ActivityPubOutboxInterface;
+
+class BlockMessage implements ActivityPubOutboxInterface
+{
+    /**
+     * Exactly of the parameters must not be null.
+     *
+     * @param int|null $magazineBanId if the block has a magazine as a target
+     * @param int|null $bannedUserId  if the block has the instance as a target
+     * @param int|null $actor         the user issuing the ban, only used for instance bans, otherwise MagazineBan::$bannedBy is used
+     *
+     * @see MagazineBan::$bannedBy
+     */
+    public function __construct(
+        public ?int $magazineBanId,
+        public ?int $bannedUserId,
+        public ?int $actor,
+    ) {
+    }
+}

--- a/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ActivityHandler.php
@@ -12,6 +12,7 @@ use App\Exception\InvalidUserPublicKeyException;
 use App\Message\ActivityPub\Inbox\ActivityMessage;
 use App\Message\ActivityPub\Inbox\AddMessage;
 use App\Message\ActivityPub\Inbox\AnnounceMessage;
+use App\Message\ActivityPub\Inbox\BlockMessage;
 use App\Message\ActivityPub\Inbox\CreateMessage;
 use App\Message\ActivityPub\Inbox\DeleteMessage;
 use App\Message\ActivityPub\Inbox\DislikeMessage;
@@ -231,6 +232,9 @@ class ActivityHandler extends MbinMessageHandler
             case 'Flag':
                 $this->bus->dispatch(new FlagMessage($payload));
                 break;
+            case 'Block':
+                $this->bus->dispatch(new BlockMessage($payload));
+                break;
         }
     }
 
@@ -254,6 +258,9 @@ class ActivityHandler extends MbinMessageHandler
                 break;
             case 'Dislike':
                 $this->bus->dispatch(new DislikeMessage($payload));
+                break;
+            case 'Block':
+                $this->bus->dispatch(new BlockMessage($payload));
                 break;
         }
     }

--- a/src/MessageHandler/ActivityPub/Inbox/BlockHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/BlockHandler.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler\ActivityPub\Inbox;
+
+use App\DTO\MagazineBanDto;
+use App\Entity\Magazine;
+use App\Entity\MagazineBan;
+use App\Entity\User;
+use App\Exception\UserCannotBeBanned;
+use App\Message\ActivityPub\Inbox\BlockMessage;
+use App\Message\ActivityPub\Outbox\GenericAnnounceMessage;
+use App\Message\Contracts\MessageInterface;
+use App\MessageHandler\MbinMessageHandler;
+use App\Repository\ActivityRepository;
+use App\Repository\MagazineBanRepository;
+use App\Service\ActivityPub\ApHttpClientInterface;
+use App\Service\ActivityPubManager;
+use App\Service\MagazineManager;
+use App\Service\UserManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsMessageHandler]
+class BlockHandler extends MbinMessageHandler
+{
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        KernelInterface $kernel,
+        private readonly MagazineBanRepository $magazineBanRepository,
+        private readonly ActivityPubManager $activityPubManager,
+        private readonly ApHttpClientInterface $apHttpClient,
+        private readonly MagazineManager $magazineManager,
+        private readonly UserManager $userManager,
+        private readonly ActivityRepository $activityRepository,
+        private readonly MessageBusInterface $bus,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct($entityManager, $kernel);
+    }
+
+    public function __invoke(BlockMessage $message): void
+    {
+        $this->workWrapper($message);
+    }
+
+    public function doWork(MessageInterface $message): void
+    {
+        if (!$message instanceof BlockMessage) {
+            throw new \LogicException();
+        }
+
+        if (!isset($message->payload['id']) || !isset($message->payload['actor']) || !isset($message->payload['object'])) {
+            throw new UnrecoverableMessageHandlingException('Malformed block activity');
+        }
+
+        $this->logger->debug('Got block message: {m}', ['m' => $message->payload]);
+
+        $isUndo = 'Undo' === $message->payload['type'];
+        $payload = $isUndo ? $message->payload['object'] : $message->payload;
+
+        if (\is_string($payload) && filter_var($payload, FILTER_VALIDATE_URL)) {
+            $payload = $this->apHttpClient->getActivityObject($payload);
+        }
+
+        if (!isset($payload['id']) || !isset($payload['actor']) || !isset($payload['object']) || !isset($payload['target'])) {
+            throw new UnrecoverableMessageHandlingException('Malformed block activity');
+        }
+
+        $actor = $this->activityPubManager->findActorOrCreate($payload['actor']);
+        if (null === $actor) {
+            throw new \Exception("Unable to find user '{$payload['actor']}'");
+        }
+
+        $bannedUser = $this->activityPubManager->findActorOrCreate($payload['object']);
+        if (null === $bannedUser) {
+            throw new \Exception("Could not find user '{$payload['object']}'");
+        }
+        if (!$bannedUser instanceof User) {
+            throw new UnrecoverableMessageHandlingException('The object has to be a user');
+        }
+
+        try {
+            $target = $this->activityPubManager->findActorOrCreate($payload['target']);
+        } catch (\Exception $e) {
+            if (parse_url($payload['target'], PHP_URL_HOST) === $bannedUser->apDomain) {
+                // if the host part of the url is the same as the users it is probably the instance actor -> ban the user completely
+                $target = null;
+            } else {
+                throw $e;
+            }
+        }
+
+        $reason = $payload['summary'] ?? '';
+        $expireDate = null;
+        if (isset($payload['expires'])) {
+            $expireDate = new \DateTimeImmutable($payload['expires']);
+        }
+
+        if (null === $target || ($target instanceof User && 'Application' === $target->type)) {
+            $this->handleInstanceBan($bannedUser, $actor, $reason, $isUndo);
+        } else {
+            $this->handleMagazineBan($message->payload, $bannedUser, $actor, $target, $reason, $expireDate, $isUndo);
+        }
+    }
+
+    private function handleInstanceBan(User $bannedUser, User $actor, string $reason, bool $isUndo): void
+    {
+        if ($bannedUser->apDomain !== $actor->apDomain) {
+            throw new UnrecoverableMessageHandlingException("Only a user of the same instance can instance ban another user and the domains of the banned $bannedUser->username and the actor $actor->username do not match");
+        }
+        if ($isUndo) {
+            $this->userManager->unban($bannedUser, $actor, $reason);
+            $this->logger->info('[BlockHandler::handleInstanceBan] {a} is unbanning {u} instance wide', ['a' => $actor->username, 'u' => $bannedUser->username]);
+        } else {
+            $this->userManager->ban($bannedUser, $actor, $reason);
+            $this->logger->info('[BlockHandler::handleInstanceBan] {a} is banning {u} instance wide', ['a' => $actor->username, 'u' => $bannedUser->username]);
+        }
+    }
+
+    private function handleMagazineBan(array $payload, User $bannedUser, User $actor, Magazine $target, string $reason, ?\DateTimeImmutable $expireDate, bool $isUndo): void
+    {
+        if (!$target->hasSameHostAsUser($actor) && !$target->userIsModerator($actor)) {
+            throw new UnrecoverableMessageHandlingException("The user $actor->username is neither from the same instance as the magazine $target->name nor a moderator in it and is therefore not allowed to ban $bannedUser->username");
+        }
+
+        $existingBan = $this->magazineBanRepository->findOneBy(['magazine' => $target, 'user' => $bannedUser]);
+        if (null === $existingBan) {
+            $this->logger->debug('it is a magazine ban and we do not have an existing one');
+            if ($isUndo) {
+                // nothing has to be done, the user is not banned
+                $this->logger->debug("We didn't know that {u} was banned from {m}, so we do not have to undo it", ['u' => $bannedUser->username, 'm' => $target->name]);
+
+                return;
+            } else {
+                $ban = $this->banImpl($reason, $expireDate, $target, $bannedUser, $actor);
+
+                if (null === $target->apId) {
+                    // local magazine and the user is allowed to ban users -> announce it
+                    $this->announceBan($payload, $target, $actor, $ban);
+                }
+            }
+        } else {
+            $this->logger->debug('it is a magazine ban and we do have an existing one');
+            if ($isUndo) {
+                $ban = $this->magazineManager->unban($target, $bannedUser);
+                $this->logger->info("[BlockHandler::handleMagazineBan] {a} is unbanning {u} from magazine {m}. Reason: '{r}'", ['a' => $actor->username, 'u' => $bannedUser->username, 'm' => $target->name, 'r' => $reason]);
+            } else {
+                $ban = $this->banImpl($reason, $expireDate, $target, $bannedUser, $actor);
+            }
+
+            if (null === $target->apId) {
+                // local magazine and the user is allowed to ban users -> announce it
+                $this->announceBan($payload, $target, $actor, $ban);
+            }
+        }
+    }
+
+    /**
+     * @throws \Symfony\Component\Messenger\Exception\ExceptionInterface
+     */
+    private function announceBan(array $payload, Magazine $target, User $actor, MagazineBan $ban): void
+    {
+        $activityToAnnounce = $payload;
+        unset($activityToAnnounce['@context']);
+        $activity = $this->activityRepository->createForRemoteActivity($payload, $ban);
+        $activity->audience = $target;
+        $activity->setActor($actor);
+
+        $this->bus->dispatch(new GenericAnnounceMessage($target->getId(), null, $actor->apInboxUrl, $activity->uuid->toString(), null));
+    }
+
+    private function banImpl(string $reason, ?\DateTimeImmutable $expireDate, Magazine $target, User $bannedUser, User $actor): MagazineBan
+    {
+        $dto = new MagazineBanDto();
+        $dto->reason = $reason;
+        $dto->expiredAt = $expireDate;
+        try {
+            $ban = $this->magazineManager->ban($target, $bannedUser, $actor, $dto);
+            $this->logger->info("[BlockHandler::handleMagazineBan] {a} is banning {u} from magazine {m}. Reason: '{r}'", ['a' => $actor->username, 'u' => $bannedUser->username, 'm' => $target->name, 'r' => $reason]);
+        } catch (UserCannotBeBanned) {
+            throw new UnrecoverableMessageHandlingException("$bannedUser->username is either an admin or a moderator of $target->name and can therefor not be banned from it");
+        }
+
+        return $ban;
+    }
+}

--- a/src/MessageHandler/ActivityPub/Outbox/BlockHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/BlockHandler.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler\ActivityPub\Outbox;
+
+use App\Entity\MagazineBan;
+use App\Entity\User;
+use App\Factory\ActivityPub\BlockFactory;
+use App\Message\ActivityPub\Outbox\BlockMessage;
+use App\Message\Contracts\MessageInterface;
+use App\MessageHandler\MbinMessageHandler;
+use App\Repository\ActivityRepository;
+use App\Repository\MagazineBanRepository;
+use App\Repository\MagazineRepository;
+use App\Repository\UserRepository;
+use App\Service\ActivityPub\ActivityJsonBuilder;
+use App\Service\ActivityPub\Wrapper\UndoWrapper;
+use App\Service\DeliverManager;
+use App\Service\UserManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+
+#[AsMessageHandler]
+class BlockHandler extends MbinMessageHandler
+{
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        KernelInterface $kernel,
+        private readonly MagazineBanRepository $magazineBanRepository,
+        private readonly BlockFactory $blockFactory,
+        private readonly UndoWrapper $undoWrapper,
+        private readonly ActivityJsonBuilder $activityJsonBuilder,
+        private readonly DeliverManager $deliverManager,
+        private readonly MagazineRepository $magazineRepository,
+        private readonly UserRepository $userRepository,
+        private readonly ActivityRepository $activityRepository,
+        private readonly UserManager $userManager,
+    ) {
+        parent::__construct($entityManager, $kernel);
+    }
+
+    public function __invoke(BlockMessage $message): void
+    {
+        $this->workWrapper($message);
+    }
+
+    public function doWork(MessageInterface $message): void
+    {
+        if (!$message instanceof BlockMessage) {
+            throw new \LogicException();
+        }
+
+        if (null !== $message->magazineBanId) {
+            $ban = $this->magazineBanRepository->find($message->magazineBanId);
+            if (null === $ban) {
+                throw new UnrecoverableMessageHandlingException("there is no ban with id $message->magazineBanId");
+            }
+            $this->handleMagazineBan($ban);
+        } elseif (null !== $message->bannedUserId) {
+            $bannedUser = $this->userRepository->find($message->bannedUserId);
+            $actor = $this->userRepository->find($message->actor);
+            if (null === $bannedUser) {
+                throw new UnrecoverableMessageHandlingException("there is no user with id $message->bannedUserId");
+            }
+            if (null === $actor) {
+                throw new UnrecoverableMessageHandlingException("there is no user with id $message->actor");
+            }
+            $this->handleUserBan($bannedUser, $actor);
+        } else {
+            throw new UnrecoverableMessageHandlingException('nothing to do. `magazineBanId` and `bannedUserId` are both null');
+        }
+    }
+
+    private function handleMagazineBan(MagazineBan $ban): void
+    {
+        $isUndo = null !== $ban->expiredAt && $ban->expiredAt < new \DateTime();
+
+        $actor = $ban->bannedBy;
+        if (null === $actor) {
+            throw new UnrecoverableMessageHandlingException('An actor is needed to ban a user');
+        } elseif (null !== $actor->apId) {
+            throw new UnrecoverableMessageHandlingException("$actor->username is not a local user");
+        }
+
+        if ($isUndo) {
+            $activity = $this->activityRepository->findFirstActivitiesByTypeAndObject('Block', $ban) ?? $this->blockFactory->createActivityFromMagazineBan($ban);
+            $activity = $this->undoWrapper->build($activity);
+        } else {
+            $activity = $this->blockFactory->createActivityFromMagazineBan($ban);
+        }
+        $json = $this->activityJsonBuilder->buildActivityJson($activity);
+
+        $this->deliverManager->deliver($this->magazineRepository->findAudience($ban->magazine), $json);
+    }
+
+    private function handleUserBan(User $bannedUser, User $actor): void
+    {
+        $isUndo = !$bannedUser->isBanned;
+
+        if ($isUndo) {
+            $activity = $this->activityRepository->findFirstActivitiesByTypeAndObject('Block', $bannedUser) ?? $this->blockFactory->createActivityFromInstanceBan($bannedUser, $actor);
+            $activity = $this->undoWrapper->build($activity);
+        } else {
+            $activity = $this->blockFactory->createActivityFromInstanceBan($bannedUser, $actor);
+        }
+        $json = $this->activityJsonBuilder->buildActivityJson($activity);
+        $inboxes = $this->userManager->getAllInboxesOfInteractions($bannedUser);
+
+        $this->deliverManager->deliver($inboxes, $json);
+    }
+}

--- a/src/MessageHandler/ActivityPub/Outbox/DeliverHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/DeliverHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\MessageHandler\ActivityPub\Outbox;
 
+use App\Entity\Instance;
 use App\Entity\User;
 use App\Exception\InstanceBannedException;
 use App\Exception\InvalidApPostException;
@@ -105,7 +106,8 @@ class DeliverHandler extends MbinMessageHandler
             throw new \LogicException();
         }
 
-        $instance = $this->instanceRepository->findOneBy(['domain' => parse_url($message->apInboxUrl, PHP_URL_HOST)]);
+        $instanceDomain = parse_url($message->apInboxUrl, PHP_URL_HOST);
+        $instance = $this->instanceRepository->findOneBy(['domain' => $instanceDomain]);
         if ($instance && $instance->isDead()) {
             $this->logger->debug('instance {n} is considered dead. Last successful delivery date: {dd}, failed attempts since then: {fa}', [
                 'n' => $instance->domain,
@@ -114,6 +116,11 @@ class DeliverHandler extends MbinMessageHandler
             ]);
 
             return;
+        }
+
+        if (null === $instance) {
+            $instance = new Instance($instanceDomain);
+            $this->entityManager->persist($instance);
         }
 
         if ('Announce' !== $message->payload['type']) {

--- a/src/Repository/ActivityRepository.php
+++ b/src/Repository/ActivityRepository.php
@@ -10,6 +10,7 @@ use App\Entity\Contracts\ActivityPubActorInterface;
 use App\Entity\Entry;
 use App\Entity\EntryComment;
 use App\Entity\Magazine;
+use App\Entity\MagazineBan;
 use App\Entity\Message;
 use App\Entity\Post;
 use App\Entity\PostComment;
@@ -35,7 +36,7 @@ class ActivityRepository extends ServiceEntityRepository
         parent::__construct($registry, Activity::class);
     }
 
-    public function findFirstActivitiesByTypeAndObject(string $type, ActivityPubActivityInterface|ActivityPubActorInterface $object): ?Activity
+    public function findFirstActivitiesByTypeAndObject(string $type, ActivityPubActivityInterface|ActivityPubActorInterface|MagazineBan $object): ?Activity
     {
         $results = $this->findAllActivitiesByTypeAndObject($type, $object);
         if (!empty($results)) {
@@ -48,7 +49,7 @@ class ActivityRepository extends ServiceEntityRepository
     /**
      * @return Activity[]|null
      */
-    public function findAllActivitiesByTypeAndObject(string $type, ActivityPubActivityInterface|ActivityPubActorInterface $object): ?array
+    public function findAllActivitiesByTypeAndObject(string $type, ActivityPubActivityInterface|ActivityPubActorInterface|MagazineBan $object): ?array
     {
         $qb = $this->createQueryBuilder('a');
         $qb->where('a.type = :type');
@@ -71,7 +72,7 @@ class ActivityRepository extends ServiceEntityRepository
         return $qb->getQuery()->getResult();
     }
 
-    private function addObjectFilter(QueryBuilder $qb, ActivityPubActivityInterface|ActivityPubActorInterface $object): void
+    private function addObjectFilter(QueryBuilder $qb, ActivityPubActivityInterface|ActivityPubActorInterface|MagazineBan $object): void
     {
         if ($object instanceof Entry) {
             $qb->andWhere('a.objectEntry = :entry')
@@ -94,6 +95,9 @@ class ActivityRepository extends ServiceEntityRepository
         } elseif ($object instanceof Magazine) {
             $qb->andWhere('a.objectMagazine = :magazine')
                 ->setParameter('magazine', $object);
+        } elseif ($object instanceof MagazineBan) {
+            $qb->andWhere('a.objectMagazineBan = :magazineBan')
+                ->setParameter('magazineBan', $object);
         }
     }
 
@@ -115,7 +119,7 @@ class ActivityRepository extends ServiceEntityRepository
         return $activity;
     }
 
-    public function createForRemoteActivity(array $payload, ActivityPubActivityInterface|Entry|EntryComment|Post|PostComment|ActivityPubActorInterface|User|Magazine|Activity|array|string|null $object = null): Activity
+    public function createForRemoteActivity(array $payload, ActivityPubActivityInterface|Entry|EntryComment|Post|PostComment|ActivityPubActorInterface|User|Magazine|MagazineBan|Activity|array|string|null $object = null): Activity
     {
         if (isset($payload['@context'])) {
             unset($payload['@context']);

--- a/src/Service/ActivityPub/ActivityJsonBuilder.php
+++ b/src/Service/ActivityPub/ActivityJsonBuilder.php
@@ -11,6 +11,7 @@ use App\Entity\Contracts\ReportInterface;
 use App\Entity\Entry;
 use App\Entity\EntryComment;
 use App\Entity\Magazine;
+use App\Entity\MagazineBan;
 use App\Entity\Message;
 use App\Entity\Post;
 use App\Entity\PostComment;
@@ -19,6 +20,7 @@ use App\Factory\ActivityPub\ActivityFactory;
 use App\Factory\ActivityPub\EntryCommentNoteFactory;
 use App\Factory\ActivityPub\EntryPageFactory;
 use App\Factory\ActivityPub\GroupFactory;
+use App\Factory\ActivityPub\InstanceFactory;
 use App\Factory\ActivityPub\PersonFactory;
 use App\Factory\ActivityPub\PostCommentNoteFactory;
 use App\Factory\ActivityPub\PostNoteFactory;
@@ -30,6 +32,7 @@ class ActivityJsonBuilder
 {
     public function __construct(
         private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly InstanceFactory $instanceFactory,
         private readonly PersonFactory $personFactory,
         private readonly GroupFactory $groupFactory,
         private readonly ActivityFactory $activityFactory,
@@ -65,6 +68,7 @@ class ActivityJsonBuilder
             'Follow' => $this->buildFollowFromActivity($activity),
             'Accept', 'Reject' => $this->buildAcceptRejectFromActivity($activity),
             'Update' => $this->buildUpdateFromActivity($activity),
+            'Block' => $this->buildBlockFromActivity($activity),
             default => new \LogicException(),
         };
         $this->logger->debug('activity json: {json}', ['json' => json_encode($json, JSON_PRETTY_PRINT)]);
@@ -433,6 +437,40 @@ class ActivityJsonBuilder
             'to' => [ActivityPubActivityInterface::PUBLIC_URL],
             'cc' => $cc,
             'object' => $activityObject,
+        ];
+    }
+
+    private function buildBlockFromActivity(Activity $activity): array
+    {
+        $object = $activity->getObject();
+        $expires = null;
+        $cc = [];
+        if ($object instanceof MagazineBan) {
+            $reason = $object->reason;
+            $jsonObject = $this->personFactory->getActivityPubId($object->user);
+            $target = $this->groupFactory->getActivityPubId($object->magazine);
+            $expires = $object->expiredAt?->format(DATE_ATOM);
+            $cc = [$this->groupFactory->getActivityPubId($activity->audience)];
+        } elseif ($object instanceof User) {
+            $reason = $object->banReason;
+            $jsonObject = $this->personFactory->getActivityPubId($object);
+            $target = $this->instanceFactory->getTargetUrl();
+        } else {
+            throw new \LogicException('Object of a block activity has to be of type MagazineBan');
+        }
+
+        return [
+            '@context' => $this->contextsProvider->referencedContexts(),
+            'id' => $this->urlGenerator->generate('ap_object', ['id' => $activity->uuid], UrlGeneratorInterface::ABSOLUTE_URL),
+            'type' => 'Block',
+            'actor' => $this->personFactory->getActivityPubId($activity->userActor),
+            'object' => $jsonObject,
+            'target' => $target,
+            'summary' => $reason,
+            'audience' => $activity->audience ? $this->groupFactory->getActivityPubId($activity->audience) : null,
+            'expires' => $expires,
+            'to' => [ActivityPubActivityInterface::PUBLIC_URL],
+            'cc' => $cc,
         ];
     }
 

--- a/templates/modlog/_blocks.html.twig
+++ b/templates/modlog/_blocks.html.twig
@@ -39,7 +39,13 @@
 {% endblock %}
 
 {% block log_ban %}
-    {{ component('user_inline', {user: log.user, showAvatar: showAvatars, showNewIcon: showNewIcons}) }} {% if log.meta is same as 'ban' %}{{ 'he_banned'|trans|lower }}{% else %}{{ 'he_unbanned'|trans|lower }}{% endif %} {{ component('user_inline', {user: log.ban.user, showAvatar: showAvatars, showNewIcon: showNewIcons}) }}
+    {{ component('user_inline', {user: log.user, showAvatar: showAvatars, showNewIcon: showNewIcons}) }}
+    {% if log.meta is same as 'ban' %}
+        {{ 'he_banned'|trans|lower }}
+    {% else %}
+        {{ 'he_unbanned'|trans|lower }}
+    {% endif %}
+    {{ component('user_inline', {user: log.ban.user, showAvatar: showAvatars, showNewIcon: showNewIcons}) }}
     {% if showMagazine %} {{ 'in'|trans|lower }} {{ component('magazine_inline', {magazine: log.ban.magazine, showAvatar: showIcons, showNewIcon: showNewIcons}) }}{% endif %}{% if log.ban.reason %} - {{ log.ban.reason }}{% endif %}
 {% endblock %}
 

--- a/tests/ActivityPubTestCase.php
+++ b/tests/ActivityPubTestCase.php
@@ -7,9 +7,11 @@ namespace App\Tests;
 use App\Entity\Magazine;
 use App\Entity\User;
 use App\Factory\ActivityPub\AddRemoveFactory;
+use App\Factory\ActivityPub\BlockFactory;
 use App\Factory\ActivityPub\EntryCommentNoteFactory;
 use App\Factory\ActivityPub\FlagFactory;
 use App\Factory\ActivityPub\GroupFactory;
+use App\Factory\ActivityPub\InstanceFactory;
 use App\Factory\ActivityPub\PersonFactory;
 use App\Factory\ActivityPub\PostCommentNoteFactory;
 use App\Factory\ActivityPub\PostNoteFactory;
@@ -35,6 +37,7 @@ class ActivityPubTestCase extends WebTestCase
 
     protected PersonFactory $personFactory;
     protected GroupFactory $groupFactory;
+    protected InstanceFactory $instanceFactory;
     protected EntryCommentNoteFactory $entryCommentNoteFactory;
     protected PostNoteFactory $postNoteFactory;
     protected PostCommentNoteFactory $postCommentNoteFactory;
@@ -48,6 +51,7 @@ class ActivityPubTestCase extends WebTestCase
     protected UndoWrapper $undoWrapper;
     protected FollowResponseWrapper $followResponseWrapper;
     protected FlagFactory $flagFactory;
+    protected BlockFactory $blockFactory;
     protected UserFollowRequestRepository $userFollowRequestRepository;
 
     public function setUp(): void
@@ -59,6 +63,7 @@ class ActivityPubTestCase extends WebTestCase
 
         $this->personFactory = $this->getService(PersonFactory::class);
         $this->groupFactory = $this->getService(GroupFactory::class);
+        $this->instanceFactory = $this->getService(InstanceFactory::class);
         $this->entryCommentNoteFactory = $this->getService(EntryCommentNoteFactory::class);
         $this->postNoteFactory = $this->getService(PostNoteFactory::class);
         $this->postCommentNoteFactory = $this->getService(PostCommentNoteFactory::class);
@@ -72,6 +77,7 @@ class ActivityPubTestCase extends WebTestCase
         $this->undoWrapper = $this->getService(UndoWrapper::class);
         $this->followResponseWrapper = $this->getService(FollowResponseWrapper::class);
         $this->flagFactory = $this->getService(FlagFactory::class);
+        $this->blockFactory = $this->getService(BlockFactory::class);
         $this->userFollowRequestRepository = $this->getService(UserFollowRequestRepository::class);
     }
 

--- a/tests/Functional/ActivityPub/ActivityPubFunctionalTestCase.php
+++ b/tests/Functional/ActivityPub/ActivityPubFunctionalTestCase.php
@@ -38,6 +38,7 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
     protected User $remoteSubscriber;
     protected ?string $prev;
 
+    protected string $localDomain;
     protected string $remoteDomain = 'remote.mbin';
     protected string $remoteSubDomain = 'remote.sub.mbin';
 
@@ -46,7 +47,7 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
     public function setUp(): void
     {
         parent::setUp();
-
+        $this->localDomain = $this->settingsManager->get('KBIN_DOMAIN');
         $this->setupLocalActors();
 
         $this->switchToRemoteDomain($this->remoteSubDomain);
@@ -464,13 +465,18 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
         $this->assertCount($expectedCount, $activities);
     }
 
-    protected function assertOneSentActivityOfType(string $type, ?string $activityId = null): void
+    protected function assertOneSentActivityOfType(string $type, ?string $activityId = null, ?string $inboxUrl = null): array
     {
         $activities = $this->getSentActivitiesOfType($type);
         self::assertCount(1, $activities);
         if (null !== $activityId) {
             self::assertEquals($activityId, $activities[0]['payload']['id']);
         }
+        if (null !== $inboxUrl) {
+            self::assertEquals($inboxUrl, $activities[0]['inboxUrl']);
+        }
+
+        return $activities[0]['payload'];
     }
 
     protected function assertOneSentAnnouncedActivityOfType(string $type, ?string $announcedActivityId = null): void
@@ -480,6 +486,23 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
         if (null !== $announcedActivityId) {
             self::assertEquals($announcedActivityId, $activities[0]['payload']['object']['id']);
         }
+    }
+
+    protected function assertOneSentAnnouncedActivityOfTypeGetInnerActivity(string $type, ?string $announcedActivityId = null, ?string $announceId = null, ?string $inboxUrl = null): array|string
+    {
+        $activities = $this->getSentAnnounceActivitiesOfInnerType($type);
+        self::assertCount(1, $activities);
+        if (null !== $announcedActivityId) {
+            self::assertEquals($announcedActivityId, $activities[0]['payload']['object']['id']);
+        }
+        if (null !== $announceId) {
+            self::assertEquals($announceId, $activities[0]['payload']['id']);
+        }
+        if (null !== $inboxUrl) {
+            self::assertEquals($inboxUrl, $activities[0]['inboxUrl']);
+        }
+
+        return $activities[0]['payload']['object'];
     }
 
     /**

--- a/tests/Functional/ActivityPub/Inbox/BlockHandlerTest.php
+++ b/tests/Functional/ActivityPub/Inbox/BlockHandlerTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\ActivityPub\Inbox;
+
+use App\DTO\MagazineBanDto;
+use App\DTO\ModeratorDto;
+use App\Entity\User;
+use App\Message\ActivityPub\Inbox\ActivityMessage;
+use App\Tests\Functional\ActivityPub\ActivityPubFunctionalTestCase;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group(name: 'ActivityPub')]
+#[Group(name: 'NonThreadSafe')]
+class BlockHandlerTest extends ActivityPubFunctionalTestCase
+{
+    private array $blockLocalUserLocalMagazine;
+    private array $undoBlockLocalUserLocalMagazine;
+    private array $blockRemoteUserLocalMagazine;
+    private array $undoBlockRemoteUserLocalMagazine;
+    private array $blockLocalUserRemoteMagazine;
+    private array $undoBlockLocalUserRemoteMagazine;
+    private array $blockRemoteUserRemoteMagazine;
+    private array $undoBlockRemoteUserRemoteMagazine;
+    private array $instanceBanRemoteUser;
+    private array $undoInstanceBanRemoteUser;
+
+    private User $localSubscriber;
+    private User $remoteAdmin;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        // it is important that the moderators are initialized here, as they would be removed from the db if added in `setupRemoteEntries`
+        $this->magazineManager->addModerator(new ModeratorDto($this->localMagazine, $this->remoteSubscriber, $this->localUser));
+        $this->remoteAdmin = $this->activityPubManager->findActorOrCreate("@remoteAdmin@$this->remoteDomain");
+    }
+
+    protected function setUpRemoteActors(): void
+    {
+        parent::setUpRemoteActors();
+        $user = $this->getUserByUsername('remoteAdmin', addImage: false);
+        $this->registerActor($user, $this->remoteDomain, true);
+        $this->remoteAdmin = $user;
+    }
+
+    public function setupLocalActors(): void
+    {
+        $this->localSubscriber = $this->getUserByUsername('localSubscriber', addImage: false);
+        parent::setupLocalActors();
+    }
+
+    public function setUpRemoteEntities(): void
+    {
+        $this->buildBlockLocalUserLocalMagazine();
+        $this->buildBlockLocalUserRemoteMagazine();
+        $this->buildBlockRemoteUserLocalMagazine();
+        $this->buildBlockRemoteUserRemoteMagazine();
+        $this->buildInstanceBanRemoteUser();
+    }
+
+    public function testBlockLocalUserLocalMagazine(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->blockLocalUserLocalMagazine)));
+        $ban = $this->magazineBanRepository->findOneBy(['magazine' => $this->localMagazine, 'user' => $this->localSubscriber]);
+        self::assertNotNull($ban);
+        $this->entityManager->refresh($this->localMagazine);
+        self::assertTrue($this->localMagazine->isBanned($this->localSubscriber));
+
+        $announcedBlock = $this->assertOneSentAnnouncedActivityOfTypeGetInnerActivity('Block', announcedActivityId: $this->blockLocalUserLocalMagazine['id'], inboxUrl: $this->remoteSubscriber->apInboxUrl);
+        self::assertEquals($this->blockLocalUserLocalMagazine['object'], $announcedBlock['object']);
+    }
+
+    #[Depends('testBlockLocalUserLocalMagazine')]
+    public function testUndoBlockLocalUserLocalMagazine(): void
+    {
+        $this->testBlockLocalUserLocalMagazine();
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->undoBlockLocalUserLocalMagazine)));
+        $ban = $this->magazineBanRepository->findOneBy(['magazine' => $this->localMagazine, 'user' => $this->localSubscriber]);
+        self::assertNotNull($ban);
+        $this->entityManager->refresh($this->localMagazine);
+        self::assertFalse($this->localMagazine->isBanned($this->localSubscriber));
+
+        $announcedUndo = $this->assertOneSentAnnouncedActivityOfTypeGetInnerActivity('Undo', announcedActivityId: $this->undoBlockLocalUserLocalMagazine['id'], inboxUrl: $this->remoteSubscriber->apInboxUrl);
+        self::assertEquals($this->undoBlockLocalUserLocalMagazine['object']['object'], $announcedUndo['object']['object']);
+        self::assertEquals($this->undoBlockLocalUserLocalMagazine['object']['id'], $announcedUndo['object']['id']);
+    }
+
+    public function testBlockRemoteUserLocalMagazine(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->blockRemoteUserLocalMagazine)));
+        $ban = $this->magazineBanRepository->findOneBy(['magazine' => $this->localMagazine, 'user' => $this->remoteUser]);
+        self::assertNotNull($ban);
+        $this->entityManager->refresh($this->localMagazine);
+        self::assertTrue($this->localMagazine->isBanned($this->remoteUser));
+
+        $blockActivity = $this->assertOneSentAnnouncedActivityOfTypeGetInnerActivity('Block', announcedActivityId: $this->blockRemoteUserLocalMagazine['id'], inboxUrl: $this->remoteSubscriber->apInboxUrl);
+        self::assertEquals($this->blockRemoteUserLocalMagazine['object'], $blockActivity['object']);
+    }
+
+    #[Depends('testBlockRemoteUserLocalMagazine')]
+    public function testUndoBlockRemoteUserLocalMagazine(): void
+    {
+        $this->testBlockRemoteUserLocalMagazine();
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->undoBlockRemoteUserLocalMagazine)));
+        $ban = $this->magazineBanRepository->findOneBy(['magazine' => $this->localMagazine, 'user' => $this->remoteUser]);
+        self::assertNotNull($ban);
+        $this->entityManager->refresh($this->localMagazine);
+        self::assertFalse($this->localMagazine->isBanned($this->remoteUser));
+
+        $announcedUndo = $this->assertOneSentAnnouncedActivityOfTypeGetInnerActivity('Undo', announcedActivityId: $this->undoBlockRemoteUserLocalMagazine['id'], inboxUrl: $this->remoteSubscriber->apInboxUrl);
+        self::assertEquals($this->undoBlockRemoteUserLocalMagazine['object']['id'], $announcedUndo['object']['id']);
+        self::assertEquals($this->undoBlockRemoteUserLocalMagazine['object']['object'], $announcedUndo['object']['object']);
+    }
+
+    public function testBlockLocalUserRemoteMagazine(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->blockLocalUserRemoteMagazine)));
+        $ban = $this->magazineBanRepository->findOneBy(['magazine' => $this->remoteMagazine, 'user' => $this->localSubscriber]);
+        self::assertNotNull($ban);
+        $this->entityManager->refresh($this->remoteMagazine);
+        self::assertTrue($this->remoteMagazine->isBanned($this->localSubscriber));
+    }
+
+    #[Depends('testBlockLocalUserRemoteMagazine')]
+    public function testUndoBlockLocalUserRemoteMagazine(): void
+    {
+        $this->testBlockLocalUserRemoteMagazine();
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->undoBlockLocalUserRemoteMagazine)));
+        $ban = $this->magazineBanRepository->findOneBy(['magazine' => $this->remoteMagazine, 'user' => $this->localSubscriber]);
+        self::assertNotNull($ban);
+        $this->entityManager->refresh($this->remoteMagazine);
+        self::assertFalse($this->remoteMagazine->isBanned($this->localSubscriber));
+    }
+
+    public function testBlockRemoteUserRemoteMagazine(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->blockRemoteUserRemoteMagazine)));
+        $ban = $this->magazineBanRepository->findOneBy(['magazine' => $this->remoteMagazine, 'user' => $this->remoteSubscriber]);
+        self::assertNotNull($ban);
+        $this->entityManager->refresh($this->remoteMagazine);
+        self::assertTrue($this->remoteMagazine->isBanned($this->remoteSubscriber));
+    }
+
+    #[Depends('testBlockRemoteUserRemoteMagazine')]
+    public function testUndoBlockRemoteUserRemoteMagazine(): void
+    {
+        $this->testBlockRemoteUserRemoteMagazine();
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->undoBlockRemoteUserRemoteMagazine)));
+        $ban = $this->magazineBanRepository->findOneBy(['magazine' => $this->remoteMagazine, 'user' => $this->remoteSubscriber]);
+        self::assertNotNull($ban);
+        $this->entityManager->refresh($this->remoteMagazine);
+        self::assertFalse($this->remoteMagazine->isBanned($this->remoteSubscriber));
+    }
+
+    public function testInstanceBanRemoteUser(): void
+    {
+        $username = "@remoteUser@$this->remoteDomain";
+        $remoteUser = $this->userRepository->findOneByUsername($username);
+        self::assertFalse($remoteUser->isBanned);
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->instanceBanRemoteUser)));
+        $this->entityManager->refresh($remoteUser);
+        self::assertTrue($remoteUser->isBanned);
+        self::assertEquals('testing', $remoteUser->banReason);
+    }
+
+    #[Depends('testInstanceBanRemoteUser')]
+    public function testUndoInstanceBanRemoteUser(): void
+    {
+        $this->testInstanceBanRemoteUser();
+        $username = "@remoteUser@$this->remoteDomain";
+        $remoteUser = $this->userRepository->findOneByUsername($username);
+        self::assertTrue($remoteUser->isBanned);
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->undoInstanceBanRemoteUser)));
+        $this->entityManager->refresh($remoteUser);
+        self::assertFalse($remoteUser->isBanned);
+    }
+
+    private function buildBlockLocalUserLocalMagazine(): void
+    {
+        $ban = $this->magazineManager->ban($this->localMagazine, $this->localSubscriber, $this->remoteSubscriber, MagazineBanDto::create('testing'));
+
+        $activity = $this->blockFactory->createActivityFromMagazineBan($ban);
+        $this->blockLocalUserLocalMagazine = $this->activityJsonBuilder->buildActivityJson($activity);
+        $this->blockLocalUserLocalMagazine['actor'] = str_replace($this->remoteDomain, $this->remoteSubDomain, $this->blockLocalUserLocalMagazine['actor']);
+        $this->blockLocalUserLocalMagazine['object'] = str_replace($this->remoteDomain, $this->localDomain, $this->blockLocalUserLocalMagazine['object']);
+        $this->blockLocalUserLocalMagazine['target'] = str_replace($this->remoteDomain, $this->localDomain, $this->blockLocalUserLocalMagazine['target']);
+
+        $undoActivity = $this->undoWrapper->build($activity);
+        $this->undoBlockLocalUserLocalMagazine = $this->activityJsonBuilder->buildActivityJson($undoActivity);
+        $this->undoBlockLocalUserLocalMagazine['actor'] = str_replace($this->remoteDomain, $this->remoteSubDomain, $this->undoBlockLocalUserLocalMagazine['actor']);
+        $this->undoBlockLocalUserLocalMagazine['object'] = $this->blockLocalUserLocalMagazine;
+
+        $this->testingApHttpClient->activityObjects[$this->blockLocalUserLocalMagazine['id']] = $this->blockLocalUserLocalMagazine;
+        $this->testingApHttpClient->activityObjects[$this->undoBlockLocalUserLocalMagazine['id']] = $this->undoBlockLocalUserLocalMagazine;
+        $this->entitiesToRemoveAfterSetup[] = $undoActivity;
+        $this->entitiesToRemoveAfterSetup[] = $activity;
+    }
+
+    private function buildBlockRemoteUserLocalMagazine(): void
+    {
+        $ban = $this->magazineManager->ban($this->localMagazine, $this->remoteUser, $this->remoteSubscriber, MagazineBanDto::create('testing'));
+
+        $activity = $this->blockFactory->createActivityFromMagazineBan($ban);
+        $this->blockRemoteUserLocalMagazine = $this->activityJsonBuilder->buildActivityJson($activity);
+        $this->blockRemoteUserLocalMagazine['actor'] = str_replace($this->remoteDomain, $this->remoteSubDomain, $this->blockRemoteUserLocalMagazine['actor']);
+        $this->blockRemoteUserLocalMagazine['target'] = str_replace($this->remoteDomain, $this->localDomain, $this->blockRemoteUserLocalMagazine['target']);
+
+        $undoActivity = $this->undoWrapper->build($activity);
+        $this->undoBlockRemoteUserLocalMagazine = $this->activityJsonBuilder->buildActivityJson($undoActivity);
+        $this->undoBlockRemoteUserLocalMagazine['actor'] = str_replace($this->remoteDomain, $this->remoteSubDomain, $this->undoBlockRemoteUserLocalMagazine['actor']);
+        $this->undoBlockRemoteUserLocalMagazine['object'] = $this->blockRemoteUserLocalMagazine;
+
+        $this->testingApHttpClient->activityObjects[$this->blockRemoteUserLocalMagazine['id']] = $this->blockRemoteUserLocalMagazine;
+        $this->testingApHttpClient->activityObjects[$this->undoBlockRemoteUserLocalMagazine['id']] = $this->undoBlockRemoteUserLocalMagazine;
+        $this->entitiesToRemoveAfterSetup[] = $undoActivity;
+        $this->entitiesToRemoveAfterSetup[] = $activity;
+    }
+
+    private function buildBlockLocalUserRemoteMagazine(): void
+    {
+        $ban = $this->magazineManager->ban($this->remoteMagazine, $this->localSubscriber, $this->remoteSubscriber, MagazineBanDto::create('testing'));
+
+        $activity = $this->blockFactory->createActivityFromMagazineBan($ban);
+        $this->blockLocalUserRemoteMagazine = $this->activityJsonBuilder->buildActivityJson($activity);
+        $this->blockLocalUserRemoteMagazine['actor'] = str_replace($this->remoteDomain, $this->remoteSubDomain, $this->blockLocalUserRemoteMagazine['actor']);
+        $this->blockLocalUserRemoteMagazine['object'] = str_replace($this->remoteDomain, $this->localDomain, $this->blockLocalUserRemoteMagazine['object']);
+
+        $undoActivity = $this->undoWrapper->build($activity);
+        $this->undoBlockLocalUserRemoteMagazine = $this->activityJsonBuilder->buildActivityJson($undoActivity);
+        $this->undoBlockLocalUserRemoteMagazine['actor'] = str_replace($this->remoteDomain, $this->remoteSubDomain, $this->undoBlockLocalUserRemoteMagazine['actor']);
+        $this->undoBlockLocalUserRemoteMagazine['object'] = $this->blockLocalUserRemoteMagazine;
+
+        $this->testingApHttpClient->activityObjects[$this->blockLocalUserRemoteMagazine['id']] = $this->blockLocalUserRemoteMagazine;
+        $this->testingApHttpClient->activityObjects[$this->undoBlockLocalUserRemoteMagazine['id']] = $this->undoBlockLocalUserRemoteMagazine;
+        $this->entitiesToRemoveAfterSetup[] = $undoActivity;
+        $this->entitiesToRemoveAfterSetup[] = $activity;
+    }
+
+    private function buildBlockRemoteUserRemoteMagazine(): void
+    {
+        $ban = $this->magazineManager->ban($this->remoteMagazine, $this->remoteSubscriber, $this->remoteUser, MagazineBanDto::create('testing'));
+
+        $activity = $this->blockFactory->createActivityFromMagazineBan($ban);
+        $this->blockRemoteUserRemoteMagazine = $this->activityJsonBuilder->buildActivityJson($activity);
+        $this->blockRemoteUserRemoteMagazine['object'] = str_replace($this->remoteDomain, $this->remoteSubDomain, $this->blockRemoteUserRemoteMagazine['object']);
+
+        $undoActivity = $this->undoWrapper->build($activity);
+        $this->undoBlockRemoteUserRemoteMagazine = $this->activityJsonBuilder->buildActivityJson($undoActivity);
+        $this->undoBlockRemoteUserRemoteMagazine['object'] = $this->blockRemoteUserRemoteMagazine;
+
+        $this->testingApHttpClient->activityObjects[$this->blockRemoteUserRemoteMagazine['id']] = $this->blockRemoteUserRemoteMagazine;
+        $this->testingApHttpClient->activityObjects[$this->undoBlockRemoteUserRemoteMagazine['id']] = $this->undoBlockRemoteUserRemoteMagazine;
+        $this->entitiesToRemoveAfterSetup[] = $undoActivity;
+        $this->entitiesToRemoveAfterSetup[] = $activity;
+    }
+
+    private function buildInstanceBanRemoteUser(): void
+    {
+        $this->remoteUser->banReason = 'testing';
+        $activity = $this->blockFactory->createActivityFromInstanceBan($this->remoteUser, $this->remoteAdmin);
+        $this->instanceBanRemoteUser = $this->activityJsonBuilder->buildActivityJson($activity);
+        $this->testingApHttpClient->activityObjects[$this->instanceBanRemoteUser['id']] = $this->instanceBanRemoteUser;
+        $this->entitiesToRemoveAfterSetup[] = $activity;
+
+        $activity = $this->undoWrapper->build($activity);
+        $this->undoInstanceBanRemoteUser = $this->activityJsonBuilder->buildActivityJson($activity);
+        $this->testingApHttpClient->activityObjects[$this->undoInstanceBanRemoteUser['id']] = $this->undoInstanceBanRemoteUser;
+        $this->entitiesToRemoveAfterSetup[] = $activity;
+    }
+}

--- a/tests/Functional/ActivityPub/Outbox/BlockHandlerTest.php
+++ b/tests/Functional/ActivityPub/Outbox/BlockHandlerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\ActivityPub\Outbox;
+
+use App\DTO\MagazineBanDto;
+use App\Entity\User;
+use App\Tests\Functional\ActivityPub\ActivityPubFunctionalTestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group(name: 'ActivityPub')]
+#[Group(name: 'NonThreadSafe')]
+class BlockHandlerTest extends ActivityPubFunctionalTestCase
+{
+    private User $localSubscriber;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->localSubscriber = $this->getUserByUsername('localSubscriber', addImage: false);
+        // so localSubscriber has one interaction with another instance
+        $this->magazineManager->subscribe($this->remoteMagazine, $this->localSubscriber);
+    }
+
+    public function setUpRemoteEntities(): void
+    {
+    }
+
+    public function testBanLocalUserLocalMagazineLocalModerator(): void
+    {
+        $this->magazineManager->ban($this->localMagazine, $this->localSubscriber, $this->localUser, MagazineBanDto::create(reason: 'test'));
+
+        $blockActivity = $this->assertOneSentActivityOfType('Block', inboxUrl: $this->remoteSubscriber->apInboxUrl);
+        self::assertEquals('test', $blockActivity['summary']);
+        self::assertEquals($this->personFactory->getActivityPubId($this->localSubscriber), $blockActivity['object']);
+        self::assertEquals($this->groupFactory->getActivityPubId($this->localMagazine), $blockActivity['target']);
+    }
+
+    public function testUndoBanLocalUserLocalMagazineLocalModerator(): void
+    {
+        $this->magazineManager->ban($this->localMagazine, $this->localSubscriber, $this->localUser, MagazineBanDto::create(reason: 'test'));
+
+        $blockActivity = $this->assertOneSentActivityOfType('Block', inboxUrl: $this->remoteSubscriber->apInboxUrl);
+        $this->magazineManager->unban($this->localMagazine, $this->localSubscriber);
+        $undoActivity = $this->assertOneSentActivityOfType('Undo', inboxUrl: $this->remoteSubscriber->apInboxUrl);
+        self::assertEquals($blockActivity['id'], $undoActivity['object']['id']);
+    }
+
+    public function testBanRemoteUserLocalMagazineLocalModerator(): void
+    {
+        $this->magazineManager->ban($this->localMagazine, $this->remoteSubscriber, $this->localUser, MagazineBanDto::create(reason: 'test'));
+
+        $blockActivity = $this->assertOneSentActivityOfType('Block', inboxUrl: $this->remoteSubscriber->apInboxUrl);
+        self::assertEquals('test', $blockActivity['summary']);
+        self::assertEquals($this->remoteSubscriber->apProfileId, $blockActivity['object']);
+        self::assertEquals($this->groupFactory->getActivityPubId($this->localMagazine), $blockActivity['target']);
+    }
+
+    public function testUndoBanRemoteUserLocalMagazineLocalModerator(): void
+    {
+        $this->magazineManager->ban($this->localMagazine, $this->remoteSubscriber, $this->localUser, MagazineBanDto::create(reason: 'test'));
+
+        $blockActivity = $this->assertOneSentActivityOfType('Block', inboxUrl: $this->remoteSubscriber->apInboxUrl);
+        $this->magazineManager->unban($this->localMagazine, $this->remoteSubscriber);
+        $undoActivity = $this->assertOneSentActivityOfType('Undo', inboxUrl: $this->remoteSubscriber->apInboxUrl);
+        self::assertEquals($blockActivity['id'], $undoActivity['object']['id']);
+    }
+
+    public function testBanLocalUserInstanceLocalModerator(): void
+    {
+        $this->userManager->ban($this->localSubscriber, $this->localUser, 'test');
+
+        $blockActivity = $this->assertOneSentActivityOfType('Block', inboxUrl: $this->remoteMagazine->apInboxUrl);
+        self::assertEquals('test', $blockActivity['summary']);
+        self::assertEquals($this->personFactory->getActivityPubId($this->localSubscriber), $blockActivity['object']);
+        self::assertEquals($this->instanceFactory->getTargetUrl(), $blockActivity['target']);
+    }
+
+    public function testUndoBanLocalUserInstanceLocalModerator(): void
+    {
+        $this->userManager->ban($this->localSubscriber, $this->localUser, 'test');
+
+        $blockActivity = $this->assertOneSentActivityOfType('Block', inboxUrl: $this->remoteMagazine->apInboxUrl);
+        $this->userManager->unban($this->localSubscriber, $this->localUser, 'test');
+        $undoActivity = $this->assertOneSentActivityOfType('Undo', inboxUrl: $this->remoteMagazine->apInboxUrl);
+        self::assertEquals($blockActivity['id'], $undoActivity['object']['id']);
+    }
+}

--- a/tests/Unit/ActivityPub/Outbox/AnnounceTest.php
+++ b/tests/Unit/ActivityPub/Outbox/AnnounceTest.php
@@ -8,6 +8,7 @@ use App\Tests\ActivityPubJsonDriver;
 use App\Tests\ActivityPubTestCase;
 use App\Tests\Unit\ActivityPub\Traits\AddRemoveActivityGeneratorTrait;
 use App\Tests\Unit\ActivityPub\Traits\AnnounceActivityGeneratorTrait;
+use App\Tests\Unit\ActivityPub\Traits\BlockActivityGeneratorTrait;
 use App\Tests\Unit\ActivityPub\Traits\CreateActivityGeneratorTrait;
 use App\Tests\Unit\ActivityPub\Traits\DeleteActivityGeneratorTrait;
 use App\Tests\Unit\ActivityPub\Traits\FollowActivityGeneratorTrait;
@@ -25,6 +26,7 @@ class AnnounceTest extends ActivityPubTestCase
     use DeleteActivityGeneratorTrait;
     use UndoActivityGeneratorTrait;
     use UpdateActivityGeneratorTrait;
+    use BlockActivityGeneratorTrait;
 
     public function testAnnounceAddModerator(): void
     {
@@ -372,6 +374,20 @@ class AnnounceTest extends ActivityPubTestCase
     public function testAnnounceUpdatePostComment(): void
     {
         $json = $this->activityJsonBuilder->buildActivityJson($this->getAnnounceUpdatePostCommentActivity());
+
+        $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
+    }
+
+    public function testAnnounceBlockUser(): void
+    {
+        $json = $this->activityJsonBuilder->buildActivityJson($this->getAnnounceBlockUserActivity());
+
+        $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
+    }
+
+    public function testAnnounceUndoBlockUser(): void
+    {
+        $json = $this->activityJsonBuilder->buildActivityJson($this->getAnnounceUndoBlockUserActivity());
 
         $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
     }

--- a/tests/Unit/ActivityPub/Outbox/BlockTest.php
+++ b/tests/Unit/ActivityPub/Outbox/BlockTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\ActivityPub\Outbox;
+
+use App\Tests\ActivityPubJsonDriver;
+use App\Tests\ActivityPubTestCase;
+use App\Tests\Unit\ActivityPub\Traits\BlockActivityGeneratorTrait;
+
+class BlockTest extends ActivityPubTestCase
+{
+    use BlockActivityGeneratorTrait;
+
+    public function testBlockUser(): void
+    {
+        $json = $this->activityJsonBuilder->buildActivityJson($this->getBlockUserActivity());
+
+        $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
+    }
+}

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceBlockUser__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceBlockUser__1.json
@@ -1,0 +1,33 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://kbin.test/contexts"
+    ],
+    "id": "SCRUBBED_ID",
+    "type": "Announce",
+    "actor": "https://kbin.test/m/test",
+    "object": {
+        "id": "SCRUBBED_ID",
+        "type": "Block",
+        "actor": "https://kbin.test/u/owner",
+        "object": "SCRUBBED_ID",
+        "target": "https://kbin.test/m/test",
+        "summary": "some test",
+        "audience": "https://kbin.test/m/test",
+        "expires": null,
+        "to": [
+            "https://www.w3.org/ns/activitystreams#Public"
+        ],
+        "cc": [
+            "https://kbin.test/m/test"
+        ]
+    },
+    "to": [
+        "https://www.w3.org/ns/activitystreams#Public"
+    ],
+    "cc": [
+        "https://kbin.test/m/test"
+    ],
+    "published": "SCRUBBED_DATE",
+    "audience": "https://kbin.test/m/test"
+}

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUndoBlockUser__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUndoBlockUser__1.json
@@ -1,0 +1,45 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://kbin.test/contexts"
+    ],
+    "id": "SCRUBBED_ID",
+    "type": "Announce",
+    "actor": "https://kbin.test/m/test",
+    "object": {
+        "id": "SCRUBBED_ID",
+        "type": "Undo",
+        "actor": "https://kbin.test/u/owner",
+        "object": {
+            "id": "SCRUBBED_ID",
+            "type": "Block",
+            "actor": "https://kbin.test/u/owner",
+            "object": "SCRUBBED_ID",
+            "target": "https://kbin.test/m/test",
+            "summary": "some test",
+            "audience": "https://kbin.test/m/test",
+            "expires": null,
+            "to": [
+                "https://www.w3.org/ns/activitystreams#Public"
+            ],
+            "cc": [
+                "https://kbin.test/m/test"
+            ]
+        },
+        "to": [
+            "https://www.w3.org/ns/activitystreams#Public"
+        ],
+        "cc": [
+            "https://kbin.test/m/test"
+        ],
+        "audience": "https://kbin.test/m/test"
+    },
+    "to": [
+        "https://www.w3.org/ns/activitystreams#Public"
+    ],
+    "cc": [
+        "https://kbin.test/m/test"
+    ],
+    "published": "SCRUBBED_DATE",
+    "audience": "https://kbin.test/m/test"
+}

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/BlockTest__testBlockUser__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/BlockTest__testBlockUser__1.json
@@ -1,0 +1,20 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://kbin.test/contexts"
+    ],
+    "id": "SCRUBBED_ID",
+    "type": "Block",
+    "actor": "https://kbin.test/u/owner",
+    "object": "SCRUBBED_ID",
+    "target": "https://kbin.test/m/test",
+    "summary": "some test",
+    "audience": "https://kbin.test/m/test",
+    "expires": null,
+    "to": [
+        "https://www.w3.org/ns/activitystreams#Public"
+    ],
+    "cc": [
+        "https://kbin.test/m/test"
+    ]
+}

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoBlockUser__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoBlockUser__1.json
@@ -1,0 +1,32 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://kbin.test/contexts"
+    ],
+    "id": "SCRUBBED_ID",
+    "type": "Undo",
+    "actor": "https://kbin.test/u/owner",
+    "object": {
+        "id": "SCRUBBED_ID",
+        "type": "Block",
+        "actor": "https://kbin.test/u/owner",
+        "object": "SCRUBBED_ID",
+        "target": "https://kbin.test/m/test",
+        "summary": "some test",
+        "audience": "https://kbin.test/m/test",
+        "expires": null,
+        "to": [
+            "https://www.w3.org/ns/activitystreams#Public"
+        ],
+        "cc": [
+            "https://kbin.test/m/test"
+        ]
+    },
+    "to": [
+        "https://www.w3.org/ns/activitystreams#Public"
+    ],
+    "cc": [
+        "https://kbin.test/m/test"
+    ],
+    "audience": "https://kbin.test/m/test"
+}

--- a/tests/Unit/ActivityPub/Outbox/UndoTest.php
+++ b/tests/Unit/ActivityPub/Outbox/UndoTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\ActivityPub\Outbox;
 
 use App\Tests\ActivityPubJsonDriver;
 use App\Tests\ActivityPubTestCase;
+use App\Tests\Unit\ActivityPub\Traits\BlockActivityGeneratorTrait;
 use App\Tests\Unit\ActivityPub\Traits\FollowActivityGeneratorTrait;
 use App\Tests\Unit\ActivityPub\Traits\LikeActivityGeneratorTrait;
 use App\Tests\Unit\ActivityPub\Traits\UndoActivityGeneratorTrait;
@@ -15,6 +16,7 @@ class UndoTest extends ActivityPubTestCase
     use FollowActivityGeneratorTrait;
     use LikeActivityGeneratorTrait;
     use UndoActivityGeneratorTrait;
+    use BlockActivityGeneratorTrait;
 
     public function testUndoLikeEntry(): void
     {
@@ -68,6 +70,13 @@ class UndoTest extends ActivityPubTestCase
     public function testUndoFollowMagazine(): void
     {
         $json = $this->activityJsonBuilder->buildActivityJson($this->getUndoFollowMagazineActivity());
+
+        $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
+    }
+
+    public function testUndoBlockUser(): void
+    {
+        $json = $this->activityJsonBuilder->buildActivityJson($this->getUndoBlockUserActivity());
 
         $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
     }

--- a/tests/Unit/ActivityPub/Traits/AnnounceActivityGeneratorTrait.php
+++ b/tests/Unit/ActivityPub/Traits/AnnounceActivityGeneratorTrait.php
@@ -305,4 +305,14 @@ trait AnnounceActivityGeneratorTrait
     {
         return $this->announceWrapper->build($this->magazine, $this->getUpdatePostCommentActivity());
     }
+
+    public function getAnnounceBlockUserActivity(): Activity
+    {
+        return $this->announceWrapper->build($this->magazine, $this->getBlockUserActivity());
+    }
+
+    public function getAnnounceUndoBlockUserActivity(): Activity
+    {
+        return $this->announceWrapper->build($this->magazine, $this->getUndoBlockUserActivity());
+    }
 }

--- a/tests/Unit/ActivityPub/Traits/BlockActivityGeneratorTrait.php
+++ b/tests/Unit/ActivityPub/Traits/BlockActivityGeneratorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\ActivityPub\Traits;
+
+use App\Entity\Activity;
+
+trait BlockActivityGeneratorTrait
+{
+    public function getBlockUserActivity(): Activity
+    {
+        $ban = $this->magazine->addBan($this->user, $this->owner, 'some test', null);
+
+        return $this->blockFactory->createActivityFromMagazineBan($ban);
+    }
+}

--- a/tests/Unit/ActivityPub/Traits/UndoActivityGeneratorTrait.php
+++ b/tests/Unit/ActivityPub/Traits/UndoActivityGeneratorTrait.php
@@ -47,4 +47,9 @@ trait UndoActivityGeneratorTrait
     {
         return $this->undoWrapper->build($this->getFollowMagazineActivity());
     }
+
+    public function getUndoBlockUserActivity(): Activity
+    {
+        return $this->undoWrapper->build($this->getBlockUserActivity());
+    }
 }

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -18,6 +18,7 @@ use App\Repository\BookmarkRepository;
 use App\Repository\EntryCommentRepository;
 use App\Repository\EntryRepository;
 use App\Repository\ImageRepository;
+use App\Repository\MagazineBanRepository;
 use App\Repository\MagazineRepository;
 use App\Repository\MagazineSubscriptionRepository;
 use App\Repository\MessageRepository;
@@ -136,6 +137,7 @@ abstract class WebTestCase extends BaseWebTestCase
     protected UserFollowRepository $userFollowRepository;
     protected MagazineSubscriptionRepository $magazineSubscriptionRepository;
     protected ActivityRepository $activityRepository;
+    protected MagazineBanRepository $magazineBanRepository;
 
     protected ImageFactory $imageFactory;
     protected MagazineFactory $magazineFactory;
@@ -212,6 +214,7 @@ abstract class WebTestCase extends BaseWebTestCase
         $this->userFollowRepository = $this->getService(UserFollowRepository::class);
         $this->magazineSubscriptionRepository = $this->getService(MagazineSubscriptionRepository::class);
         $this->activityRepository = $this->getService(ActivityRepository::class);
+        $this->magazineBanRepository = $this->getService(MagazineBanRepository::class);
 
         $this->imageFactory = $this->getService(ImageFactory::class);
         $this->personFactory = $this->getService(PersonFactory::class);

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -255,8 +255,8 @@ removed_comment_by: has removed a comment by
 restored_comment_by: has restored comment by
 removed_post_by: has removed a post by
 restored_post_by: has restored a post by
-he_banned: ban
-he_unbanned: unban
+he_banned: banned
+he_unbanned: unbanned
 read_all: Read all
 show_all: Show all
 flash_register_success: Welcome aboard! Your account is now registered. One last step


### PR DESCRIPTION
- bans are now federated, both incoming and outgoing and both magazine and instance-bans
- to support that, add a new field to the activity table to reference magazine bans
- also add a ban reason field for users. Mostly in advance, but lemmy instances will probably provide one
- add tests for all of that

Closes #943