### PR TITLE
Remove crosspost information from list API endpoints

### DIFF
--- a/src/Controller/Api/Entry/DomainEntriesRetrieveApi.php
+++ b/src/Controller/Api/Entry/DomainEntriesRetrieveApi.php
@@ -157,7 +157,7 @@ class DomainEntriesRetrieveApi extends EntriesBaseApi
             try {
                 \assert($value instanceof Entry);
                 $this->handlePrivateContent($value);
-                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value), $this->entryRepository->findCross($value));
+                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
             } catch (\Exception $e) {
                 continue;
             }

--- a/src/Controller/Api/Entry/EntriesRetrieveApi.php
+++ b/src/Controller/Api/Entry/EntriesRetrieveApi.php
@@ -208,7 +208,7 @@ class EntriesRetrieveApi extends EntriesBaseApi
             try {
                 \assert($value instanceof Entry);
                 $this->handlePrivateContent($value);
-                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value), $this->entryRepository->findCross($value));
+                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
             } catch (AccessDeniedException $e) {
                 continue;
             }
@@ -324,7 +324,7 @@ class EntriesRetrieveApi extends EntriesBaseApi
             try {
                 \assert($value instanceof Entry);
                 $this->handlePrivateContent($value);
-                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value), $this->entryRepository->findCross($value));
+                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
             } catch (\Exception $e) {
                 continue;
             }
@@ -440,7 +440,7 @@ class EntriesRetrieveApi extends EntriesBaseApi
             try {
                 \assert($value instanceof Entry);
                 $this->handlePrivateContent($value);
-                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value), $this->entryRepository->findCross($value));
+                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
             } catch (\Exception $e) {
                 continue;
             }
@@ -556,7 +556,7 @@ class EntriesRetrieveApi extends EntriesBaseApi
             try {
                 \assert($value instanceof Entry);
                 $this->handlePrivateContent($value);
-                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value), $this->entryRepository->findCross($value));
+                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
             } catch (\Exception $e) {
                 continue;
             }

--- a/src/Controller/Api/Entry/MagazineEntriesRetrieveApi.php
+++ b/src/Controller/Api/Entry/MagazineEntriesRetrieveApi.php
@@ -158,7 +158,7 @@ class MagazineEntriesRetrieveApi extends EntriesBaseApi
         foreach ($entries->getCurrentPageResults() as $value) {
             try {
                 \assert($value instanceof Entry);
-                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value), $this->entryRepository->findCross($value));
+                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
             } catch (\Exception $e) {
                 continue;
             }

--- a/src/Controller/Api/Entry/UserEntriesRetrieveApi.php
+++ b/src/Controller/Api/Entry/UserEntriesRetrieveApi.php
@@ -153,7 +153,7 @@ class UserEntriesRetrieveApi extends EntriesBaseApi
         foreach ($entries->getCurrentPageResults() as $value) {
             try {
                 \assert($value instanceof Entry);
-                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value), $this->entryRepository->findCross($value));
+                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
             } catch (\Exception $e) {
                 continue;
             }

--- a/src/DTO/EntryResponseDto.php
+++ b/src/DTO/EntryResponseDto.php
@@ -54,7 +54,9 @@ class EntryResponseDto implements \JsonSerializable
     public ?array $bookmarks = null;
 
     /**
-     * @var EntryResponseDto[]|null $crosspostedEntries other entries that share either the link or the title (if that is longer than 10 characters)
+     * @var EntryResponseDto[]|null $crosspostedEntries other entries that share either the link or the title (if that is longer than 10 characters).
+     *                              If this property is null it means that this endpoint does not contain information about it,
+     *                              only an empty array means that there are no crossposts
      */
     #[OA\Property(type: 'array', items: new OA\Items(ref: new Model(type: EntryResponseDto::class)))]
     public ?array $crosspostedEntries;

--- a/tests/Functional/Controller/Api/Entry/DomainEntryRetrieveApiTest.php
+++ b/tests/Functional/Controller/Api/Entry/DomainEntryRetrieveApiTest.php
@@ -36,6 +36,7 @@ class DomainEntryRetrieveApiTest extends WebTestCase
         self::assertSame($magazine->getId(), $jsonData['items'][0]['magazine']['magazineId']);
         self::assertEquals('link', $jsonData['items'][0]['type']);
         self::assertSame(0, $jsonData['items'][0]['numComments']);
