### PR TITLE
Properly logout user after changing the password or 2fa

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -53,6 +53,8 @@ security:
                 path: /
                 token_provider:
                     doctrine: true
+                # see https://symfony.com/doc/current/security/remember_me.html#using-signed-remember-me-tokens
+                signature_properties: ['username', 'password', 'totpSecret', 'isBanned', 'isDeleted', 'markedForDeletionAt', 'visibility']
             two_factor:
                 auth_form_path: 2fa_login
                 check_path: 2fa_login_check

--- a/src/Controller/User/Profile/User2FAController.php
+++ b/src/Controller/User/Profile/User2FAController.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace App\Controller\User\Profile;
 
 use App\Controller\AbstractController;
+use App\DTO\Temp2FADto;
 use App\DTO\UserDto;
 use App\Entity\User;
+use App\Form\UserDisable2FAType;
+use App\Form\UserRegenerate2FABackupType;
 use App\Form\UserTwoFactorType;
 use App\Service\TwoFactorManager;
 use App\Service\UserManager;
@@ -25,6 +28,7 @@ use Symfony\Component\HttpFoundation\File\Exception\AccessDeniedException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException as CoreAccessDeniedException;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -41,6 +45,7 @@ class User2FAController extends AbstractController
         private readonly TranslatorInterface $translator,
         private readonly Security $security,
         private readonly LoggerInterface $logger,
+        private readonly UserPasswordHasherInterface $userPasswordHasher,
     ) {
     }
 
@@ -73,11 +78,8 @@ class User2FAController extends AbstractController
         $dto = $this->manager->createDto($user);
         $dto->totpSecret = $totpSecret;
 
