### PR TITLE
Improve English default view

### DIFF
--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -1091,7 +1091,7 @@ federation_page_use_allowlist_help: If an allow list is used, this instance will
   only federate with the explicitly allowed instances. Otherwise this instance 
   will federate with every instance, except those that are banned.
 front_default_content: Front default view
-default_content_default: Default view (Threads)
+default_content_default: Server default (Threads)
 default_content_all: Threads + Microblog
 default_content_threads: Threads
 default_content_microblog: Microblog


### PR DESCRIPTION
- Default content doesn't sound correct. I believe it should be called the default view.
- Also the default value, just call it what it is: "Default view (Threads)"

Currently looks like this:

<img width="1182" height="420" alt="image" src="https://github.com/user-attachments/assets/e594d571-5eae-48a9-b23f-be236db5b6a8" />
After:

<img width="1212" height="232" alt="image" src="https://github.com/user-attachments/assets/22844714-4845-41ee-99f6-6952a298aa42" />
