### PR TITLE
Explain how to disable the log files of supervisor jobs

### DIFF
--- a/docs/02-admin/01-installation/01-bare_metal.md
+++ b/docs/02-admin/01-installation/01-bare_metal.md
@@ -593,7 +593,8 @@ Save and close the file.
 > [!IMPORTANT]
 > Uncomment the `stdout_logfile` and `redirect_stderr` lines if you do *not** want the Supervisor worker logs being written to `/var/log/supervisor`. After all the same log entries will be written to the Mbin production log.
 
-_Note:_ you can increase the number of running messenger jobs if your queue is building up (i.e. more messages are coming in than your messengers can handle)
+> [!NOTE]
+> you can increase the number of running messenger jobs if your queue is building up (i.e. more messages are coming in than your messengers can handle)
 
 Save and close the file. Restart supervisor jobs:
 


### PR DESCRIPTION
We should explain how to disable the Supervisor logs, since these are redundant and only costing disk I/O and storage.

I'm also in favor of adding these two lines by default and explain to comment them if admins do want to see the logs (so the other way around).