-        // QR code generation needs a user with a code. Add one for that then immediately remove
-        // to stop side effects when persisting.
-        $user->setTotpSecret($totpSecret);
-        $qrCodeContent = $this->totpAuthenticator->getQRContent($user);
-        $user->setTotpSecret(null);
+        $temp2fa = new Temp2FADto($user->username, $totpSecret);
+        $qrCodeContent = $this->totpAuthenticator->getQRContent($temp2fa);
 
         $form = $this->handleForm($this->createForm(UserTwoFactorType::class, $dto), $dto, $request);
         if (!$form instanceof FormInterface) {
@@ -102,14 +104,27 @@ class User2FAController extends AbstractController
     #[IsGranted('ROLE_USER')]
     public function disable(Request $request): Response
     {
-        $this->validateCsrf('user_2fa_remove', $request->getPayload()->get('token'));
-
         $user = $this->getUserOrThrow();
         if (!$user->isTotpAuthenticationEnabled()) {
             throw new SuspiciousOperationException('User accessed 2fa disable path without existing 2fa in place');
         }
 
-        $this->twoFactorManager->remove2FA($user);
+        $dto = $this->manager->createDto($user);
+        $dto->totpSecret = $user->getTotpSecret();
+        $form = $this->createForm(UserDisable2FAType::class, $dto);
+        $form->handleRequest($request);
+        $this->handleCurrentPassword($form);
+        $this->handleTotpCode($form, $dto);
+
+        if ($form->isValid()) {
+            $this->twoFactorManager->remove2FA($user);
+        } else {
+            $errors = $form->getErrors(true);
+            foreach ($errors as $error) {
+                /** @var $error FormError */
+                $this->addFlash('error', $error->getMessage());
+            }
+        }
 
         return $this->redirectToRefererOrHome($request);
     }
@@ -124,12 +139,12 @@ class User2FAController extends AbstractController
         if (null === $totpSecret) {
             throw new AccessDeniedException('/settings/2fa/qrcode');
         }
-        $user->setTotpSecret($totpSecret);
+        $temp2fa = new Temp2FADto($user->username, $totpSecret);
 
         $builder = new Builder(
             writer: new PngWriter(),
             writerOptions: [],
-            data: $this->totpAuthenticator->getQRContent($user),
+            data: $this->totpAuthenticator->getQRContent($temp2fa),
             encoding: new Encoding('UTF-8'),
             errorCorrectionLevel: ErrorCorrectionLevel::High,
             size: 250,
@@ -162,13 +177,30 @@ class User2FAController extends AbstractController
     }
 
     #[IsGranted('ROLE_USER')]
-    public function backup(): Response
+    public function backup(Request $request): Response
     {
         $user = $this->getUserOrThrow();
         $this->denyAccessUnlessGranted('edit_profile', $user);
 
         if (!$user->isTotpAuthenticationEnabled()) {
             throw new SuspiciousOperationException('User accessed 2fa backup path without existing 2fa');
+        }
+
+        $dto = $this->manager->createDto($user);
+        $dto->totpSecret = $user->getTotpSecret();
+        $form = $this->createForm(UserRegenerate2FABackupType::class, $dto);
+        $form->handleRequest($request);
+        $this->handleCurrentPassword($form);
+        $this->handleTotpCode($form, $dto);
+
+        if (!$form->isValid()) {
+            $errors = $form->getErrors(true);
+            foreach ($errors as $error) {
+                /** @var $error FormError */
+                $this->addFlash('error', $error->getMessage());
+            }
+
+            return $this->redirectToRefererOrHome($request);
         }
 
         return $this->render(
@@ -190,12 +222,7 @@ class User2FAController extends AbstractController
             return $form;
         }
 
-        if ($form->has('totpCode')
-                && !$this->setupHasValidCode($dto->totpSecret, $form->get('totpCode')->getData())) {
-            $form->get('totpCode')->addError(new FormError($this->translator->trans('2fa.code_invalid')));
-
-            return $form;
-        }
+        $this->handleTotpCode($form, $dto);
 
         if (!$form->isValid()) {
             $this->logger->warning('2fa error occurred user "{username}" submitting the form "{errors}"', [
@@ -204,6 +231,11 @@ class User2FAController extends AbstractController
             ]);
             $form->get('totpCode')->addError(new FormError($this->translator->trans('2fa.setup_error')));
 
+            return $form;
+        }
+
+        $this->handleCurrentPassword($form);
+        if (!$form->isValid()) {
             return $form;
         }
 
@@ -220,19 +252,35 @@ class User2FAController extends AbstractController
         return $this->redirectToRoute('app_login');
     }
 
+    private function handleTotpCode(FormInterface $form, UserDto $dto): void
+    {
+        if ($form->has('totpCode')
+            && !$this->setupHasValidCode($dto->totpSecret, $form->get('totpCode')->getData())) {
+            $form->get('totpCode')->addError(new FormError($this->translator->trans('2fa.code_invalid')));
+        }
+    }
+
+    private function handleCurrentPassword(FormInterface $form): void
+    {
+        if ($form->has('currentPassword')) {
+            if (!$this->userPasswordHasher->isPasswordValid(
+                $this->getUser(),
+                $form->get('currentPassword')->getData()
+            )) {
+                $form->get('currentPassword')->addError(new FormError($this->translator->trans('Password is invalid')));
+            }
+        }
+    }
+
     private function setupHasValidCode(string $totpSecret, string $submittedCode): bool
     {
-        $user = $this->getUser();
-        $user->setTotpSecret($totpSecret);
+        $user = $this->getUserOrThrow();
+        $temp = new Temp2FADto($user->username, $totpSecret);
 
         $isValid = false;
-        if ($this->totpAuthenticator->checkCode($user, $submittedCode)) {
+        if ($this->totpAuthenticator->checkCode($temp, $submittedCode)) {
             $isValid = true;
         }
-
-        // the totpAuthenticator checkCode method requires the secret to be present in the user, but we
-        // don't want it there right now, so we remove it after we check.
-        $user->setTotpSecret(null);
 
         return $isValid;
     }

--- a/src/Controller/User/Profile/UserEditController.php
+++ b/src/Controller/User/Profile/UserEditController.php
@@ -6,12 +6,16 @@ namespace App\Controller\User\Profile;
 
 use App\Controller\AbstractController;
 use App\DTO\UserDto;
+use App\Entity\User;
 use App\Exception\ImageDownloadTooLargeException;
 use App\Form\UserBasicType;
+use App\Form\UserDisable2FAType;
 use App\Form\UserEmailType;
 use App\Form\UserPasswordType;
+use App\Form\UserRegenerate2FABackupType;
 use App\Service\SettingsManager;
 use App\Service\UserManager;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Totp\TotpAuthenticatorInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
@@ -30,6 +34,7 @@ class UserEditController extends AbstractController
         private readonly TranslatorInterface $translator,
         private readonly Security $security,
         private readonly SettingsManager $settingsManager,
+        private readonly TotpAuthenticatorInterface $totpAuthenticator,
     ) {
     }
 
@@ -42,7 +47,7 @@ class UserEditController extends AbstractController
         $dto = $this->manager->createDto($user);
 
         $form = $this->createForm(UserBasicType::class, $dto);
-        $formHandler = $this->handleForm($form, $dto, $request);
+        $formHandler = $this->handleForm($form, $dto, $request, $user);
         if (null === $formHandler) {
             $this->addFlash('error', 'flash_user_edit_profile_error');
         } else {
@@ -73,7 +78,7 @@ class UserEditController extends AbstractController
         $dto = $this->manager->createDto($user);
 
         $form = $this->createForm(UserEmailType::class, $dto);
-        $formHandler = $this->handleForm($form, $dto, $request);
+        $formHandler = $this->handleForm($form, $dto, $request, $user);
         if (null === $formHandler) {
             $this->addFlash('error', 'flash_user_edit_email_error');
         } else {
@@ -108,7 +113,7 @@ class UserEditController extends AbstractController
         $dto = $this->manager->createDto($user);
 
         $form = $this->createForm(UserPasswordType::class, $dto);
-        $formHandler = $this->handleForm($form, $dto, $request);
+        $formHandler = $this->handleForm($form, $dto, $request, $user);
         if (null === $formHandler) {
             $this->addFlash('error', 'flash_user_edit_password_error');
         } else {
@@ -117,11 +122,19 @@ class UserEditController extends AbstractController
             }
         }
 
+        $dto2 = $this->manager->createDto($user);
+        $disable2faForm = $this->createForm(UserDisable2FAType::class, $dto2);
+
+        $dto3 = $this->manager->createDto($user);
+        $regenerateBackupCodesForm = $this->createForm(UserRegenerate2FABackupType::class, $dto3);
+
         return $this->render(
             'user/settings/password.html.twig',
             [
                 'user' => $user,
                 'form' => $form->createView(),
+                'disable2faForm' => $disable2faForm->createView(),
+                'regenerateBackupCodes' => $regenerateBackupCodesForm->createView(),
                 'has2fa' => $user->isTotpAuthenticationEnabled(),
             ],
             new Response(
@@ -138,6 +151,7 @@ class UserEditController extends AbstractController
         FormInterface $form,
         UserDto $dto,
         Request $request,
+        User $user,
     ): FormInterface|Response|null {
         try {
             // Could thrown an error on event handlers (eg. onPostSubmit if a user upload an incorrect image)
@@ -152,6 +166,15 @@ class UserEditController extends AbstractController
                 }
             }
 
+            if ($form->isSubmitted() && $form->has('totpCode') && $user->isTotpAuthenticationEnabled()) {
+                if (!$this->totpAuthenticator->checkCode(
+                    $this->getUser(),
+                    $form->get('totpCode')->getData()
+                )) {
+                    $form->get('totpCode')->addError(new FormError($this->translator->trans('2fa.code_invalid')));
+                }
+            }
+
             if ($form->has('newEmail')) {
                 $dto->email = $form->get('newEmail')->getData();
             }
@@ -160,12 +183,12 @@ class UserEditController extends AbstractController
                 $email = $this->getUser()->email;
                 $this->manager->edit($this->getUser(), $dto);
 
-                // Check succcessful to use if profile was changed (which contains the about field)
+                // Check successful to use if profile was changed (which contains the about field)
                 if ($form->has('about')) {
                     $this->addFlash('success', 'flash_user_edit_profile_success');
                 }
 
-                // Show succcessful message to user and tell them to re-login
+                // Show successful message to user and tell them to re-login
                 // In case of an email change or password change
                 if ($dto->email !== $email || $dto->plainPassword) {
                     $this->security->logout(false);

--- a/src/DTO/Temp2FADto.php
+++ b/src/DTO/Temp2FADto.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO;
+
+use Scheb\TwoFactorBundle\Model\Totp\TotpConfiguration;
+use Scheb\TwoFactorBundle\Model\Totp\TotpConfigurationInterface;
+use Scheb\TwoFactorBundle\Model\Totp\TwoFactorInterface;
+
+class Temp2FADto implements TwoFactorInterface
+{
+    public function __construct(
+        public string $forUsername,
+        public string $secret,
+    ) {
+    }
+
+    public function isTotpAuthenticationEnabled(): bool
+    {
+        return null !== $this->secret;
+    }
+
+    public function getTotpAuthenticationUsername(): string
+    {
+        return $this->forUsername;
+    }
+
+    /**
+     * Has to match User::getTotpAuthenticationConfiguration.
+     *
+     * @see User::getTotpAuthenticationConfiguration()
+     */
+    public function getTotpAuthenticationConfiguration(): ?TotpConfigurationInterface
+    {
+        return new TotpConfiguration($this->secret, TotpConfiguration::ALGORITHM_SHA1, 30, 6);
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -33,6 +33,7 @@ use Scheb\TwoFactorBundle\Model\BackupCodeInterface;
 use Scheb\TwoFactorBundle\Model\Totp\TotpConfiguration;
 use Scheb\TwoFactorBundle\Model\Totp\TotpConfigurationInterface;
 use Scheb\TwoFactorBundle\Model\Totp\TwoFactorInterface;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
@@ -326,6 +327,11 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Visibil
     public function getEmail(): string
     {
         return $this->email;
+    }
+
+    public function getTotpSecret(): ?string
+    {
+        return $this->totpSecret;
     }
 
     public function setOrRemoveAdminRole(bool $remove = false): self
@@ -727,9 +733,25 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Visibil
         // TODO: Implement @method string getUserIdentifier()
     }
 
+    /**
+     * This method is used by Symfony to determine whether a session needs to be refreshed.
+     * Every security relevant information needs to be in there.
+     * In order to check these parameters you need to add them to the __serialize function.
+     *
+     * @see User::__serialize()
+     */
     public function isEqualTo(UserInterface $user): bool
     {
-        return !$user->isBanned;
+        $pa = PropertyAccess::createPropertyAccessor();
+        $theirTotpSecret = $pa->getValue($user, 'totpSecret') ?? '';
+
+        return $pa->getValue($user, 'isBanned') === $this->isBanned
+            && $pa->getValue($user, 'isDeleted') === $this->isDeleted
+            && $pa->getValue($user, 'markedForDeletionAt') === $this->markedForDeletionAt
+            && $pa->getValue($user, 'username') === $this->username
+            && $pa->getValue($user, 'password') === $this->password
+            && $pa->getValue($user, 'visibility') === $this->visibility
+            && ($theirTotpSecret === $this->totpSecret || $theirTotpSecret === hash('sha256', $this->totpSecret) || hash('sha256', $theirTotpSecret) === $this->totpSecret);
     }
 
     public function getApName(): string
@@ -931,5 +953,27 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Visibil
     public function setApplicationStatus(EApplicationStatus $applicationStatus): void
     {
         $this->applicationStatus = $applicationStatus->value;
+    }
+
+    /**
+     * this is used to check whether the session of a user is valid
+     * if any of these values have changed the user needs to re-login
+     * it should be the same values as the remember-me cookie signature in the security.yaml
+     * also have a look at the isEqualTo function as this stuff needs to be checked there.
+     *
+     * @see User::isEqualTo()
+     */
+    public function __serialize(): array
+    {
+        return [
+            "\0".self::class."\0id" => $this->id,
+            "\0".self::class."\0username" => $this->username,
+            "\0".self::class."\0password" => $this->password,
+            "\0".self::class."\0totpSecret" => $this->totpSecret ? hash('sha256', $this->totpSecret) : '',
+            "\0".self::class."\0isBanned" => $this->isBanned,
+            "\0".self::class."\0isDeleted" => $this->isDeleted,
+            "\0".self::class."\0markedForDeletionAt" => $this->markedForDeletionAt,
+            "\0".self::class."\0visibility" => $this->visibility,
+        ];
     }
 }

--- a/src/Form/UserDisable2FAType.php
+++ b/src/Form/UserDisable2FAType.php
@@ -12,24 +12,11 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class UserTwoFactorType extends AbstractType
+class UserDisable2FAType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add(
-                'totpCode',
-                TextType::class,
-                [
-                    'label' => '2fa.verify_authentication_code.label',
-                    'mapped' => false,
-                    'attr' => [
-                        'autocomplete' => 'one-time-code',
-                        'inputmode' => 'numeric',
-                        'pattern' => '[0-9]*',
-                    ],
-                ],
-            )
             ->add('currentPassword', PasswordType::class, [
                 'label' => 'current_password',
                 'mapped' => false,
@@ -38,6 +25,18 @@ class UserTwoFactorType extends AbstractType
                     'data-controller' => 'password-preview',
                 ],
             ])
+            ->add('totpCode',
+                TextType::class,
+                [
+                    'label' => '2fa.authentication_code.label',
+                    'mapped' => false,
+                    'attr' => [
+                        'autocomplete' => 'one-time-code',
+                        'inputmode' => 'numeric',
+                        'pattern' => '[0-9]*',
+                    ],
+                ],
+            )
             ->add('submit', SubmitType::class);
     }
 

--- a/src/Form/UserPasswordType.php
+++ b/src/Form/UserPasswordType.php
@@ -9,6 +9,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -25,6 +26,18 @@ class UserPasswordType extends AbstractType
                     'data-controller' => 'password-preview',
                 ],
             ])
