### PR TITLE
Use the correct expression class

### DIFF
--- a/src/Controller/Api/User/Admin/UserApplicationApi.php
+++ b/src/Controller/Api/User/Admin/UserApplicationApi.php
@@ -17,9 +17,9 @@ use Nelmio\ApiDocBundle\Annotation\Model;
 use Nelmio\ApiDocBundle\Annotation\Security;
 use OpenApi\Attributes as OA;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
-use Symfony\Component\Language\Expression;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 


### PR DESCRIPTION
this broke our doc deploy, because the command `php bin/console nelmio:apidoc:dump --format=json --no-pretty` threw this error:

> In UserApplicationApi.php line 78:
>                                                                                                       
>  Attempted to load class "Expression" from namespace "Symfony\Component\Language".                    
  Did you forget a "use" statement for e.g. "phpDocumentor\Reflection\Types\Expression", "Symfony\Com  
  ponent\Validator\Constraints\Expression", "Symfony\Component\ExpressionLanguage\Expression", "PhpPa  
  rser\Node\Stmt\Expression", "League\Uri\UriTemplate\Expression" or "Doctrine\Common\Collections\Exp  
  r\Expression"?  

@jwr1 FYI