### PR TITLE
only enable includeBoosts if sorting is set to newest

### DIFF
--- a/src/Controller/Api/Combined/CombinedRetrieveApi.php
+++ b/src/Controller/Api/Combined/CombinedRetrieveApi.php
@@ -529,7 +529,7 @@ class CombinedRetrieveApi extends BaseApi
         $criteria->perPage = $perPage;
         $user = $security->getUser();
         if ($user instanceof User) {
-            $criteria->includeBoosts = $criteria->sortOption === Criteria::SORT_NEW && ($includeBoosts ?? $user->showBoostsOfFollowing);
+            $criteria->includeBoosts = Criteria::SORT_NEW === $criteria->sortOption && ($includeBoosts ?? $user->showBoostsOfFollowing);
             $criteria->fetchCachedItems($sqlHelpers, $user);
         }
 

--- a/src/Controller/Api/Combined/CombinedRetrieveApi.php
+++ b/src/Controller/Api/Combined/CombinedRetrieveApi.php
@@ -529,7 +529,7 @@ class CombinedRetrieveApi extends BaseApi
         $criteria->perPage = $perPage;
         $user = $security->getUser();
         if ($user instanceof User) {
-            $criteria->includeBoosts = $includeBoosts ?? $user->showBoostsOfFollowing;
+            $criteria->includeBoosts = $criteria->sortOption === Criteria::SORT_NEW && ($includeBoosts ?? $user->showBoostsOfFollowing);
             $criteria->fetchCachedItems($sqlHelpers, $user);
         }
 

--- a/src/Controller/Api/Post/PostsRetrieveApi.php
+++ b/src/Controller/Api/Post/PostsRetrieveApi.php
@@ -359,7 +359,7 @@ class PostsRetrieveApi extends PostsBaseApi
 
     #[OA\Response(
         response: 200,
-        description: 'A paginated list of posts from user\'s subscribed magazines',
+        description: 'A paginated list of posts from user\'s subscribed magazines (boosted content will only be included if sort is set to "newest")',
         content: new OA\JsonContent(
             type: 'object',
             properties: [
@@ -442,12 +442,6 @@ class PostsRetrieveApi extends PostsBaseApi
         in: 'query',
         schema: new OA\Schema(type: 'string', default: Criteria::AP_ALL, enum: Criteria::AP_OPTIONS)
     )]
-    #[OA\Parameter(
-        name: 'includeBoosts',
-        description: 'if true then boosted content from followed users are included',
-        in: 'query',
-        schema: new OA\Schema(type: 'boolean', default: false)
-    )]
     #[OA\Tag(name: 'post')]
     #[Security(name: 'oauth2', scopes: ['read'])]
     #[IsGranted('ROLE_OAUTH2_READ')]
@@ -472,7 +466,7 @@ class PostsRetrieveApi extends PostsBaseApi
         $criteria->setFederation($federation ?? Criteria::AP_ALL);
 
         $criteria->subscribed = true;
-        $criteria->includeBoosts = true;
+        $criteria->includeBoosts = $criteria->sortOption === Criteria::SORT_NEW;
         $criteria->setContent(Criteria::CONTENT_MICROBLOG);
 
         $this->handleLanguageCriteria($criteria);

--- a/src/Controller/Api/Post/PostsRetrieveApi.php
+++ b/src/Controller/Api/Post/PostsRetrieveApi.php
@@ -466,7 +466,7 @@ class PostsRetrieveApi extends PostsBaseApi
         $criteria->setFederation($federation ?? Criteria::AP_ALL);
 
         $criteria->subscribed = true;
-        $criteria->includeBoosts = $criteria->sortOption === Criteria::SORT_NEW;
+        $criteria->includeBoosts = Criteria::SORT_NEW === $criteria->sortOption;
         $criteria->setContent(Criteria::CONTENT_MICROBLOG);
 
         $this->handleLanguageCriteria($criteria);

--- a/src/Controller/Entry/EntryFrontController.php
+++ b/src/Controller/Entry/EntryFrontController.php
@@ -213,7 +213,7 @@ class EntryFrontController extends AbstractController
             return;
         }
 
