### PR TITLE
Fix null exception in ban notification

### DIFF
--- a/templates/notifications/_blocks.html.twig
+++ b/templates/notifications/_blocks.html.twig
@@ -97,7 +97,10 @@
 {% endblock message_notification %}
 
 {% block magazine_ban_notification %}
-    {{ component('user_inline', {user: notification.ban.bannedBy, showNewIcon: true}) }} {{ 'banned'|trans|lower }}. {{ 'ban_expired'|trans }} {{ component('date', {date: notification.ban.expiredAt}) }}. {{ notification.ban.reason }}
+    {{ component('user_inline', {user: notification.ban.bannedBy, showNewIcon: true}) }} {{ 'banned'|trans|lower }}. {{ 'ban_expired'|trans }}
+    {%- if notification.ban.expiredAt is not same as null -%}
+        {{ component('date', {date: notification.ban.expiredAt}) }}
+    {%- endif -%}. {{ notification.ban.reason }}
 {% endblock magazine_ban_notification %}
 
 {% block reportlink %}


### PR DESCRIPTION
If a ban does not expire the date is null. If that is the case the notification will throw an exception, fix that.