### PR TITLE
Fix flaky test case in `UserFilterListApiTest`

### DIFF
--- a/tests/Functional/Controller/Api/User/UserFilterListApiTest.php
+++ b/tests/Functional/Controller/Api/User/UserFilterListApiTest.php
@@ -201,7 +201,7 @@ class UserFilterListApiTest extends WebTestCase
 
         $this->activateFilterList($token);
 
-        $this->client->jsonRequest('GET', '/api/combined?sortBy=newest', server: ['HTTP_AUTHORIZATION' => $token]);
+        $this->client->jsonRequest('GET', '/api/combined?sort=newest', server: ['HTTP_AUTHORIZATION' => $token]);
         self::assertResponseIsSuccessful();
         $data = self::getJsonResponse($this->client);
         self::assertIsArray($data);


### PR DESCRIPTION
The sort parameter was wrong, so sometimes the order of the two items was inverted