### PR TITLE
Add missing oauth user consent and translation

### DIFF
--- a/src/Entity/OAuth2UserConsent.php
+++ b/src/Entity/OAuth2UserConsent.php
@@ -113,6 +113,7 @@ class OAuth2UserConsent
         'moderate:post' => 'oauth2.grant.moderate.post.all',
         'moderate:post:language' => 'oauth2.grant.moderate.post.change_language',
         'moderate:post:pin' => 'oauth2.grant.moderate.post.pin',
+        'moderate:post:lock' => 'oauth2.grant.moderate.post.lock',
         'moderate:post:set_adult' => 'oauth2.grant.moderate.post.set_adult',
         'moderate:post:trash' => 'oauth2.grant.moderate.post.trash',
         // Post comment moderation grants

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -644,7 +644,9 @@ oauth2.grant.moderate.entry.change_language: Change the language of threads in
   your moderated magazines.
 oauth2.grant.moderate.entry.pin: Pin threads to the top of your moderated 
   magazines.
-oauth2.grant.moderate.entry.set_adult: Mark threads as NSFW in your moderated 
+oauth2.grant.moderate.entry.lock: Lock threads in your moderated magazines,
+  so no one can comment on it
+oauth2.grant.moderate.entry.set_adult: Mark threads as NSFW in your moderated
   magazines.
 oauth2.grant.moderate.entry.trash: Trash or restore threads in your moderated 
   magazines.
@@ -659,7 +661,9 @@ oauth2.grant.moderate.entry_comment.trash: Trash or restore comments in threads
 oauth2.grant.moderate.post.all: Moderate posts in your moderated magazines.
 oauth2.grant.moderate.post.change_language: Change the language of posts in your
   moderated magazines.
-oauth2.grant.moderate.post.set_adult: Mark posts as NSFW in your moderated 
+oauth2.grant.moderate.post.lock: Lock microblogs in your moderated magazines,
+  so no one can comment on it
+oauth2.grant.moderate.post.set_adult: Mark posts as NSFW in your moderated
   magazines.
 oauth2.grant.moderate.post.trash: Trash or restore posts in your moderated 
   magazines.


### PR DESCRIPTION
- in #1773 an consent key was missing (noticed through test warnings) -> add that
- also add translation for the lock consent, for both entries and posts