+        self::assertNull($jsonData['items'][0]['crosspostedEntries']);
     }
 
     public function testApiCanGetDomainEntries(): void
@@ -72,6 +73,7 @@ class DomainEntryRetrieveApiTest extends WebTestCase
         self::assertSame($magazine->getId(), $jsonData['items'][0]['magazine']['magazineId']);
         self::assertEquals('link', $jsonData['items'][0]['type']);
         self::assertSame(0, $jsonData['items'][0]['numComments']);
+        self::assertNull($jsonData['items'][0]['crosspostedEntries']);
     }
 
     public function testApiCanGetDomainEntriesNewest(): void
@@ -372,5 +374,6 @@ class DomainEntryRetrieveApiTest extends WebTestCase
         self::assertEquals('link', $jsonData['items'][0]['type']);
         self::assertEquals('another-entry', $jsonData['items'][0]['slug']);
         self::assertNull($jsonData['items'][0]['apId']);
+        self::assertNull($jsonData['items'][0]['crosspostedEntries']);
     }
 }

--- a/tests/Functional/Controller/Api/Entry/EntryRetrieveApiTest.php
+++ b/tests/Functional/Controller/Api/Entry/EntryRetrieveApiTest.php
@@ -1199,6 +1199,10 @@ class EntryRetrieveApiTest extends WebTestCase
         self::assertFalse($jsonData['items'][1]['isAuthorModeratorInMagazine']);
     }
 
+    /**
+     * This function tests that the collection endpoint does not contain crosspost information,
+     * but fetching a single entry does.
+     */
     public function testApiContainsCrosspostInformation(): void
     {
         $magazine1 = $this->getMagazineByName('acme');
@@ -1227,17 +1231,29 @@ class EntryRetrieveApiTest extends WebTestCase
         self::assertIsArray($jsonData['items'][0]);
         self::assertArrayKeysMatch(self::ENTRY_RESPONSE_KEYS, $jsonData['items'][0]);
         self::assertSame($entry1->getId(), $jsonData['items'][0]['entryId']);
-        self::assertIsArray($jsonData['items'][0]['crosspostedEntries']);
-        self::assertCount(1, $jsonData['items'][0]['crosspostedEntries']);
-        self::assertArrayKeysMatch(self::ENTRY_RESPONSE_KEYS, $jsonData['items'][0]['crosspostedEntries'][0]);
-        self::assertSame($entry2->getId(), $jsonData['items'][0]['crosspostedEntries'][0]['entryId']);
+        self::assertNull($jsonData['items'][0]['crosspostedEntries']);
 
         self::assertIsArray($jsonData['items'][1]);
         self::assertArrayKeysMatch(self::ENTRY_RESPONSE_KEYS, $jsonData['items'][1]);
         self::assertSame($entry2->getId(), $jsonData['items'][1]['entryId']);
-        self::assertIsArray($jsonData['items'][1]['crosspostedEntries']);
-        self::assertCount(1, $jsonData['items'][1]['crosspostedEntries']);
-        self::assertArrayKeysMatch(self::ENTRY_RESPONSE_KEYS, $jsonData['items'][1]['crosspostedEntries'][0]);
-        self::assertSame($entry1->getId(), $jsonData['items'][1]['crosspostedEntries'][0]['entryId']);
+        self::assertNull($jsonData['items'][1]['crosspostedEntries']);
+
+        $this->client->request('GET', '/api/entry/'.$entry1->getId());
+        self::assertResponseIsSuccessful();
+        $jsonData = self::getJsonResponse($this->client);
+
+        self::assertIsArray($jsonData['crosspostedEntries']);
+        self::assertCount(1, $jsonData['crosspostedEntries']);
+        self::assertArrayKeysMatch(self::ENTRY_RESPONSE_KEYS, $jsonData['crosspostedEntries'][0]);
+        self::assertSame($entry2->getId(), $jsonData['crosspostedEntries'][0]['entryId']);
+
+        $this->client->request('GET', '/api/entry/'.$entry2->getId());
+        self::assertResponseIsSuccessful();
+        $jsonData = self::getJsonResponse($this->client);
+
+        self::assertIsArray($jsonData['crosspostedEntries']);
+        self::assertCount(1, $jsonData['crosspostedEntries']);
+        self::assertArrayKeysMatch(self::ENTRY_RESPONSE_KEYS, $jsonData['crosspostedEntries'][0]);
+        self::assertSame($entry1->getId(), $jsonData['crosspostedEntries'][0]['entryId']);
     }
 }

