### PR TITLE
Fix multiple mentions, fix magazine mentions

### DIFF
--- a/tests/ActivityPubTestCase.php
+++ b/tests/ActivityPubTestCase.php
@@ -16,6 +16,7 @@ use App\Factory\ActivityPub\PersonFactory;
 use App\Factory\ActivityPub\PostCommentNoteFactory;
 use App\Factory\ActivityPub\PostNoteFactory;
 use App\Repository\UserFollowRequestRepository;
+use App\Service\ActivityPub\MarkdownConverter;
 use App\Service\ActivityPub\Wrapper\AnnounceWrapper;
 use App\Service\ActivityPub\Wrapper\CreateWrapper;
 use App\Service\ActivityPub\Wrapper\DeleteWrapper;
@@ -54,6 +55,8 @@ class ActivityPubTestCase extends WebTestCase
     protected BlockFactory $blockFactory;
     protected UserFollowRequestRepository $userFollowRequestRepository;
 
+    protected MarkdownConverter $apMarkdownConverter;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -79,6 +82,8 @@ class ActivityPubTestCase extends WebTestCase
         $this->flagFactory = $this->getService(FlagFactory::class);
         $this->blockFactory = $this->getService(BlockFactory::class);
         $this->userFollowRequestRepository = $this->getService(UserFollowRequestRepository::class);
