### PR TITLE
catch all exceptions in ImageManager::getMimetype()

### DIFF
--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -206,7 +206,7 @@ class ImageManager implements ImageManagerInterface
     {
         try {
             return $this->publicUploadsFilesystem->mimeType($image->filePath);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 'none';
         }
     }


### PR DESCRIPTION
Should fix the `TypeError` occurring for some corrupted entry deletions.