-        $criteria->includeBoosts = $criteria->sortOption === Criteria::SORT_NEW && $user->showBoostsOfFollowing;
+        $criteria->includeBoosts = Criteria::SORT_NEW === $criteria->sortOption && $user->showBoostsOfFollowing;
 
         if (0 < \count($user->preferredLanguages)) {
             $criteria->languages = $user->preferredLanguages;

--- a/src/Controller/Entry/EntryFrontController.php
+++ b/src/Controller/Entry/EntryFrontController.php
@@ -213,7 +213,7 @@ class EntryFrontController extends AbstractController
             return;
         }
 
-        $criteria->includeBoosts = $user->showBoostsOfFollowing;
+        $criteria->includeBoosts = $criteria->sortOption === Criteria::SORT_NEW && $user->showBoostsOfFollowing;
 
         if (0 < \count($user->preferredLanguages)) {
             $criteria->languages = $user->preferredLanguages;

--- a/tests/Functional/Controller/Api/Combined/CombinedRetrieveApiTest.php
+++ b/tests/Functional/Controller/Api/Combined/CombinedRetrieveApiTest.php
@@ -41,7 +41,7 @@ class CombinedRetrieveApiTest extends WebTestCase
         $codes = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'read');
         $token = $codes['token_type'].' '.$codes['access_token'];
 
-        $this->client->request('GET', '/api/combined/subscribed?includeBoosts=true', server: ['HTTP_AUTHORIZATION' => $token]);
+        $this->client->request('GET', '/api/combined/subscribed?includeBoosts=true&sort=newest', server: ['HTTP_AUTHORIZATION' => $token]);
         self::assertResponseIsSuccessful();
         $jsonData = self::getJsonResponse($this->client);
 
@@ -135,7 +135,7 @@ class CombinedRetrieveApiTest extends WebTestCase
         $codes = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'read');
         $token = $codes['token_type'].' '.$codes['access_token'];
 
-        $this->client->request('GET', '/api/combined/subscribed', server: ['HTTP_AUTHORIZATION' => $token]);
+        $this->client->request('GET', '/api/combined/subscribed?sort=newest', server: ['HTTP_AUTHORIZATION' => $token]);
         self::assertResponseIsSuccessful();
         $jsonData = self::getJsonResponse($this->client);
 
@@ -151,7 +151,7 @@ class CombinedRetrieveApiTest extends WebTestCase
         $this->userRepository->find($user->getId())->showBoostsOfFollowing = true;
         $this->entityManager->flush();
 
-        $this->client->request('GET', '/api/combined/subscribed', server: ['HTTP_AUTHORIZATION' => $token]);
+        $this->client->request('GET', '/api/combined/subscribed?sort=newest', server: ['HTTP_AUTHORIZATION' => $token]);
         self::assertResponseIsSuccessful();
         $jsonData = self::getJsonResponse($this->client);
 

--- a/tests/Functional/Controller/Api/Post/PostRetrieveApiTest.php
+++ b/tests/Functional/Controller/Api/Post/PostRetrieveApiTest.php
@@ -107,7 +107,7 @@ class PostRetrieveApiTest extends WebTestCase
         $codes = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'read');
         $token = $codes['token_type'].' '.$codes['access_token'];
 
-        $this->client->request('GET', '/api/posts/subscribedWithBoosts', server: ['HTTP_AUTHORIZATION' => $token]);
+        $this->client->request('GET', '/api/posts/subscribedWithBoosts?sort=newest', server: ['HTTP_AUTHORIZATION' => $token]);
         self::assertResponseIsSuccessful();
         $jsonData = self::getJsonResponse($this->client);
 

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -1074,6 +1074,7 @@ direct_message_setting_label: Who can send you a direct message
 show_boost_following_label: Show boosted content in Microblog and Combined view
 show_boost_following_help: If this is enabled, threads, posts and comments boosted by you or users you follow
   will show up in the Combined view of your subscriptions and Microblog view.
+  This will only have an effect when the sorting is set to 'Newest'.
 delete_magazine_icon: Delete magazine icon
 flash_magazine_theme_icon_detached_success: Magazine icon deleted successfully
 delete_magazine_banner: Delete magazine banner


### PR DESCRIPTION
As boost might include comments, this makes it incompatible with cursor pagination for some sortings, so restrict it to `Newest` as it only makes sense mostly there anyway.