### PR TITLE
Add check for duplicates command (guided tour)

### DIFF
--- a/src/Command/CheckDuplicatesUsersMagazines.php
+++ b/src/Command/CheckDuplicatesUsersMagazines.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Command;
 
+use App\Entity\Magazine;
 use App\Entity\User;
 use App\Service\MagazineManager;
 use App\Service\UserManager;
@@ -174,7 +175,7 @@ class CheckDuplicatesUsersMagazines extends Command
                     $io->success("Deleted user: {$existingUser->getUsername()} (ID: $id)");
                 } else { // magazines
                     // Check if magazine exists first
-                    $magazine = $this->entityManager->getRepository(\App\Entity\Magazine::class)->find($id);
+                    $magazine = $this->entityManager->getRepository(Magazine::class)->find($id);
                     if (!$magazine) {
                         $io->warning("Magazine with ID $id not found, skipping...");
                         continue;


### PR DESCRIPTION
- Add a new command: `./bin/console mbin:check:duplicates-users-magazines`

This allow the admin to easily check for either duplicated users or magazines. In a guided tour.

Eg.

```sh
./bin/console mbin:check:duplicates-users-magazine

Duplicate Users and Magazines Checker
=====================================

 What would you like to check for duplicates? [Users]:
  [users    ] Users
  [magazines] Magazines
 > 

```

If there are duplicates. You can then use the following command to remove one or more records from the DB:

```sh
 What would you like to check for duplicates? [Users]:
  [users    ] Users
  [magazines] Magazines
 > magazines

Duplicate Magaziness Found
--------------------------

 
==============================
 Duplicate Group: https://piefed.social/c/photography
 ------- --------------------------- --------------------- --------------------- 
  ID      Name                        Created At            Last Active          
 ------- --------------------------- --------------------- --------------------- 
  44255   photography@pixelfed.de     2024-07-15 14:56:17   N/A                  
  22557   photography@piefed.social   2024-07-15 14:56:17   2026-01-17 21:33:21  
 ------- --------------------------- --------------------- --------------------- 

 
Total duplicate Magaziness: 2

 Would you like to delete any of these duplicates? (yes/no) [no]:
 > 

```

Continue with `yes`:

```sh
 Would you like to delete any of these duplicates? (yes/no) [no]:
 > yes

 Enter the IDs to delete (comma-separated, e.g., 1,2,3):
 > 44255
```