+            ->add('totpCode',
+                TextType::class,
+                [
+                    'label' => '2fa.authentication_code.label',
+                    'mapped' => false,
+                    'attr' => [
+                        'autocomplete' => 'one-time-code',
+                        'inputmode' => 'numeric',
+                        'pattern' => '[0-9]*',
+                    ],
+                ],
+            )
             ->add(
                 'plainPassword',
                 RepeatedType::class,

--- a/src/Form/UserRegenerate2FABackupType.php
+++ b/src/Form/UserRegenerate2FABackupType.php
@@ -12,24 +12,11 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class UserTwoFactorType extends AbstractType
+class UserRegenerate2FABackupType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add(
-                'totpCode',
-                TextType::class,
-                [
-                    'label' => '2fa.verify_authentication_code.label',
-                    'mapped' => false,
-                    'attr' => [
-                        'autocomplete' => 'one-time-code',
-                        'inputmode' => 'numeric',
-                        'pattern' => '[0-9]*',
-                    ],
-                ],
-            )
             ->add('currentPassword', PasswordType::class, [
                 'label' => 'current_password',
                 'mapped' => false,
@@ -38,6 +25,18 @@ class UserTwoFactorType extends AbstractType
                     'data-controller' => 'password-preview',
                 ],
             ])
+            ->add('totpCode',
+                TextType::class,
+                [
+                    'label' => '2fa.authentication_code.label',
+                    'mapped' => false,
+                    'attr' => [
+                        'autocomplete' => 'one-time-code',
+                        'inputmode' => 'numeric',
+                        'pattern' => '[0-9]*',
+                    ],
+                ],
+            )
             ->add('submit', SubmitType::class);
     }
 

