### PR TITLE
Treat `as:Public` or just `Public` correctly -> the same as `https://www.w3.org/ns/activitystreams#Public`

### DIFF
--- a/src/Entity/Contracts/ActivityPubActivityInterface.php
+++ b/src/Entity/Contracts/ActivityPubActivityInterface.php
@@ -8,14 +8,16 @@ use App\Entity\User;
 
 interface ActivityPubActivityInterface
 {
-    public const FOLLOWERS = 'followers';
-    public const FOLLOWING = 'following';
-    public const INBOX = 'inbox';
-    public const OUTBOX = 'outbox';
-    public const CONTEXT = 'context';
-    public const CONTEXT_URL = 'https://www.w3.org/ns/activitystreams';
-    public const SECURITY_URL = 'https://w3id.org/security/v1';
-    public const PUBLIC_URL = 'https://www.w3.org/ns/activitystreams#Public';
+    public const string FOLLOWERS = 'followers';
+    public const string FOLLOWING = 'following';
+    public const string INBOX = 'inbox';
+    public const string OUTBOX = 'outbox';
+    public const string CONTEXT = 'context';
+    public const string CONTEXT_URL = 'https://www.w3.org/ns/activitystreams';
+    public const string SECURITY_URL = 'https://w3id.org/security/v1';
+    public const string PUBLIC_URL = 'https://www.w3.org/ns/activitystreams#Public';
+    public const string PUBLIC_URL_NS = 'as:Public';
+    public const string PUBLIC_URL_SHORT = 'Public';
 
     public const ADDITIONAL_CONTEXTS = [
         // namespaces

--- a/src/Service/ActivityPub/ActivityPubContent.php
+++ b/src/Service/ActivityPub/ActivityPubContent.php
@@ -21,7 +21,7 @@ abstract class ActivityPubContent
     protected function getVisibility(array $object, User $actor): string
     {
         $toAndCC = array_merge(JsonldUtils::getArrayValue($object, 'to'), JsonldUtils::getArrayValue($object, 'cc'));
-        if (!\in_array(ActivityPubActivityInterface::PUBLIC_URL, $toAndCC)) {
+        if (!$this->containsPublicTarget($toAndCC)) {
             if (!\in_array($actor->apFollowersUrl, $toAndCC)) {
                 throw new \LogicException('PM: not implemented.');
             }
@@ -30,6 +30,13 @@ abstract class ActivityPubContent
         }
 
         return VisibilityInterface::VISIBILITY_VISIBLE;
+    }
+
+    protected function containsPublicTarget(array $toAndCC): bool
+    {
+        return \in_array(ActivityPubActivityInterface::PUBLIC_URL, $toAndCC)
+            || \in_array(ActivityPubActivityInterface::PUBLIC_URL_NS, $toAndCC)
+            || \in_array(ActivityPubActivityInterface::PUBLIC_URL_SHORT, $toAndCC);
     }
 
     protected function handleDate(PostDto|PostCommentDto|EntryCommentDto|EntryDto $dto, string $date): void

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -937,7 +937,7 @@ class ActivityPubManager
                     \App\Utils\JsonldUtils::getArrayValue($activity, 'cc'),
                     \App\Utils\JsonldUtils::getArrayValue($activity, 'to'),
                 ),
-                fn ($val) => !\in_array($val, [ActivityPubActivityInterface::PUBLIC_URL, $followersUrl, []])
+                fn ($val) => !\in_array($val, [ActivityPubActivityInterface::PUBLIC_URL, ActivityPubActivityInterface::PUBLIC_URL_NS, ActivityPubActivityInterface::PUBLIC_URL_SHORT, $followersUrl, []])
             )
         );
 
@@ -1076,7 +1076,7 @@ class ActivityPubManager
             $res = array_merge($res, array_map(fn ($item) => $item['id'], $groups));
         }
 
