### PR TITLE
Fix like, dislike, shares collection extraction if it is an array

### DIFF
--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -1197,16 +1197,36 @@ class ActivityPubManager
         return null;
     }
 
+    public function extractTotalAmountFromCollection(mixed $collection): ?int
+    {
+        $id = null;
+        if (\is_string($collection)) {
+            if (false !== filter_var($collection, FILTER_VALIDATE_URL)) {
+                $id = $collection;
+            }
+        } elseif (\is_array($collection)) {
+            if (isset($collection['totalItems'])) {
+                return \intval($collection['totalItems']);
+            } elseif (isset($collection['id'])) {
+                $id = $collection['id'];
+            }
+        }
+
+        if ($id) {
+            $this->apHttpClient->invalidateCollectionObjectCache($id);
+            $collection = $this->apHttpClient->getCollectionObject($id);
+            if (isset($collection['totalItems']) && \is_int($collection['totalItems'])) {
+                return $collection['totalItems'];
+            }
+        }
+
+        return null;
+    }
+
     public function extractRemoteLikeCount(array $apObject): ?int
     {
         if (!empty($apObject['likes'])) {
-            if (false !== filter_var($apObject['likes'], FILTER_VALIDATE_URL)) {
-                $this->apHttpClient->invalidateCollectionObjectCache($apObject['likes']);
-                $collection = $this->apHttpClient->getCollectionObject($apObject['likes']);
-                if (isset($collection['totalItems']) && \is_int($collection['totalItems'])) {
-                    return $collection['totalItems'];
-                }
-            }
+            return $this->extractTotalAmountFromCollection($apObject['likes']);
         }
 
         return null;
@@ -1215,13 +1235,7 @@ class ActivityPubManager
     public function extractRemoteDislikeCount(array $apObject): ?int
     {
         if (!empty($apObject['dislikes'])) {
-            if (false !== filter_var($apObject['dislikes'], FILTER_VALIDATE_URL)) {
-                $this->apHttpClient->invalidateCollectionObjectCache($apObject['dislikes']);
-                $collection = $this->apHttpClient->getCollectionObject($apObject['dislikes']);
-                if (isset($collection['totalItems']) && \is_int($collection['totalItems'])) {
-                    return $collection['totalItems'];
-                }
-            }
+            return $this->extractTotalAmountFromCollection($apObject['dislikes']);
         }
 
         return null;
@@ -1230,13 +1244,7 @@ class ActivityPubManager
     public function extractRemoteShareCount(array $apObject): ?int
     {
         if (!empty($apObject['shares'])) {
-            if (false !== filter_var($apObject['shares'], FILTER_VALIDATE_URL)) {
-                $this->apHttpClient->invalidateCollectionObjectCache($apObject['shares']);
-                $collection = $this->apHttpClient->getCollectionObject($apObject['shares']);
-                if (isset($collection['totalItems']) && \is_int($collection['totalItems'])) {
-                    return $collection['totalItems'];
-                }
-            }
+            return $this->extractTotalAmountFromCollection($apObject['shares']);
         }
 
         return null;

--- a/tests/Unit/ActivityPub/CollectionExtractionTest.php
+++ b/tests/Unit/ActivityPub/CollectionExtractionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\ActivityPub;
+
+use App\Tests\WebTestCase;
+
+class CollectionExtractionTest extends WebTestCase
+{
+    private string $collectionUrl = 'https://some.server/some/collection';
+    private array $collection;
+    private string $incompleteCollectionUrl = 'https://some.server/some/collection2';
+    private array $incompleteCollection;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->collection = [
+            'id' => $this->collectionUrl,
+            'type' => 'Collection',
+            'totalItems' => 3,
+        ];
+        $this->testingApHttpClient->collectionObjects[$this->collectionUrl] = $this->collection;
+        $this->incompleteCollection = [
+            'id' => $this->incompleteCollectionUrl,
+            'type' => 'Collection',
+        ];
+        $this->testingApHttpClient->collectionObjects[$this->incompleteCollectionUrl] = $this->incompleteCollection;
+    }
+
+    public function testCollectionId(): void
+    {
+        self::assertEquals(3, $this->activityPubManager->extractTotalAmountFromCollection($this->collection));
+    }
+
+    public function testCollectionArray(): void
+    {
+        self::assertEquals(3, $this->activityPubManager->extractTotalAmountFromCollection($this->collectionUrl));
+    }
+
+    public function testIncompleteCollectionId(): void
+    {
+        self::assertNull($this->activityPubManager->extractTotalAmountFromCollection($this->incompleteCollectionUrl));
+    }
+
+    public function testIncompleteCollectionArray(): void
+    {
+        self::assertNull($this->activityPubManager->extractTotalAmountFromCollection($this->incompleteCollection));
+    }
+}


### PR DESCRIPTION
- Mastodon uses an inline array instead of just the URL (like PeerTube). Take that into account on extraction
- consolidate the 3 extraction methods
- add testing

Example Mastodon:
```json
{
  ...
  "likes": {
    "id": "https://troet.cafe/users/morsuapri/statuses/115892452289787939/likes",
    "type": "Collection",
    "totalItems": 8
  }
}
```

Example PeerTube:
```json
{
  ...
  "likes": "https://peertube.heise.de/videos/watch/3905db91-7e6e-44d8-8adc-e43326dc8de8/likes",
}
```