### PR TITLE
Fix A logged in user is required to resolve the authorization request (500 error)

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -121,7 +121,7 @@ security:
         - { path: ^/2fa, role: IS_AUTHENTICATED_2FA_IN_PROGRESS }
 
         - { path: ^/admin, roles: [ROLE_ADMIN, ROLE_MODERATOR] }
-        - { path: ^/authorize, roles: PUBLIC_ACCESS }
+        - { path: ^/authorize, roles: IS_AUTHENTICATED_REMEMBERED }
         - { path: ^/token, roles: PUBLIC_ACCESS }
         - { path: ^/api/doc, roles: PUBLIC_ACCESS }
         - { path: ^/api/client, roles: PUBLIC_ACCESS }


### PR DESCRIPTION
When using Interstellar I was trying to relogin on my kbin.melroy.org. However, I was faced with an Internal Server Error (500 server error coming from `oauth2-server-bundle`) 😢 .

Logging said:

```json
{"message":"Uncaught PHP Exception RuntimeException: \"A logged in user is required to resolve the authorization request.\" at AuthorizationRequestResolveEventFactoryTrait.php line 44","context":{"exception":{"class":"RuntimeException","message":"A logged in user is required to resolve the authorization request.","code":0,"file":"/var/www/kbin.melroy.org/html/vendor/league/oauth2-server-bundle/src/Event/AuthorizationRequestResolveEventFactoryTrait.php:44"}},"level":500,"level_name":"CRITICAL","channel":"request","datetime":"2025-11-16T21:00:13.914366+01:00","extra":{}}
```

So, I followed the documentation instructions: https://github.com/thephpleague/oauth2-server-bundle/blob/44272ff229da25305d4f5612546851bbcaa72d9a/docs/index.md?plain=1#L149

(Related PR: https://github.com/thephpleague/oauth2-server-bundle/issues/200)

---

I tested it.. And this PR fixes the issue I was having on my kbin.melroy.org with Interstellar and an expired login session I guess.

This will maybe also fix the session issues with people that are getting logged-out?