### PR TITLE
Clean up the duplicates from .env.devcontainer

### DIFF
--- a/.devcontainer/.env.devcontainer
+++ b/.devcontainer/.env.devcontainer
@@ -74,15 +74,6 @@ S3_REGION=
 S3_ENDPOINT=
 S3_VERSION=
 
-# Only let admins generate oauth clients
-KBIN_ADMIN_ONLY_OAUTH_CLIENTS=false
-
-# Manually approve every new user
-MBIN_NEW_USERS_NEED_APPROVAL=false
-
-# use an allowlist instead of a ban list
-MBIN_USE_FEDERATION_ALLOW_LIST=false
-
 # oAuth (optional)
 OAUTH_AZURE_ID=
 OAUTH_AZURE_SECRET=


### PR DESCRIPTION
After rearranging the .env file for the devcontainer I forgot to cleanup the duplicates.

Since from now onwards all our `MBIN_*` and `KBIN_*` env vars are defined at the top of the file.

