### PR TITLE
Change user clause to use user_id instead of user

### DIFF
--- a/src/Repository/ContentRepository.php
+++ b/src/Repository/ContentRepository.php
@@ -57,7 +57,7 @@ class ContentRepository
 
         $userClause = '';
         if ($criteria->user) {
-            $userClause = 'c.user = :user';
+            $userClause = 'c.user_id = :user';
             $parameters['user'] = $criteria->user->getId();
         }
 


### PR DESCRIPTION
This caused the following error to appear in the production log

`/var/www/kbin/var/log/prod-2026-03-05.log:{"message":"Uncaught PHP Exception Doctrine\\DBAL\\Exception\\InvalidFieldNameException: \"An exception occurred while executing a query: SQLSTATE[42703]: Undefined column: 7 ERROR:  column c.user does not exist\nLINE 4:             WHERE (c.user = $1) AND (m.visibility = $2) AND ...\n                           ^\" at ExceptionConverter.php line 68","context":{"exception":{"class":"Doctrine\\DBAL\\Exception\\InvalidFieldNameException","message":"An exception occurred while executing a query: SQLSTATE[42703]: Undefined column: 7 ERROR:  column c.user does not exist\nLINE 4:             WHERE (c.user = $1) AND (m.visibility = $2) AND ...\n                           ^","code":7,"file":"/var/www/kbin/vendor/doctrine/dbal/src/Driver/API/PostgreSQL/ExceptionConverter.php:68","previous":{"class":"Doctrine\\DBAL\\Driver\\PDO\\Exception","message":"SQLSTATE[42703]: Undefined column: 7 ERROR:  column c.user does not exist\nLINE 4:             WHERE (c.user = $1) AND (m.visibility = $2) AND ...\n                           ^","code":7,"file":"/var/www/kbin/vendor/doctrine/dbal/src/Driver/PDO/Exception.php:24","previous":{"class":"PDOException","message":"SQLSTATE[42703]: Undefined column: 7 ERROR:  column c.user does not exist\nLINE 4:             WHERE (c.user = $1) AND (m.visibility = $2) AND ...\n                           ^","code":42703,"file":"/var/www/kbin/vendor/doctrine/dbal/src/Driver/PDO/Statement.php:130"}}}},"level":500,"level_name":"CRITICAL","channel":"request","datetime":"2026-03-05T18:26:12.481915+00:00","extra":{}}

`