### PR TITLE
Fix type error in `NotificationBaseApi`

### DIFF
--- a/src/Controller/Api/Notification/NotificationBaseApi.php
+++ b/src/Controller/Api/Notification/NotificationBaseApi.php
@@ -139,7 +139,7 @@ class NotificationBaseApi extends BaseApi
             case 'new_signup':
                 /** @var NewSignupNotification $n */
                 $n = $dto;
-                $toReturn['subject'] = $this->userFactory->createDto($n->getSubject()->getId());
+                $toReturn['subject'] = $this->userFactory->createDto($n->getSubject());
                 break;
         }
 


### PR DESCRIPTION
- `UserFactory::createDto` expects a user and not their id. Fix the wrong call

Fixes #1815 