### PR TITLE
Use Ubuntu 25.04 for PHP 8.4

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,5 +1,5 @@
-# Using the latest LTS release
-FROM ubuntu:latest
+# Using the Ubuntu Plucky (25.04)⁠ release
+FROM ubuntu:plucky⁠
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Use [Ubuntu Plucky Puffin](https://releases.ubuntu.com/plucky)  (25.04) in order to fetch `php8.4-*` packages.

Too bad Ubuntu 24.04 only has PHP 8.3 in the default package repositories. Assuming we do not add additional PPAs.

Follow-up from: https://github.com/MbinOrg/mbin/pull/1763