### PR TITLE
Fix support for `image` property on `Page` type, add support for string

### DIFF
--- a/src/Service/ActivityPub/Page.php
+++ b/src/Service/ActivityPub/Page.php
@@ -91,7 +91,7 @@ class Page extends ActivityPubContent
             $dto->title = $object['name'];
             $dto->apId = $object['id'];
 
-            if ((isset($object['attachment']) || isset($object['image'])) && $image = $this->activityPubManager->handleImages($object['attachment'])) {
+            if ((isset($object['attachment']) || isset($object['image'])) && $image = $this->activityPubManager->handleImages($object['attachment'] ?? $object['image'])) {
                 $this->logger->debug("adding image to entry '{title}', {image}", ['title' => $dto->title, 'image' => $image->getId()]);
                 $dto->image = $this->imageFactory->createDto($image);
             }

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -524,8 +524,23 @@ class ActivityPubManager
         return null;
     }
 
-    public function handleImages(array $attachment): ?Image
+    public function handleImages(array|string $attachment): ?Image
     {
+        if (\is_string($attachment) && filter_var($attachment, FILTER_VALIDATE_URL)) {
+            $path = parse_url($attachment, PHP_URL_PATH);
+            $query = parse_url($attachment, PHP_URL_QUERY);
+            $attachment = [
+                [
+                    'url' => $attachment,
+                    'type' => 'Image',
+                ],
+            ];
+            if (str_contains($path, 'jpg') || str_contains($path, 'jpeg') || str_contains($query, 'jpg') || str_contains($query, 'jpeg')) {
+                $attachment[0]['mediaType'] = 'image/jpeg';
+            } elseif (str_contains($path, 'png') || str_contains($query, 'png')) {
+                $attachment[0]['mediaType'] = 'image/png';
+            }
+        }
         $images = array_filter(
             $attachment,
             fn ($val) => $this->isImageAttachment($val)


### PR DESCRIPTION
- When a `Page` ActivityPub object contains only an `image` property, but no `attachment` property our code threw an error
- Add support for either `attachment` or `image` property to contain only a string (Ghost does this for example)

With this change an AP-Object like this: https://www.shoptechblog.com/.ghost/activitypub/article/38919605-5b90-4b0b-ad3c-5991a889855c
will properly work and get the image attached

Also connection to #2107