+
+        $this->apMarkdownConverter = $this->getService(MarkdownConverter::class);
     }
 
     /**

--- a/tests/Functional/ActivityPub/ActivityPubFunctionalTestCase.php
+++ b/tests/Functional/ActivityPub/ActivityPubFunctionalTestCase.php
@@ -82,6 +82,9 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
         for ($i = \sizeof($this->entitiesToRemoveAfterSetup) - 1; $i >= 0; --$i) {
             $this->entityManager->remove($this->entitiesToRemoveAfterSetup[$i]);
         }
+        $this->entries = new ArrayCollection();
+        $this->magazines = new ArrayCollection();
+        $this->users = new ArrayCollection();
 
         $this->entityManager->flush();
         $this->entityManager->clear();

--- a/tests/Functional/ActivityPub/Inbox/CreateHandlerTest.php
+++ b/tests/Functional/ActivityPub/Inbox/CreateHandlerTest.php
@@ -200,8 +200,10 @@ class CreateHandlerTest extends ActivityPubFunctionalTestCase
         $post = $this->postRepository->findOneBy(['apId' => $this->createMastodonPostWithMention['object']['id']]);
         self::assertNotNull($post);
         $mentions = $this->mentionManager->extract($post->body);
-        self::assertCount(1, $mentions);
+        self::assertCount(3, $mentions);
         self::assertEquals('@someOtherUser@some.instance.tld', $mentions[0]);
+        self::assertEquals('@someUser@some.instance.tld', $mentions[1]);
+        self::assertEquals('@someMagazine@some.instance.tld', $mentions[2]);
     }
 
     public function testMastodonMentionInPostWithoutTagArray(): void
@@ -218,8 +220,16 @@ class CreateHandlerTest extends ActivityPubFunctionalTestCase
     {
         $domain = 'some.instance.tld';
         $this->switchToRemoteDomain($domain);
+
         $user = $this->getUserByUsername('someOtherUser', addImage: false, email: 'user@some.tld');
         $this->registerActor($user, $domain, true);
+
+        $user = $this->getUserByUsername('someUser', addImage: false, email: 'user2@some.tld');
+        $this->registerActor($user, $domain, true);
+
+        $magazine = $this->getMagazineByName('someMagazine', user: $user);
+        $this->registerActor($magazine, $domain, true);
+
         $this->switchToLocalDomain();
     }
 
@@ -228,7 +238,7 @@ class CreateHandlerTest extends ActivityPubFunctionalTestCase
         $this->createMastodonPostWithMention = $this->createRemotePostInLocalMagazine($this->localMagazine, $this->remoteUser);
         unset($this->createMastodonPostWithMention['object']['source']);
         // this is what it would look like if a user created a post in Mastodon with just a single mention and nothing else
-        $text = '<p><span class="h-card" translate="no"><a href="https://some.instance.tld/u/someOtherUser" class="u-url mention">@<span>someOtherUser</span></a></span>';
+        $text = '<p><span class="h-card" translate="no"><a href="https://some.instance.tld/u/someOtherUser" class="u-url mention">@<span>someOtherUser</span></a></span> <span class="h-card" translate="no"><a href="https://some.instance.tld/u/someUser" class="u-url mention">@<span>someUser</span></a></span> <span class="h-card" translate="no"><a href="https://some.instance.tld/m/someMagazine" class="u-url mention">@<span>someMagazine</span></a></span></p>';
         $this->createMastodonPostWithMention['object']['contentMap']['en'] = $text;
         $this->createMastodonPostWithMention['object']['content'] = $text;
         $this->createMastodonPostWithMention['object']['tag'] = [
@@ -236,6 +246,16 @@ class CreateHandlerTest extends ActivityPubFunctionalTestCase
                 'type' => 'Mention',
                 'href' => 'https://some.instance.tld/u/someOtherUser',
                 'name' => '@someOtherUser',
+            ],
+            [
+                'type' => 'Mention',
+                'href' => 'https://some.instance.tld/u/someUser',
+                'name' => '@someUser',
+            ],
+            [
+                'type' => 'Mention',
+                'href' => 'https://some.instance.tld/m/someMagazine',
+                'name' => '@someMagazine',
             ],
         ];
     }

--- a/tests/Functional/ActivityPub/MarkdownConverterTest.php
+++ b/tests/Functional/ActivityPub/MarkdownConverterTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\ActivityPub;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+use function PHPUnit\Framework\assertEquals;
+
+class MarkdownConverterTest extends ActivityPubFunctionalTestCase
+{
+    public function setUpRemoteEntities(): void
+    {
+    }
+
+    public function setUpLocalEntities(): void
+    {
+        $domain = 'some.domain.tld';
+        $this->switchToRemoteDomain($domain);
+
+        $this->registerActor($this->getUserByUsername('someUser', email: "someUser@$domain"), $domain, true);
+        $this->registerActor($this->getMagazineByName('someMagazine'), $domain, true);
+
+        $this->switchToLocalDomain();
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // generate the local user 'someUser'
+        $user = $this->getUserByUsername('someUser', email: 'someUser@kbin.test');
+        $this->getMagazineByName('someMagazine', $user);
+    }
+
+    #[DataProvider('htmlMentionsProvider')]
+    public function testMentions(string $html, array $apTags, array $expectedMentions, string $name): void
+    {
+        $converted = $this->apMarkdownConverter->convert($html, $apTags);
+        $mentions = $this->mentionManager->extract($converted);
+        assertEquals($expectedMentions, $mentions, message: "Mention test '$name'");
+    }
+
+    public static function htmlMentionsProvider(): array
+    {
+        return [
+            [
+                'html' => '<p><span class="h-card" translate="no"><a href="https://some.domain.tld/u/someUser" class="u-url mention">@<span>someUser</span></a></span> <span class="h-card" translate="no"><a href="https://kbin.test/u/someUser" class="u-url mention">@<span>someUser@kbin.test</span></a></span></p>',
+                'apTags' => [
+                    [
+                        'type' => 'Mention',
+                        'href' => 'https://some.domain.tld/u/someUser',
+                        'name' => '@someUser',
+                    ],
+                    [
+                        'type' => 'Mention',
+                        'href' => 'https://kbin.test/u/someUser',
+                        'name' => '@someUser@kbin.test',
+                    ],
+                ],
+                'expectedMentions' => ['@someUser@some.domain.tld', '@someUser@kbin.test'],
+                'name' => 'Local and remote user',
+            ],
+            [
+                'html' => '<p><span class="h-card" translate="no"><a href="https://some.domain.tld/m/someMagazine" class="u-url mention">@<span>someMagazine</span></a></span></p>',
+                'apTags' => [
+                    [
+                        'type' => 'Mention',
+                        'href' => 'https://some.domain.tld/m/someMagazine',
+                        'name' => '@someMagazine',
+                    ],
+                ],
+                'expectedMentions' => ['@someMagazine@some.domain.tld'],
+                'name' => 'Magazine mention',
+            ],
+            [
+                'html' => '<p><span class="h-card" translate="no"><a href="https://kbin.test/m/someMagazine" class="u-url mention">@<span>someMagazine</span></a></span></p>',
+                'apTags' => [
+                    [
+                        'type' => 'Mention',
+                        'href' => 'https://kbin.test/m/someMagazine',
+                        'name' => '@someMagazine',
+                    ],
+                ],
+                'expectedMentions' => ['@someMagazine@kbin.test'],
+                'name' => 'Local magazine mention',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
- magazine mentions were not working, because their name in the DB does not contain an `@` in front of them like users do
- fix mentioning multiple people. The missing brackets messed the filter up, so that all mentions were in this array and it always used only the first one
- fix local users not being found in testing
- fix local users and magazines not being mentioned correctly (you were right @melroy89 :) )
- add tests for that, which can also be easily expanded

Former PR: #1856 
Fixes #1898 

Note that this really only applies to posts which do not contain a markdown source. If there are platforms that add mentions for local users like this: `[@localUser](https://some.instance.tld/u/localUser)` instead of just as `@localUser@some.instance.tld` then they will not work. (they did also not work previously, this is just a reminder)