-        $res = array_filter($res, fn ($i) => null !== $i and ActivityPubActivityInterface::PUBLIC_URL !== $i);
+        $res = array_filter($res, fn ($i) => null !== $i && ActivityPubActivityInterface::PUBLIC_URL !== $i && ActivityPubActivityInterface::PUBLIC_URL_NS !== $i && ActivityPubActivityInterface::PUBLIC_URL_SHORT !== $i);
 
         return array_unique($res);
     }

--- a/tests/Functional/ActivityPub/Inbox/CreateHandlerTest.php
+++ b/tests/Functional/ActivityPub/Inbox/CreateHandlerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Tests\Functional\ActivityPub\Inbox;
 
+use App\Entity\Contracts\ActivityPubActivityInterface;
+use App\Entity\Contracts\VisibilityInterface;
 use App\Entity\Magazine;
 use App\Entity\User;
 use App\Enums\EDirectMessageSettings;
@@ -29,6 +31,8 @@ class CreateHandlerTest extends ActivityPubFunctionalTestCase
     private array $createMessage;
     private array $createMastodonPostWithMention;
     private array $createMastodonPostWithMentionWithoutTagArray;
+    private array $createPostWithPublicNS;
+    private array $createPostWithPublicShortURL;
 
     public function setUpRemoteEntities(): void
     {
@@ -44,6 +48,7 @@ class CreateHandlerTest extends ActivityPubFunctionalTestCase
         $this->createMessage = $this->createRemoteMessage($this->remoteUser, $this->localUser);
         $this->setupMastodonPost();
         $this->setupMastodonPostWithoutTagArray();
+        $this->setupPostWithOtherPublicStrings();
     }
 
     public function setUpLocalEntities(): void
@@ -246,6 +251,21 @@ class CreateHandlerTest extends ActivityPubFunctionalTestCase
         self::assertEquals('@remoteUser@remote.mbin', $mentions[0]);
     }
 
+    public function testPostWithPublicNs(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createPostWithPublicNS)));
+        $post = $this->postRepository->findOneBy(['apId' => $this->createPostWithPublicNS['object']['id']]);
+        self::assertNotNull($post);
+        self::assertEquals(VisibilityInterface::VISIBILITY_VISIBLE, $post->getVisibility());
+    }
+
+    public function testPostWithPublicShortURL(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createPostWithPublicShortURL)));
+        $post = $this->postRepository->findOneBy(['apId' => $this->createPostWithPublicShortURL['object']['id']]);
+        self::assertNotNull($post);
+    }
+
     private function setupRemoteActor(): void
     {
         $domain = 'some.instance.tld';
@@ -316,5 +336,16 @@ class CreateHandlerTest extends ActivityPubFunctionalTestCase
         $this->entitiesToRemoveAfterSetup[] = $entry;
 
         return $create;
+    }
+
+    private function setupPostWithOtherPublicStrings(): void
+    {
+        $this->createPostWithPublicNS = $this->createRemotePostInLocalMagazine($this->localMagazine, $this->remoteUser);
+        $this->createPostWithPublicNS['to'] = ActivityPubActivityInterface::PUBLIC_URL_NS;
+        $this->createPostWithPublicNS['object']['to'] = ActivityPubActivityInterface::PUBLIC_URL_NS;
+
+        $this->createPostWithPublicShortURL = $this->createRemotePostInLocalMagazine($this->localMagazine, $this->remoteUser);
+        $this->createPostWithPublicShortURL['to'] = ActivityPubActivityInterface::PUBLIC_URL_SHORT;
+        $this->createPostWithPublicShortURL['object']['to'] = ActivityPubActivityInterface::PUBLIC_URL_SHORT;
     }
 }


### PR DESCRIPTION
- according to https://www.w3.org/TR/activitypub/#x5-6-public-addressing `as:Public` and `Public` should be treated the same as `https://www.w3.org/ns/activitystreams#Public`
- add constants for the other public URL string
- ignore the new constants the same as the PUBLIC_URL constant
- treat the new constants the same as PUBLIC_URL in getting the visibility

#2107