### PR TITLE
Fix missing delete activity when normal user deletes their content

### DIFF
--- a/src/Service/ActivityPub/DeleteService.php
+++ b/src/Service/ActivityPub/DeleteService.php
@@ -28,7 +28,7 @@ class DeleteService
 
     public function announceIfNecessary(?User $deletingUser, Entry|EntryComment|Post|PostComment $content): void
     {
-        if (null !== $deletingUser && (!$content->apId || !$content->magazine->apId || !$deletingUser->apId) && ($content->magazine->userIsModerator($deletingUser) || $content->magazine->hasSameHostAsUser($deletingUser))) {
+        if (null !== $deletingUser && (!$content->apId || !$content->magazine->apId || !$deletingUser->apId) && ($content->magazine->userIsModerator($deletingUser) || $content->magazine->hasSameHostAsUser($deletingUser) || $content->isAuthor($deletingUser))) {
             if ($deletingUser->apId) {
                 $deleteActivity = $this->activityRepository->findFirstActivitiesByTypeAndObject('Delete', $content);
                 if (!$deleteActivity) {


### PR DESCRIPTION
- Add tests for a local user deleting their content
- fix the `DeleteService::announceIfNecessary` not taking into account local users without being moderators