### PR TITLE
Add missing migration for front_default_content DB enum

### DIFF
--- a/migrations/Version20251129140919.php
+++ b/migrations/Version20251129140919.php
@@ -16,11 +16,11 @@ final class Version20251129140919 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TYPE enumfrontcontentoptions RENAME VALUE \'all\' TO \'combined\'');
+        $this->addSql('ALTER TYPE enumFrontContentOptions RENAME VALUE \'all\' TO \'combined\'');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TYPE enumfrontcontentoptions RENAME VALUE \'combined\' TO \'all\'');
+        $this->addSql('ALTER TYPE enumFrontContentOptions RENAME VALUE \'combined\' TO \'all\'');
     }
 }


### PR DESCRIPTION
I forgot to include the migration after PR: https://github.com/MbinOrg/mbin/pull/1883

We just need to rename `all` to `combined`.

Now you can change the setting again without errors.
