### PR TITLE
Fix `Create` -> `Announce` -> `Deliver` circle

### DIFF
--- a/src/MessageHandler/ActivityPub/Inbox/CreateHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/CreateHandler.php
@@ -152,12 +152,6 @@ class CreateHandler extends MbinMessageHandler
                     } else {
                         $this->logger->warning('[CreateHandler::handleChain] Could not create the activity with the full create payload because it was just missing...');
                     }
-                } else {
-                    $previousAnnounce = $this->activityRepository->findAllActivitiesByTypeObjectAndActor('Announce', $createActivity, $note->magazine);
-                    if (\sizeof($previousAnnounce)) {
-                        // do not announce the 'Create' activity if the magazine already announced that previously
-                        return;
-                    }
                 }
                 // local magazine, but remote post. Random magazine is ignored, as it should not be federated at all
                 $this->bus->dispatch(new AnnounceMessage(null, $note->magazine->getId(), $note->getId(), \get_class($note)));

--- a/src/MessageHandler/ActivityPub/Inbox/CreateHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/CreateHandler.php
@@ -152,6 +152,12 @@ class CreateHandler extends MbinMessageHandler
                     } else {
                         $this->logger->warning('[CreateHandler::handleChain] Could not create the activity with the full create payload because it was just missing...');
                     }
+                } else {
+                    $previousAnnounce = $this->activityRepository->findAllActivitiesByTypeObjectAndActor('Announce', $createActivity, $note->magazine);
+                    if ($previousAnnounce) {
+                        // do not announce the 'Create' activity if the magazine already announced that previously
+                        return;
+                    }
                 }
                 // local magazine, but remote post. Random magazine is ignored, as it should not be federated at all
                 $this->bus->dispatch(new AnnounceMessage(null, $note->magazine->getId(), $note->getId(), \get_class($note)));

--- a/src/MessageHandler/ActivityPub/Inbox/CreateHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/CreateHandler.php
@@ -154,7 +154,7 @@ class CreateHandler extends MbinMessageHandler
                     }
                 } else {
                     $previousAnnounce = $this->activityRepository->findAllActivitiesByTypeObjectAndActor('Announce', $createActivity, $note->magazine);
-                    if ($previousAnnounce) {
+                    if (\sizeof($previousAnnounce)) {
                         // do not announce the 'Create' activity if the magazine already announced that previously
                         return;
                     }

--- a/src/MessageHandler/ActivityPub/Outbox/AnnounceHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/AnnounceHandler.php
@@ -24,6 +24,7 @@ use App\Service\ActivityPubManager;
 use App\Service\DeliverManager;
 use App\Service\SettingsManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
@@ -44,6 +45,7 @@ class AnnounceHandler extends MbinMessageHandler
         private readonly SettingsManager $settingsManager,
         private readonly ActivityJsonBuilder $activityJsonBuilder,
         private readonly ActivityRepository $activityRepository,
+        private readonly LoggerInterface $logger,
     ) {
         parent::__construct($this->entityManager, $this->kernel);
     }
@@ -80,6 +82,16 @@ class AnnounceHandler extends MbinMessageHandler
                 } else {
                     throw new UnrecoverableMessageHandlingException("We need a create activity to announce objects, but none was found and the object (id: '$object->apId' is from a remote instance, so we cannot build a create activity");
                 }
+            }
+            $alreadySentActivities = $this->activityRepository->findAllActivitiesByTypeObjectAndActor('Announce', $object, $actor);
+            if (!$message->removeAnnounce && \sizeof($alreadySentActivities) > 0) {
+                $this->logger->info('[AnnounceHandler::doWork] not sending announcing {object}, because it is not an Undo and the same actor (magazine {magazine}) already announced the Create activity {create}', [
+                    'object' => \get_class($object)." \"{$object->getShortTitle()}\"",
+                    'magazine' => $actor->name,
+                    'create' => $createActivity->uuid,
+                ]);
+
+                return;
             }
             $activity = $this->announceWrapper->build($actor, $createActivity, true);
         } else {

--- a/src/MessageHandler/ActivityPub/Outbox/GenericAnnounceHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/GenericAnnounceHandler.php
@@ -14,6 +14,7 @@ use App\Service\ActivityPub\Wrapper\AnnounceWrapper;
 use App\Service\DeliverManager;
 use App\Service\SettingsManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -32,6 +33,7 @@ class GenericAnnounceHandler extends MbinMessageHandler
         private readonly DeliverManager $deliverManager,
         private readonly ActivityRepository $activityRepository,
         private readonly ActivityJsonBuilder $activityJsonBuilder,
+        private readonly LoggerInterface $logger,
     ) {
         parent::__construct($this->entityManager, $this->kernel);
     }