--- a/tests/Functional/Controller/Api/Entry/MagazineEntryRetrieveApiTest.php
+++ b/tests/Functional/Controller/Api/Entry/MagazineEntryRetrieveApiTest.php
@@ -36,6 +36,7 @@ class MagazineEntryRetrieveApiTest extends WebTestCase
         self::assertSame($magazine->getId(), $jsonData['items'][0]['magazine']['magazineId']);
         self::assertEquals('link', $jsonData['items'][0]['type']);
         self::assertSame(0, $jsonData['items'][0]['numComments']);
+        self::assertNull($jsonData['items'][0]['crosspostedEntries']);
     }
 
     public function testApiCanGetMagazineEntries(): void
@@ -72,6 +73,7 @@ class MagazineEntryRetrieveApiTest extends WebTestCase
         self::assertSame($magazine->getId(), $jsonData['items'][0]['magazine']['magazineId']);
         self::assertEquals('link', $jsonData['items'][0]['type']);
         self::assertSame(0, $jsonData['items'][0]['numComments']);
+        self::assertNull($jsonData['items'][0]['crosspostedEntries']);
     }
 
     public function testApiCanGetMagazineEntriesPinnedFirst(): void
@@ -118,6 +120,7 @@ class MagazineEntryRetrieveApiTest extends WebTestCase
         self::assertSame(0, $jsonData['items'][0]['numComments']);
         self::assertSame(0, $jsonData['items'][0]['uv']);
         self::assertTrue($jsonData['items'][0]['isPinned']);
+        self::assertNull($jsonData['items'][0]['crosspostedEntries']);
 
         self::assertIsArray($jsonData['items'][1]);
         self::assertArrayKeysMatch(self::ENTRY_RESPONSE_KEYS, $jsonData['items'][1]);
@@ -129,6 +132,7 @@ class MagazineEntryRetrieveApiTest extends WebTestCase
         self::assertSame(1, $jsonData['items'][1]['numComments']);
         self::assertSame(1, $jsonData['items'][1]['uv']);
         self::assertFalse($jsonData['items'][1]['isPinned']);
+        self::assertNull($jsonData['items'][1]['crosspostedEntries']);
     }
 
     public function testApiCanGetMagazineEntriesNewest(): void

--- a/tests/Functional/Controller/Api/Entry/UserEntryRetrieveApiTest.php
+++ b/tests/Functional/Controller/Api/Entry/UserEntryRetrieveApiTest.php
@@ -40,6 +40,7 @@ class UserEntryRetrieveApiTest extends WebTestCase
         self::assertSame($otherUser->getId(), $jsonData['items'][0]['user']['userId']);
         self::assertEquals('link', $jsonData['items'][0]['type']);
         self::assertSame(0, $jsonData['items'][0]['numComments']);
+        self::assertNull($jsonData['items'][0]['crosspostedEntries']);
     }
 
     public function testApiCanGetUserEntries(): void
@@ -80,6 +81,7 @@ class UserEntryRetrieveApiTest extends WebTestCase
         self::assertSame($otherUser->getId(), $jsonData['items'][0]['user']['userId']);
         self::assertEquals('link', $jsonData['items'][0]['type']);
         self::assertSame(0, $jsonData['items'][0]['numComments']);
+        self::assertNull($jsonData['items'][0]['crosspostedEntries']);
     }
 
     public function testApiCanGetUserEntriesNewest(): void
@@ -381,5 +383,6 @@ class UserEntryRetrieveApiTest extends WebTestCase
         self::assertEquals('link', $jsonData['items'][0]['type']);
         self::assertEquals('another-entry', $jsonData['items'][0]['slug']);
         self::assertNull($jsonData['items'][0]['apId']);
+        self::assertNull($jsonData['items'][0]['crosspostedEntries']);
     }
 }


### PR DESCRIPTION
- remove the crosspost information of entries from API endpoints that return multiple entries. This is mainly a performance consideration, but also the same behaviour as the web UI as
- add asserts about this property (`crosspostedEntries`) in the tests

@jwr1 FYI