### PR TITLE
Fix criteria missing when rendering for front xml request

### DIFF
--- a/src/Controller/Entry/EntryFrontController.php
+++ b/src/Controller/Entry/EntryFrontController.php
@@ -229,7 +229,7 @@ class EntryFrontController extends AbstractController
 
         if ($request->isXmlHttpRequest()) {
             return new JsonResponse([
-                'html' => $this->renderView($templatePath.'_list.html.twig', $data),
+                'html' => $this->renderView($templatePath.'_list.html.twig', $baseData),
             ]);
         }
 


### PR DESCRIPTION
`$baseData` contains the criteria, `$data` does not