@@ -62,10 +64,25 @@ class GenericAnnounceHandler extends MbinMessageHandler
 
         if (null !== $message->innerActivityUUID) {
             $object = $this->activityRepository->findOneBy(['uuid' => Uuid::fromString($message->innerActivityUUID)]);
+            if (!$object) {
+                // this should literally not be possible, but check for it anyway
+
+                throw new \LogicException('could not find an Object by their Uuid '.$message->innerActivityUUID);
+            }
         } elseif (null !== $message->innerActivityUrl) {
             $object = $message->innerActivityUrl;
         } else {
             throw new \LogicException('expect at least one of innerActivityUUID or innerActivityUrl to not be null');
+        }
+
+        $alreadySentActivities = $this->activityRepository->findAllActivitiesByTypeObjectAndActor('Announce', $object, $magazine);
+        if (\sizeof($alreadySentActivities) > 0) {
+            $this->logger->info('[GenericAnnounceHandler::doWork] not announcing activity {object}, because the same actor (magazine {magazine}) already announced it', [
+                'object' => $object->uuid,
+                'magazine' => $magazine->name,
+            ]);
+
+            return;
         }
 
         $announce = $this->announceWrapper->build($magazine, $object);

--- a/src/Repository/ActivityRepository.php
+++ b/src/Repository/ActivityRepository.php
@@ -75,7 +75,7 @@ class ActivityRepository extends ServiceEntityRepository
     /**
      * @return Activity[]|null
      */
-    public function findAllActivitiesByTypeObjectAndActor(string $type, Activity|ActivityPubActivityInterface|ActivityPubActorInterface $object, ActivityPubActorInterface $actor): ?array
+    public function findAllActivitiesByTypeObjectAndActor(string $type, Activity|ActivityPubActivityInterface|ActivityPubActorInterface|string $object, ActivityPubActorInterface $actor): ?array
     {
         $qb = $this->createQueryBuilder('a');
         $qb->where('a.type = :type');
@@ -108,7 +108,7 @@ class ActivityRepository extends ServiceEntityRepository
         return $qb->getQuery()->getResult();
     }
 
-    private function addObjectFilter(QueryBuilder $qb, Activity|ActivityPubActivityInterface|ActivityPubActorInterface|MagazineBan $object): void
+    private function addObjectFilter(QueryBuilder $qb, Activity|ActivityPubActivityInterface|ActivityPubActorInterface|MagazineBan|string $object): void
     {
         if ($object instanceof Entry) {
             $qb->andWhere('a.objectEntry = :entry')
@@ -137,6 +137,9 @@ class ActivityRepository extends ServiceEntityRepository
         } elseif ($object instanceof Activity) {
             $qb->andWhere('a.innerActivity = :innerActivity')
                 ->setParameter('innerActivity', $object);
+        } elseif (\is_string($object)) {
+            $qb->andWhere('a.innerActivityUrl = :innerActivityUrl')
+                ->setParameter('innerActivityUrl', $object);
         }
     }
 

--- a/src/Repository/ActivityRepository.php
+++ b/src/Repository/ActivityRepository.php
@@ -75,7 +75,7 @@ class ActivityRepository extends ServiceEntityRepository
     /**
      * @return Activity[]|null
      */
-    public function findAllActivitiesByTypeObjectAndActor(string $type, ActivityPubActivityInterface|ActivityPubActorInterface $object, ActivityPubActorInterface $actor): ?array
+    public function findAllActivitiesByTypeObjectAndActor(string $type, Activity|ActivityPubActivityInterface|ActivityPubActorInterface $object, ActivityPubActorInterface $actor): ?array
     {
         $qb = $this->createQueryBuilder('a');
         $qb->where('a.type = :type');
@@ -108,7 +108,7 @@ class ActivityRepository extends ServiceEntityRepository
         return $qb->getQuery()->getResult();
     }
 
-    private function addObjectFilter(QueryBuilder $qb, ActivityPubActivityInterface|ActivityPubActorInterface|MagazineBan $object): void
+    private function addObjectFilter(QueryBuilder $qb, Activity|ActivityPubActivityInterface|ActivityPubActorInterface|MagazineBan $object): void
     {
         if ($object instanceof Entry) {
             $qb->andWhere('a.objectEntry = :entry')
@@ -134,6 +134,9 @@ class ActivityRepository extends ServiceEntityRepository
         } elseif ($object instanceof MagazineBan) {
             $qb->andWhere('a.objectMagazineBan = :magazineBan')
                 ->setParameter('magazineBan', $object);
+        } elseif ($object instanceof Activity) {
+            $qb->andWhere('a.innerActivity = :innerActivity')
+                ->setParameter('innerActivity', $object);
         }
     }
 


### PR DESCRIPTION
It seems like we have a bug where a magazine can infinitely re-`Announce` a `Create`-activity in some specific circumstances. To avoid that this PR introduces a new check for existing `Announce` activities of the same object by the same actor.