### PR TITLE
Fix `FollowHandler`

### DIFF
--- a/src/MessageHandler/ActivityPub/Outbox/FollowHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/FollowHandler.php
@@ -62,7 +62,7 @@ class FollowHandler extends MbinMessageHandler
             $following = $this->userRepository->find($message->followingId);
         }
 
-        $followObject = $this->activityRepository->findFirstActivitiesByTypeAndObject('Follow', $following);
+        $followObject = $this->activityRepository->findFirstActivitiesByTypeObjectAndActor('Follow', $following, $follower);
         if (null === $followObject) {
             $followObject = $this->followWrapper->build($follower, $following);
         }

--- a/src/Repository/ActivityRepository.php
+++ b/src/Repository/ActivityRepository.php
@@ -64,6 +64,40 @@ class ActivityRepository extends ServiceEntityRepository
         return $qb->getQuery()->getResult();
     }
 
+    public function findFirstActivitiesByTypeObjectAndActor(string $type, ActivityPubActivityInterface|ActivityPubActorInterface $object, ActivityPubActorInterface $actor): ?Activity
+    {
+        $results = $this->findAllActivitiesByTypeObjectAndActor($type, $object, $actor);
+        if (!empty($results)) {
+            return $results[0];
+        }
+
+        return null;
+    }
+
+    /**
+     * @return Activity[]|null
+     */
+    public function findAllActivitiesByTypeObjectAndActor(string $type, ActivityPubActivityInterface|ActivityPubActorInterface $object, ActivityPubActorInterface $actor): ?array
+    {
+        $qb = $this->createQueryBuilder('a');
+        $qb->where('a.type = :type');
+        $qb->setParameter('type', $type);
+
+        $this->addObjectFilter($qb, $object);
+
+        if ($actor instanceof User) {
+            $qb->andWhere('a.userActor = :user');
+            $qb->setParameter('user', $actor);
+        } elseif ($actor instanceof Magazine) {
+            $qb->andWhere('a.magazineActor = :magazine');
+            $qb->setParameter('magazine', $actor);
+        } else {
+            throw new \LogicException('Only magazine and user actors supported');
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
     /**
      * @return Activity[]|null
      */


### PR DESCRIPTION
- Undoing a follow lead to an exception in the `ActivityJsonBuilder` due to the array not containing a `cc` field
- Following someone searched for the first existing follow activity completely disregarding the actor -> a follow activity from the first one to follow another actor was sent, which is just not what should be happening -> added the actor to the filter. For every other case this was fine, as a `Create` activity can only be sent by the creator of the content