### PR TITLE
Fix migration from banned instances

### DIFF
--- a/migrations/Version20250813132233.php
+++ b/migrations/Version20250813132233.php
@@ -30,7 +30,7 @@ BEGIN
     LOOP
         IF NOT EXISTS (SELECT * FROM instance i WHERE i.domain = tempRow.value) THEN
             INSERT INTO instance(id, domain, created_at, failed_delivers, updated_at, is_banned)
-                VALUES (NEXTVAL('instance_id_seq'), current_timestamp(0), 0, current_timestamp(0), true);
+                VALUES (NEXTVAL('instance_id_seq'), tempRow.value, current_timestamp(0), 0, current_timestamp(0), true);
         ELSE
             UPDATE instance SET is_banned = true WHERE domain = tempRow.value;
         END IF;


### PR DESCRIPTION
In one of the cases where an instance is marked as banned, but there is not a corresponding Instance entity with that domain, the migration would fail, because one column value was missing, fix that

The bug was introduced in #1780 