--- a/templates/user/settings/2fa.html.twig
+++ b/templates/user/settings/2fa.html.twig
@@ -47,6 +47,7 @@
         <div class="container">
             {{ form_start(form) }}
             {{ form_row(form.totpCode) }}
+            {{ form_row(form.currentPassword) }}
             <div class="row actions">
                 <div><span class="cancel"><a href="{{ path('user_settings_password') }}">{{ 'cancel'|trans }}</a></span></div>
                 {{ form_row(form.submit, {label: '2fa.add', attr: {class: 'btn btn__primary'}}) }}

--- a/templates/user/settings/password.html.twig
+++ b/templates/user/settings/password.html.twig
@@ -23,6 +23,9 @@
             <h2>{{ 'change_password'|trans }}</h2>
             {{ form_start(form) }}
             {{ form_row(form.currentPassword) }}
+            <div class="{{ html_classes({ "hidden": not has2fa }) }}">
+                {{ form_row(form.totpCode, {required: has2fa}) }}
+            </div>
             {{ form_row(form.plainPassword) }}
             <div class="row actions">
                 {{ form_row(form.submit, {label: 'save', attr: {class: 'btn btn__primary'}}) }}
@@ -35,28 +38,24 @@
         <div class="container">
             <h2>{{ 'two_factor_authentication'|trans }}</h2>
                 {% if has2fa %}
