### PR TITLE
fix infinite scrolling for comments

### DIFF
--- a/src/Controller/Entry/EntrySingleController.php
+++ b/src/Controller/Entry/EntrySingleController.php
@@ -10,6 +10,7 @@ use App\Controller\User\ThemeSettingsController;
 use App\DTO\EntryCommentDto;
 use App\Entity\Entry;
 use App\Entity\Magazine;
+use App\Entity\User;
 use App\Event\Entry\EntryHasBeenSeenEvent;
 use App\Form\EntryCommentType;
 use App\PageView\EntryCommentPageView;
@@ -92,11 +93,11 @@ class EntrySingleController extends AbstractController
 
         $this->dispatcher->dispatch(new EntryHasBeenSeenEvent($entry));
 
-        if ($request->isXmlHttpRequest()) {
-            return $this->getJsonResponse($magazine, $entry, $comments);
-        }
-
         $user = $this->getUser();
+
+        if ($request->isXmlHttpRequest()) {
+            return $this->getJsonResponse($comments, $criteria, $entry, $magazine, $user);
+        }
 
         $dto = new EntryCommentDto();
         if ($user && $user->addMentionsEntries && $entry->user !== $user) {
@@ -126,16 +127,18 @@ class EntrySingleController extends AbstractController
         );
     }
 
-    private function getJsonResponse(Magazine $magazine, Entry $entry, PagerfantaInterface $comments): JsonResponse
+    private function getJsonResponse(PagerfantaInterface $comments, Criteria $criteria, Entry $entry, Magazine $magazine, ?User $user): JsonResponse
     {
         return new JsonResponse(
             [
                 'html' => $this->renderView(
-                    'entry/_single_popup.html.twig',
+                    'entry/comments_json.html.twig',
                     [
+                        'user' => $user,
                         'magazine' => $magazine,
                         'comments' => $comments,
                         'entry' => $entry,
+                        'criteria' => $criteria,
                     ]
                 ),
             ]

--- a/src/Controller/Post/PostSingleController.php
+++ b/src/Controller/Post/PostSingleController.php
@@ -92,7 +92,7 @@ class PostSingleController extends AbstractController
         $this->dispatcher->dispatch(new PostHasBeenSeenEvent($post));
 
         if ($request->isXmlHttpRequest()) {
-            return $this->getJsonResponse($magazine, $post, $comments);
+            return $this->getJsonResponse($magazine, $post, $criteria, $comments);
         }
 
         $dto = new PostCommentDto();
@@ -119,16 +119,17 @@ class PostSingleController extends AbstractController
         );
     }
 
-    private function getJsonResponse(Magazine $magazine, Post $post, PagerfantaInterface $comments): JsonResponse
+    private function getJsonResponse(Magazine $magazine, Post $post, Criteria $criteria, PagerfantaInterface $comments): JsonResponse
     {
         return new JsonResponse(
             [
                 'html' => $this->renderView(
-                    'post/_single_popup.html.twig',
+                    'post/comments_json.html.twig',
                     [
                         'magazine' => $magazine,
                         'post' => $post,
                         'comments' => $comments,
+                        'criteria' => $criteria,
                     ]
                 ),
             ]

--- a/templates/entry/comments_json.html.twig
+++ b/templates/entry/comments_json.html.twig
@@ -1,0 +1,5 @@
+<div id="content">
+    <div id="comments">
+        {% include 'entry/comment/_list.html.twig' %}
+    </div>
+</div>

--- a/templates/post/comments_json.html.twig
+++ b/templates/post/comments_json.html.twig
@@ -1,0 +1,5 @@
+<div id="content">
+    <div id="comments">
+        {% include 'post/comment/_list.html.twig' %}
+    </div>
+</div>


### PR DESCRIPTION
Infinite scrolling on the comments of threads (and posts) would load forever as the server threw a 500 as the template used in the controller was deleted years ago. This PR creates a small template to restore the functionality.