### PR TITLE
Table td padding

### DIFF
--- a/assets/styles/layout/_layout.scss
+++ b/assets/styles/layout/_layout.scss
@@ -167,7 +167,7 @@ table th a{
 
 table th,
 table td {
-  padding: .25rem;
+  padding: 0.5rem 0.25rem;
   position: relative;
   border: var(--kbin-section-border);
 


### PR DESCRIPTION
- Create just a little bit more "~~breeding~~ breathing room" in the table without claustrophobia :)
  - Especially because user facing pages are also effected
- A very small increase in height to _only_ 0.5rem, but still **far from** the 1.5 rem what is used to be...
- Vertical padding kept the same at 0.25rem (like its now in the `main`)

| Before | After |
| ------ | ----- |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/3495c924-328a-44a0-9a78-fd574f96ee9e" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/e624d421-5ee5-4599-9bc4-d93dff4da1e5" />  | 

Previous PR: https://github.com/MbinOrg/mbin/pull/1781