### PR TITLE
Increase memory limit to 512M (and slightly increase post_max_size)

### DIFF
--- a/docs/02-admin/01-installation/01-bare_metal.md
+++ b/docs/02-admin/01-installation/01-bare_metal.md
@@ -15,7 +15,7 @@ This guide is aimed for Debian / Ubuntu distribution servers, but it could run o
 - **RAM:** 6GB (_more is recommended_ for large instances)
 - **Storage:** 40GB (_more is recommended_, especially if you have a lot of remote/local magazines and/or have a lot of (local) users)
 
-You can start with a smaller server and add more resources later if you are using a VPS for example.
+You can start with a smaller server and add more resources later if you are using a VPS for example. Our _recommendation_ is to have 12 vCPUs with 32GB of RAM.
 
 ## Software Requirements
 
@@ -277,10 +277,10 @@ sudo nano /etc/php/8.4/fpm/php.ini
 ; Maximum execution time of each script, in seconds
 max_execution_time = 60
 ; Both max file size and post body size are personal preferences
-upload_max_filesize = 8M
-post_max_size = 8M
+upload_max_filesize = 12M
+post_max_size = 12M
 ; Remember the memory limit is per child process
-memory_limit = 256M
+memory_limit = 512M
 ; maximum memory allocated to store the results
 realpath_cache_size = 4096K
 ; save the results for 10 minutes (600 seconds)


### PR DESCRIPTION
- Align the PHP `memory_limit` to the same limit as in our Docker setup: `memory_limit = 512M`
 https://github.com/MbinOrg/mbin/blob/ac88b76988e343e408e80b46680605f940f77ba5/docker/conf.d/10-app.ini#L15
- Increase the low 128M to 512M for `memory_limit`
- Fix the `MB` to `M`
- Explain our recommended server setup, which is around 12 vCPU cores with 32GB RAM. This seems to be a nice sweet spot for now.
- Slightly increase the upload size to 12M

Next, I'm also considering adding the same upload max file size and post max size to the Docker setup. Since currently it doesn't have set anything here https://github.com/MbinOrg/mbin/blob/main/docker/conf.d/