### PR TITLE
Add safe directory before get composer cache steps

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -42,9 +42,6 @@ jobs:
         id: npm-cache-dir-path
         run: echo "dir=$(npm get cache)" >> $GITHUB_OUTPUT
 
-      - name: What is the GITHUB_WORKSPACE?
-        run: echo "GITHUB_WORKSPACE is $GITHUB_WORKSPACE"
-
       - name: Add GITHUB_WORKSPACE as a safe directory
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
@@ -85,10 +82,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Add GITHUB_WORKSPACE as a safe directory
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: |
-          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Get NPM cache directory path
         id: npm-cache-dir-path
@@ -183,10 +182,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Get Composer cache directory
+      - name: Add GITHUB_WORKSPACE as a safe directory
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
+      - name: Get Composer Cache Directory
         id: composer-cache
-        run: |
-          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache vendor directory
         uses: actions/cache@v4
@@ -212,10 +213,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Add GITHUB_WORKSPACE as a safe directory
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: |
-          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v4
         with:
@@ -239,10 +242,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Add GITHUB_WORKSPACE as a safe directory
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: |
-          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Get NPM cache directory path
         id: npm-cache-dir-path


### PR DESCRIPTION
- Adding an additional step to all the jobs that require the `git config --global --add safe.directory` command , necessary for `composer config cache-files-dir`.. But also for `composer install ` without giving warnings/errors.

Should fix:

> echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
>   shell: sh -e {0}
> The repository at "/__w/mbin/mbin" does not have the correct ownership and git refuses to use it:
> 
> fatal: detected dubious ownership in repository at '/__w/mbin/mbin'
> To add an exception for this directory, call:
> 
> 	git config --global --add safe.directory /__w/mbin/mbin