### PR TITLE
Fix Mercure transport configuration on Docker setups

### DIFF
--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -29,6 +29,11 @@
 	encode zstd br gzip
 
 	mercure {
+		# The transport to use
+		transport bolt {
+			path {$MERCURE_BOLT_PATH:/data/mercure.db}
+			{$MERCURE_BOLT_EXTRA_DIRECTIVES}
+		}
 		# Publisher JWT key
 		publisher_jwt {env.MERCURE_PUBLISHER_JWT_KEY} {env.MERCURE_PUBLISHER_JWT_ALG}
 		# Subscriber JWT key

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,9 +42,6 @@ RUN set -eux; \
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
-# Transport to use by Mercure (default to Bolt)
-ENV MERCURE_TRANSPORT_URL=bolt:///data/mercure.db
-
 ENV PHP_INI_SCAN_DIR=":$PHP_INI_DIR/app.conf.d"
 
 COPY --link docker/conf.d/10-app.ini $PHP_INI_DIR/app.conf.d/


### PR DESCRIPTION
this was causing my docker setup to not properly start the php container because of an upstream change with FrankenPHP and Mercure 

Fixes on Docker Setups:

`Error: loading initial config: loading new config: loading frankenphp app module: provision frankenphp: failed to provision caddy http: loading http app module: provision http: server srv0: setting up route handlers: route 0: loading handler modules: position 0: loading module 'subroute': provision http.handlers.subroute: setting up subroutes: route 2: loading handler modules: position 2: loading module 'mercure': provision http.handlers.mercure: provision http.handlers.mercure.bolt: "": invalid transport: open bolt.db: permission denied`

see https://github.com/dunglas/symfony-docker/issues/870 and https://github.com/dunglas/symfony-docker/pull/871