### PR TITLE
Fix z5 focus issue with more button

### DIFF
--- a/assets/controllers/subject_controller.js
+++ b/assets/controllers/subject_controller.js
@@ -381,7 +381,7 @@ export default class extends Controller {
                 if (active && parent.contains(active) && !self.moreTarget.contains(active)) {
                     try {
                         active.blur();
-                    } catch (e) {
+                    } catch {
                         // ignore environments where blur may throw
                     }
                 }


### PR DESCRIPTION
The with the more button on desktop always annoyed me for very long, caused by a .z-5 class (which is using `z-index: 5 !important`).

So for example when you "click" on the more button, you will get more focus. Which is nice, but it breaks when you go to the other more button.

I found an easy way to solve this.. First we need to remove `.z-5` CSS class in case of another more target, but due to the `:focus-within` CSS Pseudo class, but I also need to re-focus the correct element now (using `blur()`) since that will trigger the `:focus-within` that is currently used in our CSS styles. These two combined resolved the issue.

More info about focus-within: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:focus-within

More info about: the `blur()` method (no it has nothing to do with image blur... ><): https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/blur

**Before:**

https://github.com/user-attachments/assets/15af559f-930b-49a2-ace6-2326e5dab30a


**After:**


https://github.com/user-attachments/assets/9bc37bd6-fcd6-4a6f-9eea-530574c52dc7

