### PR TITLE
Restore compatibility with Mastodon

### DIFF
--- a/src/Service/ActivityPub/ContextsProvider.php
+++ b/src/Service/ActivityPub/ContextsProvider.php
@@ -17,8 +17,6 @@ class ContextsProvider
     public static function embeddedContexts(): array
     {
         return [
-            ActivityPubActivityInterface::CONTEXT_URL,
-            ActivityPubActivityInterface::SECURITY_URL,
             [
                 ...ActivityPubActivityInterface::ADDITIONAL_CONTEXTS,
             ],
@@ -28,6 +26,8 @@ class ContextsProvider
     public function referencedContexts(): array
     {
         return [
+            ActivityPubActivityInterface::CONTEXT_URL,
+            ActivityPubActivityInterface::SECURITY_URL,
             $this->urlGenerator->generate('ap_contexts', [], UrlGeneratorInterface::ABSOLUTE_URL),
         ];
     }

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AddHandlerTest__testAddModerator__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AddHandlerTest__testAddModerator__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AddHandlerTest__testAddPinnedPost__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AddHandlerTest__testAddPinnedPost__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AddHandlerTest__testRemoveModerator__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AddHandlerTest__testRemoveModerator__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AddHandlerTest__testRemovePinnedPost__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AddHandlerTest__testRemovePinnedPost__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceAddModerator__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceAddModerator__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceAddPinnedPost__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceAddPinnedPost__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceBlockUser__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceBlockUser__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceCreateEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceCreateEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceCreateEntry__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceCreateEntry__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceCreateMessage__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceCreateMessage__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceCreateNestedEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceCreateNestedEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceCreateNestedPostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceCreateNestedPostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceCreatePostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceCreatePostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceCreatePost__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceCreatePost__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceDeleteEntryByModerator__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceDeleteEntryByModerator__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceDeleteEntryCommentByModerator__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceDeleteEntryCommentByModerator__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceDeleteEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceDeleteEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceDeleteEntry__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceDeleteEntry__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceDeletePostByModerator__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceDeletePostByModerator__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceDeletePostCommentByModerator__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceDeletePostCommentByModerator__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceDeletePostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceDeletePostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceDeletePost__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceDeletePost__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceDeleteUser__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceDeleteUser__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceLikeEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceLikeEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceLikeEntry__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceLikeEntry__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceLikeNestedEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceLikeNestedEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceLikeNestedPostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceLikeNestedPostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceLikePostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceLikePostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceLikePost__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceLikePost__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceRemoveModerator__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceRemoveModerator__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceRemovePinnedPost__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceRemovePinnedPost__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUndoBlockUser__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUndoBlockUser__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUndoLikeEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUndoLikeEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUndoLikeEntry__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUndoLikeEntry__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUndoLikeNestedEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUndoLikeNestedEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUndoLikeNestedPostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUndoLikeNestedPostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUndoLikePostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUndoLikePostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUndoLikePost__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUndoLikePost__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUpdateEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUpdateEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUpdateEntry__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUpdateEntry__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUpdateMagazine__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUpdateMagazine__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUpdatePostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUpdatePostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUpdatePost__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUpdatePost__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUpdateUser__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testAnnounceUpdateUser__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testMagazineBoostEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testMagazineBoostEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testMagazineBoostEntry__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testMagazineBoostEntry__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testMagazineBoostNestedEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testMagazineBoostNestedEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testMagazineBoostNestedPostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testMagazineBoostNestedPostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testMagazineBoostPostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testMagazineBoostPostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testMagazineBoostPost__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testMagazineBoostPost__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testUserBoostEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testUserBoostEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testUserBoostEntry__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testUserBoostEntry__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testUserBoostNestedEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testUserBoostNestedEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testUserBoostNestedPostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testUserBoostNestedPostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testUserBoostPostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testUserBoostPostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testUserBoostPost__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/AnnounceTest__testUserBoostPost__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/BlockTest__testBlockUser__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/BlockTest__testBlockUser__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateEntryWithUrlAndImage__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateEntryWithUrlAndImage__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateEntry__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateEntry__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateMessage__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateMessage__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateNestedEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateNestedEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateNestedPostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateNestedPostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreatePostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreatePostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreatePost__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreatePost__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/DeleteTest__testDeleteEntryByModerator__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/DeleteTest__testDeleteEntryByModerator__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/DeleteTest__testDeleteEntryCommentByModerator__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/DeleteTest__testDeleteEntryCommentByModerator__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/DeleteTest__testDeleteEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/DeleteTest__testDeleteEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/DeleteTest__testDeleteEntry__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/DeleteTest__testDeleteEntry__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/DeleteTest__testDeletePostByModerator__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/DeleteTest__testDeletePostByModerator__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/DeleteTest__testDeletePostCommentByModerator__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/DeleteTest__testDeletePostCommentByModerator__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/DeleteTest__testDeletePostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/DeleteTest__testDeletePostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/DeleteTest__testDeletePost__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/DeleteTest__testDeletePost__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/FollowTest__testAcceptFollowMagazine__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/FollowTest__testAcceptFollowMagazine__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/FollowTest__testAcceptFollowUser__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/FollowTest__testAcceptFollowUser__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/FollowTest__testFollowUser__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/FollowTest__testFollowUser__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/FollowTest__testRejectFollowMagazine__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/FollowTest__testRejectFollowMagazine__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/FollowTest__testRejectFollowUser__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/FollowTest__testRejectFollowUser__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LikeTest__testLikeEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LikeTest__testLikeEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LikeTest__testLikeEntry__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LikeTest__testLikeEntry__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LikeTest__testLikeNestedEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LikeTest__testLikeNestedEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LikeTest__testLikeNestedPostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LikeTest__testLikeNestedPostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LikeTest__testLikePostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LikeTest__testLikePostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LikeTest__testLikePost__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LikeTest__testLikePost__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LockTest__testLockEntryByAuthor__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LockTest__testLockEntryByAuthor__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LockTest__testLockEntryByModerator__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LockTest__testLockEntryByModerator__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LockTest__testLockPostByAuthor__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LockTest__testLockPostByAuthor__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LockTest__testLockPostByModerator__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/LockTest__testLockPostByModerator__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoBlockUser__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoBlockUser__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoFollowMagazine__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoFollowMagazine__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoFollowUser__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoFollowUser__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoLikeEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoLikeEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoLikeEntry__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoLikeEntry__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoLikeNestedEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoLikeNestedEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoLikeNestedPostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoLikeNestedPostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoLikePostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoLikePostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoLikePost__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UndoTest__testUndoLikePost__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UpdateTest__testUpdateEntryComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UpdateTest__testUpdateEntryComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UpdateTest__testUpdateEntry__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UpdateTest__testUpdateEntry__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UpdateTest__testUpdateMagazine__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UpdateTest__testUpdateMagazine__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UpdateTest__testUpdatePostComment__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UpdateTest__testUpdatePostComment__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UpdateTest__testUpdatePost__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UpdateTest__testUpdatePost__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UpdateTest__testUpdateUser__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/UpdateTest__testUpdateUser__1.json
@@ -1,5 +1,7 @@
 {
     "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
         "https://kbin.test/contexts"
     ],
     "id": "SCRUBBED_ID",


### PR DESCRIPTION
We didn't really do anything wrong, our actors and activities are compliant, however, Mastodon determines whether it does support an actor/activity by the default `https://www.w3.org/ns/activitystreams` being present in the `@context` variable. In order to fix this quickly and still keep the json-ld compliance, I just moved the 2 default URLs into the referenced contexts.

The error in the log looks like this (I couldn't find it in my production log, only on my dev instance): 

> Truncated content: {"error":"Unsupported JSON-LD context for document URL_HERE"}.

This incompatibility was introduced in #1997