### PR TITLE
Docs: comment-out options in messenger (for developers)

### DIFF
--- a/docs/03-contributing/01-getting_started.md
+++ b/docs/03-contributing/01-getting_started.md
@@ -218,6 +218,23 @@ POSTGRES_PASSWORD=<password>
 MESSENGER_TRANSPORT_DSN=doctrine://default
 ```
 
+### Change yaml configuration
+
+In case you are using Doctrine as the messenger transport (see `MESSENGER_TRANSPORT_DSN` above), then you will also need to comment-out all the `options:` sections in the `config/packages/messenger.yaml` file. So the whole section, for example:
+
+```yaml
+    # options:
+    #     queues:
+    #         receive:
+    #             arguments:
+    #                 x-queue-version: 2
+    #                 x-queue-type: 'classic'
+    #     exchange:
+    #         name: receive
+```
+
+This is because those options are only meant for AMQP transport (like with RabbitMQ), but these options can **not** be used with Doctrine transport.
+
 ### Install Symfony CLI tool
 
 1. Install Symfony CLI: `wget https://get.symfony.com/cli/installer -O - | bash`


### PR DESCRIPTION
I do not want to create a copy the `messenger.yaml` since that will only lead to out of sync issues between the two files.
Hence I document to just explain that you will need to comment `options:` section out.

Also normally nobody is using `doctrine://` transport for their messenger queues, this is only relevant in development setups in case you do not want to setup RabbitMQ.

Introduced in: https://github.com/MbinOrg/mbin/pull/595
