### PR TITLE
Keep the sort options close together profile settings

### DIFF
--- a/templates/user/settings/general.html.twig
+++ b/templates/user/settings/general.html.twig
@@ -23,8 +23,8 @@
             {{ form_start(form) }}
             <h2>{{ 'appearance'|trans }}</h2>
             {{ form_row(form.homepage, {label: 'homepage'}) }}
-            {{ form_row(form.frontDefaultSort, {label: 'front_default_sort'}) }}
             {{ form_row(form.frontDefaultContent, {label: 'front_default_content'}) }}
+            {{ form_row(form.frontDefaultSort, {label: 'front_default_sort'}) }}
             {{ form_row(form.commentDefaultSort, {label: 'comment_default_sort'}) }}
             {{ form_row(form.preferredLanguages, {label: 'preferred_languages'}) }}
             {{ form_row(form.featuredMagazines, {label: 'featured_magazines'}) }}

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -1092,7 +1092,7 @@ federation_page_use_allowlist_help: If an allow list is used, this instance will
 you_have_been_banned_from_magazine: You have been banned from magazine %m.
 you_have_been_banned_from_magazine_permanently: You have been permanently banned from magazine %m.
 you_are_no_longer_banned_from_magazine: You are no longer banned from magazine %m.
-front_default_content: Front default view
+front_default_content: Frontpage default view
 default_content_default: Server default (Threads)
 default_content_combined: Threads + Microblog
 default_content_threads: Threads


### PR DESCRIPTION
Minor change in form.

- Reorder the options, keep the frontpage sorting and comment sorting together, put the default view above it
- Rename "Front default view" the same as how the sorting is called, thus: "Front**page** default view"

| Before | After |
|--------|--------|
| <img width="616" height="456" alt="image" src="https://github.com/user-attachments/assets/eecf8dec-9c7d-4e79-994f-0a874856bf12" /> | <img width="599" height="462" alt="image" src="https://github.com/user-attachments/assets/9ac7b4aa-27d1-4507-bab7-7fa75740fa8b" /> |
