### PR TITLE
Fix type error on mention extraction from tags

### DIFF
--- a/src/Service/ActivityPub/MarkdownConverter.php
+++ b/src/Service/ActivityPub/MarkdownConverter.php
@@ -11,6 +11,7 @@ use App\Service\MentionManager;
 use App\Service\TagExtractor;
 use League\HTMLToMarkdown\Converter\TableConverter;
 use League\HTMLToMarkdown\HtmlConverter;
+use Psr\Log\LoggerInterface;
 
 class MarkdownConverter
 {
@@ -18,6 +19,7 @@ class MarkdownConverter
         private readonly TagExtractor $tagExtractor,
         private readonly MentionManager $mentionManager,
         private readonly ActivityPubManager $activityPubManager,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -73,6 +75,8 @@ class MarkdownConverter
         $res = [];
         foreach ($apTags as $tag) {
             if (!\is_array($tag) || !isset($tag['type']) || !isset($tag['name']) || !isset($tag['href'])) {
+                $this->logger->warning('Ignoring tag (not an array or missing "name", "type" or "href": {t}', ['t' => $tag]);
+
                 continue;
             }
             if ('Mention' === $tag['type']) {

--- a/src/Service/ActivityPub/MarkdownConverter.php
+++ b/src/Service/ActivityPub/MarkdownConverter.php
@@ -72,6 +72,9 @@ class MarkdownConverter
     {
         $res = [];
         foreach ($apTags as $tag) {
+            if (!\is_array($tag) || !isset($tag['type']) || !isset($tag['name']) || !isset($tag['href'])) {
+                continue;
+            }
             if ('Mention' === $tag['type']) {
                 if ($match[2] === $tag['href']) {
                     // the href in the tag array might be the same as the link from the text

--- a/src/Service/ActivityPub/MarkdownConverter.php
+++ b/src/Service/ActivityPub/MarkdownConverter.php
@@ -75,7 +75,7 @@ class MarkdownConverter
         $res = [];
         foreach ($apTags as $tag) {
             if (!\is_array($tag) || !isset($tag['type']) || !isset($tag['name']) || !isset($tag['href'])) {
-                $this->logger->warning('Ignoring tag (not an array or missing "name", "type" or "href": {t}', ['t' => $tag]);
+                $this->logger->warning('Ignoring tag (not an array or missing "name", "type" or "href"): {t}', ['t' => $tag]);
 
                 continue;
             }


### PR DESCRIPTION
- ignore something in the tag array if it is not an array or is missing one of the required fields `type`, `name` or `href`

#2107