### PR TITLE
Break out of function when banned

### DIFF
--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -1075,6 +1075,7 @@ class ActivityPubManager
     public function getEntityObject(string|array $apObject, array $fullPayload, callable $chainDispatch): Entry|EntryComment|Post|PostComment|null
     {
         $object = null;
+        $activity = null;
         $calledUrl = null;
         if (\is_string($apObject)) {
             if (false === filter_var($apObject, FILTER_VALIDATE_URL)) {


### PR DESCRIPTION
To avoid unnecessary errors like this now:

```
{"message":"[ActivityPubManager::getEntityObject] The activity is still null and we couldn't get the object from the url, discarding","context":{"id":"https://lemmy.ca/activities/like/2f52148e-6a2a-4f3a-a878-83f7f66c3a8c","actor":"https://lemmy.ca/u/Facelesbutcher","@context":["https://join-lemmy.org/context.json","https://www.w3.org/ns/activitystreams"],"object":"https://aussie.zone/comment/19925343","type":"Like","audience":"https://lemmy.world/c/microblogmemes"},"level":400,"level_name":"ERROR","channel":"app","datetime":"2025-11-30T15:59:22.035978+00:00","extra":{}}
{"message":"[ActivityPubManager::getEntityObject] The activity is still null and we couldn't get the object from the url, discarding","context":{"id":"https://lemmy.ca/activities/like/b73945bb-1d45-42d0-bd69-17303d3e7341","actor":"https://lemmy.ca/u/Facelesbutcher","@context":["https://join-lemmy.org/context.json","https://www.w3.org/ns/activitystreams"],"object":"https://aussie.zone/comment/19942494","type":"Like","audience":"https://lemmy.world/c/microblogmemes"},"level":400,"level_name":"ERROR","channel":"app","datetime":"2025-11-30T15:59:22.468268+00:00","extra":{}}
{"message":"[ActivityPubManager::getEntityObject] The activity is still null and we couldn't get the object from the url, discarding","context":{"id":"https://lemmy.sdf.org/activities/like/ec85f577-6fc7-491e-97a3-3ce2489d0eae","actor":"https://lemmy.sdf.org/u/Funky_Beak","@context":["https://join-lemmy.org/context.json","https://www.w3.org/ns/activitystreams"],"object":"https://aussie.zone/post/27181450","type":"Like","audience":"https://slrpnk.net/c/climate"},"level":400,"level_name":"ERROR","channel":"app","datetime":"2025-11-30T16:01:30.165609+00:00","extra":{}}
```

1. I think we should just `return null` in case of a banned instance, so we break out of the function. We do the same thing in `findActorOrCreate` for example.
2. Explicitly set `$activity` to null at the top of the function. This doesn't change anything, but its better code and more consistent with the rest.

Now it shows me errors (see above), which is coming from line 1108.. But I do **not** want to see errors for banned instances like that.