-                    <form action="{{ path('user_settings_2fa_disable') }}"
-                        method="POST"
-                        data-action="confirmation#ask" data-confirmation-message-param="{{ 'are_you_sure'|trans }}">
-                        <input type="hidden" name="token" value="{{ csrf_token('user_2fa_remove') }}">
-                        <div class="row">
-                            <button type="submit" class="btn btn__primary">
-                                {{ '2fa.disable'|trans }}
-                            </button>
-                        </div>
-                    </form>
+
+                    {{ form_start(disable2faForm, {action: path('user_settings_2fa_disable'), attr: {'data-action': "confirmation#ask", 'data-confirmation-message-param': 'are_you_sure'|trans}}) }}
+                    {{ form_row(disable2faForm.currentPassword) }}
+                    {{ form_row(disable2faForm.totpCode, {required: has2fa}) }}
+                    <div class="row actions">
+                        {{ form_row(disable2faForm.submit, {label: '2fa.disable', attr: {class: 'btn btn__primary'}}) }}
+                    </div>
+                    {{ form_end(disable2faForm) }}
 
                     <p id="backup-create-help" class="mt-4">{{ '2fa.backup-create.help' | trans }}</p>
 
-                    <form action="{{ path('user_settings_2fa_backup') }}"
-                          method="POST">
-                        <input type="hidden" name="token" value="{{ csrf_token('user_2fa_backup') }}">
-                        <div class="row">
-                            <button type="submit" class="btn btn__primary" aria-describedby="backup-create-help">
-                                {{ '2fa.backup-create.label' | trans }}
-                            </button>
-                        </div>
-                    </form>
+                    {{ form_start(regenerateBackupCodes, {action: path('user_settings_2fa_backup'), attr: {'data-action': "confirmation#ask", 'data-confirmation-message-param': 'are_you_sure'|trans}}) }}
+                    {{ form_row(regenerateBackupCodes.currentPassword) }}
+                    {{ form_row(regenerateBackupCodes.totpCode, {required: has2fa}) }}
+                    <div class="row actions">
+                        {{ form_row(regenerateBackupCodes.submit, {label: '2fa.backup-create.label', attr: {class: 'btn btn__primary'}}) }}
+                    </div>
+                    {{ form_end(regenerateBackupCodes) }}
                 {% else %}
                     <div class="row params__left">
                         <a href="{{ path('user_settings_2fa') }}" class="btn btn__primary" role="button">{{ '2fa.enable'|trans }}</a>


### PR DESCRIPTION
- Previously only the active session was logged out when the password or 2FA changed, now every active session gets logged out when that happens. The way symfony does this is by checking whether the serialized version of a user saved in the session object is equal to the freshly fetched one. Previously the `User::isEqualTo` function did not really check anything, other than whether the user is banned. To properly check that we need to add some more information to the serialized object, so do that in the `User::__serialize` function
- To also invalidate the remember me cookies they will be signed with some properties of the user now, see `security.yaml`
- Change the password change dialog so that the user also has to put in a 2fa code if they have that enabled
- Change the 2fa change dialog (remove and regenerate backup codes) so that a user has to insert their password and 2fa code if they want to change that
- create a dto for generating 2fa codes for the setup so the user object does not get changed. With the new logout mechanism one would get logged out as soon as one accesses the 2fa setup page (also it is just better this way)