### PR TITLE
Initial poll implementation

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -51,6 +51,7 @@
 @use 'components/inline_md';
 @use 'components/emoji_picker';
 @use 'components/filter_list';
+@use 'components/poll';
 @use 'pages/post_single';
 @use 'pages/post_front';
 @use 'pages/page_bookmarks';

--- a/assets/styles/components/_poll.scss
+++ b/assets/styles/components/_poll.scss
@@ -1,0 +1,24 @@
+.poll {
+  margin: auto;
+
+  form {
+    margin: auto;
+    max-width: 400px;
+  }
+
+  .poll-result {
+    margin: .5rem 0;
+  }
+
+  .choice-result {
+    margin-bottom: .5rem;
+
+    .choice-bar {
+      background-color: var(--kbin-button-primary-bg);
+      color: var(--kbin-button-primary-text-color);
+      height: .5rem;
+      border: var(--kbin-button-primary-border);
+      border-radius: var(--kbin-rounded-edges-radius);
+    }
+  }
+}

--- a/assets/styles/components/_post.scss
+++ b/assets/styles/components/_post.scss
@@ -23,6 +23,10 @@
   div {
     margin-bottom: 0;
   }
+
+  .poll-area div {
+    margin-bottom: 1rem;
+  }
 }
 
 .post-container {

--- a/assets/styles/layout/_forms.scss
+++ b/assets/styles/layout/_forms.scss
@@ -258,7 +258,8 @@ form {
   flex-direction: row-reverse;
   justify-content: flex-end;
 
-  input[type=checkbox] {
+  input[type=checkbox],
+  input[type=radio] {
     margin-right: .5rem;
   }
 }
@@ -573,4 +574,19 @@ div.input-box {
   display: block;
   width: 100%;
 
+}
+
+.poll-area {
+  .sub-form {
+    display: none;
+  }
+  &:has(input:checked) .sub-form {
+    display: block;
+  }
+}
+
+form {
+  .collection-container.hide-index .existing-collection-items > div > label {
+    display: none;
+  }
 }

--- a/config/mbin_routes/activity_pub.yaml
+++ b/config/mbin_routes/activity_pub.yaml
@@ -162,3 +162,9 @@ ap_contexts:
     path: /contexts.{_format}
     methods: [GET]
     format: jsonld
+
+ap_poll_vote:
+    controller: App\Controller\ActivityPub\PollVoteController
+    path: /u/{username}/votes/{uuid}
+    methods: [GET]
+    condition: '%kbin_ap_route_condition%'

--- a/config/mbin_routes/poll.yaml
+++ b/config/mbin_routes/poll.yaml
@@ -1,0 +1,4 @@
+poll_vote:
+  controller: App\Controller\PollVoteController::vote
+  path: /poll/{id}/vote
+  methods: [GET]

--- a/config/mbin_routes/poll.yaml
+++ b/config/mbin_routes/poll.yaml
@@ -2,3 +2,8 @@ poll_vote:
   controller: App\Controller\PollVoteController::vote
   path: /poll/{id}/vote
   methods: [GET]
+
+poll_refresh:
+    controller: App\Controller\PollVoteController::refreshVoteCounts
+    path: /poll/{id}/refresh
+    methods: [GET]

--- a/config/mbin_routes/poll_api.yaml
+++ b/config/mbin_routes/poll_api.yaml
@@ -1,0 +1,19 @@
+api_poll_vote_entry:
+  controller: App\Controller\Api\Poll\PollVoteController::voteOnEntry
+  path: /api/entry/{entryId}/poll/vote
+  methods: [ PUT ]
+
+api_poll_vote_entry_comment:
+  controller: App\Controller\Api\Poll\PollVoteController::voteOnEntryComment
+  path: /api/entry/{entryId}/comments/{commentId}/poll/vote
+  methods: [ PUT ]
+
+api_poll_vote_post:
+    controller: App\Controller\Api\Poll\PollVoteController::voteOnPost
+    path: /api/post/{postId}/poll/vote
+    methods: [ PUT ]
+
+api_poll_vote_post_comment:
+    controller: App\Controller\Api\Poll\PollVoteController::voteOnPostComment
+    path: /api/post/{postId}/comments/{commentId}/poll/vote
+    methods: [ PUT ]

--- a/docs/05-fediverse_developers/README.md
+++ b/docs/05-fediverse_developers/README.md
@@ -84,6 +84,30 @@ Each magazine has an AP actor at `https://instance.tld/m/name`:
 %object_message%
 ```
 
+### Polls
+
+Polls can be part of all of the above, except private messages. If that is the case, their `type` becomes `Question`.
+The deciding factor if an object is a thread or microblog in that case is the existence of the `title` property.
+
+Mbin's representation of polls are mostly the same as Mastodons (see [Mastodon's documentation](https://docs.joinmastodon.org/spec/activitypub/#Question)):
+
+- Poll options are part of the `oneOf` (for single choice polls) or the `anyOf` property (for multiple choice polls)
+- Each option has a `name` property, which is both the value and the label of this option
+- Each option has a `replies` property containing the amount of votes in their `totalItems` property
+
+```json
+%object_poll%
+```
+
+#### Poll Votes
+
+A vote in a poll is represented as a `Note` object with a `name` property containing the exact value of the choice that is voted for.
+For multiple-choice-polls, multiple activities will be sent, each containing one vote for one choice.
+
+```json
+%object_poll_vote%
+```
+
 ## Collections
 
 ### User Outbox

--- a/migrations/Version20260408134939.php
+++ b/migrations/Version20260408134939.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260408134939 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create initial poll table and relations';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE SEQUENCE poll_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('CREATE SEQUENCE poll_choice_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('CREATE TABLE poll (id INT NOT NULL, multiple_choice BOOLEAN NOT NULL, voter_count INT DEFAULT 0 NOT NULL, end_date TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, is_remote BOOLEAN NOT NULL, created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL, sent_notifications BOOLEAN NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE TABLE poll_choice (id INT NOT NULL, name VARCHAR(255) NOT NULL, vote_count INT NOT NULL, poll_id INT NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE INDEX IDX_2DAE19C93C947C0F ON poll_choice (poll_id)');
+        $this->addSql('CREATE TABLE poll_vote (uuid UUID NOT NULL, created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL, ap_id VARCHAR(255) DEFAULT NULL, voter_id INT NOT NULL, choice_id INT NOT NULL, poll_id INT NOT NULL, PRIMARY KEY (uuid))');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_ED568EBE904F155E ON poll_vote (ap_id)');
+        $this->addSql('CREATE INDEX IDX_ED568EBEEBB4B8AD ON poll_vote (voter_id)');
+        $this->addSql('CREATE INDEX IDX_ED568EBE998666D1 ON poll_vote (choice_id)');
+        $this->addSql('CREATE INDEX IDX_ED568EBE3C947C0F ON poll_vote (poll_id)');
+        $this->addSql('ALTER TABLE poll_choice ADD CONSTRAINT FK_2DAE19C93C947C0F FOREIGN KEY (poll_id) REFERENCES poll (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE poll_vote ADD CONSTRAINT FK_ED568EBEEBB4B8AD FOREIGN KEY (voter_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE poll_vote ADD CONSTRAINT FK_ED568EBE998666D1 FOREIGN KEY (choice_id) REFERENCES poll_choice (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE poll_vote ADD CONSTRAINT FK_ED568EBE3C947C0F FOREIGN KEY (poll_id) REFERENCES poll (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE activity ADD object_poll_vote_id UUID DEFAULT NULL');
+        $this->addSql('ALTER TABLE activity ADD CONSTRAINT FK_AC74095A69F3DEA4 FOREIGN KEY (object_poll_vote_id) REFERENCES poll_vote (uuid) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('CREATE INDEX IDX_AC74095A69F3DEA4 ON activity (object_poll_vote_id)');
+        $this->addSql('ALTER TABLE entry ADD poll_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE entry ADD CONSTRAINT FK_2B219D703C947C0F FOREIGN KEY (poll_id) REFERENCES poll (id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_2B219D703C947C0F ON entry (poll_id)');
+        $this->addSql('ALTER TABLE entry_comment ADD poll_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE entry_comment ADD CONSTRAINT FK_B892FDFB3C947C0F FOREIGN KEY (poll_id) REFERENCES poll (id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_B892FDFB3C947C0F ON entry_comment (poll_id)');
+        $this->addSql('ALTER TABLE post ADD poll_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE post ADD CONSTRAINT FK_5A8A6C8D3C947C0F FOREIGN KEY (poll_id) REFERENCES poll (id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_5A8A6C8D3C947C0F ON post (poll_id)');
+        $this->addSql('ALTER TABLE post_comment ADD poll_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE post_comment ADD CONSTRAINT FK_A99CE55F3C947C0F FOREIGN KEY (poll_id) REFERENCES poll (id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_A99CE55F3C947C0F ON post_comment (poll_id)');
+        $this->addSql('ALTER TABLE notification ADD poll_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE notification ADD CONSTRAINT FK_BF5476CA3C947C0F FOREIGN KEY (poll_id) REFERENCES poll (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('CREATE INDEX IDX_BF5476CA3C947C0F ON notification (poll_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP SEQUENCE poll_id_seq CASCADE');
+        $this->addSql('DROP SEQUENCE poll_choice_id_seq CASCADE');
+        $this->addSql('ALTER TABLE activity DROP CONSTRAINT FK_AC74095A69F3DEA4');
+        $this->addSql('DROP INDEX IDX_AC74095A69F3DEA4');
+        $this->addSql('ALTER TABLE activity DROP object_poll_vote_id');
+        $this->addSql('ALTER TABLE entry DROP CONSTRAINT FK_2B219D703C947C0F');
+        $this->addSql('DROP INDEX UNIQ_2B219D703C947C0F');
+        $this->addSql('ALTER TABLE entry DROP poll_id');
+        $this->addSql('ALTER TABLE entry_comment DROP CONSTRAINT FK_B892FDFB3C947C0F');
+        $this->addSql('DROP INDEX UNIQ_B892FDFB3C947C0F');
+        $this->addSql('ALTER TABLE entry_comment DROP poll_id');
+        $this->addSql('ALTER TABLE post DROP CONSTRAINT FK_5A8A6C8D3C947C0F');
+        $this->addSql('DROP INDEX UNIQ_5A8A6C8D3C947C0F');
+        $this->addSql('ALTER TABLE post DROP poll_id');
+        $this->addSql('ALTER TABLE post_comment DROP CONSTRAINT FK_A99CE55F3C947C0F');
+        $this->addSql('ALTER TABLE notification DROP CONSTRAINT FK_BF5476CA3C947C0F');
+        $this->addSql('DROP INDEX IDX_BF5476CA3C947C0F');
+        $this->addSql('ALTER TABLE notification DROP poll_id');
+        $this->addSql('DROP INDEX UNIQ_A99CE55F3C947C0F');
+        $this->addSql('ALTER TABLE post_comment DROP poll_id');
+        $this->addSql('ALTER TABLE poll_choice DROP CONSTRAINT FK_2DAE19C93C947C0F');
+        $this->addSql('ALTER TABLE poll_vote DROP CONSTRAINT FK_ED568EBEEBB4B8AD');
+        $this->addSql('ALTER TABLE poll_vote DROP CONSTRAINT FK_ED568EBE998666D1');
+        $this->addSql('ALTER TABLE poll_vote DROP CONSTRAINT FK_ED568EBE3C947C0F');
+        $this->addSql('DROP TABLE poll');
+        $this->addSql('DROP TABLE poll_choice');
+        $this->addSql('DROP TABLE poll_vote');
+    }
+}

--- a/migrations/Version20260408134939.php
+++ b/migrations/Version20260408134939.php
@@ -18,7 +18,7 @@ final class Version20260408134939 extends AbstractMigration
     {
         $this->addSql('CREATE SEQUENCE poll_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
         $this->addSql('CREATE SEQUENCE poll_choice_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
-        $this->addSql('CREATE TABLE poll (id INT NOT NULL, multiple_choice BOOLEAN NOT NULL, voter_count INT DEFAULT 0 NOT NULL, end_date TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, is_remote BOOLEAN NOT NULL, created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL, sent_notifications BOOLEAN NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE TABLE poll (id INT NOT NULL, multiple_choice BOOLEAN NOT NULL, voter_count INT DEFAULT 0 NOT NULL, end_date TIMESTAMP(0) WITH TIME ZONE NOT NULL, is_remote BOOLEAN NOT NULL, created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL, sent_notifications BOOLEAN NOT NULL, PRIMARY KEY (id))');
         $this->addSql('CREATE TABLE poll_choice (id INT NOT NULL, name VARCHAR(255) NOT NULL, vote_count INT NOT NULL, poll_id INT NOT NULL, PRIMARY KEY (id))');
         $this->addSql('CREATE INDEX IDX_2DAE19C93C947C0F ON poll_choice (poll_id)');
         $this->addSql('CREATE TABLE poll_vote (uuid UUID NOT NULL, created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL, ap_id VARCHAR(255) DEFAULT NULL, voter_id INT NOT NULL, choice_id INT NOT NULL, poll_id INT NOT NULL, PRIMARY KEY (uuid))');

--- a/src/Command/DebugCommand.php
+++ b/src/Command/DebugCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Repository\PollRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand('mbin:debug')]
+class DebugCommand extends Command
+{
+    public function __construct(
+        private readonly PollRepository $pollRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        foreach ($this->pollRepository->getAllEndedPollsToSentNotifications() as $poll) {
+            $output->writeln("poll {$poll->getId()}");
+            foreach ($this->pollRepository->getAllLocalVotersOfPoll($poll) as $voter) {
+                $output->writeln("Voter $voter->username in poll {$poll->getId()}");
+            }
+        }
+
+        return 0;
+    }
+}

--- a/src/Command/DocumentationGenerateFederationCommand.php
+++ b/src/Command/DocumentationGenerateFederationCommand.php
@@ -25,6 +25,7 @@ use App\Factory\ActivityPub\InstanceFactory;
 use App\Factory\ActivityPub\LockFactory;
 use App\Factory\ActivityPub\MessageFactory;
 use App\Factory\ActivityPub\PersonFactory;
+use App\Factory\ActivityPub\PollVoteFactory;
 use App\Factory\ActivityPub\PostCommentNoteFactory;
 use App\Factory\ActivityPub\PostNoteFactory;
 use App\Factory\ImageFactory;
@@ -44,6 +45,7 @@ use App\Service\EntryCommentManager;
 use App\Service\EntryManager;
 use App\Service\MagazineManager;
 use App\Service\MessageManager;
+use App\Service\PollManager;
 use App\Service\PostCommentManager;
 use App\Service\PostManager;
 use App\Service\ReportManager;
@@ -103,6 +105,8 @@ class DocumentationGenerateFederationCommand extends Command
         private readonly CollectionInfoWrapper $collectionInfoWrapper,
         private readonly BlockFactory $blockFactory,
         private readonly LockFactory $lockFactory,
+        private readonly PollVoteFactory $pollVoteFactory,
+        private readonly PollManager $pollManager,
     ) {
         parent::__construct();
     }
@@ -224,6 +228,18 @@ class DocumentationGenerateFederationCommand extends Command
         $thread = $this->messageManager->toThread($dto, $user, $user2);
         $message = $thread->getLastMessage();
 
+        $dto = new EntryDto();
+        $dto->user = $user;
+        $dto->magazine = $magazine;
+        $dto->title = 'Do you like FOSS?';
+        $dto->lang = 'en';
+        $dto->addPoll = true;
+        $dto->choices = ['Yes', 'No'];
+        $dto->isMultipleChoicePoll = false;
+        $entryWithPoll = $this->entryManager->create($dto, $user, rateLimit: false);
+        $this->pollManager->vote($entryWithPoll->poll, $entryWithPoll, $user2, ['Yes']);
+        $pollVote = $entryWithPoll->poll->getUserVotes($user2)[0];
+
         $userOutboxCollectionInfo = $this->collectionFactory->getUserOutboxCollection($user, false);
         $userOutboxCollectionItems = $this->collectionFactory->getUserOutboxCollectionItems($user, 1, false);
         $userFollowerCollection = $this->collectionInfoWrapper->build('ap_user_followers', ['username' => $user->username], $this->userRepository->findFollowers(1, $user)->getNbResults());
@@ -279,6 +295,8 @@ class DocumentationGenerateFederationCommand extends Command
             '%object_post%' => json_encode($this->postNoteFactory->create($post, []), $jsonFlags),
             '%object_post_comment%' => json_encode($this->postCommentNoteFactory->create($postComment, []), $jsonFlags),
             '%object_message%' => json_encode($this->messageFactory->build($message, false), $jsonFlags),
+            '%object_poll%' => json_encode($this->entryPageFactory->create($entryWithPoll, []), $jsonFlags),
+            '%object_poll_vote%' => json_encode($this->pollVoteFactory->build($pollVote), $jsonFlags),
             '%collection_user_outbox%' => json_encode($userOutboxCollectionInfo, $jsonFlags),
             '%collection_items_user_outbox%' => json_encode($userOutboxCollectionItems, $jsonFlags),
             '%collection_user_followers%' => json_encode($userFollowerCollection, $jsonFlags),

--- a/src/Controller/ActivityPub/PollVoteController.php
+++ b/src/Controller/ActivityPub/PollVoteController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\ActivityPub;
+
+use App\Controller\AbstractController;
+use App\Entity\PollVote;
+use App\Entity\User;
+use App\Factory\ActivityPub\PollVoteFactory;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class PollVoteController extends AbstractController
+{
+    public function __invoke(
+        Request $request,
+        PollVoteFactory $pollVoteFactory,
+        #[MapEntity(mapping: ['username' => 'username'])] User $user,
+        #[MapEntity(mapping: ['uuid' => 'uuid'])] PollVote $pollVote,
+    ): JsonResponse {
+        if ($pollVote->getUser()->getId() !== $user->getId()) {
+            throw new NotFoundHttpException();
+        }
+
+        return new JsonResponse(
+            $pollVoteFactory->build($pollVote),
+            headers: ['Content-Type' => 'application/activity+json'],
+        );
+    }
+}

--- a/src/Controller/Api/BaseApi.php
+++ b/src/Controller/Api/BaseApi.php
@@ -5,15 +5,12 @@ declare(strict_types=1);
 namespace App\Controller\Api;
 
 use App\Controller\AbstractController;
-use App\DTO\EntryCommentDto;
 use App\DTO\EntryCommentResponseDto;
-use App\DTO\EntryDto;
 use App\DTO\EntryResponseDto;
 use App\DTO\MagazineDto;
 use App\DTO\MagazineResponseDto;
-use App\DTO\PostCommentDto;
+use App\DTO\PollResponseDto;
 use App\DTO\PostCommentResponseDto;
-use App\DTO\PostDto;
 use App\DTO\PostResponseDto;
 use App\DTO\ReportDto;
 use App\DTO\ReportRequestDto;
@@ -30,6 +27,7 @@ use App\Entity\EntryComment;
 use App\Entity\Image;
 use App\Entity\MagazineLog;
 use App\Entity\OAuth2ClientAccess;
+use App\Entity\Poll;
 use App\Entity\Post;
 use App\Entity\PostComment;
 use App\Entity\UserFilterList;
@@ -461,22 +459,22 @@ class BaseApi extends AbstractController
      *
      * @param Entry[]|null $crosspostedEntries
      */
-    protected function serializeEntry(EntryDto|Entry $dto, array $tags, ?array $crosspostedEntries = null): EntryResponseDto
+    protected function serializeEntry(Entry $entry, array $tags, ?array $crosspostedEntries = null): EntryResponseDto
     {
         $crosspostedEntryDtos = null;
         if (null !== $crosspostedEntries) {
             $crosspostedEntryDtos = array_map(fn (Entry $item) => $this->entryFactory->createResponseDto($item, []), $crosspostedEntries);
         }
-        $response = $this->entryFactory->createResponseDto($dto, $tags, $crosspostedEntryDtos);
+        $response = $this->entryFactory->createResponseDto($entry, $tags, $crosspostedEntryDtos);
 
         if ($this->isGranted('ROLE_OAUTH2_ENTRY:VOTE')) {
-            $response->isFavourited = $dto instanceof EntryDto ? $dto->isFavourited : $dto->isFavored($this->getUserOrThrow());
-            $response->userVote = $dto instanceof EntryDto ? $dto->userVote : $dto->getUserChoice($this->getUserOrThrow());
+            $response->isFavourited = $entry->isFavored($this->getUserOrThrow());
+            $response->userVote = $entry->getUserChoice($this->getUserOrThrow());
         }
 
         if ($user = $this->getUser()) {
-            $response->canAuthUserModerate = $dto->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
-            $response->notificationStatus = $this->notificationSettingsRepository->findOneByTarget($user, $dto)?->getStatus() ?? ENotificationStatus::Default;
+            $response->canAuthUserModerate = $entry->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
+            $response->notificationStatus = $this->notificationSettingsRepository->findOneByTarget($user, $entry)?->getStatus() ?? ENotificationStatus::Default;
         }
 
         return $response;
@@ -485,13 +483,13 @@ class BaseApi extends AbstractController
     /**
      * Serialize a single entry comment to JSON.
      */
-    protected function serializeEntryComment(EntryCommentDto $comment, array $tags): EntryCommentResponseDto
+    protected function serializeEntryComment(EntryComment $comment, array $tags): EntryCommentResponseDto
     {
         $response = $this->entryCommentFactory->createResponseDto($comment, $tags);
 
         if ($this->isGranted('ROLE_OAUTH2_ENTRY_COMMENT:VOTE')) {
-            $response->isFavourited = $comment->isFavourited;
-            $response->userVote = $comment->userVote;
+            $response->isFavourited = $comment->isFavored($this->getUserOrThrow());
+            $response->userVote = $comment->getUserChoice($this->getUserOrThrow());
         }
 
         if ($user = $this->getUser()) {
@@ -504,21 +502,18 @@ class BaseApi extends AbstractController
     /**
      * Serialize a single post to JSON.
      */
-    protected function serializePost(Post|PostDto $dto, array $tags): PostResponseDto
+    protected function serializePost(Post $post, array $tags): PostResponseDto
     {
-        if (null === $dto) {
-            return [];
-        }
-        $response = $this->postFactory->createResponseDto($dto, $tags);
+        $response = $this->postFactory->createResponseDto($post, $tags);
 
         if ($this->isGranted('ROLE_OAUTH2_POST:VOTE')) {
-            $response->isFavourited = $dto instanceof PostDto ? $dto->isFavourited : $dto->isFavored($this->getUserOrThrow());
-            $response->userVote = $dto instanceof PostDto ? $dto->userVote : $dto->getUserChoice($this->getUserOrThrow());
+            $response->isFavourited = $post->isFavored($this->getUserOrThrow());
+            $response->userVote = $post->getUserChoice($this->getUserOrThrow());
         }
 
         if ($user = $this->getUser()) {
-            $response->canAuthUserModerate = $dto->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
-            $response->notificationStatus = $this->notificationSettingsRepository->findOneByTarget($user, $dto)?->getStatus() ?? ENotificationStatus::Default;
+            $response->canAuthUserModerate = $post->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
+            $response->notificationStatus = $this->notificationSettingsRepository->findOneByTarget($user, $post)?->getStatus() ?? ENotificationStatus::Default;
         }
 
         return $response;
@@ -527,13 +522,13 @@ class BaseApi extends AbstractController
     /**
      * Serialize a single comment to JSON.
      */
-    protected function serializePostComment(PostCommentDto $comment, array $tags): PostCommentResponseDto
+    protected function serializePostComment(PostComment $comment, array $tags): PostCommentResponseDto
     {
         $response = $this->postCommentFactory->createResponseDto($comment, $tags);
 
         if ($this->isGranted('ROLE_OAUTH2_POST_COMMENT:VOTE')) {
-            $response->isFavourited = $comment instanceof PostCommentDto ? $comment->isFavourited : $comment->isFavored($this->getUserOrThrow());
-            $response->userVote = $comment instanceof PostCommentDto ? $comment->userVote : $comment->getUserChoice($this->getUserOrThrow());
+            $response->isFavourited = $comment->isFavored($this->getUserOrThrow());
+            $response->userVote = $comment->getUserChoice($this->getUserOrThrow());
         }
 
         if ($user = $this->getUser()) {
@@ -541,5 +536,10 @@ class BaseApi extends AbstractController
         }
 
         return $response;
+    }
+
+    protected function serializePoll(Poll $poll): PollResponseDto
+    {
+        return PollResponseDto::createFromPoll($poll, $this->getUser());
     }
 }

--- a/src/Controller/Api/BaseApi.php
+++ b/src/Controller/Api/BaseApi.php
@@ -5,15 +5,12 @@ declare(strict_types=1);
 namespace App\Controller\Api;
 
 use App\Controller\AbstractController;
-use App\DTO\EntryCommentDto;
 use App\DTO\EntryCommentResponseDto;
-use App\DTO\EntryDto;
 use App\DTO\EntryResponseDto;
 use App\DTO\MagazineDto;
 use App\DTO\MagazineResponseDto;
-use App\DTO\PostCommentDto;
+use App\DTO\PollResponseDto;
 use App\DTO\PostCommentResponseDto;
-use App\DTO\PostDto;
 use App\DTO\PostResponseDto;
 use App\DTO\ReportDto;
 use App\DTO\ReportRequestDto;
@@ -30,6 +27,7 @@ use App\Entity\EntryComment;
 use App\Entity\Image;
 use App\Entity\MagazineLog;
 use App\Entity\OAuth2ClientAccess;
+use App\Entity\Poll;
 use App\Entity\Post;
 use App\Entity\PostComment;
 use App\Entity\UserFilterList;
@@ -463,22 +461,22 @@ class BaseApi extends AbstractController
      *
      * @param Entry[]|null $crosspostedEntries
      */
-    protected function serializeEntry(EntryDto|Entry $dto, array $tags, ?array $crosspostedEntries = null): EntryResponseDto
+    protected function serializeEntry(Entry $entry, array $tags, ?array $crosspostedEntries = null): EntryResponseDto
     {
         $crosspostedEntryDtos = null;
         if (null !== $crosspostedEntries) {
             $crosspostedEntryDtos = array_map(fn (Entry $item) => $this->entryFactory->createResponseDto($item, []), $crosspostedEntries);
         }
-        $response = $this->entryFactory->createResponseDto($dto, $tags, $crosspostedEntryDtos);
+        $response = $this->entryFactory->createResponseDto($entry, $tags, $crosspostedEntryDtos);
 
         if ($this->isGranted('ROLE_OAUTH2_ENTRY:VOTE')) {
-            $response->isFavourited = $dto instanceof EntryDto ? $dto->isFavourited : $dto->isFavored($this->getUserOrThrow());
-            $response->userVote = $dto instanceof EntryDto ? $dto->userVote : $dto->getUserChoice($this->getUserOrThrow());
+            $response->isFavourited = $entry->isFavored($this->getUserOrThrow());
+            $response->userVote = $entry->getUserChoice($this->getUserOrThrow());
         }
 
         if ($user = $this->getUser()) {
-            $response->canAuthUserModerate = $dto->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
-            $response->notificationStatus = $this->notificationSettingsRepository->findOneByTarget($user, $dto)?->getStatus() ?? ENotificationStatus::Default;
+            $response->canAuthUserModerate = $entry->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
+            $response->notificationStatus = $this->notificationSettingsRepository->findOneByTarget($user, $entry)?->getStatus() ?? ENotificationStatus::Default;
         }
 
         return $response;
@@ -487,13 +485,13 @@ class BaseApi extends AbstractController
     /**
      * Serialize a single entry comment to JSON.
      */
-    protected function serializeEntryComment(EntryCommentDto $comment, array $tags): EntryCommentResponseDto
+    protected function serializeEntryComment(EntryComment $comment, array $tags): EntryCommentResponseDto
     {
         $response = $this->entryCommentFactory->createResponseDto($comment, $tags);
 
         if ($this->isGranted('ROLE_OAUTH2_ENTRY_COMMENT:VOTE')) {
-            $response->isFavourited = $comment->isFavourited;
-            $response->userVote = $comment->userVote;
+            $response->isFavourited = $comment->isFavored($this->getUserOrThrow());
+            $response->userVote = $comment->getUserChoice($this->getUserOrThrow());
         }
 
         if ($user = $this->getUser()) {
@@ -506,21 +504,18 @@ class BaseApi extends AbstractController
     /**
      * Serialize a single post to JSON.
      */
-    protected function serializePost(Post|PostDto $dto, array $tags): PostResponseDto
+    protected function serializePost(Post $post, array $tags): PostResponseDto
     {
-        if (null === $dto) {
-            return [];
-        }
-        $response = $this->postFactory->createResponseDto($dto, $tags);
+        $response = $this->postFactory->createResponseDto($post, $tags);
 
         if ($this->isGranted('ROLE_OAUTH2_POST:VOTE')) {
-            $response->isFavourited = $dto instanceof PostDto ? $dto->isFavourited : $dto->isFavored($this->getUserOrThrow());
-            $response->userVote = $dto instanceof PostDto ? $dto->userVote : $dto->getUserChoice($this->getUserOrThrow());
+            $response->isFavourited = $post->isFavored($this->getUserOrThrow());
+            $response->userVote = $post->getUserChoice($this->getUserOrThrow());
         }
 
         if ($user = $this->getUser()) {
-            $response->canAuthUserModerate = $dto->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
-            $response->notificationStatus = $this->notificationSettingsRepository->findOneByTarget($user, $dto)?->getStatus() ?? ENotificationStatus::Default;
+            $response->canAuthUserModerate = $post->getMagazine()->userIsModerator($user) || $user->isModerator() || $user->isAdmin();
+            $response->notificationStatus = $this->notificationSettingsRepository->findOneByTarget($user, $post)?->getStatus() ?? ENotificationStatus::Default;
         }
 
         return $response;
@@ -529,13 +524,13 @@ class BaseApi extends AbstractController
     /**
      * Serialize a single comment to JSON.
      */
-    protected function serializePostComment(PostCommentDto $comment, array $tags): PostCommentResponseDto
+    protected function serializePostComment(PostComment $comment, array $tags): PostCommentResponseDto
     {
         $response = $this->postCommentFactory->createResponseDto($comment, $tags);
 
         if ($this->isGranted('ROLE_OAUTH2_POST_COMMENT:VOTE')) {
-            $response->isFavourited = $comment instanceof PostCommentDto ? $comment->isFavourited : $comment->isFavored($this->getUserOrThrow());
-            $response->userVote = $comment instanceof PostCommentDto ? $comment->userVote : $comment->getUserChoice($this->getUserOrThrow());
+            $response->isFavourited = $comment->isFavored($this->getUserOrThrow());
+            $response->userVote = $comment->getUserChoice($this->getUserOrThrow());
         }
 
         if ($user = $this->getUser()) {
@@ -543,5 +538,10 @@ class BaseApi extends AbstractController
         }
 
         return $response;
+    }
+
+    protected function serializePoll(Poll $poll): PollResponseDto
+    {
+        return PollResponseDto::createFromPoll($poll, $this->getUser());
     }
 }

--- a/src/Controller/Api/Combined/CombinedRetrieveApi.php
+++ b/src/Controller/Api/Combined/CombinedRetrieveApi.php
@@ -813,16 +813,16 @@ class CombinedRetrieveApi extends BaseApi
         foreach ($content as $item) {
             if ($item instanceof Entry) {
                 $this->handlePrivateContent($item);
-                $result[] = new ContentResponseDto(entry: $this->serializeEntry($this->entryFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
+                $result[] = new ContentResponseDto(entry: $this->serializeEntry($item, $this->tagLinkRepository->getTagsOfContent($item)));
             } elseif ($item instanceof Post) {
                 $this->handlePrivateContent($item);
-                $result[] = new ContentResponseDto(post: $this->serializePost($this->postFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
+                $result[] = new ContentResponseDto(post: $this->serializePost($item, $this->tagLinkRepository->getTagsOfContent($item)));
             } elseif ($item instanceof EntryComment) {
                 $this->handlePrivateContent($item);
-                $result[] = new ContentResponseDto(entryComment: $this->serializeEntryComment($this->entryCommentFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
+                $result[] = new ContentResponseDto(entryComment: $this->serializeEntryComment($item, $this->tagLinkRepository->getTagsOfContent($item)));
             } elseif ($item instanceof PostComment) {
                 $this->handlePrivateContent($item);
-                $result[] = new ContentResponseDto(postComment: $this->serializePostComment($this->postCommentFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
+                $result[] = new ContentResponseDto(postComment: $this->serializePostComment($item, $this->tagLinkRepository->getTagsOfContent($item)));
             }
         }
 
@@ -835,10 +835,10 @@ class CombinedRetrieveApi extends BaseApi
         foreach ($content as $item) {
             if ($item instanceof Entry) {
                 $this->handlePrivateContent($item);
-                $result[] = new ContentResponseDto(entry: $this->serializeEntry($this->entryFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
+                $result[] = new ContentResponseDto(entry: $this->serializeEntry($item, $this->tagLinkRepository->getTagsOfContent($item)));
             } elseif ($item instanceof Post) {
                 $this->handlePrivateContent($item);
-                $result[] = new ContentResponseDto(post: $this->serializePost($this->postFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
+                $result[] = new ContentResponseDto(post: $this->serializePost($item, $this->tagLinkRepository->getTagsOfContent($item)));
             }
         }
 

--- a/src/Controller/Api/Entry/Admin/EntriesChangeMagazineApi.php
+++ b/src/Controller/Api/Entry/Admin/EntriesChangeMagazineApi.php
@@ -86,7 +86,7 @@ class EntriesChangeMagazineApi extends EntriesBaseApi
         $manager->changeMagazine($entry, $target);
 
         return new JsonResponse(
-            $this->serializeEntry($factory->createDto($entry), $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
+            $this->serializeEntry($entry, $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Entry/Comments/EntryCommentsCreateApi.php
+++ b/src/Controller/Api/Entry/Comments/EntryCommentsCreateApi.php
@@ -118,11 +118,10 @@ class EntryCommentsCreateApi extends EntriesBaseApi
 
         // Rate limiting already taken care of
         $comment = $manager->create($dto, $this->getUserOrThrow(), rateLimit: false);
-        $dto = $factory->createDto($comment);
         $dto->parent = $parent;
 
         return new JsonResponse(
-            $this->serializeEntryComment($dto, $this->tagLinkRepository->getTagsOfContent($comment)),
+            $this->serializeEntryComment($comment, $this->tagLinkRepository->getTagsOfContent($comment)),
             status: 201,
             headers: $headers
         );
@@ -227,11 +226,10 @@ class EntryCommentsCreateApi extends EntriesBaseApi
 
         // Rate limiting already taken care of
         $comment = $manager->create($dto, $this->getUserOrThrow(), rateLimit: false);
-        $dto = $factory->createDto($comment);
         $dto->parent = $parent;
 
         return new JsonResponse(
-            $this->serializeEntryComment($dto, $this->tagLinkRepository->getTagsOfContent($comment)),
+            $this->serializeEntryComment($comment, $this->tagLinkRepository->getTagsOfContent($comment)),
             status: 201,
             headers: $headers
         );

--- a/src/Controller/Api/Entry/Comments/EntryCommentsFavouriteApi.php
+++ b/src/Controller/Api/Entry/Comments/EntryCommentsFavouriteApi.php
@@ -78,7 +78,7 @@ class EntryCommentsFavouriteApi extends EntriesBaseApi
         $manager->toggle($this->getUserOrThrow(), $comment);
 
         return new JsonResponse(
-            $this->serializeEntryComment($factory->createDto($comment), $this->tagLinkRepository->getTagsOfContent($comment)),
+            $this->serializeEntryComment($comment, $this->tagLinkRepository->getTagsOfContent($comment)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Entry/Comments/EntryCommentsVoteApi.php
+++ b/src/Controller/Api/Entry/Comments/EntryCommentsVoteApi.php
@@ -98,7 +98,7 @@ class EntryCommentsVoteApi extends EntriesBaseApi
         $manager->vote($choice, $comment, $this->getUserOrThrow(), rateLimit: false);
 
         return new JsonResponse(
-            $this->serializeEntryComment($factory->createDto($comment), $this->tagLinkRepository->getTagsOfContent($comment)),
+            $this->serializeEntryComment($comment, $this->tagLinkRepository->getTagsOfContent($comment)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Entry/Comments/Moderate/EntryCommentsSetAdultApi.php
+++ b/src/Controller/Api/Entry/Comments/Moderate/EntryCommentsSetAdultApi.php
@@ -86,7 +86,7 @@ class EntryCommentsSetAdultApi extends EntriesBaseApi
         $manager->flush();
 
         return new JsonResponse(
-            $this->serializeEntryComment($factory->createDto($comment), $this->tagLinkRepository->getTagsOfContent($comment)),
+            $this->serializeEntryComment($comment, $this->tagLinkRepository->getTagsOfContent($comment)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Entry/Comments/Moderate/EntryCommentsSetLanguageApi.php
+++ b/src/Controller/Api/Entry/Comments/Moderate/EntryCommentsSetLanguageApi.php
@@ -100,7 +100,7 @@ class EntryCommentsSetLanguageApi extends EntriesBaseApi
         $manager->flush();
 
         return new JsonResponse(
-            $this->serializeEntryComment($factory->createDto($comment), $this->tagLinkRepository->getTagsOfContent($comment)),
+            $this->serializeEntryComment($comment, $this->tagLinkRepository->getTagsOfContent($comment)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Entry/Comments/Moderate/EntryCommentsTrashApi.php
+++ b/src/Controller/Api/Entry/Comments/Moderate/EntryCommentsTrashApi.php
@@ -82,7 +82,7 @@ class EntryCommentsTrashApi extends EntriesBaseApi
         // Force response to have all fields visible
         $visibility = $comment->visibility;
         $comment->visibility = VisibilityInterface::VISIBILITY_VISIBLE;
-        $response = $this->serializeEntryComment($factory->createDto($comment), $this->tagLinkRepository->getTagsOfContent($comment))->jsonSerialize();
+        $response = $this->serializeEntryComment($comment, $this->tagLinkRepository->getTagsOfContent($comment))->jsonSerialize();
         $response['visibility'] = $visibility;
 
         return new JsonResponse(
@@ -159,7 +159,7 @@ class EntryCommentsTrashApi extends EntriesBaseApi
         }
 
         return new JsonResponse(
-            $this->serializeEntryComment($factory->createDto($comment), $this->tagLinkRepository->getTagsOfContent($comment)),
+            $this->serializeEntryComment($comment, $this->tagLinkRepository->getTagsOfContent($comment)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Entry/DomainEntriesRetrieveApi.php
+++ b/src/Controller/Api/Entry/DomainEntriesRetrieveApi.php
@@ -164,7 +164,7 @@ class DomainEntriesRetrieveApi extends EntriesBaseApi
             try {
                 \assert($value instanceof Entry);
                 $this->handlePrivateContent($value);
-                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
+                $dtos[] = $this->serializeEntry($value, $this->tagLinkRepository->getTagsOfContent($value));
             } catch (\Exception $e) {
                 continue;
             }

--- a/src/Controller/Api/Entry/EntriesFavouriteApi.php
+++ b/src/Controller/Api/Entry/EntriesFavouriteApi.php
@@ -69,7 +69,7 @@ class EntriesFavouriteApi extends EntriesBaseApi
         $manager->toggle($this->getUserOrThrow(), $entry);
 
         return new JsonResponse(
-            $this->serializeEntry($factory->createDto($entry), $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
+            $this->serializeEntry($entry, $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Entry/EntriesRetrieveApi.php
+++ b/src/Controller/Api/Entry/EntriesRetrieveApi.php
@@ -83,10 +83,8 @@ class EntriesRetrieveApi extends EntriesBaseApi
 
         $dispatcher->dispatch(new EntryHasBeenSeenEvent($entry));
 
-        $dto = $factory->createDto($entry);
-
         return new JsonResponse(
-            $this->serializeEntry($dto, $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
+            $this->serializeEntry($entry, $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
             headers: $headers
         );
     }
@@ -216,7 +214,7 @@ class EntriesRetrieveApi extends EntriesBaseApi
             try {
                 \assert($value instanceof Entry);
                 $this->handlePrivateContent($value);
-                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
+                $dtos[] = $this->serializeEntry($value, $this->tagLinkRepository->getTagsOfContent($value));
             } catch (AccessDeniedException $e) {
                 continue;
             }
@@ -338,7 +336,7 @@ class EntriesRetrieveApi extends EntriesBaseApi
             try {
                 \assert($value instanceof Entry);
                 $this->handlePrivateContent($value);
-                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
+                $dtos[] = $this->serializeEntry($value, $this->tagLinkRepository->getTagsOfContent($value));
             } catch (\Exception $e) {
                 continue;
             }
@@ -460,7 +458,7 @@ class EntriesRetrieveApi extends EntriesBaseApi
             try {
                 \assert($value instanceof Entry);
                 $this->handlePrivateContent($value);
-                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
+                $dtos[] = $this->serializeEntry($value, $this->tagLinkRepository->getTagsOfContent($value));
             } catch (\Exception $e) {
                 continue;
             }
@@ -582,7 +580,7 @@ class EntriesRetrieveApi extends EntriesBaseApi
             try {
                 \assert($value instanceof Entry);
                 $this->handlePrivateContent($value);
-                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
+                $dtos[] = $this->serializeEntry($value, $this->tagLinkRepository->getTagsOfContent($value));
             } catch (\Exception $e) {
                 continue;
             }

--- a/src/Controller/Api/Entry/EntriesVoteApi.php
+++ b/src/Controller/Api/Entry/EntriesVoteApi.php
@@ -97,7 +97,7 @@ class EntriesVoteApi extends EntriesBaseApi
         $manager->vote($choice, $entry, $this->getUserOrThrow(), rateLimit: false);
 
         return new JsonResponse(
-            $this->serializeEntry($factory->createDto($entry), $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
+            $this->serializeEntry($entry, $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Entry/MagazineEntriesRetrieveApi.php
+++ b/src/Controller/Api/Entry/MagazineEntriesRetrieveApi.php
@@ -166,7 +166,7 @@ class MagazineEntriesRetrieveApi extends EntriesBaseApi
         foreach ($entries->getCurrentPageResults() as $value) {
             try {
                 \assert($value instanceof Entry);
-                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
+                $dtos[] = $this->serializeEntry($value, $this->tagLinkRepository->getTagsOfContent($value));
             } catch (\Exception $e) {
                 continue;
             }

--- a/src/Controller/Api/Entry/MagazineEntryCreateApi.php
+++ b/src/Controller/Api/Entry/MagazineEntryCreateApi.php
@@ -101,7 +101,7 @@ class MagazineEntryCreateApi extends EntriesBaseApi
         ]);
 
         return new JsonResponse(
-            $this->serializeEntry($manager->createDto($entry), $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
+            $this->serializeEntry($entry, $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
             status: 201,
             headers: $headers
         );
@@ -180,7 +180,7 @@ class MagazineEntryCreateApi extends EntriesBaseApi
         ]);
 
         return new JsonResponse(
-            $this->serializeEntry($manager->createDto($entry), $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
+            $this->serializeEntry($entry, $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
             status: 201,
             headers: $headers
         );
@@ -254,7 +254,7 @@ class MagazineEntryCreateApi extends EntriesBaseApi
         ]);
 
         return new JsonResponse(
-            $this->serializeEntry($manager->createDto($entry), $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
+            $this->serializeEntry($entry, $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
             status: 201,
             headers: $headers
         );
@@ -361,7 +361,7 @@ class MagazineEntryCreateApi extends EntriesBaseApi
         $entry = $manager->create($dto, $this->getUserOrThrow());
 
         return new JsonResponse(
-            $this->serializeEntry($manager->createDto($entry), $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
+            $this->serializeEntry($entry, $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
             status: 201,
             headers: $headers
         );
@@ -470,12 +470,11 @@ class MagazineEntryCreateApi extends EntriesBaseApi
 
         $entry = $manager->create($dto, $this->getUserOrThrow());
 
-        $retDto = $manager->createDto($entry);
         $tags = $this->tagLinkRepository->getTagsOfContent($entry);
         $crossposts = $this->entryRepository->findCross($entry);
 
         return new JsonResponse(
-            $this->serializeEntry($retDto, $tags, $crossposts),
+            $this->serializeEntry($entry, $tags, $crossposts),
             status: 201,
             headers: $headers
         );

--- a/src/Controller/Api/Entry/Moderate/EntriesLockApi.php
+++ b/src/Controller/Api/Entry/Moderate/EntriesLockApi.php
@@ -80,7 +80,7 @@ class EntriesLockApi extends EntriesBaseApi
         $manager->toggleLock($entry, $this->getUserOrThrow());
 
         return new JsonResponse(
-            $this->serializeEntry($factory->createDto($entry), $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
+            $this->serializeEntry($entry, $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Entry/Moderate/EntriesPinApi.php
+++ b/src/Controller/Api/Entry/Moderate/EntriesPinApi.php
@@ -76,7 +76,7 @@ class EntriesPinApi extends EntriesBaseApi
         $manager->pin($entry, $this->getUserOrThrow());
 
         return new JsonResponse(
-            $this->serializeEntry($factory->createDto($entry), $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
+            $this->serializeEntry($entry, $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Entry/Moderate/EntriesSetAdultApi.php
+++ b/src/Controller/Api/Entry/Moderate/EntriesSetAdultApi.php
@@ -86,7 +86,7 @@ class EntriesSetAdultApi extends EntriesBaseApi
         $manager->flush();
 
         return new JsonResponse(
-            $this->serializeEntry($factory->createDto($entry), $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
+            $this->serializeEntry($entry, $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Entry/Moderate/EntriesSetLanguageApi.php
+++ b/src/Controller/Api/Entry/Moderate/EntriesSetLanguageApi.php
@@ -100,7 +100,7 @@ class EntriesSetLanguageApi extends EntriesBaseApi
         $manager->flush();
 
         return new JsonResponse(
-            $this->serializeEntry($factory->createDto($entry), $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
+            $this->serializeEntry($entry, $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Entry/Moderate/EntriesTrashApi.php
+++ b/src/Controller/Api/Entry/Moderate/EntriesTrashApi.php
@@ -79,7 +79,7 @@ class EntriesTrashApi extends EntriesBaseApi
 
         $manager->trash($moderator, $entry);
 
-        $response = $this->serializeEntry($factory->createDto($entry), $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry));
+        $response = $this->serializeEntry($entry, $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry));
 
         // Force response to have all fields visible
         $visibility = $response->visibility;
@@ -161,7 +161,7 @@ class EntriesTrashApi extends EntriesBaseApi
         }
 
         return new JsonResponse(
-            $this->serializeEntry($factory->createDto($entry), $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
+            $this->serializeEntry($entry, $this->tagLinkRepository->getTagsOfContent($entry), $this->entryRepository->findCross($entry)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Entry/UserEntriesRetrieveApi.php
+++ b/src/Controller/Api/Entry/UserEntriesRetrieveApi.php
@@ -153,7 +153,7 @@ class UserEntriesRetrieveApi extends EntriesBaseApi
         foreach ($entries->getCurrentPageResults() as $value) {
             try {
                 \assert($value instanceof Entry);
-                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
+                $dtos[] = $this->serializeEntry($value, $this->tagLinkRepository->getTagsOfContent($value));
             } catch (\Exception $e) {
                 continue;
             }

--- a/src/Controller/Api/Poll/PollVoteController.php
+++ b/src/Controller/Api/Poll/PollVoteController.php
@@ -1,0 +1,302 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Api\Poll;
+
+use App\Controller\Api\BaseApi;
+use App\DTO\PollResponseDto;
+use App\Entity\Entry;
+use App\Entity\EntryComment;
+use App\Entity\Poll;
+use App\Entity\Post;
+use App\Entity\PostComment;
+use App\Entity\User;
+use App\Schema\Errors\BadRequestErrorSchema;
+use App\Schema\Errors\NotFoundErrorSchema;
+use App\Schema\Errors\TooManyRequestsErrorSchema;
+use App\Schema\Errors\UnauthorizedErrorSchema;
+use App\Service\PollManager;
+use Nelmio\ApiDocBundle\Attribute\Model;
+use Nelmio\ApiDocBundle\Attribute\Security;
+use OpenApi\Attributes as OA;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+class PollVoteController extends BaseApi
+{
+    #[OA\Response(
+        response: 200,
+        description: 'voted on poll',
+        headers: [
+            new OA\Header(header: 'X-RateLimit-Remaining', description: 'Number of requests left until you will be rate limited', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Retry-After', description: 'Unix timestamp to retry the request after', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Limit', description: 'Number of requests available', schema: new OA\Schema(type: 'integer')),
+        ],
+        content: new Model(type: PollResponseDto::class)
+    )]
+    #[OA\Response(
+        response: 400,
+        description: 'Poll was not valid. Possibly: poll already ended, choices do not exist, user already voted',
+        content: new OA\JsonContent(ref: new Model(type: BadRequestErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'Permission denied due to missing or expired token',
+        content: new OA\JsonContent(ref: new Model(type: UnauthorizedErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 404,
+        description: 'Poll not found',
+        content: new OA\JsonContent(ref: new Model(type: NotFoundErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 429,
+        description: 'You are being rate limited',
+        headers: [
+            new OA\Header(header: 'X-RateLimit-Remaining', description: 'Number of requests left until you will be rate limited', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Retry-After', description: 'Unix timestamp to retry the request after', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Limit', description: 'Number of requests available', schema: new OA\Schema(type: 'integer')),
+        ],
+        content: new OA\JsonContent(ref: new Model(type: TooManyRequestsErrorSchema::class))
+    )]
+    #[OA\Parameter(
+        name: 'choices',
+        description: 'The user\'s voting choices',
+        in: 'query',
+        schema: new OA\Schema(type: 'array', items: new OA\Items(type: 'string')),
+    )]
+    #[OA\Tag(name: 'entry')]
+    #[OA\Tag(name: 'poll')]
+    #[Security(name: 'oauth2', scopes: ['entry:vote'])]
+    #[IsGranted('ROLE_OAUTH2_ENTRY:VOTE')]
+    public function voteOnEntry(
+        #[MapEntity(mapping: ['entryId' => 'id'])] Entry $entry,
+        Request $request,
+        PollManager $pollManager,
+        RateLimiterFactoryInterface $apiVoteLimiter,
+    ): JsonResponse {
+        $headers = $this->rateLimit($apiVoteLimiter);
+        $poll = $entry->poll;
+        if (null === $poll) {
+            throw new NotFoundHttpException();
+        }
+
+        return $this->voteOnPoll($request, $pollManager, $this->getUserOrThrow(), $entry, $poll, $headers);
+    }
+
+    #[OA\Response(
+        response: 200,
+        description: 'voted on poll',
+        headers: [
+            new OA\Header(header: 'X-RateLimit-Remaining', description: 'Number of requests left until you will be rate limited', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Retry-After', description: 'Unix timestamp to retry the request after', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Limit', description: 'Number of requests available', schema: new OA\Schema(type: 'integer')),
+        ],
+        content: new Model(type: PollResponseDto::class)
+    )]
+    #[OA\Response(
+        response: 400,
+        description: 'Poll was not valid. Possibly: poll already ended, choices do not exist, user already voted',
+        content: new OA\JsonContent(ref: new Model(type: BadRequestErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'Permission denied due to missing or expired token',
+        content: new OA\JsonContent(ref: new Model(type: UnauthorizedErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 404,
+        description: 'Poll not found',
+        content: new OA\JsonContent(ref: new Model(type: NotFoundErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 429,
+        description: 'You are being rate limited',
+        headers: [
+            new OA\Header(header: 'X-RateLimit-Remaining', description: 'Number of requests left until you will be rate limited', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Retry-After', description: 'Unix timestamp to retry the request after', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Limit', description: 'Number of requests available', schema: new OA\Schema(type: 'integer')),
+        ],
+        content: new OA\JsonContent(ref: new Model(type: TooManyRequestsErrorSchema::class))
+    )]
+    #[OA\Parameter(
+        name: 'choices',
+        description: 'The user\'s voting choices',
+        in: 'query',
+        schema: new OA\Schema(type: 'array', items: new OA\Items(type: 'string')),
+    )]
+    #[OA\Tag(name: 'entry_comment')]
+    #[OA\Tag(name: 'poll')]
+    #[Security(name: 'oauth2', scopes: ['entry_comment:vote'])]
+    #[IsGranted('ROLE_OAUTH2_ENTRY_COMMENT:VOTE')]
+    public function voteOnEntryComment(
+        #[MapEntity(mapping: ['entryId' => 'id'])] Entry $entry,
+        #[MapEntity(mapping: ['commentId' => 'id'])] EntryComment $comment,
+        Request $request,
+        PollManager $pollManager,
+        RateLimiterFactoryInterface $apiVoteLimiter,
+    ): JsonResponse {
+        $headers = $this->rateLimit($apiVoteLimiter);
+        $poll = $comment->poll;
+        if (null === $poll) {
+            throw new NotFoundHttpException();
+        }
+
+        if ($comment->entry->getId() !== $entry->getId()) {
+            throw new BadRequestHttpException();
+        }
+
+        return $this->voteOnPoll($request, $pollManager, $this->getUserOrThrow(), $comment, $poll, $headers);
+    }
+
+    #[OA\Response(
+        response: 200,
+        description: 'voted on poll',
+        headers: [
+            new OA\Header(header: 'X-RateLimit-Remaining', description: 'Number of requests left until you will be rate limited', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Retry-After', description: 'Unix timestamp to retry the request after', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Limit', description: 'Number of requests available', schema: new OA\Schema(type: 'integer')),
+        ],
+        content: new Model(type: PollResponseDto::class)
+    )]
+    #[OA\Response(
+        response: 400,
+        description: 'Poll was not valid. Possibly: poll already ended, choices do not exist, user already voted',
+        content: new OA\JsonContent(ref: new Model(type: BadRequestErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'Permission denied due to missing or expired token',
+        content: new OA\JsonContent(ref: new Model(type: UnauthorizedErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 404,
+        description: 'Poll not found',
+        content: new OA\JsonContent(ref: new Model(type: NotFoundErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 429,
+        description: 'You are being rate limited',
+        headers: [
+            new OA\Header(header: 'X-RateLimit-Remaining', description: 'Number of requests left until you will be rate limited', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Retry-After', description: 'Unix timestamp to retry the request after', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Limit', description: 'Number of requests available', schema: new OA\Schema(type: 'integer')),
+        ],
+        content: new OA\JsonContent(ref: new Model(type: TooManyRequestsErrorSchema::class))
+    )]
+    #[OA\Parameter(
+        name: 'choices',
+        description: 'The user\'s voting choices',
+        in: 'query',
+        schema: new OA\Schema(type: 'array', items: new OA\Items(type: 'string')),
+    )]
+    #[OA\Tag(name: 'post')]
+    #[OA\Tag(name: 'poll')]
+    #[Security(name: 'oauth2', scopes: ['post:vote'])]
+    #[IsGranted('ROLE_OAUTH2_POST:VOTE')]
+    public function voteOnPost(
+        #[MapEntity(mapping: ['postId' => 'id'])] Post $post,
+        Request $request,
+        PollManager $pollManager,
+        RateLimiterFactoryInterface $apiVoteLimiter,
+    ): JsonResponse {
+        $headers = $this->rateLimit($apiVoteLimiter);
+        $poll = $post->poll;
+        if (null === $poll) {
+            throw new NotFoundHttpException();
+        }
+
+        return $this->voteOnPoll($request, $pollManager, $this->getUserOrThrow(), $post, $poll, $headers);
+    }
+
+    #[OA\Response(
+        response: 200,
+        description: 'voted on poll',
+        headers: [
+            new OA\Header(header: 'X-RateLimit-Remaining', description: 'Number of requests left until you will be rate limited', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Retry-After', description: 'Unix timestamp to retry the request after', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Limit', description: 'Number of requests available', schema: new OA\Schema(type: 'integer')),
+        ],
+        content: new Model(type: PollResponseDto::class)
+    )]
+    #[OA\Response(
+        response: 400,
+        description: 'Poll was not valid. Possibly: poll already ended, choices do not exist, user already voted',
+        content: new OA\JsonContent(ref: new Model(type: BadRequestErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'Permission denied due to missing or expired token',
+        content: new OA\JsonContent(ref: new Model(type: UnauthorizedErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 404,
+        description: 'Poll not found',
+        content: new OA\JsonContent(ref: new Model(type: NotFoundErrorSchema::class))
+    )]
+    #[OA\Response(
+        response: 429,
+        description: 'You are being rate limited',
+        headers: [
+            new OA\Header(header: 'X-RateLimit-Remaining', description: 'Number of requests left until you will be rate limited', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Retry-After', description: 'Unix timestamp to retry the request after', schema: new OA\Schema(type: 'integer')),
+            new OA\Header(header: 'X-RateLimit-Limit', description: 'Number of requests available', schema: new OA\Schema(type: 'integer')),
+        ],
+        content: new OA\JsonContent(ref: new Model(type: TooManyRequestsErrorSchema::class))
+    )]
+    #[OA\Parameter(
+        name: 'choices',
+        description: 'The user\'s voting choices',
+        in: 'query',
+        schema: new OA\Schema(type: 'array', items: new OA\Items(type: 'string')),
+    )]
+    #[OA\Tag(name: 'post_comment')]
+    #[OA\Tag(name: 'poll')]
+    #[Security(name: 'oauth2', scopes: ['post_comment:vote'])]
+    #[IsGranted('ROLE_OAUTH2_POST_COMMENT:VOTE')]
+    public function voteOnPostComment(
+        #[MapEntity(mapping: ['postId' => 'id'])] Post $post,
+        #[MapEntity(mapping: ['commentId' => 'id'])] PostComment $comment,
+        Request $request,
+        PollManager $pollManager,
+        RateLimiterFactoryInterface $apiVoteLimiter,
+    ): JsonResponse {
+        $headers = $this->rateLimit($apiVoteLimiter);
+        $poll = $comment->poll;
+        if (null === $poll) {
+            throw new NotFoundHttpException();
+        }
+
+        if ($comment->post->getId() !== $post->getId()) {
+            throw new BadRequestHttpException();
+        }
+
+        return $this->voteOnPoll($request, $pollManager, $this->getUserOrThrow(), $comment, $poll, $headers);
+    }
+
+    public function voteOnPoll(Request $request, PollManager $pollManager, User $user, Entry|EntryComment|Post|PostComment $content, Poll $poll, array $headers): JsonResponse
+    {
+        if ($content->poll->getId() !== $poll->getId() || $content->poll->hasEnded() || $content->poll->hasUserVoted($user)) {
+            throw new BadRequestHttpException();
+        }
+
+        $choices = $request->query->all('choices');
+
+        foreach ($choices as $choice) {
+            if (!$content->poll->findChoice($choice)) {
+                throw new BadRequestHttpException();
+            }
+        }
+
+        $pollManager->vote($poll, $content, $user, $choices);
+        $this->entityManager->refresh($poll);
+
+        return new JsonResponse($this->serializePoll($poll), headers: $headers);
+    }
+}

--- a/src/Controller/Api/Post/Comments/Moderate/PostCommentsSetAdultApi.php
+++ b/src/Controller/Api/Post/Comments/Moderate/PostCommentsSetAdultApi.php
@@ -86,7 +86,7 @@ class PostCommentsSetAdultApi extends PostsBaseApi
         $manager->flush();
 
         return new JsonResponse(
-            $this->serializePostComment($factory->createDto($comment), $this->tagLinkRepository->getTagsOfContent($comment)),
+            $this->serializePostComment($comment, $this->tagLinkRepository->getTagsOfContent($comment)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Post/Comments/Moderate/PostCommentsSetLanguageApi.php
+++ b/src/Controller/Api/Post/Comments/Moderate/PostCommentsSetLanguageApi.php
@@ -100,7 +100,7 @@ class PostCommentsSetLanguageApi extends PostsBaseApi
         $manager->flush();
 
         return new JsonResponse(
-            $this->serializePostComment($factory->createDto($comment), $this->tagLinkRepository->getTagsOfContent($comment)),
+            $this->serializePostComment($comment, $this->tagLinkRepository->getTagsOfContent($comment)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Post/Comments/Moderate/PostCommentsTrashApi.php
+++ b/src/Controller/Api/Post/Comments/Moderate/PostCommentsTrashApi.php
@@ -82,7 +82,7 @@ class PostCommentsTrashApi extends PostsBaseApi
         // Force response to have all fields visible
         $visibility = $comment->visibility;
         $comment->visibility = VisibilityInterface::VISIBILITY_VISIBLE;
-        $response = $this->serializePostComment($factory->createDto($comment), $this->tagLinkRepository->getTagsOfContent($comment))->jsonSerialize();
+        $response = $this->serializePostComment($comment, $this->tagLinkRepository->getTagsOfContent($comment))->jsonSerialize();
         $response['visibility'] = $visibility;
 
         return new JsonResponse(
@@ -159,7 +159,7 @@ class PostCommentsTrashApi extends PostsBaseApi
         }
 
         return new JsonResponse(
-            $this->serializePostComment($factory->createDto($comment), $this->tagLinkRepository->getTagsOfContent($comment)),
+            $this->serializePostComment($comment, $this->tagLinkRepository->getTagsOfContent($comment)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Post/Comments/PostCommentsCreateApi.php
+++ b/src/Controller/Api/Post/Comments/PostCommentsCreateApi.php
@@ -120,7 +120,7 @@ class PostCommentsCreateApi extends PostsBaseApi
         $comment = $manager->create($dto, $this->getUserOrThrow(), rateLimit: false);
 
         return new JsonResponse(
-            $this->serializePostComment($factory->createDto($comment), $this->tagLinkRepository->getTagsOfContent($comment)),
+            $this->serializePostComment($comment, $this->tagLinkRepository->getTagsOfContent($comment)),
             status: 201,
             headers: $headers
         );
@@ -226,7 +226,7 @@ class PostCommentsCreateApi extends PostsBaseApi
         $comment = $manager->create($dto, $this->getUserOrThrow(), rateLimit: false);
 
         return new JsonResponse(
-            $this->serializePostComment($factory->createDto($comment), $this->tagLinkRepository->getTagsOfContent($comment)),
+            $this->serializePostComment($comment, $this->tagLinkRepository->getTagsOfContent($comment)),
             status: 201,
             headers: $headers
         );

--- a/src/Controller/Api/Post/Comments/PostCommentsFavouriteApi.php
+++ b/src/Controller/Api/Post/Comments/PostCommentsFavouriteApi.php
@@ -78,7 +78,7 @@ class PostCommentsFavouriteApi extends PostsBaseApi
         $manager->toggle($this->getUserOrThrow(), $comment);
 
         return new JsonResponse(
-            $this->serializePostComment($factory->createDto($comment), $this->tagLinkRepository->getTagsOfContent($comment)),
+            $this->serializePostComment($comment, $this->tagLinkRepository->getTagsOfContent($comment)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Post/Comments/PostCommentsVoteApi.php
+++ b/src/Controller/Api/Post/Comments/PostCommentsVoteApi.php
@@ -97,7 +97,7 @@ class PostCommentsVoteApi extends PostsBaseApi
         $manager->vote($choice, $comment, $this->getUserOrThrow(), rateLimit: false);
 
         return new JsonResponse(
-            $this->serializePostComment($factory->createDto($comment), $this->tagLinkRepository->getTagsOfContent($comment)),
+            $this->serializePostComment($comment, $this->tagLinkRepository->getTagsOfContent($comment)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Post/Moderate/PostsLockApi.php
+++ b/src/Controller/Api/Post/Moderate/PostsLockApi.php
@@ -80,7 +80,7 @@ class PostsLockApi extends PostsBaseApi
         $manager->toggleLock($post, $this->getUserOrThrow());
 
         return new JsonResponse(
-            $this->serializePost($factory->createDto($post), $this->tagLinkRepository->getTagsOfContent($post)),
+            $this->serializePost($post, $this->tagLinkRepository->getTagsOfContent($post)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Post/Moderate/PostsPinApi.php
+++ b/src/Controller/Api/Post/Moderate/PostsPinApi.php
@@ -76,7 +76,7 @@ class PostsPinApi extends PostsBaseApi
         $manager->pin($post);
 
         return new JsonResponse(
-            $this->serializePost($factory->createDto($post), $this->tagLinkRepository->getTagsOfContent($post)),
+            $this->serializePost($post, $this->tagLinkRepository->getTagsOfContent($post)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Post/Moderate/PostsSetAdultApi.php
+++ b/src/Controller/Api/Post/Moderate/PostsSetAdultApi.php
@@ -86,7 +86,7 @@ class PostsSetAdultApi extends PostsBaseApi
         $manager->flush();
 
         return new JsonResponse(
-            $this->serializePost($factory->createDto($post), $this->tagLinkRepository->getTagsOfContent($post)),
+            $this->serializePost($post, $this->tagLinkRepository->getTagsOfContent($post)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Post/Moderate/PostsSetLanguageApi.php
+++ b/src/Controller/Api/Post/Moderate/PostsSetLanguageApi.php
@@ -100,7 +100,7 @@ class PostsSetLanguageApi extends PostsBaseApi
         $manager->flush();
 
         return new JsonResponse(
-            $this->serializePost($factory->createDto($post), $this->tagLinkRepository->getTagsOfContent($post)),
+            $this->serializePost($post, $this->tagLinkRepository->getTagsOfContent($post)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Post/Moderate/PostsTrashApi.php
+++ b/src/Controller/Api/Post/Moderate/PostsTrashApi.php
@@ -82,7 +82,7 @@ class PostsTrashApi extends PostsBaseApi
         // Force response to have all fields visible
         $visibility = $post->visibility;
         $post->visibility = VisibilityInterface::VISIBILITY_VISIBLE;
-        $response = $this->serializePost($factory->createDto($post), $this->tagLinkRepository->getTagsOfContent($post))->jsonSerialize();
+        $response = $this->serializePost($post, $this->tagLinkRepository->getTagsOfContent($post))->jsonSerialize();
         $response['visibility'] = $visibility;
 
         return new JsonResponse(
@@ -159,7 +159,7 @@ class PostsTrashApi extends PostsBaseApi
         }
 
         return new JsonResponse(
-            $this->serializePost($factory->createDto($post), $this->tagLinkRepository->getTagsOfContent($post)),
+            $this->serializePost($post, $this->tagLinkRepository->getTagsOfContent($post)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Post/PostsBaseApi.php
+++ b/src/Controller/Api/Post/PostsBaseApi.php
@@ -106,10 +106,6 @@ class PostsBaseApi extends BaseApi
      */
     protected function serializePostCommentTree(?PostComment $comment, PostCommentPageView $commentPageView, ?int $depth = null): array
     {
-        if (null === $comment) {
-            return [];
-        }
-
         if (null === $depth) {
             $depth = self::constrainDepth($this->request->getCurrentRequest()->get('d', self::DEPTH));
         }

--- a/src/Controller/Api/Post/PostsCreateApi.php
+++ b/src/Controller/Api/Post/PostsCreateApi.php
@@ -110,7 +110,7 @@ class PostsCreateApi extends PostsBaseApi
         $post = $manager->create($dto, $this->getUserOrThrow(), rateLimit: false);
 
         return new JsonResponse(
-            $this->serializePost($manager->createDto($post), $this->tagLinkRepository->getTagsOfContent($post)),
+            $this->serializePost($post, $this->tagLinkRepository->getTagsOfContent($post)),
             status: 201,
             headers: $headers
         );
@@ -207,7 +207,7 @@ class PostsCreateApi extends PostsBaseApi
         $post = $manager->create($dto, $this->getUserOrThrow(), rateLimit: false);
 
         return new JsonResponse(
-            $this->serializePost($manager->createDto($post), $this->tagLinkRepository->getTagsOfContent($post)),
+            $this->serializePost($post, $this->tagLinkRepository->getTagsOfContent($post)),
             status: 201,
             headers: $headers
         );

--- a/src/Controller/Api/Post/PostsFavouriteApi.php
+++ b/src/Controller/Api/Post/PostsFavouriteApi.php
@@ -69,7 +69,7 @@ class PostsFavouriteApi extends PostsBaseApi
         $manager->toggle($this->getUserOrThrow(), $post);
 
         return new JsonResponse(
-            $this->serializePost($factory->createDto($post), $this->tagLinkRepository->getTagsOfContent($post)),
+            $this->serializePost($post, $this->tagLinkRepository->getTagsOfContent($post)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Post/PostsRetrieveApi.php
+++ b/src/Controller/Api/Post/PostsRetrieveApi.php
@@ -86,10 +86,8 @@ class PostsRetrieveApi extends PostsBaseApi
 
         $dispatcher->dispatch(new PostHasBeenSeenEvent($post));
 
-        $dto = $factory->createDto($post);
-
         return new JsonResponse(
-            $this->serializePost($dto, $this->tagLinkRepository->getTagsOfContent($post)),
+            $this->serializePost($post, $this->tagLinkRepository->getTagsOfContent($post)),
             headers: $headers
         );
     }
@@ -208,7 +206,7 @@ class PostsRetrieveApi extends PostsBaseApi
             try {
                 \assert($value instanceof Post);
                 $this->handlePrivateContent($value);
-                array_push($dtos, $this->serializePost($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value)));
+                $dtos[] = $this->serializePost($value, $this->tagLinkRepository->getTagsOfContent($value));
             } catch (\Exception $e) {
                 continue;
             }
@@ -345,7 +343,7 @@ class PostsRetrieveApi extends PostsBaseApi
             try {
                 \assert($value instanceof Post);
                 $this->handlePrivateContent($value);
-                $dtos[] = $this->serializePost($this->postFactory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
+                $dtos[] = $this->serializePost($value, $this->tagLinkRepository->getTagsOfContent($value));
             } catch (\Exception $e) {
                 continue;
             }
@@ -481,10 +479,10 @@ class PostsRetrieveApi extends PostsBaseApi
             try {
                 if ($value instanceof Post) {
                     $this->handlePrivateContent($value);
-                    $dtos[] = new ContentResponseDto(post: $this->serializePost($this->postFactory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value)));
+                    $dtos[] = new ContentResponseDto(post: $this->serializePost($value, $this->tagLinkRepository->getTagsOfContent($value)));
                 } elseif ($value instanceof PostComment) {
                     $this->handlePrivateContent($value);
-                    $dtos[] = new ContentResponseDto(postComment: $this->serializePostComment($this->postCommentFactory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value)));
+                    $dtos[] = new ContentResponseDto(postComment: $this->serializePostComment($value, $this->tagLinkRepository->getTagsOfContent($value)));
                 } else {
                     throw new \AssertionError('got unexpected type '.\get_class($value));
                 }
@@ -611,7 +609,7 @@ class PostsRetrieveApi extends PostsBaseApi
             try {
                 \assert($value instanceof Post);
                 $this->handlePrivateContent($value);
-                array_push($dtos, $this->serializePost($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value)));
+                $dtos[] = $this->serializePost($value, $this->tagLinkRepository->getTagsOfContent($value));
             } catch (\Exception $e) {
                 continue;
             }
@@ -732,7 +730,7 @@ class PostsRetrieveApi extends PostsBaseApi
             try {
                 \assert($value instanceof Post);
                 $this->handlePrivateContent($value);
-                array_push($dtos, $this->serializePost($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value)));
+                $dtos[] = $this->serializePost($value, $this->tagLinkRepository->getTagsOfContent($value));
             } catch (\Exception $e) {
                 continue;
             }
@@ -882,7 +880,7 @@ class PostsRetrieveApi extends PostsBaseApi
             try {
                 \assert($value instanceof Post);
                 $this->handlePrivateContent($value);
-                array_push($dtos, $this->serializePost($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value)));
+                $dtos[] = $this->serializePost($value, $this->tagLinkRepository->getTagsOfContent($value));
             } catch (\Exception $e) {
                 continue;
             }

--- a/src/Controller/Api/Post/PostsUpdateApi.php
+++ b/src/Controller/Api/Post/PostsUpdateApi.php
@@ -100,7 +100,7 @@ class PostsUpdateApi extends PostsBaseApi
         $post = $manager->edit($post, $dto, $user);
 
         return new JsonResponse(
-            $this->serializePost($factory->createDto($post), $this->tagLinkRepository->getTagsOfContent($post)),
+            $this->serializePost($post, $this->tagLinkRepository->getTagsOfContent($post)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Post/PostsVoteApi.php
+++ b/src/Controller/Api/Post/PostsVoteApi.php
@@ -100,7 +100,7 @@ class PostsVoteApi extends PostsBaseApi
         $manager->vote($choice, $post, $this->getUserOrThrow(), rateLimit: false);
 
         return new JsonResponse(
-            $this->serializePost($factory->createDto($post), $this->tagLinkRepository->getTagsOfContent($post)),
+            $this->serializePost($post, $this->tagLinkRepository->getTagsOfContent($post)),
             headers: $headers
         );
     }

--- a/src/Controller/Api/Post/UserPostsRetrieveApi.php
+++ b/src/Controller/Api/Post/UserPostsRetrieveApi.php
@@ -146,7 +146,7 @@ class UserPostsRetrieveApi extends PostsBaseApi
             try {
                 \assert($value instanceof Post);
                 $this->handlePrivateContent($value);
-                array_push($dtos, $this->serializePost($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value)));
+                $dtos[] = $this->serializePost($value, $this->tagLinkRepository->getTagsOfContent($value));
             } catch (\Exception $e) {
                 continue;
             }

--- a/src/Controller/Api/Search/SearchRetrieveApi.php
+++ b/src/Controller/Api/Search/SearchRetrieveApi.php
@@ -384,19 +384,19 @@ class SearchRetrieveApi extends BaseApi
         if ($item instanceof Entry) {
             $this->handlePrivateContent($item);
 
-            return new SearchResponseDto(entry: $this->serializeEntry($this->entryFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
+            return new SearchResponseDto(entry: $this->serializeEntry($item, $this->tagLinkRepository->getTagsOfContent($item)));
         } elseif ($item instanceof Post) {
             $this->handlePrivateContent($item);
 
-            return new SearchResponseDto(post: $this->serializePost($this->postFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
+            return new SearchResponseDto(post: $this->serializePost($item, $this->tagLinkRepository->getTagsOfContent($item)));
         } elseif ($item instanceof EntryComment) {
             $this->handlePrivateContent($item);
 
-            return new SearchResponseDto(entryComment: $this->serializeEntryComment($this->entryCommentFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
+            return new SearchResponseDto(entryComment: $this->serializeEntryComment($item, $this->tagLinkRepository->getTagsOfContent($item)));
         } elseif ($item instanceof PostComment) {
             $this->handlePrivateContent($item);
 
-            return new SearchResponseDto(postComment: $this->serializePostComment($this->postCommentFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
+            return new SearchResponseDto(postComment: $this->serializePostComment($item, $this->tagLinkRepository->getTagsOfContent($item)));
         } elseif ($item instanceof Magazine) {
             return new SearchResponseDto(magazine: $this->serializeMagazine($this->magazineFactory->createDto($item)));
         } elseif ($item instanceof User) {

--- a/src/Controller/Api/Search/SearchRetrieveApi.php
+++ b/src/Controller/Api/Search/SearchRetrieveApi.php
@@ -387,19 +387,19 @@ class SearchRetrieveApi extends BaseApi
         if ($item instanceof Entry) {
             $this->handlePrivateContent($item);
 
-            return new SearchResponseDto(entry: $this->serializeEntry($this->entryFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
+            return new SearchResponseDto(entry: $this->serializeEntry($item, $this->tagLinkRepository->getTagsOfContent($item)));
         } elseif ($item instanceof Post) {
             $this->handlePrivateContent($item);
 
-            return new SearchResponseDto(post: $this->serializePost($this->postFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
+            return new SearchResponseDto(post: $this->serializePost($item, $this->tagLinkRepository->getTagsOfContent($item)));
         } elseif ($item instanceof EntryComment) {
             $this->handlePrivateContent($item);
 
-            return new SearchResponseDto(entryComment: $this->serializeEntryComment($this->entryCommentFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
+            return new SearchResponseDto(entryComment: $this->serializeEntryComment($item, $this->tagLinkRepository->getTagsOfContent($item)));
         } elseif ($item instanceof PostComment) {
             $this->handlePrivateContent($item);
 
-            return new SearchResponseDto(postComment: $this->serializePostComment($this->postCommentFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
+            return new SearchResponseDto(postComment: $this->serializePostComment($item, $this->tagLinkRepository->getTagsOfContent($item)));
         } elseif ($item instanceof Magazine) {
             return new SearchResponseDto(magazine: $this->serializeMagazine($this->magazineFactory->createDto($item)));
         } elseif ($item instanceof User) {

--- a/src/Controller/Api/Tag/TagContentRetrieveApiController.php
+++ b/src/Controller/Api/Tag/TagContentRetrieveApiController.php
@@ -198,7 +198,7 @@ class TagContentRetrieveApiController extends BaseApi
             try {
                 \assert($value instanceof Entry);
                 $this->handlePrivateContent($value);
-                $dtos[] = $this->serializeEntry($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
+                $dtos[] = $this->serializeEntry($value, $this->tagLinkRepository->getTagsOfContent($value));
             } catch (AccessDeniedException $e) {
                 continue;
             }
@@ -353,7 +353,7 @@ class TagContentRetrieveApiController extends BaseApi
             try {
                 \assert($value instanceof EntryComment);
                 $this->handlePrivateContent($value);
-                $dtos[] = $this->serializeEntryComment($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
+                $dtos[] = $this->serializeEntryComment($value, $this->tagLinkRepository->getTagsOfContent($value));
             } catch (AccessDeniedException $e) {
                 continue;
             }
@@ -509,7 +509,7 @@ class TagContentRetrieveApiController extends BaseApi
             try {
                 \assert($value instanceof Post);
                 $this->handlePrivateContent($value);
-                $dtos[] = $this->serializePost($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
+                $dtos[] = $this->serializePost($value, $this->tagLinkRepository->getTagsOfContent($value));
             } catch (AccessDeniedException $e) {
                 continue;
             }
@@ -665,7 +665,7 @@ class TagContentRetrieveApiController extends BaseApi
             try {
                 \assert($value instanceof PostComment);
                 $this->handlePrivateContent($value);
-                $dtos[] = $this->serializePostComment($factory->createDto($value), $this->tagLinkRepository->getTagsOfContent($value));
+                $dtos[] = $this->serializePostComment($value, $this->tagLinkRepository->getTagsOfContent($value));
             } catch (AccessDeniedException $e) {
                 continue;
             }

--- a/src/Controller/Api/User/UserContentApi.php
+++ b/src/Controller/Api/User/UserContentApi.php
@@ -194,16 +194,16 @@ class UserContentApi extends UserBaseApi
             try {
                 if ($item instanceof Entry) {
                     $this->handlePrivateContent($item);
-                    $result[] = new ExtendedContentResponseDto(entry: $this->serializeEntry($this->entryFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
+                    $result[] = new ExtendedContentResponseDto(entry: $this->serializeEntry($item, $this->tagLinkRepository->getTagsOfContent($item)));
                 } elseif ($item instanceof Post) {
                     $this->handlePrivateContent($item);
-                    $result[] = new ExtendedContentResponseDto(post: $this->serializePost($this->postFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
+                    $result[] = new ExtendedContentResponseDto(post: $this->serializePost($item, $this->tagLinkRepository->getTagsOfContent($item)));
                 } elseif ($item instanceof EntryComment) {
                     $this->handlePrivateContent($item);
-                    $result[] = new ExtendedContentResponseDto(entryComment: $this->serializeEntryComment($this->entryCommentFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
+                    $result[] = new ExtendedContentResponseDto(entryComment: $this->serializeEntryComment($item, $this->tagLinkRepository->getTagsOfContent($item)));
                 } elseif ($item instanceof PostComment) {
                     $this->handlePrivateContent($item);
-                    $result[] = new ExtendedContentResponseDto(postComment: $this->serializePostComment($this->postCommentFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
+                    $result[] = new ExtendedContentResponseDto(postComment: $this->serializePostComment($item, $this->tagLinkRepository->getTagsOfContent($item)));
                 }
             } catch (\Exception) {
             }

--- a/src/Controller/Entry/Comment/EntryCommentCreateController.php
+++ b/src/Controller/Entry/Comment/EntryCommentCreateController.php
@@ -59,7 +59,6 @@ class EntryCommentCreateController extends AbstractController
                 $dto->entry = $entry;
                 $dto->parent = $parent;
                 $dto->ip = $this->ipResolver->resolve();
-
                 if (!$this->isGranted('create_content', $dto->magazine)) {
                     throw new AccessDeniedHttpException();
                 }
@@ -98,6 +97,7 @@ class EntryCommentCreateController extends AbstractController
     private function getForm(Entry $entry, ?EntryComment $parent = null): FormInterface
     {
         $dto = new EntryCommentDto();
+        $dto->addEmptyChoices();
 
         if ($parent && $this->getUser()->addMentionsEntries) {
             $handle = $this->mentionManager->addHandle([$parent->user->username])[0];

--- a/src/Controller/Entry/EntryCreateController.php
+++ b/src/Controller/Entry/EntryCreateController.php
@@ -21,7 +21,9 @@ use App\Repository\TagRepository;
 use App\Service\EntryCommentManager;
 use App\Service\EntryManager;
 use App\Service\IpResolver;
+use App\Service\PollManager;
 use App\Service\SettingsManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\FormInterface;
@@ -50,6 +52,8 @@ class EntryCreateController extends AbstractController
         private readonly ValidatorInterface $validator,
         private readonly IpResolver $ipResolver,
         private readonly Security $security,
+        private readonly PollManager $pollManager,
+        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 
@@ -89,6 +93,7 @@ class EntryCreateController extends AbstractController
         $dto->isAdult = '1' === $isNsfw;
         $dto->isOc = '1' === $isOc;
         $dto->tags = $tags;
+        $dto->addEmptyChoices();
 
         if (null !== $imageHash) {
             $img = $this->imageRepository->findOneBySha256(hex2bin($imageHash));

--- a/src/Controller/Entry/EntryEditController.php
+++ b/src/Controller/Entry/EntryEditController.php
@@ -10,6 +10,7 @@ use App\Entity\Entry;
 use App\Entity\Magazine;
 use App\Form\EntryEditType;
 use App\Service\EntryManager;
+use App\Service\PollManager;
 use App\Service\SettingsManager;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
@@ -26,6 +27,7 @@ class EntryEditController extends AbstractController
         private readonly EntryManager $manager,
         private readonly LoggerInterface $logger,
         private readonly SettingsManager $settingsManager,
+        private readonly PollManager $pollManager,
     ) {
     }
 

--- a/src/Controller/Entry/EntryFrontController.php
+++ b/src/Controller/Entry/EntryFrontController.php
@@ -229,6 +229,7 @@ class EntryFrontController extends AbstractController
 
         if ('microblog' === $criteria->content) {
             $dto = new PostDto();
+            $dto->addEmptyChoices();
 
             if (isset($data['magazine'])) {
                 $dto->magazine = $data['magazine'];

--- a/src/Controller/Entry/EntrySingleController.php
+++ b/src/Controller/Entry/EntrySingleController.php
@@ -100,6 +100,7 @@ class EntrySingleController extends AbstractController
         }
 
         $dto = new EntryCommentDto();
+        $dto->addEmptyChoices();
         if ($user && $user->addMentionsEntries && $entry->user !== $user) {
             $dto->body = $this->mentionManager->addHandle([$entry->user->username])[0];
         }

--- a/src/Controller/PollVoteController.php
+++ b/src/Controller/PollVoteController.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\Entry;
+use App\Entity\EntryComment;
+use App\Entity\Poll;
+use App\Entity\Post;
+use App\Entity\PostComment;
+use App\Service\PollManager;
+use Psr\Log\LoggerInterface;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+class PollVoteController extends AbstractController
+{
+    public function __construct(
+        private readonly PollManager $pollManager,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    #[IsGranted('ROLE_USER')]
+    public function vote(#[MapEntity] Poll $poll, Request $request): Response
+    {
+        $user = $this->getUserOrThrow();
+        $choices = $request->query->all('choice');
+
+        $content = $this->pollManager->getContentOfPoll($poll);
+
+        if (null === $content) {
+            throw new NotFoundHttpException();
+        }
+
+        try {
+            $this->pollManager->vote($poll, $content, $user, $choices);
+        } catch (\Throwable $e) {
+            $this->logger->error('There was an error voting on poll {id}: {class} - {m}', [
+                'id' => $poll->getId(),
+                'class' => \get_class($e),
+                'm' => $e->getMessage(),
+            ]);
+            throw new BadRequestHttpException(previous: $e);
+        }
+
+        if ($content instanceof Entry) {
+            return $this->redirectToRoute('entry_single', ['entry_id' => $content->getId(), 'magazine_name' => $content->magazine->name]);
+        } elseif ($content instanceof EntryComment) {
+            return $this->redirectToRoute('entry_comment_view', ['entry_id' => $content->entry->getId(), 'comment_id' => $content->getId(), 'slug' => '-', 'magazine_name' => $content->magazine->name]);
+        } elseif ($content instanceof Post) {
+            return $this->redirectToRoute('post_single', ['post_id' => $content->getId(), 'magazine_name' => $content->magazine->name]);
+        } elseif ($content instanceof PostComment) {
+            return $this->redirectToRoute('post_single', ['post_id' => $content->post->getId(), 'magazine_name' => $content->magazine->name]);
+        } else {
+            throw new BadRequestHttpException();
+        }
+    }
+}

--- a/src/Controller/PollVoteController.php
+++ b/src/Controller/PollVoteController.php
@@ -9,6 +9,7 @@ use App\Entity\EntryComment;
 use App\Entity\Poll;
 use App\Entity\Post;
 use App\Entity\PostComment;
+use App\Service\ActivityPub\ApHttpClientInterface;
 use App\Service\PollManager;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
@@ -23,6 +24,7 @@ class PollVoteController extends AbstractController
     public function __construct(
         private readonly PollManager $pollManager,
         private readonly LoggerInterface $logger,
+        private readonly ApHttpClientInterface $apHttpClient,
     ) {
     }
 
@@ -49,6 +51,28 @@ class PollVoteController extends AbstractController
             throw new BadRequestHttpException(previous: $e);
         }
 
+        return $this->redirectToPollContent($poll);
+    }
+
+    #[IsGranted('ROLE_USER')]
+    public function refreshVoteCounts(#[MapEntity] Poll $poll): Response
+    {
+        if (null === $poll->getSubject()->apId) {
+            throw new BadRequestHttpException('Cannot refresh the vote counts of a local poll');
+        }
+
+        $this->apHttpClient->invalidateActivityObjectCache($poll->getSubject()->apId);
+        $object = $this->apHttpClient->getActivityObject($poll->getSubject()->apId);
+        if ($this->pollManager->hasPollProperties($object)) {
+            $this->pollManager->updatePollCounts($poll, $object);
+        }
+
+        return $this->redirectToPollContent($poll);
+    }
+
+    protected function redirectToPollContent(Poll $poll): Response
+    {
+        $content = $poll->getSubject();
         if ($content instanceof Entry) {
             return $this->redirectToRoute('entry_single', ['entry_id' => $content->getId(), 'magazine_name' => $content->magazine->name]);
         } elseif ($content instanceof EntryComment) {

--- a/src/Controller/Post/Comment/PostCommentCreateController.php
+++ b/src/Controller/Post/Comment/PostCommentCreateController.php
@@ -106,6 +106,7 @@ class PostCommentCreateController extends AbstractController
     private function getForm(Post $post, ?PostComment $parent): FormInterface
     {
         $dto = new PostCommentDto();
+        $dto->addEmptyChoices();
 
         if ($parent && $this->getUser()->addMentionsPosts) {
             $handle = $this->mentionManager->addHandle([$parent->user->username])[0];

--- a/src/Controller/Post/PostCreateController.php
+++ b/src/Controller/Post/PostCreateController.php
@@ -32,6 +32,7 @@ class PostCreateController extends AbstractController
     public function __invoke(Request $request): Response
     {
         $dto = new PostDto();
+        $dto->addEmptyChoices();
         // check if the "random" magazine exists and if so, use it
         $randomMagazine = $this->magazineRepository->findOneByName('random');
         if (null !== $randomMagazine) {
@@ -45,6 +46,7 @@ class PostCreateController extends AbstractController
             $form->handleRequest($request);
 
             if ($form->isSubmitted() && $form->isValid()) {
+                /** @var PostDto $dto */
                 $dto = $form->getData();
                 $dto->ip = $this->ipResolver->resolve();
 

--- a/src/DTO/ContentWithPollDto.php
+++ b/src/DTO/ContentWithPollDto.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO;
+
+use App\DTO\Contracts\PollDtoTrait;
+
+class ContentWithPollDto
+{
+    use PollDtoTrait;
+
+    public function __construct()
+    {
+        $this->pollEndsAt = new \DateTimeImmutable('now + 7 days');
+    }
+
+    public function addEmptyChoices(): void
+    {
+        $choicesToAdd = 5 - \sizeof($this->choices);
+        if ($choicesToAdd <= 0) {
+            $choicesToAdd = 1;
+        }
+
+        for ($i = 0; $i < $choicesToAdd; ++$i) {
+            $this->choices[] = '';
+        }
+    }
+}

--- a/src/DTO/Contracts/PollDtoTrait.php
+++ b/src/DTO/Contracts/PollDtoTrait.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Contracts;
+
+trait PollDtoTrait
+{
+    public ?bool $addPoll = null;
+    public ?bool $isMultipleChoicePoll = null;
+    public ?\DateTimeImmutable $pollEndsAt;
+    /**
+     * @var ?string[]
+     */
+    public ?array $choices = [];
+}

--- a/src/DTO/EntryCommentDto.php
+++ b/src/DTO/EntryCommentDto.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class EntryCommentDto implements ContentVisibilityInterface
+class EntryCommentDto extends ContentWithPollDto implements ContentVisibilityInterface
 {
     public const MAX_BODY_LENGTH = 5000;
 

--- a/src/DTO/EntryCommentResponseDto.php
+++ b/src/DTO/EntryCommentResponseDto.php
@@ -94,6 +94,7 @@ class EntryCommentResponseDto implements \JsonSerializable
     #[OA\Property(type: 'array', items: new OA\Items(type: 'string'))]
     public ?array $bookmarks = null;
     public ?bool $isAuthorModeratorInMagazine = null;
+    public ?PollResponseDto $poll = null;
 
     public static function create(
         ?int $id = null,
@@ -120,6 +121,7 @@ class EntryCommentResponseDto implements \JsonSerializable
         ?bool $canAuthUserModerate = null,
         ?array $bookmarks = null,
         ?bool $isAuthorModeratorInMagazine = null,
+        ?PollResponseDto $poll = null,
     ): self {
         $dto = new EntryCommentResponseDto();
         $dto->commentId = $id;
@@ -146,6 +148,7 @@ class EntryCommentResponseDto implements \JsonSerializable
         $dto->canAuthUserModerate = $canAuthUserModerate;
         $dto->bookmarks = $bookmarks;
         $dto->isAuthorModeratorInMagazine = $isAuthorModeratorInMagazine;
+        $dto->poll = $poll;
 
         return $dto;
     }
@@ -168,6 +171,7 @@ class EntryCommentResponseDto implements \JsonSerializable
                 'isFavourited',
                 'userVote',
                 'mentions',
+                'poll',
             ];
         }
 
@@ -199,6 +203,7 @@ class EntryCommentResponseDto implements \JsonSerializable
             'canAuthUserModerate' => $this->canAuthUserModerate,
             'bookmarks' => $this->bookmarks,
             'isAuthorModeratorInMagazine' => $this->isAuthorModeratorInMagazine,
+            'poll' => $this->poll?->jsonSerialize(),
         ]);
     }
 }

--- a/src/DTO/EntryDto.php
+++ b/src/DTO/EntryDto.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class EntryDto implements ContentVisibilityInterface
+class EntryDto extends ContentWithPollDto implements ContentVisibilityInterface
 {
     #[Assert\NotBlank]
     public Magazine|MagazineDto|null $magazine = null;

--- a/src/DTO/EntryDto.php
+++ b/src/DTO/EntryDto.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class EntryDto implements ContentVisibilityInterface
+class EntryDto extends ContentWithPollDto implements ContentVisibilityInterface
 {
     #[Assert\NotBlank]
     public Magazine|MagazineDto|null $magazine = null;

--- a/src/DTO/EntryRequestDto.php
+++ b/src/DTO/EntryRequestDto.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\DTO;
 
+use App\DTO\Contracts\PollDtoTrait;
 use App\Entity\Entry;
 use App\Service\SettingsManager;
 use OpenApi\Attributes as OA;
@@ -12,6 +13,8 @@ use Symfony\Component\Serializer\Annotation\Groups;
 #[OA\Schema(required: ['title'])]
 class EntryRequestDto extends ContentRequestDto
 {
+    use PollDtoTrait;
+
     #[Groups([
         Entry::ENTRY_TYPE_ARTICLE,
         Entry::ENTRY_TYPE_LINK,
@@ -72,6 +75,11 @@ class EntryRequestDto extends ContentRequestDto
         $dto->lang = $this->lang ?? $dto->lang ?? $settingsManager->getValue('KBIN_DEFAULT_LANG');
         $dto->url = $this->url ?? $dto->url;
         $dto->tags = $this->tags ?? $dto->tags;
+
+        $dto->addPoll = $this->addPoll ?? $dto->addPoll;
+        $dto->choices = $this->choices ?? $dto->choices;
+        $dto->isMultipleChoicePoll = $this->isMultipleChoicePoll ?? $dto->isMultipleChoicePoll;
+        $dto->pollEndsAt = $this->pollEndsAt ?? $dto->pollEndsAt;
 
         return $dto;
     }

--- a/src/DTO/EntryResponseDto.php
+++ b/src/DTO/EntryResponseDto.php
@@ -61,6 +61,7 @@ class EntryResponseDto implements \JsonSerializable
      */
     #[OA\Property(type: 'array', items: new OA\Items(ref: new Model(type: EntryResponseDto::class)))]
     public ?array $crosspostedEntries;
+    public ?PollResponseDto $poll = null;
 
     /**
      * @param string[]|null $bookmarks
@@ -96,6 +97,7 @@ class EntryResponseDto implements \JsonSerializable
         ?array $bookmarks = null,
         ?array $crosspostedEntries = null,
         ?bool $isAuthorModeratorInMagazine = null,
+        ?PollResponseDto $poll = null,
     ): self {
         $dto = new EntryResponseDto();
         $dto->entryId = $id;
@@ -128,6 +130,7 @@ class EntryResponseDto implements \JsonSerializable
         $dto->bookmarks = $bookmarks;
         $dto->crosspostedEntries = $crosspostedEntries;
         $dto->isAuthorModeratorInMagazine = $isAuthorModeratorInMagazine;
+        $dto->poll = $poll;
 
         return $dto;
     }
@@ -149,6 +152,7 @@ class EntryResponseDto implements \JsonSerializable
                 'isFavourited',
                 'userVote',
                 'slug',
+                'poll',
             ];
         }
 
@@ -186,6 +190,7 @@ class EntryResponseDto implements \JsonSerializable
             'bookmarks' => $this->bookmarks,
             'crosspostedEntries' => $this->crosspostedEntries,
             'isAuthorModeratorInMagazine' => $this->isAuthorModeratorInMagazine,
+            'poll' => $this->poll?->jsonSerialize(),
         ]);
     }
 }

--- a/src/DTO/PollChoiceResponseDto.php
+++ b/src/DTO/PollChoiceResponseDto.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO;
+
+use App\Entity\PollChoice;
+use App\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+#[OA\Schema]
+class PollChoiceResponseDto implements \JsonSerializable
+{
+    public string $name;
+
+    public int $voteCount;
+
+    public ?bool $currentUserHasVoted = null;
+
+    public static function createFromPollChoice(PollChoice $choice, UserInterface|User|null $user): self
+    {
+        $dto = new self();
+        $dto->name = $choice->name;
+        $dto->voteCount = $choice->voteCount;
+        $dto->currentUserHasVoted = $user instanceof User ? $choice->hasUserVoted($user) : null;
+
+        return $dto;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'name' => $this->name,
+            'voteCount' => $this->voteCount,
+            'currentUserHasVoted' => $this->currentUserHasVoted,
+        ];
+    }
+}

--- a/src/DTO/PollResponseDto.php
+++ b/src/DTO/PollResponseDto.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO;
+
+use App\Entity\Poll;
+use App\Entity\PollChoice;
+use App\Entity\User;
+use Nelmio\ApiDocBundle\Attribute\Model;
+use OpenApi\Attributes as OA;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class PollResponseDto implements \JsonSerializable
+{
+    public int $voterCount = 0;
+    public ?bool $currentUserHasVoted = null;
+    #[OA\Property(type: 'array', items: new OA\Items(ref: new Model(type: PollChoiceResponseDto::class)))]
+    public ?array $choices = null;
+
+    public static function createFromPoll(Poll $poll, User|UserInterface|null $user): self
+    {
+        $dto = new PollResponseDto();
+        $dto->voterCount = $poll->voterCount;
+        $dto->currentUserHasVoted = $user instanceof User ? $poll->hasUserVoted($user) : null;
+        $dto->choices = array_map(fn (PollChoice $choice) => PollChoiceResponseDto::createFromPollChoice($choice, $user), $poll->choices->toArray());
+
+        return $dto;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'voterCount' => $this->voterCount,
+            'currentUserHasVoted' => $this->currentUserHasVoted,
+            'choices' => $this->choices ? array_map(fn (PollChoiceResponseDto $dto) => $dto->jsonSerialize(), $this->choices) : null,
+        ];
+    }
+}

--- a/src/DTO/PollResponseDto.php
+++ b/src/DTO/PollResponseDto.php
@@ -15,6 +15,7 @@ class PollResponseDto implements \JsonSerializable
 {
     public int $voterCount = 0;
     public ?bool $currentUserHasVoted = null;
+    public ?\DateTimeImmutable $endDate = null;
     #[OA\Property(type: 'array', items: new OA\Items(ref: new Model(type: PollChoiceResponseDto::class)))]
     public ?array $choices = null;
 
@@ -22,6 +23,7 @@ class PollResponseDto implements \JsonSerializable
     {
         $dto = new PollResponseDto();
         $dto->voterCount = $poll->voterCount;
+        $dto->endDate = $poll->endDate;
         $dto->currentUserHasVoted = $user instanceof User ? $poll->hasUserVoted($user) : null;
         $dto->choices = array_map(fn (PollChoice $choice) => PollChoiceResponseDto::createFromPollChoice($choice, $user), $poll->choices->toArray());
 
@@ -32,6 +34,7 @@ class PollResponseDto implements \JsonSerializable
     {
         return [
             'voterCount' => $this->voterCount,
+            'endDate' => $this->endDate,
             'currentUserHasVoted' => $this->currentUserHasVoted,
             'choices' => $this->choices ? array_map(fn (PollChoiceResponseDto $dto) => $dto->jsonSerialize(), $this->choices) : null,
         ];

--- a/src/DTO/PostCommentDto.php
+++ b/src/DTO/PostCommentDto.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class PostCommentDto implements ContentVisibilityInterface
+class PostCommentDto extends ContentWithPollDto implements ContentVisibilityInterface
 {
     public const MAX_BODY_LENGTH = 5000;
 

--- a/src/DTO/PostCommentResponseDto.php
+++ b/src/DTO/PostCommentResponseDto.php
@@ -87,6 +87,8 @@ class PostCommentResponseDto implements \JsonSerializable
     #[OA\Property(type: 'array', items: new OA\Items(type: 'string'))]
     public ?array $bookmarks = null;
 
+    public ?PollResponseDto $poll = null;
+
     /**
      * @param string[] $bookmarks
      */
@@ -114,6 +116,7 @@ class PostCommentResponseDto implements \JsonSerializable
         ?bool $canAuthUserModerate = null,
         ?array $bookmarks = null,
         ?bool $isAuthorModeratorInMagazine = null,
+        ?PollResponseDto $poll = null,
     ): self {
         $dto = new PostCommentResponseDto();
         $dto->commentId = $id;
@@ -140,6 +143,7 @@ class PostCommentResponseDto implements \JsonSerializable
         $dto->canAuthUserModerate = $canAuthUserModerate;
         $dto->bookmarks = $bookmarks;
         $dto->isAuthorModeratorInMagazine = $isAuthorModeratorInMagazine;
+        $dto->poll = $poll;
 
         return $dto;
     }
@@ -158,6 +162,7 @@ class PostCommentResponseDto implements \JsonSerializable
                 'userVote',
                 'slug',
                 'mentions',
+                'poll',
             ];
         }
 
@@ -189,6 +194,7 @@ class PostCommentResponseDto implements \JsonSerializable
             'canAuthUserModerate' => $this->canAuthUserModerate,
             'bookmarks' => $this->bookmarks,
             'isAuthorModeratorInMagazine' => $this->isAuthorModeratorInMagazine,
+            'poll' => $this->poll?->jsonSerialize(),
         ]);
     }
 

--- a/src/DTO/PostDto.php
+++ b/src/DTO/PostDto.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class PostDto implements ContentVisibilityInterface
+class PostDto extends ContentWithPollDto implements ContentVisibilityInterface
 {
     public const MAX_BODY_LENGTH = 5000;
 

--- a/src/DTO/PostResponseDto.php
+++ b/src/DTO/PostResponseDto.php
@@ -45,6 +45,7 @@ class PostResponseDto implements \JsonSerializable
     #[OA\Property(type: 'array', items: new OA\Items(type: 'string'))]
     public ?array $bookmarks = null;
     public ?bool $isAuthorModeratorInMagazine = null;
+    public ?PollResponseDto $poll = null;
 
     /**
      * @param string[] $bookmarks
@@ -74,6 +75,7 @@ class PostResponseDto implements \JsonSerializable
         ?bool $canAuthUserModerate = null,
         ?array $bookmarks = null,
         ?bool $isAuthorModeratorInMagazine = null,
+        ?PollResponseDto $poll = null,
     ): self {
         $dto = new PostResponseDto();
         $dto->postId = $id;
@@ -100,6 +102,7 @@ class PostResponseDto implements \JsonSerializable
         $dto->canAuthUserModerate = $canAuthUserModerate;
         $dto->bookmarks = $bookmarks;
         $dto->isAuthorModeratorInMagazine = $isAuthorModeratorInMagazine;
+        $dto->poll = $poll;
 
         return $dto;
     }
@@ -118,6 +121,7 @@ class PostResponseDto implements \JsonSerializable
                 'userVote',
                 'slug',
                 'mentions',
+                'poll',
             ];
         }
 
@@ -149,6 +153,7 @@ class PostResponseDto implements \JsonSerializable
             'notificationStatus' => $this->notificationStatus,
             'bookmarks' => $this->bookmarks,
             'isAuthorModeratorInMagazine' => $this->isAuthorModeratorInMagazine,
+            'poll' => $this->poll?->jsonSerialize(),
         ]);
     }
 }

--- a/src/Entity/Activity.php
+++ b/src/Entity/Activity.php
@@ -64,6 +64,9 @@ class Activity
     #[ManyToOne, JoinColumn(nullable: true, onDelete: 'CASCADE')]
     public ?PostComment $objectPostComment = null;
 
+    #[ManyToOne(targetEntity: PollVote::class), JoinColumn(referencedColumnName: 'uuid', nullable: true, onDelete: 'CASCADE')]
+    public ?PollVote $objectPollVote = null;
+
     #[ManyToOne, JoinColumn(nullable: true, onDelete: 'CASCADE')]
     public ?Message $objectMessage = null;
 
@@ -97,7 +100,7 @@ class Activity
         $this->createdAtTraitConstruct();
     }
 
-    public function setObject(ActivityPubActivityInterface|Entry|EntryComment|Post|PostComment|ActivityPubActorInterface|User|Magazine|MagazineBan|Activity|array|string $object): void
+    public function setObject(ActivityPubActivityInterface|Entry|EntryComment|Post|PostComment|PollVote|ActivityPubActorInterface|User|Magazine|MagazineBan|Activity|array|string $object): void
     {
         if ($object instanceof Entry) {
             $this->objectEntry = $object;
@@ -107,6 +110,8 @@ class Activity
             $this->objectPost = $object;
         } elseif ($object instanceof PostComment) {
             $this->objectPostComment = $object;
+        } elseif ($object instanceof PollVote) {
+            $this->objectPollVote = $object;
         } elseif ($object instanceof Message) {
             $this->objectMessage = $object;
         } elseif ($object instanceof User) {
@@ -129,9 +134,9 @@ class Activity
         }
     }
 
-    public function getObject(): Post|EntryComment|PostComment|Entry|Message|User|Magazine|MagazineBan|array|string|null
+    public function getObject(): Entry|Post|EntryComment|PostComment|PollVote|Message|User|Magazine|MagazineBan|array|string|null
     {
-        $o = $this->objectEntry ?? $this->objectEntryComment ?? $this->objectPost ?? $this->objectPostComment ?? $this->objectMessage ?? $this->objectUser ?? $this->objectMagazine ?? $this->objectMagazineBan;
+        $o = $this->objectEntry ?? $this->objectEntryComment ?? $this->objectPost ?? $this->objectPostComment ?? $this->objectPollVote ?? $this->objectMessage ?? $this->objectUser ?? $this->objectMagazine ?? $this->objectMagazineBan;
         if (null !== $o) {
             return $o;
         }

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -32,6 +32,7 @@ use Doctrine\ORM\Mapping\Index;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\OrderBy;
 use Webmozart\Assert\Assert;
 
@@ -115,6 +116,8 @@ class Entry implements VotableInterface, CommentInterface, DomainInterface, Visi
     public ?string $ip = null;
     #[Column(type: Types::JSONB, nullable: true)]
     public ?array $mentions = null;
+    #[OneToOne(targetEntity: Poll::class, inversedBy: 'entry')]
+    public ?Poll $poll = null;
     #[OneToMany(mappedBy: 'entry', targetEntity: EntryComment::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     public Collection $comments;
     #[OneToMany(mappedBy: 'entry', targetEntity: EntryVote::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -32,6 +32,7 @@ use Doctrine\ORM\Mapping\Index;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\OrderBy;
 use Webmozart\Assert\Assert;
 
@@ -116,6 +117,8 @@ class Entry implements VotableInterface, CommentInterface, DomainInterface, Visi
     public ?string $ip = null;
     #[Column(type: Types::JSONB, nullable: true)]
     public ?array $mentions = null;
+    #[OneToOne(targetEntity: Poll::class, inversedBy: 'entry')]
+    public ?Poll $poll = null;
     #[OneToMany(mappedBy: 'entry', targetEntity: EntryComment::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     public Collection $comments;
     #[OneToMany(mappedBy: 'entry', targetEntity: EntryVote::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]

--- a/src/Entity/EntryComment.php
+++ b/src/Entity/EntryComment.php
@@ -30,6 +30,7 @@ use Doctrine\ORM\Mapping\Index;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\OrderBy;
 use Webmozart\Assert\Assert;
 
@@ -80,6 +81,8 @@ class EntryComment implements VotableInterface, VisibilityInterface, ReportInter
     public ?string $ip = null;
     #[Column(type: 'json', nullable: true)]
     public ?array $mentions = null;
+    #[OneToOne(targetEntity: Poll::class)]
+    public ?Poll $poll = null;
     #[OneToMany(mappedBy: 'parent', targetEntity: EntryComment::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
     #[OrderBy(['createdAt' => 'ASC'])]
     public Collection $children;

--- a/src/Entity/EntryComment.php
+++ b/src/Entity/EntryComment.php
@@ -30,6 +30,7 @@ use Doctrine\ORM\Mapping\Index;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\OrderBy;
 use Webmozart\Assert\Assert;
 
@@ -81,6 +82,8 @@ class EntryComment implements VotableInterface, VisibilityInterface, ReportInter
     public ?string $ip = null;
     #[Column(type: 'json', nullable: true)]
     public ?array $mentions = null;
+    #[OneToOne(targetEntity: Poll::class)]
+    public ?Poll $poll = null;
     #[OneToMany(mappedBy: 'parent', targetEntity: EntryComment::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
     #[OrderBy(['createdAt' => 'ASC'])]
     public Collection $children;

--- a/src/Entity/Notification.php
+++ b/src/Entity/Notification.php
@@ -31,6 +31,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
     'entry_comment_reply' => 'EntryCommentReplyNotification',
     'entry_comment_deleted' => 'EntryCommentDeletedNotification',
     'entry_comment_mentioned' => 'EntryCommentMentionedNotification',
+    'poll_ended' => 'PollEndedNotification',
+    'poll_edited' => 'PollEditedNotification',
     'post_created' => 'PostCreatedNotification',
     'post_edited' => 'PostEditedNotification',
     'post_deleted' => 'PostDeletedNotification',

--- a/src/Entity/Poll.php
+++ b/src/Entity/Poll.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Entity\Traits\CreatedAtTrait;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\OneToOne;
+
+#[Entity]
+class Poll
+{
+    use CreatedAtTrait {
+        CreatedAtTrait::__construct as createdAtTraitConstruct;
+    }
+
+    #[Id, GeneratedValue, Column]
+    private int $id;
+
+    #[Column]
+    public bool $multipleChoice = false;
+
+    /**
+     * @var int the number of individual users voting on this poll
+     */
+    #[Column(options: ['default' => 0])]
+    public int $voterCount = 0;
+
+    #[Column(type: Types::DATETIME_IMMUTABLE)]
+    public \DateTimeImmutable $endDate;
+
+    #[Column]
+    public bool $isRemote = false;
+
+    #[Column]
+    public bool $sentNotifications = false;
+
+    /**
+     * @var Collection<PollVote>
+     */
+    #[OneToMany(targetEntity: PollVote::class, mappedBy: 'poll')]
+    public Collection $votes;
+
+    /** @var Collection<PollChoice> */
+    #[OneToMany(targetEntity: PollChoice::class, mappedBy: 'poll')]
+    public Collection $choices;
+
+    #[OneToOne(targetEntity: Entry::class, mappedBy: 'poll')]
+    public ?Entry $entry;
+
+    #[OneToOne(targetEntity: EntryComment::class, mappedBy: 'poll')]
+    public ?EntryComment $entryComment;
+
+    #[OneToOne(targetEntity: Post::class, mappedBy: 'poll')]
+    public ?Post $post;
+
+    #[OneToOne(targetEntity: PostComment::class, mappedBy: 'poll')]
+    public ?PostComment $postComment;
+
+    public function __construct(?\DateTimeImmutable $endDate = null)
+    {
+        $this->createdAtTraitConstruct();
+        $this->endDate = $endDate ?? new \DateTimeImmutable('now + 7days');
+        $this->votes = new ArrayCollection();
+        $this->choices = new ArrayCollection();
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function hasUserVoted(User $user): bool
+    {
+        return \count($this->getUserVotes($user)) > 0;
+    }
+
+    /**
+     * @return PollVote[]
+     */
+    public function getUserVotes(User $user): array
+    {
+        $criteria = Criteria::create();
+        $criteria->where(Criteria::expr()->eq('voter', $user));
+
+        return $this->votes->matching($criteria)->toArray();
+    }
+
+    public function findChoice(string $name): ?PollChoice
+    {
+        $criteria = Criteria::create();
+        $criteria->where(Criteria::expr()->eq('name', $name));
+
+        return $this->choices->matching($criteria)->first() ?: null;
+    }
+
+    public function hasEnded(): bool
+    {
+        return new \DateTimeImmutable() > $this->endDate;
+    }
+
+    /**
+     * @return array<array{name: string, userVoted: bool, percentage: float}>
+     */
+    public function getResultData(?User $user): array
+    {
+        $result = [];
+        foreach ($this->choices as $choice) {
+            $result[] = [
+                'name' => $choice->name,
+                'userVoted' => $user ? $choice->hasUserVoted($user) : false,
+                'percentage' => $this->voterCount ? round(100 / $this->voterCount * $choice->voteCount, 2) : 0,
+            ];
+        }
+
+        return $result;
+    }
+
+    public function updateVoterCount(): void
+    {
+        if ($this->isRemote) {
+            ++$this->voterCount;
+        } else {
+            $voteUsers = [];
+            foreach ($this->votes as $vote) {
+                $voteUsers[$vote->voter->getId()] = $vote->voter;
+            }
+            $this->voterCount = \count($voteUsers);
+        }
+    }
+
+    public function getSubject(): Entry|EntryComment|Post|PostComment|null
+    {
+        return $this->entry ?? $this->entryComment ?? $this->post ?? $this->postComment;
+    }
+}

--- a/src/Entity/Poll.php
+++ b/src/Entity/Poll.php
@@ -35,7 +35,7 @@ class Poll
     #[Column(options: ['default' => 0])]
     public int $voterCount = 0;
 
-    #[Column(type: Types::DATETIME_IMMUTABLE)]
+    #[Column(type: Types::DATETIMETZ_IMMUTABLE)]
     public \DateTimeImmutable $endDate;
 
     #[Column]

--- a/src/Entity/PollChoice.php
+++ b/src/Entity/PollChoice.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\OneToMany;
+
+#[Entity]
+class PollChoice
+{
+    #[Id, GeneratedValue, Column]
+    public int $id;
+
+    #[Column]
+    public string $name;
+
+    #[Column]
+    public int $voteCount = 0;
+
+    /**
+     * @var Collection<PollVote>
+     */
+    #[OneToMany(targetEntity: PollVote::class, mappedBy: 'choice')]
+    public Collection $votes;
+
+    #[JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[ManyToOne(targetEntity: Poll::class)]
+    public Poll $poll;
+
+    public function __construct()
+    {
+        $this->votes = new ArrayCollection();
+    }
+
+    /**
+     * @return Collection<PollVote>
+     */
+    public function getUserVotes(User $user): Collection
+    {
+        $criteria = Criteria::create();
+        $criteria->where(Criteria::expr()->eq('voter', $user));
+
+        return $this->votes->matching($criteria);
+    }
+
+    public function hasUserVoted(User $user): bool
+    {
+        return !$this->getUserVotes($user)->isEmpty();
+    }
+
+    public function updateVoteCount(): void
+    {
+        if ($this->poll->isRemote) {
+            ++$this->voteCount;
+        } else {
+            $this->voteCount = $this->votes->count();
+        }
+    }
+}

--- a/src/Entity/PollEditedNotification.php
+++ b/src/Entity/PollEditedNotification.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Payloads\PushNotification;
+use App\Repository\ApActivityRepository;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+#[Entity]
+class PollEditedNotification extends Notification
+{
+    #[JoinColumn(onDelete: 'CASCADE')]
+    #[ManyToOne(targetEntity: Poll::class)]
+    public ?Poll $poll;
+
+    public function __construct(User $receiver, Poll $poll)
+    {
+        parent::__construct($receiver);
+        $this->poll = $poll;
+    }
+
+    public function getType(): string
+    {
+        return 'poll_edited';
+    }
+
+    public function getMessage(TranslatorInterface $trans, string $locale, UrlGeneratorInterface $urlGenerator): PushNotification
+    {
+        $content = $this->poll->entry ?? $this->poll->entryComment ?? $this->poll->post ?? $this->poll->postComment;
+        $message = '';
+        $title = $trans->trans('notification_title_poll_edited', locale: $locale);
+        $action = ApActivityRepository::s_getLocalUrlOfEntity($urlGenerator, $content, true);
+
+        return new PushNotification($this->getId(), $message, $title, $action);
+    }
+}

--- a/src/Entity/PollEndedNotification.php
+++ b/src/Entity/PollEndedNotification.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Payloads\PushNotification;
+use App\Repository\ApActivityRepository;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+#[Entity]
+class PollEndedNotification extends Notification
+{
+    #[JoinColumn(onDelete: 'CASCADE')]
+    #[ManyToOne(targetEntity: Poll::class)]
+    public Poll $poll;
+
+    public function __construct(User $receiver, Poll $poll)
+    {
+        parent::__construct($receiver);
+        $this->poll = $poll;
+    }
+
+    public function getType(): string
+    {
+        return 'poll_ended';
+    }
+
+    public function getMessage(TranslatorInterface $trans, string $locale, UrlGeneratorInterface $urlGenerator): PushNotification
+    {
+        $content = $this->poll->entry ?? $this->poll->entryComment ?? $this->poll->post ?? $this->poll->postComment;
+        $message = '';
+        $title = $trans->trans('notification_title_poll_ended', locale: $locale);
+        $action = ApActivityRepository::s_getLocalUrlOfEntity($urlGenerator, $content, true);
+
+        return new PushNotification($this->getId(), $message, $title, $action);
+    }
+}

--- a/src/Entity/PollVote.php
+++ b/src/Entity/PollVote.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Entity\Contracts\ActivityPubActivityInterface;
+use App\Entity\Traits\ActivityPubActivityTrait;
+use App\Entity\Traits\CreatedAtTrait;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\CustomIdGenerator;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Symfony\Component\Uid\Uuid;
+
+#[Entity]
+class PollVote implements ActivityPubActivityInterface
+{
+    use CreatedAtTrait {
+        CreatedAtTrait::__construct as createdAtTraitConstruct;
+    }
+    use ActivityPubActivityTrait;
+
+    #[Column(type: 'uuid'), Id, GeneratedValue(strategy: 'CUSTOM')]
+    #[CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    public Uuid $uuid;
+
+    #[JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[ManyToOne(targetEntity: User::class)]
+    public User $voter;
+
+    #[JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[ManyToOne(targetEntity: PollChoice::class)]
+    public PollChoice $choice;
+
+    #[JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[ManyToOne(targetEntity: Poll::class)]
+    public Poll $poll;
+
+    public function __construct()
+    {
+        $this->createdAtTraitConstruct();
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->voter;
+    }
+}

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -30,6 +30,7 @@ use Doctrine\ORM\Mapping\Index;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\OneToOne;
 use Webmozart\Assert\Assert;
 
 #[Entity(repositoryClass: PostRepository::class)]
@@ -85,6 +86,8 @@ class Post implements VotableInterface, CommentInterface, VisibilityInterface, R
     public ?string $ip = null;
     #[Column(type: Types::JSONB, nullable: true)]
     public ?array $mentions = null;
+    #[OneToOne(targetEntity: Poll::class)]
+    public ?Poll $poll = null;
     #[OneToMany(mappedBy: 'post', targetEntity: PostComment::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
     public Collection $comments;
     #[OneToMany(mappedBy: 'post', targetEntity: PostVote::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -30,6 +30,7 @@ use Doctrine\ORM\Mapping\Index;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\OneToOne;
 use Webmozart\Assert\Assert;
 
 #[Entity(repositoryClass: PostRepository::class)]
@@ -86,6 +87,8 @@ class Post implements VotableInterface, CommentInterface, VisibilityInterface, R
     public ?string $ip = null;
     #[Column(type: Types::JSONB, nullable: true)]
     public ?array $mentions = null;
+    #[OneToOne(targetEntity: Poll::class)]
+    public ?Poll $poll = null;
     #[OneToMany(mappedBy: 'post', targetEntity: PostComment::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     public Collection $comments;
     #[OneToMany(mappedBy: 'post', targetEntity: PostVote::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]

--- a/src/Entity/PostComment.php
+++ b/src/Entity/PostComment.php
@@ -30,6 +30,7 @@ use Doctrine\ORM\Mapping\Index;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\OrderBy;
 use Webmozart\Assert\Assert;
 
@@ -82,6 +83,8 @@ class PostComment implements VotableInterface, VisibilityInterface, ReportInterf
     public bool $isAdult = false;
     #[Column(type: 'boolean', nullable: false, options: ['default' => false])]
     public ?bool $updateMark = false;
+    #[OneToOne(targetEntity: Poll::class)]
+    public ?Poll $poll = null;
     #[OneToMany(mappedBy: 'parent', targetEntity: PostComment::class, orphanRemoval: true)]
     #[OrderBy(['createdAt' => 'ASC'])]
     public Collection $children;

--- a/src/Entity/PostComment.php
+++ b/src/Entity/PostComment.php
@@ -30,6 +30,7 @@ use Doctrine\ORM\Mapping\Index;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\OrderBy;
 use Webmozart\Assert\Assert;
 
@@ -83,6 +84,8 @@ class PostComment implements VotableInterface, VisibilityInterface, ReportInterf
     public bool $isAdult = false;
     #[Column(type: 'boolean', nullable: false, options: ['default' => false])]
     public ?bool $updateMark = false;
+    #[OneToOne(targetEntity: Poll::class)]
+    public ?Poll $poll = null;
     #[OneToMany(mappedBy: 'parent', targetEntity: PostComment::class, orphanRemoval: true)]
     #[OrderBy(['createdAt' => 'ASC'])]
     public Collection $children;

--- a/src/Event/Poll/PollEditedEvent.php
+++ b/src/Event/Poll/PollEditedEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Event\Poll;
+
+use App\Entity\Entry;
+use App\Entity\EntryComment;
+use App\Entity\Poll;
+use App\Entity\Post;
+use App\Entity\PostComment;
+use App\Entity\User;
+
+class PollEditedEvent
+{
+    public function __construct(
+        public Poll $poll,
+        public Entry|EntryComment|Post|PostComment $content,
+        public User $editor,
+    ) {
+    }
+}

--- a/src/Event/Poll/PollEndedEvent.php
+++ b/src/Event/Poll/PollEndedEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Event\Poll;
+
+use App\Entity\Contracts\ContentInterface;
+use App\Entity\Poll;
+
+class PollEndedEvent
+{
+    public function __construct(
+        public Poll $poll,
+        public ContentInterface $content,
+    ) {
+    }
+}

--- a/src/Event/Poll/PollPreEditedEvent.php
+++ b/src/Event/Poll/PollPreEditedEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Event\Poll;
+
+use App\Entity\Entry;
+use App\Entity\EntryComment;
+use App\Entity\Poll;
+use App\Entity\Post;
+use App\Entity\PostComment;
+use App\Entity\User;
+
+class PollPreEditedEvent
+{
+    public function __construct(
+        public Poll $poll,
+        public Entry|EntryComment|Post|PostComment $content,
+        public User $editor,
+    ) {
+    }
+}

--- a/src/Event/Poll/PollVoteEvent.php
+++ b/src/Event/Poll/PollVoteEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Event\Poll;
+
+use App\Entity\Entry;
+use App\Entity\EntryComment;
+use App\Entity\Poll;
+use App\Entity\PollVote;
+use App\Entity\Post;
+use App\Entity\PostComment;
+use App\Entity\User;
+
+class PollVoteEvent
+{
+    /**
+     * @param PollVote[] $votes
+     */
+    public function __construct(
+        public Poll $poll,
+        public Entry|EntryComment|Post|PostComment $content,
+        public User $voter,
+        public array $votes,
+    ) {
+    }
+}

--- a/src/EventSubscriber/PollEventSubscriber.php
+++ b/src/EventSubscriber/PollEventSubscriber.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use App\Event\Poll\PollEditedEvent;
+use App\Event\Poll\PollPreEditedEvent;
+use App\Event\Poll\PollVoteEvent;
+use App\Message\ActivityPub\Outbox\PollVoteMessage;
+use App\Service\Notification\PollNotificationManager;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+readonly class PollEventSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private MessageBusInterface $bus,
+        private PollNotificationManager $notificationManager,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PollVoteEvent::class => 'onPollVote',
+            PollEditedEvent::class => 'onPollEdited',
+            PollPreEditedEvent::class => 'onPollPreEdited',
+        ];
+    }
+
+    public function onPollVote(PollVoteEvent $event): void
+    {
+        if ($event->poll->isRemote && null === $event->voter->apId) {
+            // remote poll, local user -> send the vote
+            foreach ($event->poll->votes as $vote) {
+                $this->bus->dispatch(new PollVoteMessage($vote->uuid->toString()));
+            }
+        }
+    }
+
+    public function onPollEdited(PollEditedEvent $event): void
+    {
+    }
+
+    public function onPollPreEdited(PollPreEditedEvent $event): void
+    {
+        try {
+            $this->notificationManager->sendPollEditedNotification($event->poll);
+        } catch (\Throwable $exception) {
+            $this->logger->error('Something went wrong while sending the poll edited notifications for poll {p}: {e} - {m}', [
+                'p' => $event->poll->getId(),
+                'e' => \get_class($exception),
+                'm' => $exception->getMessage(),
+            ]);
+        }
+    }
+}

--- a/src/EventSubscriber/PollEventSubscriber.php
+++ b/src/EventSubscriber/PollEventSubscriber.php
@@ -8,6 +8,7 @@ use App\Event\Poll\PollEditedEvent;
 use App\Event\Poll\PollPreEditedEvent;
 use App\Event\Poll\PollVoteEvent;
 use App\Message\ActivityPub\Outbox\PollVoteMessage;
+use App\Message\ActivityPub\Outbox\UpdateMessage;
 use App\Service\Notification\PollNotificationManager;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -38,6 +39,10 @@ readonly class PollEventSubscriber implements EventSubscriberInterface
             foreach ($event->poll->votes as $vote) {
                 $this->bus->dispatch(new PollVoteMessage($vote->uuid->toString()));
             }
+        } elseif (!$event->poll->isRemote) {
+            // remote poll -> send update with new vote numbers
+            $this->bus->dispatch(new UpdateMessage($event->content->getId(), \get_class($event->content)));
+            $event->content->editedAt = new \DateTimeImmutable();
         }
     }
 

--- a/src/Exception/PollHasEndedException.php
+++ b/src/Exception/PollHasEndedException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+class PollHasEndedException extends \Exception
+{
+}

--- a/src/Factory/ActivityPub/ActivityFactory.php
+++ b/src/Factory/ActivityPub/ActivityFactory.php
@@ -8,6 +8,7 @@ use App\Entity\Contracts\ActivityPubActivityInterface;
 use App\Entity\Entry;
 use App\Entity\EntryComment;
 use App\Entity\Message;
+use App\Entity\PollVote;
 use App\Entity\Post;
 use App\Entity\PostComment;
 use App\Repository\TagLinkRepository;
@@ -21,6 +22,7 @@ class ActivityFactory
         private readonly PostNoteFactory $postNoteFactory,
         private readonly PostCommentNoteFactory $postCommentNoteFactory,
         private readonly MessageFactory $messageFactory,
+        private readonly PollVoteFactory $pollVoteFactory,
     ) {
     }
 
@@ -32,6 +34,7 @@ class ActivityFactory
             $activity instanceof Post => $this->postNoteFactory->create($activity, $this->tagLinkRepository->getTagsOfContent($activity), $context),
             $activity instanceof PostComment => $this->postCommentNoteFactory->create($activity, $this->tagLinkRepository->getTagsOfContent($activity), $context),
             $activity instanceof Message => $this->messageFactory->build($activity, $context),
+            $activity instanceof PollVote => $this->pollVoteFactory->build($activity, $context),
             default => throw new \LogicException('Cannot handle activity of type '.\get_class($activity)),
         };
     }

--- a/src/Factory/ActivityPub/EntryCommentNoteFactory.php
+++ b/src/Factory/ActivityPub/EntryCommentNoteFactory.php
@@ -31,6 +31,7 @@ class EntryCommentNoteFactory
         private readonly ApHttpClientInterface $client,
         private readonly ActivityPubManager $activityPubManager,
         private readonly MarkdownConverter $markdownConverter,
+        private readonly PollFactory $pollFactory,
     ) {
     }
 
@@ -107,6 +108,10 @@ class EntryCommentNoteFactory
                 )
             )
         );
+
+        if ($comment->poll) {
+            $this->pollFactory->addToNote($note, $comment->poll);
+        }
 
         return $note;
     }

--- a/src/Factory/ActivityPub/EntryPageFactory.php
+++ b/src/Factory/ActivityPub/EntryPageFactory.php
@@ -28,6 +28,7 @@ class EntryPageFactory
         private readonly ApHttpClientInterface $client,
         private readonly ActivityPubManager $activityPubManager,
         private readonly MarkdownConverter $markdownConverter,
+        private readonly PollFactory $pollFactory,
     ) {
     }
 
@@ -48,7 +49,7 @@ class EntryPageFactory
 
         $page = array_merge($page ?? [], [
             'id' => $this->getActivityPubId($entry),
-            'type' => 'Page',
+            'type' => $entry->poll ? 'Question' : 'Page',
             'attributedTo' => $this->activityPubManager->getActorProfileId($entry->user),
             'inReplyTo' => null,
             'to' => [
@@ -103,6 +104,10 @@ class EntryPageFactory
             $page['to'] = array_unique(
                 array_merge($page['to'], $this->activityPubManager->createCcFromBody($entry->body))
             );
+        }
+
+        if ($entry->poll) {
+            $this->pollFactory->addToNote($page, $entry->poll);
         }
 
         return $page;

--- a/src/Factory/ActivityPub/PollChoiceNoteFactory.php
+++ b/src/Factory/ActivityPub/PollChoiceNoteFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory\ActivityPub;
+
+use App\Entity\PollChoice;
+use App\Service\ActivityPub\ContextsProvider;
+
+class PollChoiceNoteFactory
+{
+    public function __construct(
+        private readonly ContextsProvider $contextsProvider,
+    ) {
+    }
+
+    public function create(PollChoice $pollChoice, bool $includeContext = false): array
+    {
+        $note = [
+            'type' => 'Note',
+            'name' => $pollChoice->name,
+            'replies' => [
+                'type' => 'Collection',
+                'totalItems' => $pollChoice->voteCount,
+            ],
+        ];
+
+        if ($includeContext) {
+            $note['@context'] = [
+                $this->contextsProvider->referencedContexts(),
+            ];
+        }
+
+        return $note;
+    }
+}

--- a/src/Factory/ActivityPub/PollFactory.php
+++ b/src/Factory/ActivityPub/PollFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory\ActivityPub;
+
+use App\Entity\Poll;
+
+class PollFactory
+{
+    public function __construct(
+        private readonly PollChoiceNoteFactory $pollChoiceNoteFactory,
+    ) {
+    }
+
+    public function addToNote(array &$note, Poll $poll): void
+    {
+        $note['votersCount'] = $poll->voterCount;
+        $note['endTime'] = $poll->endDate->format(DATE_ATOM);
+        $options = [];
+        foreach ($poll->choices as $choice) {
+            $options[] = $this->pollChoiceNoteFactory->create($choice);
+        }
+        if ($poll->multipleChoice) {
+            $note['anyOf'] = $options;
+        } else {
+            $note['oneOf'] = $options;
+        }
+    }
+}

--- a/src/Factory/ActivityPub/PollVoteFactory.php
+++ b/src/Factory/ActivityPub/PollVoteFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory\ActivityPub;
+
+use App\Entity\PollVote;
+use App\Repository\ApActivityRepository;
+use App\Repository\EntryRepository;
+use App\Repository\PostRepository;
+use App\Service\ActivityPub\ContextsProvider;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class PollVoteFactory
+{
+    public function __construct(
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly ContextsProvider $contextsProvider,
+        private readonly EntryRepository $entryRepository,
+        private readonly PostRepository $postRepository,
+        private readonly PersonFactory $personFactory,
+        private readonly ApActivityRepository $apActivityRepository,
+    ) {
+    }
+
+    public function build(PollVote $vote, bool $includeContext = true): array
+    {
+        $actorUrl = $this->personFactory->getActivityPubId($vote->getUser());
+        $content = $this->entryRepository->findOneBy(['poll' => $vote->poll]) ?? $this->postRepository->findOneBy(['poll' => $vote->poll]) ?? throw new \LogicException();
+
+        $result = [
+            '@context' => $this->contextsProvider->referencedContexts(),
+            'id' => $this->urlGenerator->generate('ap_poll_vote', ['username' => $vote->getUser()->username, 'uuid' => $vote->uuid], UrlGeneratorInterface::ABSOLUTE_URL),
+            'attributedTo' => $actorUrl,
+            'to' => [$this->personFactory->getActivityPubId($content->user)],
+            'cc' => [],
+            'type' => 'Note',
+            'published' => $vote->createdAt->format(DATE_ATOM),
+            'inReplyTo' => $content->apId ?? $this->apActivityRepository->getLocalUrlOfEntity($content, true),
+            'name' => $vote->choice->name,
+        ];
+
+        if (!$includeContext) {
+            unset($result['@context']);
+        }
+
+        return $result;
+    }
+}

--- a/src/Factory/ActivityPub/PollVoteFactory.php
+++ b/src/Factory/ActivityPub/PollVoteFactory.php
@@ -6,7 +6,9 @@ namespace App\Factory\ActivityPub;
 
 use App\Entity\PollVote;
 use App\Repository\ApActivityRepository;
+use App\Repository\EntryCommentRepository;
 use App\Repository\EntryRepository;
+use App\Repository\PostCommentRepository;
 use App\Repository\PostRepository;
 use App\Service\ActivityPub\ContextsProvider;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -17,7 +19,9 @@ class PollVoteFactory
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly ContextsProvider $contextsProvider,
         private readonly EntryRepository $entryRepository,
+        private readonly EntryCommentRepository $entryCommentRepository,
         private readonly PostRepository $postRepository,
+        private readonly PostCommentRepository $postCommentRepository,
         private readonly PersonFactory $personFactory,
         private readonly ApActivityRepository $apActivityRepository,
     ) {
@@ -26,7 +30,11 @@ class PollVoteFactory
     public function build(PollVote $vote, bool $includeContext = true): array
     {
         $actorUrl = $this->personFactory->getActivityPubId($vote->getUser());
-        $content = $this->entryRepository->findOneBy(['poll' => $vote->poll]) ?? $this->postRepository->findOneBy(['poll' => $vote->poll]) ?? throw new \LogicException();
+        $content = $this->entryRepository->findOneBy(['poll' => $vote->poll])
+            ?? $this->entryCommentRepository->findOneBy(['poll' => $vote->poll])
+            ?? $this->postRepository->findOneBy(['poll' => $vote->poll])
+            ?? $this->postCommentRepository->findOneBy(['poll' => $vote->poll])
+            ?? throw new \LogicException();
 
         $result = [
             '@context' => $this->contextsProvider->referencedContexts(),

--- a/src/Factory/ActivityPub/PostCommentNoteFactory.php
+++ b/src/Factory/ActivityPub/PostCommentNoteFactory.php
@@ -31,6 +31,7 @@ class PostCommentNoteFactory
         private readonly ApHttpClientInterface $client,
         private readonly ActivityPubManager $activityPubManager,
         private readonly MarkdownConverter $markdownConverter,
+        private readonly PollFactory $pollFactory,
     ) {
     }
 
@@ -107,6 +108,10 @@ class PostCommentNoteFactory
                 )
             )
         );
+
+        if ($comment->poll) {
+            $this->pollFactory->addToNote($note, $comment->poll);
+        }
 
         return $note;
     }

--- a/src/Factory/ActivityPub/PostNoteFactory.php
+++ b/src/Factory/ActivityPub/PostNoteFactory.php
@@ -32,6 +32,7 @@ class PostNoteFactory
         private readonly MentionManager $mentionManager,
         private readonly TagExtractor $tagExtractor,
         private readonly MarkdownConverter $markdownConverter,
+        private readonly PollFactory $pollFactory,
     ) {
     }
 
@@ -92,6 +93,10 @@ class PostNoteFactory
 
         if ($post->image) {
             $note = $this->imageWrapper->build($note, $post->image, $post->getShortTitle());
+        }
+
+        if ($post->poll) {
+            $this->pollFactory->addToNote($note, $post->poll);
         }
 
         $note['to'] = array_unique(array_merge($note['to'], $this->activityPubManager->createCcFromBody($post->body)));

--- a/src/Factory/EntryCommentFactory.php
+++ b/src/Factory/EntryCommentFactory.php
@@ -6,7 +6,10 @@ namespace App\Factory;
 
 use App\DTO\EntryCommentDto;
 use App\DTO\EntryCommentResponseDto;
+use App\DTO\PollChoiceResponseDto;
+use App\DTO\PollResponseDto;
 use App\Entity\EntryComment;
+use App\Entity\PollChoice;
 use App\Entity\User;
 use App\PageView\EntryCommentPageView;
 use App\Repository\BookmarkListRepository;
@@ -38,9 +41,17 @@ class EntryCommentFactory
         );
     }
 
-    public function createResponseDto(EntryCommentDto|EntryComment $comment, array $tags, int $childCount = 0): EntryCommentResponseDto
+    public function createResponseDto(EntryComment $comment, array $tags, int $childCount = 0): EntryCommentResponseDto
     {
-        $dto = $comment instanceof EntryComment ? $this->createDto($comment) : $comment;
+        $dto = $this->createDto($comment);
+        $pollDto = null;
+        if ($dto->addPoll) {
+            $pollDto = new PollResponseDto();
+            $pollDto->voterCount = $comment->poll->voterCount;
+            $user = $this->security->getUser();
+            $pollDto->currentUserHasVoted = $user instanceof User ? $comment->poll->hasUserVoted($user) : null;
+            $pollDto->choices = $comment->poll->choices ? array_map(fn (PollChoice $choice) => PollChoiceResponseDto::createFromPollChoice($choice, $user), $comment->poll->choices->toArray()) : null;
+        }
 
         return EntryCommentResponseDto::create(
             $dto->getId(),
@@ -66,13 +77,14 @@ class EntryCommentFactory
             $childCount,
             bookmarks: $this->bookmarkListRepository->getBookmarksOfContentInterface($comment),
             isAuthorModeratorInMagazine: $dto->magazine->userIsModerator($dto->user),
+            poll: $pollDto,
         );
     }
 
     public function createResponseTree(EntryComment $comment, EntryCommentPageView $commentPageView, int $depth = -1, ?bool $canModerate = null): EntryCommentResponseDto
     {
         $commentDto = $this->createDto($comment);
-        $toReturn = $this->createResponseDto($commentDto, $this->tagLinkRepository->getTagsOfContent($comment), array_reduce($comment->children->toArray(), EntryCommentResponseDto::class.'::recursiveChildCount', 0));
+        $toReturn = $this->createResponseDto($comment, $this->tagLinkRepository->getTagsOfContent($comment), array_reduce($comment->children->toArray(), EntryCommentResponseDto::class.'::recursiveChildCount', 0));
         $toReturn->isFavourited = $commentDto->isFavourited;
         $toReturn->userVote = $commentDto->userVote;
         $toReturn->canAuthUserModerate = $canModerate;

--- a/src/Factory/EntryCommentFactory.php
+++ b/src/Factory/EntryCommentFactory.php
@@ -47,6 +47,7 @@ class EntryCommentFactory
         $pollDto = null;
         if ($dto->addPoll) {
             $pollDto = new PollResponseDto();
+            $pollDto->endDate = $dto->pollEndsAt;
             $pollDto->voterCount = $comment->poll->voterCount;
             $user = $this->security->getUser();
             $pollDto->currentUserHasVoted = $user instanceof User ? $comment->poll->hasUserVoted($user) : null;

--- a/src/Factory/EntryFactory.php
+++ b/src/Factory/EntryFactory.php
@@ -6,8 +6,11 @@ namespace App\Factory;
 
 use App\DTO\EntryDto;
 use App\DTO\EntryResponseDto;
+use App\DTO\PollChoiceResponseDto;
+use App\DTO\PollResponseDto;
 use App\Entity\Badge;
 use App\Entity\Entry;
+use App\Entity\PollChoice;
 use App\Entity\User;
 use App\Repository\BookmarkListRepository;
 use App\Repository\TagLinkRepository;
@@ -42,10 +45,18 @@ class EntryFactory
         );
     }
 
-    public function createResponseDto(EntryDto|Entry $entry, array $tags, ?array $crosspostedEntries = null): EntryResponseDto
+    public function createResponseDto(Entry $entry, array $tags, ?array $crosspostedEntries = null): EntryResponseDto
     {
-        $dto = $entry instanceof Entry ? $this->createDto($entry) : $entry;
+        $dto = $this->createDto($entry);
         $badges = $dto->badges ? array_map(fn (Badge $badge) => $this->badgeFactory->createDto($badge), $dto->badges->toArray()) : null;
+        $pollDto = null;
+        if ($dto->addPoll) {
+            $user = $this->security->getUser();
+            $pollDto = new PollResponseDto();
+            $pollDto->voterCount = $entry->poll->voterCount;
+            $pollDto->currentUserHasVoted = $user instanceof User ? $entry->poll->hasUserVoted($user) : null;
+            $pollDto->choices = $entry->poll->choices ? array_map(fn (PollChoice $choice) => PollChoiceResponseDto::createFromPollChoice($choice, $user), $entry->poll->choices->toArray()) : null;
+        }
 
         return EntryResponseDto::create(
             $dto->getId(),
@@ -77,6 +88,7 @@ class EntryFactory
             bookmarks: $this->bookmarkListRepository->getBookmarksOfContentInterface($entry),
             crosspostedEntries: $crosspostedEntries,
             isAuthorModeratorInMagazine: $dto->magazine->userIsModerator($dto->user),
+            poll: $pollDto
         );
     }
 
@@ -115,6 +127,15 @@ class EntryFactory
         $dto->apDislikeCount = $entry->apDislikeCount;
         $dto->apShareCount = $entry->apShareCount;
         $dto->tags = $this->tagLinkRepository->getTagsOfContent($entry);
+
+        if ($entry->poll) {
+            $dto->addPoll = true;
+            $dto->pollEndsAt = $entry->poll->endDate;
+            $dto->isMultipleChoicePoll = $entry->poll->multipleChoice;
+            foreach ($entry->poll->choices as $choice) {
+                $dto->choices[] = $choice->name;
+            }
+        }
 
         $currentUser = $this->security->getUser();
         // Only return the user's vote if permission to control voting has been given

--- a/src/Factory/PostCommentFactory.php
+++ b/src/Factory/PostCommentFactory.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Factory;
 
+use App\DTO\PollChoiceResponseDto;
+use App\DTO\PollResponseDto;
 use App\DTO\PostCommentDto;
 use App\DTO\PostCommentResponseDto;
+use App\Entity\PollChoice;
 use App\Entity\PostComment;
 use App\Entity\User;
 use App\PageView\PostCommentPageView;
@@ -38,9 +41,18 @@ class PostCommentFactory
         );
     }
 
-    public function createResponseDto(PostCommentDto|PostComment $comment, array $tags, int $childCount = 0): PostCommentResponseDto
+    public function createResponseDto(PostComment $comment, array $tags, int $childCount = 0): PostCommentResponseDto
     {
-        $dto = $comment instanceof PostComment ? $this->createDto($comment) : $comment;
+        $dto = $this->createDto($comment);
+
+        $pollDto = null;
+        if ($dto->addPoll) {
+            $pollDto = new PollResponseDto();
+            $pollDto->voterCount = $comment->poll->voterCount;
+            $user = $this->security->getUser();
+            $pollDto->currentUserHasVoted = $user instanceof User ? $comment->poll->hasUserVoted($user) : null;
+            $pollDto->choices = $comment->poll->choices ? array_map(fn (PollChoice $choice) => PollChoiceResponseDto::createFromPollChoice($choice, $user), $comment->poll->choices->toArray()) : null;
+        }
 
         return PostCommentResponseDto::create(
             $dto->getId(),
@@ -65,13 +77,14 @@ class PostCommentFactory
             $dto->lastActive,
             bookmarks: $this->bookmarkListRepository->getBookmarksOfContentInterface($comment),
             isAuthorModeratorInMagazine: $dto->magazine->userIsModerator($dto->user),
+            poll: $pollDto,
         );
     }
 
     public function createResponseTree(PostComment $comment, PostCommentPageView $criteria, int $depth, ?bool $canModerate = null): PostCommentResponseDto
     {
         $commentDto = $this->createDto($comment);
-        $toReturn = $this->createResponseDto($commentDto, $this->tagLinkRepository->getTagsOfContent($comment), array_reduce($comment->children->toArray(), PostCommentResponseDto::class.'::recursiveChildCount', 0));
+        $toReturn = $this->createResponseDto($comment, $this->tagLinkRepository->getTagsOfContent($comment), array_reduce($comment->children->toArray(), PostCommentResponseDto::class.'::recursiveChildCount', 0));
         $toReturn->isFavourited = $commentDto->isFavourited;
         $toReturn->userVote = $commentDto->userVote;
         $toReturn->canAuthUserModerate = $canModerate;
@@ -122,8 +135,8 @@ class PostCommentFactory
 
         $currentUser = $this->security->getUser();
         // Only return the user's vote if permission to control voting has been given
-        $dto->isFavourited = $this->security->isGranted('ROLE_OAUTH2_POST_COMMENT:VOTE') ? $comment->isFavored($currentUser) : null;
-        $dto->userVote = $this->security->isGranted('ROLE_OAUTH2_POST_COMMENT:VOTE') ? $comment->getUserChoice($currentUser) : null;
+        $dto->isFavourited = $this->security->isGranted('ROLE_OAUTH2_POST_COMMENT:VOTE') && $currentUser instanceof User ? $comment->isFavored($currentUser) : null;
+        $dto->userVote = $this->security->isGranted('ROLE_OAUTH2_POST_COMMENT:VOTE') && $currentUser instanceof User ? $comment->getUserChoice($currentUser) : null;
 
         return $dto;
     }

--- a/src/Factory/PostCommentFactory.php
+++ b/src/Factory/PostCommentFactory.php
@@ -48,6 +48,7 @@ class PostCommentFactory
         $pollDto = null;
         if ($dto->addPoll) {
             $pollDto = new PollResponseDto();
+            $pollDto->endDate = $dto->pollEndsAt;
             $pollDto->voterCount = $comment->poll->voterCount;
             $user = $this->security->getUser();
             $pollDto->currentUserHasVoted = $user instanceof User ? $comment->poll->hasUserVoted($user) : null;

--- a/src/Factory/PostFactory.php
+++ b/src/Factory/PostFactory.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Factory;
 
+use App\DTO\PollChoiceResponseDto;
+use App\DTO\PollResponseDto;
 use App\DTO\PostDto;
 use App\DTO\PostResponseDto;
+use App\Entity\PollChoice;
 use App\Entity\Post;
 use App\Entity\User;
 use App\Repository\BookmarkListRepository;
@@ -33,9 +36,18 @@ class PostFactory
         );
     }
 
-    public function createResponseDto(PostDto|Post $post, array $tags): PostResponseDto
+    public function createResponseDto(Post $post, array $tags): PostResponseDto
     {
-        $dto = $post instanceof Post ? $this->createDto($post) : $post;
+        $dto = $this->createDto($post);
+
+        $pollDto = null;
+        if ($dto->addPoll) {
+            $pollDto = new PollResponseDto();
+            $pollDto->voterCount = $post->poll->voterCount;
+            $user = $this->security->getUser();
+            $pollDto->currentUserHasVoted = $user instanceof User ? $post->poll->hasUserVoted($user) : null;
+            $pollDto->choices = $post->poll->choices ? array_map(fn (PollChoice $choice) => PollChoiceResponseDto::createFromPollChoice($choice, $user), $post->poll->choices->toArray()) : null;
+        }
 
         return PostResponseDto::create(
             $dto->getId(),
@@ -61,6 +73,7 @@ class PostFactory
             $dto->slug,
             bookmarks: $this->bookmarkListRepository->getBookmarksOfContentInterface($post),
             isAuthorModeratorInMagazine: $dto->magazine->userIsModerator($dto->user),
+            poll: $pollDto,
         );
     }
 

--- a/src/Factory/PostFactory.php
+++ b/src/Factory/PostFactory.php
@@ -43,6 +43,7 @@ class PostFactory
         $pollDto = null;
         if ($dto->addPoll) {
             $pollDto = new PollResponseDto();
+            $pollDto->endDate = $dto->pollEndsAt;
             $pollDto->voterCount = $post->poll->voterCount;
             $user = $this->security->getUser();
             $pollDto->currentUserHasVoted = $user instanceof User ? $post->poll->hasUserVoted($user) : null;

--- a/src/Form/EntryCommentType.php
+++ b/src/Form/EntryCommentType.php
@@ -11,9 +11,13 @@ use App\Form\EventListener\ImageListener;
 use App\Form\Type\LanguageType;
 use App\Service\SettingsManager;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -45,6 +49,30 @@ class EntryCommentType extends AbstractType
             )
             ->add('imageUrl', UrlType::class, ['required' => false, 'default_protocol' => 'https'])
             ->add('imageAlt', TextareaType::class, ['required' => false])
+            ->add('addPoll', CheckboxType::class, [
+                'required' => false,
+            ])
+            ->add('isMultipleChoicePoll', CheckboxType::class, [
+                'required' => false,
+                'label' => 'poll_is_multiple_choice',
+            ])
+            ->add('pollEndsAt', DateTimeType::class, [
+                'attr' => [
+                    'class' => 'form-control',
+                ],
+                'required' => false,
+                'label' => 'poll_ends_at',
+            ])
+            ->add('choices', CollectionType::class, [
+                'entry_type' => TextType::class,
+                'allow_add' => true,
+                'allow_delete' => true,
+                'required' => false,
+                'attr' => [
+                    'class' => 'existing-collection-items',
+                ],
+                'label' => 'poll_choices',
+            ])
             ->add('submit', SubmitType::class);
 
         $builder->addEventSubscriber($this->defaultLanguage);

--- a/src/Form/EntryEditType.php
+++ b/src/Form/EntryEditType.php
@@ -11,10 +11,13 @@ use App\Form\EventListener\DefaultLanguage;
 use App\Form\EventListener\DisableFieldsOnEntryEdit;
 use App\Form\EventListener\ImageListener;
 // use App\Form\Type\BadgesType;
+use App\Form\EventListener\RemovePollFieldsOnEntryEdit;
 use App\Form\Type\LanguageType;
 use App\Form\Type\MagazineAutocompleteType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -29,6 +32,7 @@ class EntryEditType extends AbstractType
         private readonly ImageListener $imageListener,
         private readonly DefaultLanguage $defaultLanguage,
         private readonly DisableFieldsOnEntryEdit $disableFieldsOnEntryEdit,
+        private readonly RemovePollFieldsOnEntryEdit $removePollFieldsOnEntryEdit,
     ) {
     }
 
@@ -85,6 +89,27 @@ class EntryEditType extends AbstractType
             ->add('isOc', CheckboxType::class, [
                 'required' => false,
             ])
+            ->add('isMultipleChoicePoll', CheckboxType::class, [
+                'required' => false,
+                'label' => 'poll_is_multiple_choice',
+            ])
+            ->add('pollEndsAt', DateTimeType::class, [
+                'attr' => [
+                    'class' => 'form-control',
+                ],
+                'required' => false,
+                'label' => 'poll_ends_at',
+            ])
+            ->add('choices', CollectionType::class, [
+                'entry_type' => TextType::class,
+                'allow_add' => true,
+                'allow_delete' => true,
+                'required' => false,
+                'attr' => [
+                    'class' => 'existing-collection-items',
+                ],
+                'label' => 'poll_choices',
+            ])
             ->add('submit', SubmitType::class);
 
         $builder->get('tags')->addModelTransformer(
@@ -94,6 +119,7 @@ class EntryEditType extends AbstractType
         $builder->addEventSubscriber($this->defaultLanguage);
         $builder->addEventSubscriber($this->disableFieldsOnEntryEdit);
         $builder->addEventSubscriber($this->imageListener);
+        $builder->addEventSubscriber($this->removePollFieldsOnEntryEdit);
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Form/EntryType.php
+++ b/src/Form/EntryType.php
@@ -10,11 +10,12 @@ use App\Form\DataTransformer\TagTransformer;
 use App\Form\EventListener\DefaultLanguage;
 use App\Form\EventListener\DisableFieldsOnEntryEdit;
 use App\Form\EventListener\ImageListener;
-// use App\Form\Type\BadgesType;
 use App\Form\Type\LanguageType;
 use App\Form\Type\MagazineAutocompleteType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -84,6 +85,30 @@ class EntryType extends AbstractType
             ->add('lang', LanguageType::class)
             ->add('isOc', CheckboxType::class, [
                 'required' => false,
+            ])
+            ->add('addPoll', CheckboxType::class, [
+                'required' => false,
+            ])
+            ->add('isMultipleChoicePoll', CheckboxType::class, [
+                'required' => false,
+                'label' => 'poll_is_multiple_choice',
+            ])
+            ->add('pollEndsAt', DateTimeType::class, [
+                'attr' => [
+                    'class' => 'form-control',
+                ],
+                'required' => false,
+                'label' => 'poll_ends_at',
+            ])
+            ->add('choices', CollectionType::class, [
+                'entry_type' => TextType::class,
+                'allow_add' => true,
+                'allow_delete' => true,
+                'required' => false,
+                'attr' => [
+                    'class' => 'existing-collection-items',
+                ],
+                'label' => 'poll_choices',
             ])
             ->add('submit', SubmitType::class);
 

--- a/src/Form/EventListener/RemovePollFieldsOnEntryEdit.php
+++ b/src/Form/EventListener/RemovePollFieldsOnEntryEdit.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+final class RemovePollFieldsOnEntryEdit implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [FormEvents::PRE_SET_DATA => 'preSetData'];
+    }
+
+    public function preSetData(FormEvent $event): void
+    {
+        $dto = $event->getData();
+        $form = $event->getForm();
+
+        if (!$dto || null === $dto->getId()) {
+            return;
+        }
+
+        if (!$dto->addPoll) {
+            $form->remove('isMultipleChoicePoll');
+            $form->remove('pollEndsAt');
+            $form->remove('choices');
+        }
+    }
+}

--- a/src/Form/PostCommentType.php
+++ b/src/Form/PostCommentType.php
@@ -11,9 +11,13 @@ use App\Form\EventListener\ImageListener;
 use App\Form\Type\LanguageType;
 use App\Service\SettingsManager;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -45,6 +49,30 @@ class PostCommentType extends AbstractType
             )
             ->add('imageUrl', UrlType::class, ['required' => false, 'default_protocol' => 'https'])
             ->add('imageAlt', TextareaType::class, ['required' => false])
+            ->add('addPoll', CheckboxType::class, [
+                'required' => false,
+            ])
+            ->add('isMultipleChoicePoll', CheckboxType::class, [
+                'required' => false,
+                'label' => 'poll_is_multiple_choice',
+            ])
+            ->add('pollEndsAt', DateTimeType::class, [
+                'attr' => [
+                    'class' => 'form-control',
+                ],
+                'required' => false,
+                'label' => 'poll_ends_at',
+            ])
+            ->add('choices', CollectionType::class, [
+                'entry_type' => TextType::class,
+                'allow_add' => true,
+                'allow_delete' => true,
+                'required' => false,
+                'attr' => [
+                    'class' => 'existing-collection-items',
+                ],
+                'label' => 'poll_choices',
+            ])
             ->add('submit', SubmitType::class);
 
         $builder->addEventSubscriber($this->defaultLanguage);

--- a/src/Form/PostType.php
+++ b/src/Form/PostType.php
@@ -10,12 +10,14 @@ use App\Form\EventListener\DefaultLanguage;
 use App\Form\EventListener\ImageListener;
 use App\Form\Type\LanguageType;
 use App\Form\Type\MagazineAutocompleteType;
-use App\Service\SettingsManager;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -25,7 +27,6 @@ class PostType extends AbstractType
     public function __construct(
         private readonly ImageListener $imageListener,
         private readonly DefaultLanguage $defaultLanguage,
-        private readonly SettingsManager $settingsManager,
     ) {
     }
 
@@ -47,6 +48,36 @@ class PostType extends AbstractType
             ->add('imageUrl', UrlType::class, ['required' => false, 'default_protocol' => 'https'])
             ->add('imageAlt', TextareaType::class, ['required' => false])
             ->add('isAdult', CheckboxType::class, ['required' => false])
+            ->add('addPoll', CheckboxType::class, [
+                'required' => false,
+                'row_attr' => [
+                    'class' => 'checkbox',
+                ],
+            ])
+            ->add('isMultipleChoicePoll', CheckboxType::class, [
+                'required' => false,
+                'label' => 'poll_is_multiple_choice',
+                'row_attr' => [
+                    'class' => 'checkbox',
+                ],
+            ])
+            ->add('pollEndsAt', DateTimeType::class, [
+                'attr' => [
+                    'class' => 'form-control',
+                ],
+                'required' => false,
+                'label' => 'poll_ends_at',
+            ])
+            ->add('choices', CollectionType::class, [
+                'entry_type' => TextType::class,
+                'allow_add' => true,
+                'allow_delete' => true,
+                'required' => false,
+                'attr' => [
+                    'class' => 'existing-collection-items',
+                ],
+                'label' => 'poll_choices',
+            ])
             ->add('submit', SubmitType::class);
 
         $builder->addEventSubscriber($this->defaultLanguage);

--- a/src/Message/ActivityPub/Outbox/PollVoteMessage.php
+++ b/src/Message/ActivityPub/Outbox/PollVoteMessage.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message\ActivityPub\Outbox;
+
+use App\Message\Contracts\ActivityPubOutboxInterface;
+
+class PollVoteMessage implements ActivityPubOutboxInterface
+{
+    public function __construct(
+        public string $voteUuid,
+    ) {
+    }
+}

--- a/src/Message/CheckPollEndedMessage.php
+++ b/src/Message/CheckPollEndedMessage.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+use App\Message\Contracts\AsyncMessageInterface;
+
+class CheckPollEndedMessage implements AsyncMessageInterface
+{
+}

--- a/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/ChainActivityHandler.php
@@ -134,6 +134,12 @@ class ChainActivityHandler extends MbinMessageHandler
 
             switch ($object['type']) {
                 case 'Question':
+                    if (isset($object['title'])) {
+                        return $this->page->create($object);
+                    } else {
+                        return $this->note->create($object);
+                    }
+                    break;
                 case 'Note':
                     $this->logger->debug('[ChainActivityHandler::retrieveObject] Creating note {o}', ['o' => $object]);
 

--- a/src/MessageHandler/ActivityPub/Inbox/CreateHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/CreateHandler.php
@@ -13,6 +13,7 @@ use App\Exception\EntryLockedException;
 use App\Exception\InstanceBannedException;
 use App\Exception\InvalidApPostException;
 use App\Exception\InvalidWebfingerException;
+use App\Exception\PollHasEndedException;
 use App\Exception\PostingRestrictedException;
 use App\Exception\PostLockedException;
 use App\Exception\TagBannedException;
@@ -79,22 +80,19 @@ class CreateHandler extends MbinMessageHandler
         try {
             if ('ChatMessage' === $object['type']) {
                 $this->handlePrivateMessage($object);
+            } elseif ('Question' === $object['type']) {
+                if (isset($object['name'])) {
+                    $this->handlePage($object, $stickyIt, $message->fullCreatePayload);
+                } else {
+                    $this->handleChain($object, $stickyIt, $message->fullCreatePayload);
+                }
+                $this->invalidateTagsOfId($object['id']);
             } elseif (\in_array($object['type'], $postTypes)) {
                 $this->handleChain($object, $stickyIt, $message->fullCreatePayload);
-                if (method_exists($this->cache, 'invalidateTags')) {
-                    // clear markdown renders that are tagged with the id of the post
-                    $tag = UrlUtils::getCacheKeyForMarkdownUrl($object['id']);
-                    $this->cache->invalidateTags([$tag]);
-                    $this->logger->debug('cleared cached items with tag {t}', ['t' => $tag]);
-                }
+                $this->invalidateTagsOfId($object['id']);
             } elseif (\in_array($object['type'], $entryTypes)) {
                 $this->handlePage($object, $stickyIt, $message->fullCreatePayload);
-                if (method_exists($this->cache, 'invalidateTags')) {
-                    // clear markdown renders that are tagged with the id of the entry
-                    $tag = UrlUtils::getCacheKeyForMarkdownUrl($object['id']);
-                    $this->cache->invalidateTags([$tag]);
-                    $this->logger->debug('cleared cached items with tag {t}', ['t' => $tag]);
-                }
+                $this->invalidateTagsOfId($object['id']);
             } else {
                 $this->logger->warning('received Create activity for unknown type {t} of object {o}; ignoring', [
                     't' => $object['type'],
@@ -120,6 +118,8 @@ class CreateHandler extends MbinMessageHandler
             $this->logger->info('[CreateHandler::doWork] Did not create the message, because the user is blocked by one of the receivers');
         } catch (EntryLockedException|PostLockedException) {
             $this->logger->info('[CreateHandler::doWork] Did not create the comment, because the entry/post is locked');
+        } catch (PollHasEndedException) {
+            $this->logger->info('[CreateHandler::doWork] Did not create the vote ({vId}), because the poll ({pId}) has already ended', ['vId' => $object['id'], 'pId' => $object['inReplyTo']]);
         }
     }
 
@@ -130,6 +130,7 @@ class CreateHandler extends MbinMessageHandler
      * @throws InstanceBannedException
      * @throws EntryLockedException
      * @throws PostLockedException
+     * @throws PollHasEndedException
      */
     private function handleChain(array $object, bool $stickyIt, ?array $fullCreatePayload): void
     {
@@ -201,5 +202,15 @@ class CreateHandler extends MbinMessageHandler
     private function handlePrivateMentions(): void
     {
         // TODO implement private mentions
+    }
+
+    private function invalidateTagsOfId(string $id): void
+    {
+        if (method_exists($this->cache, 'invalidateTags')) {
+            // clear markdown renders that are tagged with the id
+            $tag = UrlUtils::getCacheKeyForMarkdownUrl($id);
+            $this->cache->invalidateTags([$tag]);
+            $this->logger->debug('cleared cached items with tag {t}', ['t' => $tag]);
+        }
     }
 }

--- a/src/MessageHandler/ActivityPub/Inbox/UpdateHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/UpdateHandler.php
@@ -31,6 +31,7 @@ use App\Service\ActivityPubManager;
 use App\Service\EntryCommentManager;
 use App\Service\EntryManager;
 use App\Service\MessageManager;
+use App\Service\PollManager;
 use App\Service\PostCommentManager;
 use App\Service\PostManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -60,6 +61,7 @@ class UpdateHandler extends MbinMessageHandler
         private readonly LoggerInterface $logger,
         private readonly MessageBusInterface $bus,
         private readonly ImageFactory $imageFactory,
+        private readonly PollManager $pollManager,
     ) {
         parent::__construct($this->entityManager, $this->kernel);
     }
@@ -149,6 +151,7 @@ class UpdateHandler extends MbinMessageHandler
 
         $this->extractChanges($dto, $payload);
         $this->entryManager->edit($entry, $dto, $user);
+        $this->updatePollCounts($entry, $payload);
     }
 
     private function editEntryComment(EntryComment $comment, User $user, array $payload): void
@@ -163,6 +166,7 @@ class UpdateHandler extends MbinMessageHandler
         $this->extractChanges($dto, $payload);
 
         $this->entryCommentManager->edit($comment, $dto, $user);
+        $this->updatePollCounts($comment, $payload);
     }
 
     private function editPost(Post $post, User $user, array $payload): void
@@ -177,6 +181,7 @@ class UpdateHandler extends MbinMessageHandler
         $this->extractChanges($dto, $payload);
 
         $this->postManager->edit($post, $dto, $user);
+        $this->updatePollCounts($post, $payload);
     }
 
     private function editPostComment(PostComment $comment, User $user, array $payload): void
@@ -191,6 +196,14 @@ class UpdateHandler extends MbinMessageHandler
         $this->extractChanges($dto, $payload);
 
         $this->postCommentManager->edit($comment, $dto, $user);
+        $this->updatePollCounts($comment, $payload);
+    }
+
+    private function updatePollCounts(Entry|EntryComment|Post|PostComment $content, array $payload): void
+    {
+        if (($poll = $content->poll) && $this->pollManager->hasPollProperties($payload)) {
+            $this->pollManager->updatePollCounts($poll, $payload);
+        }
     }
 
     private function extractChanges(EntryDto|EntryCommentDto|PostDto|PostCommentDto $dto, array $payload): void

--- a/src/MessageHandler/ActivityPub/Inbox/UpdateHandler.php
+++ b/src/MessageHandler/ActivityPub/Inbox/UpdateHandler.php
@@ -149,9 +149,9 @@ class UpdateHandler extends MbinMessageHandler
 
         $dto->title = $payload['object']['name'];
 
-        $this->extractChanges($dto, $payload);
-        $this->entryManager->edit($entry, $dto, $user);
-        $this->updatePollCounts($entry, $payload);
+        $contentChanged = $this->extractChanges($dto, $payload);
+        $this->entryManager->edit($entry, $dto, $user, $contentChanged);
+        $this->updatePollCounts($entry, $payload['object']);
     }
 
     private function editEntryComment(EntryComment $comment, User $user, array $payload): void
@@ -163,10 +163,10 @@ class UpdateHandler extends MbinMessageHandler
         }
         $dto = $this->entryCommentFactory->createDto($comment);
 
-        $this->extractChanges($dto, $payload);
+        $contentChanged = $this->extractChanges($dto, $payload);
 
-        $this->entryCommentManager->edit($comment, $dto, $user);
-        $this->updatePollCounts($comment, $payload);
+        $this->entryCommentManager->edit($comment, $dto, $user, $contentChanged);
+        $this->updatePollCounts($comment, $payload['object']);
     }
 
     private function editPost(Post $post, User $user, array $payload): void
@@ -178,10 +178,10 @@ class UpdateHandler extends MbinMessageHandler
         }
         $dto = $this->postFactory->createDto($post);
 
-        $this->extractChanges($dto, $payload);
+        $contentChanged = $this->extractChanges($dto, $payload);
 
-        $this->postManager->edit($post, $dto, $user);
-        $this->updatePollCounts($post, $payload);
+        $this->postManager->edit($post, $dto, $user, $contentChanged);
+        $this->updatePollCounts($post, $payload['object']);
     }
 
     private function editPostComment(PostComment $comment, User $user, array $payload): void
@@ -193,35 +193,54 @@ class UpdateHandler extends MbinMessageHandler
         }
         $dto = $this->postCommentFactory->createDto($comment);
 
-        $this->extractChanges($dto, $payload);
+        $contentChanged = $this->extractChanges($dto, $payload);
 
-        $this->postCommentManager->edit($comment, $dto, $user);
-        $this->updatePollCounts($comment, $payload);
+        $this->postCommentManager->edit($comment, $dto, $user, $contentChanged);
+        $this->updatePollCounts($comment, $payload['object']);
     }
 
     private function updatePollCounts(Entry|EntryComment|Post|PostComment $content, array $payload): void
     {
-        if (($poll = $content->poll) && $this->pollManager->hasPollProperties($payload)) {
+        $poll = $content->poll;
+        if (null !== $poll && $this->pollManager->hasPollProperties($payload)) {
             $this->pollManager->updatePollCounts($poll, $payload);
         }
     }
 
-    private function extractChanges(EntryDto|EntryCommentDto|PostDto|PostCommentDto $dto, array $payload): void
+    /**
+     * @return bool true if the content of the post has changed (title, body, url, image), otherwise false
+     */
+    private function extractChanges(EntryDto|EntryCommentDto|PostDto|PostCommentDto $dto, array $payload): bool
     {
+        $isContentSame = true;
         $this->logger->debug('[UpdateHandler::extractChanges] extracting changes from {c}', ['c' => \get_class($dto)]);
         if (!empty($payload['object']['content'])) {
+            $previousBody = $dto->body;
             $dto->body = $this->objectExtractor->getMarkdownBody($payload['object']);
+            if ($previousBody !== $dto->body) {
+                $isContentSame = false;
+            }
         } else {
+            if (null !== $dto->body) {
+                $isContentSame = false;
+            }
             $dto->body = null;
         }
         if (!empty($payload['object']['attachment'])) {
             $this->logger->debug('[UpdateHandler::extractChanges] was not empty :)');
             $image = $this->activityPubManager->handleImages($payload['object']['attachment']);
             if (null !== $image) {
+                $previousImage = $dto->image;
                 $dto->image = $this->imageFactory->createDto($image);
+                if ($previousImage->id !== $dto->image->id) {
+                    $isContentSame = false;
+                }
             }
             if ($dto instanceof EntryDto) {
                 $url = ActivityPubManager::extractUrlFromAttachment($payload['object']['attachment']);
+                if ($dto->url !== $url) {
+                    $isContentSame = false;
+                }
                 $dto->url = $url;
                 $this->logger->debug('[UpdateHandler::extractChanges] setting url to {u} which was extracted from the attachment array', ['u' => $url]);
             }
@@ -233,6 +252,17 @@ class UpdateHandler extends MbinMessageHandler
         if (isset($payload['object']['commentsEnabled']) && \is_bool($payload['object']['commentsEnabled']) && ($dto instanceof EntryDto || $dto instanceof PostDto)) {
             $dto->isLocked = !$payload['object']['commentsEnabled'];
         }
+        $this->logger->debug('[UpdateHandler::extractChanges] content was the same: {x}', ['x' => $isContentSame ? 'true' : 'false']);
+
+        if ($this->pollManager->hasPollProperties($payload['object'])) {
+            $pollIsSame = $this->pollManager->extractPollChanges($payload['object'], $dto);
+            $this->logger->debug('[UpdateHandler::extractChanges] poll was the same: {x}', ['x' => $pollIsSame ? 'true' : 'false']);
+            if (!$pollIsSame) {
+                $isContentSame = false;
+            }
+        }
+
+        return !$isContentSame;
     }
 
     private function editMessage(Message $message, User $user, array $payload): void

--- a/src/MessageHandler/ActivityPub/Outbox/PollVoteHandler.php
+++ b/src/MessageHandler/ActivityPub/Outbox/PollVoteHandler.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler\ActivityPub\Outbox;
+
+use App\Entity\PollVote;
+use App\Message\ActivityPub\Outbox\PollVoteMessage;
+use App\Message\Contracts\MessageInterface;
+use App\MessageHandler\MbinMessageHandler;
+use App\Service\ActivityPub\ActivityJsonBuilder;
+use App\Service\ActivityPub\Wrapper\CreateWrapper;
+use App\Service\DeliverManager;
+use App\Service\PollManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Uid\Uuid;
+
+#[AsMessageHandler]
+class PollVoteHandler extends MbinMessageHandler
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly CreateWrapper $createWrapper,
+        private readonly ActivityJsonBuilder $activityJsonBuilder,
+        private readonly DeliverManager $deliverManager,
+        private readonly PollManager $pollManager,
+        private readonly LoggerInterface $logger,
+        KernelInterface $kernel,
+    ) {
+        parent::__construct($entityManager, $kernel);
+    }
+
+    public function __invoke(PollVoteMessage $message): void
+    {
+        $this->workWrapper($message);
+    }
+
+    public function doWork(MessageInterface $message): void
+    {
+        if (!$message instanceof PollVoteMessage) {
+            throw new \LogicException();
+        }
+
+        $vote = $this->entityManager->getRepository(PollVote::class)->find(Uuid::fromString($message->voteUuid));
+        if (!$vote->poll->isRemote) {
+            $this->logger->info('The poll {p} is not remote, so we do not have to send anything', ['p' => $message->voteUuid]);
+
+            return;
+        } elseif (null !== $vote->voter->apId) {
+            $this->logger->info('The voter of poll {p} is not a local user, so we do not have to send anything', ['p' => $message->voteUuid]);
+
+            return;
+        }
+
+        $content = $this->pollManager->getContentOfPoll($vote->poll);
+        if (null === $content) {
+            $this->logger->warning('Could not find the content the poll {p} belongs to', ['p' => $vote->poll]);
+
+            return;
+        }
+
+        if (null === $content->user->apId) {
+            $this->logger->info('The content of poll {p} is not a local, so we do not have to send anything', ['p' => $message->voteUuid]);
+
+            return;
+        }
+
+        $activity = $this->createWrapper->build($vote);
+        $json = $this->activityJsonBuilder->buildActivityJson($activity);
+        $this->deliverManager->deliver([$content->user->apInboxUrl], $json);
+    }
+}

--- a/src/MessageHandler/CheckPollEndedMessageHandler.php
+++ b/src/MessageHandler/CheckPollEndedMessageHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\Message\CheckPollEndedMessage;
+use App\Message\Contracts\MessageInterface;
+use App\Repository\PollRepository;
+use App\Service\Notification\PollNotificationManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class CheckPollEndedMessageHandler extends MbinMessageHandler
+{
+    public function __construct(
+        private readonly PollRepository $pollRepository,
+        private readonly PollNotificationManager $notificationManager,
+        private readonly LoggerInterface $logger,
+        private readonly EntityManagerInterface $entityManager,
+        KernelInterface $kernel,
+    ) {
+        parent::__construct($entityManager, $kernel);
+    }
+
+    public function __invoke(CheckPollEndedMessage $message): void
+    {
+        $this->workWrapper($message);
+    }
+
+    public function doWork(MessageInterface $message): void
+    {
+        if (!$message instanceof CheckPollEndedMessage) {
+            throw new \LogicException();
+        }
+
+        foreach ($this->pollRepository->getAllEndedPollsToSentNotifications() as $poll) {
+            try {
+                $this->logger->debug('Sending notifications for poll {p}', ['p' => $poll->getId()]);
+                $this->notificationManager->sendPollEndedNotification($poll);
+                $poll->sentNotifications = true;
+                $this->entityManager->flush();
+            } catch (\Throwable $exception) {
+                $this->logger->error('An error occurred while sending the notifications for the ended poll {p}: {e} - {m}', [
+                    'p' => $poll->getId(),
+                    'e' => \get_class($exception),
+                    'm' => $exception->getMessage(),
+                ]);
+            }
+        }
+    }
+}

--- a/src/Repository/ApActivityRepository.php
+++ b/src/Repository/ApActivityRepository.php
@@ -168,16 +168,22 @@ class ApActivityRepository extends ServiceEntityRepository
         return $this->getLocalUrlOfEntity($entity);
     }
 
-    public function getLocalUrlOfEntity(Entry|EntryComment|Post|PostComment $entity): ?string
+    public function getLocalUrlOfEntity(Entry|EntryComment|Post|PostComment $entity, bool $absoluteUrl = false): ?string
     {
+        return self::s_getLocalUrlOfEntity($this->urlGenerator, $entity, $absoluteUrl);
+    }
+
+    public static function s_getLocalUrlOfEntity(UrlGeneratorInterface $urlGenerator, Entry|EntryComment|Post|PostComment $entity, bool $absoluteUrl = false): ?string
+    {
+        $reference = $absoluteUrl ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH;
         if ($entity instanceof Entry) {
-            return $this->urlGenerator->generate('entry_single', ['entry_id' => $entity->getId(), 'magazine_name' => $entity->magazine->name]);
+            return $urlGenerator->generate('entry_single', ['entry_id' => $entity->getId(), 'magazine_name' => $entity->magazine->name], $reference);
         } elseif ($entity instanceof EntryComment) {
-            return $this->urlGenerator->generate('entry_comment_view', ['comment_id' => $entity->getId(), 'entry_id' => $entity->entry->getId(), 'magazine_name' => $entity->magazine->name]);
+            return $urlGenerator->generate('entry_comment_view', ['comment_id' => $entity->getId(), 'entry_id' => $entity->entry->getId(), 'magazine_name' => $entity->magazine->name], $reference);
         } elseif ($entity instanceof Post) {
-            return $this->urlGenerator->generate('post_single', ['post_id' => $entity->getId(), 'magazine_name' => $entity->magazine->name]);
+            return $urlGenerator->generate('post_single', ['post_id' => $entity->getId(), 'magazine_name' => $entity->magazine->name], $reference);
         } elseif ($entity instanceof PostComment) {
-            return $this->urlGenerator->generate('post_single', ['post_id' => $entity->post->getId(), 'magazine_name' => $entity->magazine->name])."#post-comment-{$entity->getId()}";
+            return $urlGenerator->generate('post_single', ['post_id' => $entity->post->getId(), 'magazine_name' => $entity->magazine->name], $reference)."#post-comment-{$entity->getId()}";
         }
 
         return null;

--- a/src/Repository/NotificationRepository.php
+++ b/src/Repository/NotificationRepository.php
@@ -8,6 +8,7 @@ use App\Entity\Entry;
 use App\Entity\EntryComment;
 use App\Entity\Magazine;
 use App\Entity\Notification;
+use App\Entity\Poll;
 use App\Entity\Post;
 use App\Entity\PostComment;
 use App\Entity\User;
@@ -80,6 +81,7 @@ class NotificationRepository extends ServiceEntityRepository
             $result,
             fn ($notification) => (isset($notification->entry) && $notification->entry === $entry)
                 || (isset($notification->entryComment) && $notification->entryComment->entry === $entry)
+                || (isset($notification->poll) && $notification->poll instanceof Poll && ($notification->poll->entry === $entry || $notification->poll->entryComment?->entry === $entry))
         );
     }
 
@@ -111,6 +113,7 @@ class NotificationRepository extends ServiceEntityRepository
             $result,
             fn ($notification) => (isset($notification->post) && $notification->post === $post)
                 || (isset($notification->postComment) && $notification->postComment->post === $post)
+                || (isset($notification->poll) && $notification->poll instanceof Poll && ($notification->poll->post === $post || $notification->poll->postComment?->post === $post))
         );
     }
 

--- a/src/Repository/PollRepository.php
+++ b/src/Repository/PollRepository.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Poll;
+use App\Entity\PollVote;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Poll>
+ *
+ * @method Poll|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Poll|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Poll|null findOneByUrl(string $url)
+ * @method Poll[]    findAll()
+ * @method Poll[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class PollRepository extends ServiceEntityRepository
+{
+    public const PER_PAGE = 25;
+
+    public function __construct(
+        ManagerRegistry $registry,
+    ) {
+        parent::__construct($registry, Poll::class);
+    }
+
+    /**
+     * @return User[]
+     */
+    public function getAllLocalVotersOfPoll(Poll $poll): array
+    {
+        $localVotes = array_filter($poll->votes->toArray(), fn (PollVote $vote) => null === $vote->voter->apId);
+
+        return array_map(fn (PollVote $vote) => $vote->voter, $localVotes);
+    }
+
+    /**
+     * @return Poll[]
+     */
+    public function getAllEndedPollsToSentNotifications(): array
+    {
+        return $this->createQueryBuilder('p')
+            ->andWhere('p.endDate <= :now')
+            ->andWhere('p.sentNotifications = false')
+            ->setParameter('now', new \DateTime())
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/src/Scheduler/MbinTaskProvider.php
+++ b/src/Scheduler/MbinTaskProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Scheduler;
 
+use App\Message\CheckPollEndedMessage;
 use App\Message\ClearDeadMessagesMessage;
 use App\Message\ClearDeletedUserMessage;
 use Symfony\Component\Scheduler\Attribute\AsSchedule;
@@ -29,6 +30,7 @@ class MbinTaskProvider implements ScheduleProviderInterface
                 ->add(
                     RecurringMessage::every('1 day', new ClearDeletedUserMessage()),
                     RecurringMessage::every('1 day', new ClearDeadMessagesMessage()),
+                    RecurringMessage::every('5 minutes', new CheckPollEndedMessage())
                 )
                 ->stateful($this->cache);
         }

--- a/src/Service/ActivityPub/ActivityJsonBuilder.php
+++ b/src/Service/ActivityPub/ActivityJsonBuilder.php
@@ -83,7 +83,7 @@ class ActivityJsonBuilder
 
     public function buildCreateFromActivity(Activity $activity): array
     {
-        $o = $activity->objectEntry ?? $activity->objectEntryComment ?? $activity->objectPost ?? $activity->objectPostComment ?? $activity->objectMessage;
+        $o = $activity->objectEntry ?? $activity->objectEntryComment ?? $activity->objectPost ?? $activity->objectPostComment ?? $activity->objectMessage ?? $activity->objectPollVote;
         $item = $this->activityFactory->create($o, true);
 
         unset($item['@context']);

--- a/src/Service/ActivityPub/ApHttpClient.php
+++ b/src/Service/ActivityPub/ApHttpClient.php
@@ -147,6 +147,11 @@ class ApHttpClient implements ApHttpClientInterface
         return 'ap_object_'.hash('sha256', $url);
     }
 
+    public function invalidateActivityObjectCache(string $url): void
+    {
+        $this->cache->delete($this->getActivityObjectCacheKey($url));
+    }
+
     /**
      * Retrieve AP actor object (could be a user or magazine).
      *

--- a/src/Service/ActivityPub/ApHttpClientInterface.php
+++ b/src/Service/ActivityPub/ApHttpClientInterface.php
@@ -54,6 +54,13 @@ interface ApHttpClientInterface
     public function getActorObject(string $apProfileId): ?array;
 
     /**
+     * Remove activity object from cache.
+     *
+     * @param string $url URL to remove from the activity cache
+     */
+    public function invalidateActivityObjectCache(string $url): void;
+
+    /**
      * Remove actor object from cache.
      *
      * @param string $apProfileId AP profile ID to remove from cache

--- a/src/Service/ActivityPub/Note.php
+++ b/src/Service/ActivityPub/Note.php
@@ -11,11 +11,16 @@ use App\Entity\Contracts\ActivityPubActivityInterface;
 use App\Entity\Entry;
 use App\Entity\EntryComment;
 use App\Entity\Magazine;
+use App\Entity\Poll;
+use App\Entity\PollVote;
 use App\Entity\Post;
 use App\Entity\PostComment;
 use App\Entity\User;
 use App\Exception\EntryLockedException;
 use App\Exception\InstanceBannedException;
+use App\Exception\InvalidApPostException;
+use App\Exception\InvalidWebfingerException;
+use App\Exception\PollHasEndedException;
 use App\Exception\PostLockedException;
 use App\Exception\TagBannedException;
 use App\Exception\UserBannedException;
@@ -24,10 +29,13 @@ use App\Factory\ImageFactory;
 use App\Repository\ApActivityRepository;
 use App\Service\ActivityPubManager;
 use App\Service\EntryCommentManager;
+use App\Service\PollManager;
 use App\Service\PostCommentManager;
 use App\Service\PostManager;
 use App\Service\SettingsManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Exception\ORMException;
+use Psr\Cache\InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
@@ -44,6 +52,7 @@ class Note extends ActivityPubContent
         private readonly SettingsManager $settingsManager,
         private readonly ImageFactory $imageFactory,
         private readonly ApObjectExtractor $objectExtractor,
+        private readonly PollManager $pollManager,
     ) {
     }
 
@@ -54,9 +63,10 @@ class Note extends ActivityPubContent
      * @throws InstanceBannedException
      * @throws EntryLockedException
      * @throws PostLockedException
+     * @throws PollHasEndedException
      * @throws \Exception
      */
-    public function create(array $object, ?array $root = null, bool $stickyIt = false): EntryComment|PostComment|Post
+    public function create(array $object, ?array $root = null, bool $stickyIt = false): EntryComment|PostComment|Post|PollVote
     {
         // First try to find the activity object in the database
         $current = $this->repository->findByObjectId($object['id']);
@@ -81,6 +91,14 @@ class Note extends ActivityPubContent
             // Create post or entry comment
             $parentObjectId = $this->repository->findByObjectId($replyTo);
             $parent = $this->entityManager->getRepository($parentObjectId['type'])->find((int) $parentObjectId['id']);
+
+            if (isset($object['name'])) {
+                if ($parent instanceof Entry || $parent instanceof EntryComment || $parent instanceof Post || $parent instanceof PostComment) {
+                    if ($parent->poll && $parent->poll->findChoice($object['name'])) {
+                        return $this->voteOnPoll($parent->poll, $parent, $object);
+                    }
+                }
+            }
 
             if ($parent instanceof Entry) {
                 $root = $parent;
@@ -221,7 +239,15 @@ class Note extends ActivityPubContent
                 $dto->isLocked = !$object['commentsEnabled'];
             }
 
-            return $this->postManager->create($dto, $actor, false, $stickyIt);
+            $post = $this->postManager->create($dto, $actor, false, $stickyIt);
+
+            if ($this->pollManager->hasPollProperties($object)) {
+                $poll = $this->pollManager->createFromApObject($object);
+                $post->poll = $poll;
+                $this->entityManager->flush();
+            }
+
+            return $post;
         } elseif ($actor instanceof Magazine) {
             throw new UnrecoverableMessageHandlingException('Actor "'.$object['attributedTo'].'" is not a user, but a magazine for post "'.$dto->apId.'".');
         } else {
@@ -287,6 +313,50 @@ class Note extends ActivityPubContent
             throw new UnrecoverableMessageHandlingException('Actor "'.$object['attributedTo'].'" is not a user, but a magazine for post "'.$dto->apId.'".');
         } else {
             throw new UnrecoverableMessageHandlingException('Actor "'.$object['attributedTo'].'"could not be found for post "'.$dto->apId.'".');
+        }
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @throws ORMException
+     * @throws InvalidApPostException
+     * @throws PollHasEndedException
+     * @throws UserDeletedException
+     * @throws InvalidWebfingerException
+     * @throws UserBannedException
+     */
+    private function voteOnPoll(?Poll $poll, Entry|EntryComment|Post|PostComment $content, array $object): PollVote
+    {
+        $apId = $object['id'];
+        $actor = $this->activityPubManager->findActorOrCreate($object['attributedTo']);
+        if ($actor instanceof User) {
+            if ($actor->isBanned) {
+                throw new UserBannedException();
+            }
+            if ($actor->isDeleted || $actor->isSoftDeleted() || $actor->isTrashed()) {
+                throw new UserDeletedException();
+            }
+
+            $choice = $object['name'];
+            $existingVotes = $poll->getUserVotes($actor);
+            $existingSameVote = array_filter($existingVotes, fn (PollVote $vote) => $vote->choice->name === $choice);
+            if (\sizeof($existingSameVote) > 0) {
+                throw new \LogicException("User $actor->username has already voted on the poll {$poll->getId()} with choice '$choice'.");
+            }
+
+            $this->pollManager->vote($poll, $content, $actor, [$choice], true);
+            $this->entityManager->refresh($poll);
+            $newVotes = $poll->getUserVotes($actor);
+            $newVote = array_filter($newVotes, fn (PollVote $vote) => $vote->choice->name === $choice);
+            if (1 !== \sizeof($newVote)) {
+                throw new \LogicException('Created the vote, but it could not be found!');
+            }
+
+            return $newVote[array_key_first($newVote)];
+        } elseif ($actor instanceof Magazine) {
+            throw new UnrecoverableMessageHandlingException('Actor "'.$object['attributedTo'].'" is not a user, but a magazine for voting on poll "'.$apId.'".');
+        } else {
+            throw new UnrecoverableMessageHandlingException('Actor "'.$object['attributedTo'].'"could not be found for post "'.$apId.'".');
         }
     }
 }

--- a/src/Service/ActivityPub/Page.php
+++ b/src/Service/ActivityPub/Page.php
@@ -18,6 +18,7 @@ use App\Repository\ApActivityRepository;
 use App\Repository\InstanceRepository;
 use App\Service\ActivityPubManager;
 use App\Service\EntryManager;
+use App\Service\PollManager;
 use App\Service\SettingsManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -34,6 +35,7 @@ class Page extends ActivityPubContent
         private readonly ApObjectExtractor $objectExtractor,
         private readonly LoggerInterface $logger,
         private readonly InstanceRepository $instanceRepository,
+        private readonly PollManager $pollManager,
     ) {
     }
 
@@ -125,7 +127,15 @@ class Page extends ActivityPubContent
 
             $this->logger->debug('creating page');
 
-            return $this->entryManager->create($dto, $actor, false, $stickyIt);
+            $entry = $this->entryManager->create($dto, $actor, false, $stickyIt);
+
+            if ($this->pollManager->hasPollProperties($object)) {
+                $poll = $this->pollManager->createFromApObject($object);
+                $entry->poll = $poll;
+                $this->entityManager->flush();
+            }
+
+            return $entry;
         } else {
             throw new EntityNotFoundException('Actor could not be found for entry.');
         }

--- a/src/Service/ActivityPub/Wrapper/CreateWrapper.php
+++ b/src/Service/ActivityPub/Wrapper/CreateWrapper.php
@@ -28,6 +28,8 @@ class CreateWrapper
             $activity->userActor = $item->getUser();
         } elseif ($item instanceof Message) {
             $activity->userActor = $item->sender;
+        } else {
+            $activity->userActor = $item->getUser();
         }
         $this->entityManager->persist($activity);
         $this->entityManager->flush();

--- a/src/Service/EntryCommentManager.php
+++ b/src/Service/EntryCommentManager.php
@@ -45,6 +45,7 @@ class EntryCommentManager implements ContentManagerInterface
         private readonly EntityManagerInterface $entityManager,
         private readonly ImageRepository $imageRepository,
         private readonly SettingsManager $settingsManager,
+        private readonly PollManager $pollManager,
     ) {
     }
 
@@ -114,6 +115,10 @@ class EntryCommentManager implements ContentManagerInterface
         $this->entityManager->persist($comment);
         $this->entityManager->flush();
 
+        if ($dto->addPoll) {
+            $this->pollManager->createPoll($dto, $comment);
+        }
+
         $this->tagManager->updateEntryCommentTags($comment, $this->tagExtractor->extract($comment->body) ?? []);
 
         $this->dispatcher->dispatch(new EntryCommentCreatedEvent($comment));
@@ -149,6 +154,10 @@ class EntryCommentManager implements ContentManagerInterface
         $comment->editedAt = new \DateTimeImmutable('@'.time());
         if (empty($comment->body) && null === $comment->image) {
             throw new \Exception('Comment body and image cannot be empty');
+        }
+
+        if ($comment->poll) {
+            $this->pollManager->edit($comment->poll, $dto, $editedByUser);
         }
 
         $comment->apLikeCount = $dto->apLikeCount;

--- a/src/Service/EntryCommentManager.php
+++ b/src/Service/EntryCommentManager.php
@@ -135,7 +135,7 @@ class EntryCommentManager implements ContentManagerInterface
         return $entryCommentHost === $userHost || $userHost === $magazineHost || $comment->magazine->userIsModerator($user);
     }
 
-    public function edit(EntryComment $comment, EntryCommentDto $dto, ?User $editedByUser = null): EntryComment
+    public function edit(EntryComment $comment, EntryCommentDto $dto, ?User $editedByUser = null, bool $contentChanged = true): EntryComment
     {
         Assert::same($comment->entry->getId(), $dto->entry->getId());
 
@@ -156,7 +156,7 @@ class EntryCommentManager implements ContentManagerInterface
             throw new \Exception('Comment body and image cannot be empty');
         }
 
-        if ($comment->poll) {
+        if ($comment->poll && $contentChanged) {
             $this->pollManager->edit($comment->poll, $dto, $editedByUser);
         }
 

--- a/src/Service/EntryManager.php
+++ b/src/Service/EntryManager.php
@@ -68,6 +68,7 @@ class EntryManager implements ContentManagerInterface
         private readonly ImageRepository $imageRepository,
         private readonly ApHttpClientInterface $apHttpClient,
         private readonly CacheInterface $cache,
+        private readonly PollManager $pollManager,
     ) {
     }
 
@@ -144,6 +145,10 @@ class EntryManager implements ContentManagerInterface
         $this->entityManager->persist($entry);
         $this->entityManager->flush();
 
+        if ($dto->addPoll) {
+            $this->pollManager->createPoll($dto, $entry);
+        }
+
         $tags = array_unique(array_merge($this->tagExtractor->extract($entry->body) ?? [], $dto->tags ?? []));
         $this->tagManager->updateEntryTags($entry, $tags);
 
@@ -219,6 +224,10 @@ class EntryManager implements ContentManagerInterface
         }
         if (empty($entry->body) && empty($entry->title) && null === $entry->image && null === $entry->url) {
             throw new \Exception('Entry body, name, url and image cannot all be empty');
+        }
+
+        if ($entry->poll) {
+            $this->pollManager->edit($entry->poll, $dto, $editedBy);
         }
 
         $entry->apLikeCount = $dto->apLikeCount;

--- a/src/Service/EntryManager.php
+++ b/src/Service/EntryManager.php
@@ -194,7 +194,7 @@ class EntryManager implements ContentManagerInterface
         return $entryHost === $userHost || $userHost === $magazineHost || $entry->magazine->userIsModerator($user);
     }
 
-    public function edit(Entry $entry, EntryDto $dto, User $editedBy): Entry
+    public function edit(Entry $entry, EntryDto $dto, User $editedBy, bool $contentChanged = true): Entry
     {
         Assert::same($entry->magazine->getId(), $dto->magazine->getId());
 
@@ -226,7 +226,7 @@ class EntryManager implements ContentManagerInterface
             throw new \Exception('Entry body, name, url and image cannot all be empty');
         }
 
-        if ($entry->poll) {
+        if ($entry->poll && $contentChanged) {
             $this->pollManager->edit($entry->poll, $dto, $editedBy);
         }
 
@@ -249,6 +249,19 @@ class EntryManager implements ContentManagerInterface
         $this->dispatcher->dispatch(new EntryEditedEvent($entry, $editedBy));
 
         return $entry;
+    }
+
+    public function refreshFromRemote(Entry $entry, EntryDto $dto): void
+    {
+        if ($entry->poll) {
+            $this->pollManager->refreshFromRemote($entry->poll, $dto);
+        }
+
+        $entry->apLikeCount = $dto->apLikeCount;
+        $entry->apDislikeCount = $dto->apDislikeCount;
+        $entry->apShareCount = $dto->apShareCount;
+        $entry->updateScore();
+        $entry->updateRanking();
     }
 
     public function delete(User $user, Entry $entry): void

--- a/src/Service/EntryManager.php
+++ b/src/Service/EntryManager.php
@@ -68,6 +68,7 @@ class EntryManager implements ContentManagerInterface
         private readonly ImageRepository $imageRepository,
         private readonly ApHttpClientInterface $apHttpClient,
         private readonly CacheInterface $cache,
+        private readonly PollManager $pollManager,
     ) {
     }
 
@@ -143,6 +144,10 @@ class EntryManager implements ContentManagerInterface
 
         $this->entityManager->persist($entry);
         $this->entityManager->flush();
+
+        if ($dto->addPoll) {
+            $this->pollManager->createPoll($dto, $entry);
+        }
 
         $tags = array_unique(array_merge($this->tagExtractor->extract($entry->body) ?? [], $dto->tags ?? []));
         $this->tagManager->updateEntryTags($entry, $tags);
@@ -220,6 +225,10 @@ class EntryManager implements ContentManagerInterface
         }
         if (empty($entry->body) && empty($entry->title) && null === $entry->image && null === $entry->url) {
             throw new \Exception('Entry body, name, url and image cannot all be empty');
+        }
+
+        if ($entry->poll) {
+            $this->pollManager->edit($entry->poll, $dto, $editedBy);
         }
 
         $entry->apLikeCount = $dto->apLikeCount;

--- a/src/Service/EntryManager.php
+++ b/src/Service/EntryManager.php
@@ -195,7 +195,7 @@ class EntryManager implements ContentManagerInterface
         return $entryHost === $userHost || $userHost === $magazineHost || $entry->magazine->userIsModerator($user);
     }
 
-    public function edit(Entry $entry, EntryDto $dto, User $editedBy): Entry
+    public function edit(Entry $entry, EntryDto $dto, User $editedBy, bool $contentChanged = true): Entry
     {
         Assert::same($entry->magazine->getId(), $dto->magazine->getId());
 
@@ -227,7 +227,7 @@ class EntryManager implements ContentManagerInterface
             throw new \Exception('Entry body, name, url and image cannot all be empty');
         }
 
-        if ($entry->poll) {
+        if ($entry->poll && $contentChanged) {
             $this->pollManager->edit($entry->poll, $dto, $editedBy);
         }
 
@@ -250,6 +250,19 @@ class EntryManager implements ContentManagerInterface
         $this->dispatcher->dispatch(new EntryEditedEvent($entry, $editedBy));
 
         return $entry;
+    }
+
+    public function refreshFromRemote(Entry $entry, EntryDto $dto): void
+    {
+        if ($entry->poll) {
+            $this->pollManager->refreshFromRemote($entry->poll, $dto);
+        }
+
+        $entry->apLikeCount = $dto->apLikeCount;
+        $entry->apDislikeCount = $dto->apDislikeCount;
+        $entry->apShareCount = $dto->apShareCount;
+        $entry->updateScore();
+        $entry->updateRanking();
     }
 
     public function delete(User $user, Entry $entry): void

--- a/src/Service/Notification/PollNotificationManager.php
+++ b/src/Service/Notification/PollNotificationManager.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Notification;
+
+use App\Entity\Poll;
+use App\Entity\PollEditedNotification;
+use App\Entity\PollEndedNotification;
+use App\Repository\PollRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+readonly class PollNotificationManager
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private PollRepository $pollRepository,
+    ) {
+    }
+
+    public function sendPollEditedNotification(Poll $poll): void
+    {
+        foreach ($this->pollRepository->getAllLocalVotersOfPoll($poll) as $user) {
+            $notification = new PollEditedNotification($user, $poll);
+            $this->entityManager->persist($notification);
+        }
+        $this->entityManager->flush();
+    }
+
+    public function sendPollEndedNotification(Poll $poll): void
+    {
+        foreach ($this->pollRepository->getAllLocalVotersOfPoll($poll) as $user) {
+            $notification = new PollEndedNotification($user, $poll);
+            $this->entityManager->persist($notification);
+        }
+        $this->entityManager->flush();
+    }
+}

--- a/src/Service/NotificationManager.php
+++ b/src/Service/NotificationManager.php
@@ -10,6 +10,7 @@ use App\Entity\Message;
 use App\Entity\MessageNotification;
 use App\Entity\Notification;
 use App\Entity\User;
+use App\Repository\PollRepository;
 use App\Service\Notification\MagazineBanNotificationManager;
 use App\Service\Notification\MessageNotificationManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -21,6 +22,7 @@ class NotificationManager
         private readonly MessageNotificationManager $messageNotificationManager,
         private readonly EntityManagerInterface $entityManager,
         private readonly MagazineBanNotificationManager $magazineBanNotificationManager,
+        private readonly PollRepository $pollRepository,
     ) {
     }
 

--- a/src/Service/PollManager.php
+++ b/src/Service/PollManager.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\DTO\ContentWithPollDto;
+use App\Entity\Entry;
+use App\Entity\EntryComment;
+use App\Entity\Poll;
+use App\Entity\PollChoice;
+use App\Entity\PollVote;
+use App\Entity\Post;
+use App\Entity\PostComment;
+use App\Entity\User;
+use App\Event\Poll\PollEditedEvent;
+use App\Event\Poll\PollPreEditedEvent;
+use App\Event\Poll\PollVoteEvent;
+use App\Exception\PollHasEndedException;
+use App\Repository\EntryCommentRepository;
+use App\Repository\EntryRepository;
+use App\Repository\PostCommentRepository;
+use App\Repository\PostRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Exception\ORMException;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+readonly class PollManager
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private EventDispatcherInterface $eventDispatcher,
+        private EntryRepository $entryRepository,
+        private EntryCommentRepository $entryCommentRepository,
+        private PostRepository $postRepository,
+        private PostCommentRepository $postCommentRepository,
+    ) {
+    }
+
+    public function createPoll(ContentWithPollDto $dto, Entry|EntryComment|Post|PostComment $object): Poll
+    {
+        $poll = new Poll();
+        $poll->multipleChoice = $dto->isMultipleChoicePoll;
+        $this->entityManager->persist($poll);
+
+        $this->createChoices($dto, $poll);
+        $object->poll = $poll;
+        $this->entityManager->flush();
+
+        return $poll;
+    }
+
+    public function edit(?Poll $poll, ContentWithPollDto $dto, User $editor): void
+    {
+        $this->eventDispatcher->dispatch(new PollPreEditedEvent($poll, $this->getContentOfPoll($poll), $editor));
+        $poll->endDate = $dto->pollEndsAt;
+        $poll->multipleChoice = $dto->isMultipleChoicePoll;
+        foreach ($poll->choices as $choice) {
+            // remove all choices, which also removes all votes
+            $this->entityManager->remove($choice);
+        }
+        $this->createChoices($dto, $poll);
+        $this->entityManager->flush();
+        $this->eventDispatcher->dispatch(new PollEditedEvent($poll, $this->getContentOfPoll($poll), $editor));
+    }
+
+    private function createChoices(ContentWithPollDto $dto, Poll $poll): void
+    {
+        foreach ($dto->choices as $choice) {
+            if (!trim($choice ?? '')) {
+                continue;
+            }
+            $pollChoice = new PollChoice();
+            $pollChoice->poll = $poll;
+            $pollChoice->name = trim($choice);
+            $poll->choices[] = $pollChoice;
+            $this->entityManager->persist($pollChoice);
+        }
+    }
+
+    /**
+     * @param Entry|EntryComment|Post|PostComment $content              where the poll belongs to
+     * @param string[]                            $choices              the choices a user votes for
+     * @param bool                                $allowMultipleChoices if the context allows for the user to vote again, that should only be allowed from activity pub
+     *
+     * @throws ORMException
+     * @throws PollHasEndedException
+     * @throws \LogicException
+     */
+    public function vote(Poll $poll, Entry|EntryComment|Post|PostComment $content, User $user, array $choices, bool $allowMultipleChoices = false): void
+    {
+        if (!$poll->multipleChoice && \sizeof($choices) > 1) {
+            throw new \LogicException('Poll does not allow multiple choices.');
+        }
+        if (0 === \sizeof($choices)) {
+            throw new \LogicException('No choice found');
+        }
+        if ($poll->hasUserVoted($user) && !$allowMultipleChoices) {
+            throw new \LogicException('Already voted');
+        }
+        if ($poll->hasEnded()) {
+            throw new PollHasEndedException('Poll has already ended');
+        }
+
+        $voteEntities = [];
+        foreach (array_unique($choices) as $choice) {
+            $choiceEntity = $poll->findChoice($choice);
+            $vote = new PollVote();
+            $vote->voter = $user;
+            $vote->poll = $poll;
+            $vote->choice = $choiceEntity;
+            $this->entityManager->persist($vote);
+            $voteEntities[] = $vote;
+            $this->entityManager->flush();
+            $this->entityManager->refresh($choiceEntity);
+            $choiceEntity->updateVoteCount();
+        }
+        $this->entityManager->flush();
+        $this->entityManager->refresh($poll);
+        $poll->updateVoterCount();
+        $this->entityManager->flush();
+
+        $this->eventDispatcher->dispatch(new PollVoteEvent($poll, $content, $user, $voteEntities));
+    }
+
+    public function getContentOfPoll(Poll $poll): Entry|EntryComment|Post|PostComment|null
+    {
+        return $this->entryRepository->findOneBy(['poll' => $poll])
+            ?? $this->entryCommentRepository->findOneBy(['poll' => $poll])
+            ?? $this->postRepository->findOneBy(['poll' => $poll])
+            ?? $this->postCommentRepository->findOneBy(['poll' => $poll])
+        ;
+    }
+
+    public function hasPollProperties(array $object): bool
+    {
+        if ('Question' === $object['type'] && isset($object['votersCount']) && isset($object['endTime']) && (isset($object['anyOf']) || isset($object['oneOf']))) {
+            $choices = $object['anyOf'] ?? $object['oneOf'];
+            if (\is_array($choices)) {
+                foreach ($choices as $choice) {
+                    if (!\is_array($choice)) {
+                        return false;
+                    }
+                    if (isset($choice['type']) && 'Note' === $choice['type'] && isset($choice['name']) && \is_string($choice['name'])) {
+                        if (isset($choice['replies']['type']) && 'Collection' === $choice['replies']['type'] && isset($choice['replies']['totalItems'])) {
+                            // this is the positive case
+                        } else {
+                            return false;
+                        }
+                    } else {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Call PollManager::canCreateFromApObject() first, this that $object contains all the necessary information.
+     *
+     * @throws \DateMalformedStringException
+     */
+    public function createFromApObject(array $object): Poll
+    {
+        $poll = new Poll();
+        $poll->endDate = new \DateTimeImmutable($object['endTime']);
+        $poll->createdAt = new \DateTimeImmutable($object['published']);
+        $poll->isRemote = true;
+        $poll->voterCount = $object['votersCount'];
+        $poll->multipleChoice = isset($object['anyOf']);
+
+        $choices = $object['anyOf'] ?? $object['oneOf'];
+        $choiceNames = [];
+        foreach ($choices as $choice) {
+            if (array_find($choiceNames, fn (string $choiceName) => $choiceName === $choice['name'])) {
+                // do not create duplicate choices
+                continue;
+            }
+            $pollChoice = new PollChoice();
+            $pollChoice->poll = $poll;
+            $pollChoice->name = $choice['name'];
+            $pollChoice->voteCount = $choice['replies']['totalItems'];
+            $this->entityManager->persist($pollChoice);
+        }
+        $this->entityManager->persist($poll);
+        $this->entityManager->flush();
+
+        return $poll;
+    }
+
+    /**
+     * Call PollManager::canCreateFromApObject() first, this that $payload contains all the necessary information.
+     */
+    public function updatePollCounts(Poll $poll, array $payload): void
+    {
+        $poll->voterCount = $payload['voterCount'];
+
+        $choices = $payload['anyOf'] ?? $payload['oneOf'];
+        foreach ($choices as $choice) {
+            $pollChoice = $poll->findChoice($choice['name']);
+            $pollChoice->voteCount = $choice['replies']['totalItems'];
+        }
+        $this->entityManager->flush();
+    }
+}

--- a/src/Service/PollManager.php
+++ b/src/Service/PollManager.php
@@ -23,6 +23,7 @@ use App\Repository\PostCommentRepository;
 use App\Repository\PostRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\ORMException;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 readonly class PollManager
@@ -34,6 +35,7 @@ readonly class PollManager
         private EntryCommentRepository $entryCommentRepository,
         private PostRepository $postRepository,
         private PostCommentRepository $postCommentRepository,
+        private LoggerInterface $logger,
     ) {
     }
 
@@ -41,6 +43,7 @@ readonly class PollManager
     {
         $poll = new Poll();
         $poll->multipleChoice = $dto->isMultipleChoicePoll;
+        $poll->endDate = $dto->pollEndsAt;
         $this->entityManager->persist($poll);
 
         $this->createChoices($dto, $poll);
@@ -52,6 +55,7 @@ readonly class PollManager
 
     public function edit(?Poll $poll, ContentWithPollDto $dto, User $editor): void
     {
+        $this->logger->info('[PollManager] the poll {p} was changed, resetting all votes', ['p' => $poll->getId()]);
         $this->eventDispatcher->dispatch(new PollPreEditedEvent($poll, $this->getContentOfPoll($poll), $editor));
         $poll->endDate = $dto->pollEndsAt;
         $poll->multipleChoice = $dto->isMultipleChoicePoll;
@@ -134,7 +138,7 @@ readonly class PollManager
 
     public function hasPollProperties(array $object): bool
     {
-        if ('Question' === $object['type'] && isset($object['votersCount']) && isset($object['endTime']) && (isset($object['anyOf']) || isset($object['oneOf']))) {
+        if ('Question' === $object['type'] && isset($object['votersCount']) && (isset($object['endTime']) || isset($object['closed'])) && (isset($object['anyOf']) || isset($object['oneOf']))) {
             $choices = $object['anyOf'] ?? $object['oneOf'];
             if (\is_array($choices)) {
                 foreach ($choices as $choice) {
@@ -167,7 +171,7 @@ readonly class PollManager
     public function createFromApObject(array $object): Poll
     {
         $poll = new Poll();
-        $poll->endDate = new \DateTimeImmutable($object['endTime']);
+        $poll->endDate = new \DateTimeImmutable($object['endTime'] ?? $object['closed']);
         $poll->createdAt = new \DateTimeImmutable($object['published']);
         $poll->isRemote = true;
         $poll->voterCount = $object['votersCount'];
@@ -197,7 +201,8 @@ readonly class PollManager
      */
     public function updatePollCounts(Poll $poll, array $payload): void
     {
-        $poll->voterCount = $payload['voterCount'];
+        $this->logger->info('[PollManager] Updating vote counts for poll {p}', ['p' => $poll->getId()]);
+        $poll->voterCount = $payload['votersCount'];
 
         $choices = $payload['anyOf'] ?? $payload['oneOf'];
         foreach ($choices as $choice) {
@@ -205,5 +210,55 @@ readonly class PollManager
             $pollChoice->voteCount = $choice['replies']['totalItems'];
         }
         $this->entityManager->flush();
+    }
+
+    public function extractPollChanges(array $object, ContentWithPollDto $dto): bool
+    {
+        $isContentSame = true;
+        $dto->addPoll = true;
+        $isMultipleChoice = isset($object['anyOf']);
+        if ($dto->isMultipleChoicePoll !== $isMultipleChoice) {
+            $isContentSame = false;
+            $this->logger->debug('[PollManager::extractPollChanges] multiple choice setting is not the same: {p} -> {n}', [
+                'p' => $dto->isMultipleChoicePoll,
+                'n' => $isMultipleChoice,
+            ]);
+        }
+        $dto->isMultipleChoicePoll = $isMultipleChoice;
+        $endTime = new \DateTimeImmutable($object['endTime'] ?? $object['closed']);
+        if ($dto->pollEndsAt->getTimestamp() !== $endTime->getTimestamp()) {
+            $isContentSame = false;
+            $this->logger->debug('[PollManager::extractPollChanges] endTime is not the same: {p} -> {n}', [
+                'p' => $dto->pollEndsAt,
+                'n' => $endTime,
+            ]);
+        }
+        $dto->pollEndsAt = $endTime;
+
+        $choicesObject = $object['anyOf'] ?? $object['oneOf'];
+        $choices = [];
+        foreach ($choicesObject as $choice) {
+            $choiceName = $choice['name'];
+            $choices[] = $choiceName;
+            if (!\in_array($choiceName, $dto->choices)) {
+                $isContentSame = false;
+                $this->logger->debug('[PollManager::extractPollChanges] choice {c} did not exist previously', [
+                    'c' => $choiceName,
+                ]);
+            }
+        }
+
+        foreach ($dto->choices as $choice) {
+            if (!\in_array($choice, $choices)) {
+                $isContentSame = false;
+                $this->logger->debug('[PollManager::extractPollChanges] choice {c} did exist previously, but doesn\'t anymore', [
+                    'c' => $choice,
+                ]);
+            }
+        }
+
+        $dto->choices = $choices;
+
+        return $isContentSame;
     }
 }

--- a/src/Service/PostCommentManager.php
+++ b/src/Service/PostCommentManager.php
@@ -45,6 +45,7 @@ class PostCommentManager implements ContentManagerInterface
         private readonly MessageBusInterface $bus,
         private readonly SettingsManager $settingsManager,
         private readonly EntityManagerInterface $entityManager,
+        private readonly PollManager $pollManager,
     ) {
     }
 
@@ -113,6 +114,10 @@ class PostCommentManager implements ContentManagerInterface
         $this->entityManager->persist($comment);
         $this->entityManager->flush();
 
+        if ($dto->addPoll) {
+            $this->pollManager->createPoll($dto, $comment);
+        }
+
         $this->tagManager->updatePostCommentTags($comment, $this->tagExtractor->extract($comment->body) ?? []);
 
         $this->dispatcher->dispatch(new PostCommentCreatedEvent($comment));
@@ -151,6 +156,10 @@ class PostCommentManager implements ContentManagerInterface
         $comment->editedAt = new \DateTimeImmutable('@'.time());
         if (empty($comment->body) && null === $comment->image) {
             throw new \Exception('Comment body and image cannot be empty');
+        }
+
+        if ($comment->poll) {
+            $this->pollManager->edit($comment->poll, $dto, $editedBy);
         }
 
         $comment->apLikeCount = $dto->apLikeCount;

--- a/src/Service/PostCommentManager.php
+++ b/src/Service/PostCommentManager.php
@@ -137,7 +137,7 @@ class PostCommentManager implements ContentManagerInterface
     /**
      * @throws \Exception
      */
-    public function edit(PostComment $comment, PostCommentDto $dto, ?User $editedBy = null): PostComment
+    public function edit(PostComment $comment, PostCommentDto $dto, ?User $editedBy = null, bool $contentChanged = true): PostComment
     {
         Assert::same($comment->post->getId(), $dto->post->getId());
 
@@ -158,7 +158,7 @@ class PostCommentManager implements ContentManagerInterface
             throw new \Exception('Comment body and image cannot be empty');
         }
 
-        if ($comment->poll) {
+        if ($comment->poll && $contentChanged) {
             $this->pollManager->edit($comment->poll, $dto, $editedBy);
         }
 

--- a/src/Service/PostManager.php
+++ b/src/Service/PostManager.php
@@ -60,6 +60,7 @@ class PostManager implements ContentManagerInterface
         private readonly ApHttpClientInterface $apHttpClient,
         private readonly SettingsManager $settingsManager,
         private readonly CacheInterface $cache,
+        private readonly PollManager $pollManager,
     ) {
     }
 
@@ -121,6 +122,10 @@ class PostManager implements ContentManagerInterface
         $this->entityManager->persist($post);
         $this->entityManager->flush();
 
+        if ($dto->addPoll) {
+            $this->pollManager->createPoll($dto, $post);
+        }
+
         $this->tagManager->updatePostTags($post, $this->tagExtractor->extract($post->body) ?? []);
 
         $this->dispatcher->dispatch(new PostCreatedEvent($post));
@@ -160,6 +165,10 @@ class PostManager implements ContentManagerInterface
         $post->editedAt = new \DateTimeImmutable('@'.time());
         if (empty($post->body) && null === $post->image) {
             throw new \Exception('Post body and image cannot be empty');
+        }
+
+        if ($post->poll) {
+            $this->pollManager->edit($post->poll, $dto, $editedBy);
         }
 
         $post->apLikeCount = $dto->apLikeCount;

--- a/src/Service/PostManager.php
+++ b/src/Service/PostManager.php
@@ -146,7 +146,7 @@ class PostManager implements ContentManagerInterface
         return $postHost === $userHost || $userHost === $magazineHost || $post->magazine->userIsModerator($user);
     }
 
-    public function edit(Post $post, PostDto $dto, ?User $editedBy = null): Post
+    public function edit(Post $post, PostDto $dto, ?User $editedBy = null, bool $contentChanged = true): Post
     {
         Assert::same($post->magazine->getId(), $dto->magazine->getId());
 
@@ -167,7 +167,7 @@ class PostManager implements ContentManagerInterface
             throw new \Exception('Post body and image cannot be empty');
         }
 
-        if ($post->poll) {
+        if ($post->poll && $contentChanged) {
             $this->pollManager->edit($post->poll, $dto, $editedBy);
         }
 

--- a/src/Twig/Components/PollComponent.php
+++ b/src/Twig/Components/PollComponent.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig\Components;
+
+use App\Entity\Poll;
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+#[AsTwigComponent('poll')]
+class PollComponent
+{
+    public Poll $poll;
+
+    public bool $isExternal = false;
+}

--- a/src/Twig/Extension/UrlExtension.php
+++ b/src/Twig/Extension/UrlExtension.php
@@ -41,6 +41,7 @@ final class UrlExtension extends AbstractExtension
             new TwigFunction('options_url', [UrlExtensionRuntime::class, 'optionsUrl']),
             new TwigFunction('mention_url', [UrlExtensionRuntime::class, 'mentionUrl']),
             new TwigFunction('get_cursor_url_value', [UrlExtensionRuntime::class, 'getCursorUrlValue']),
+            new TwigFunction('content_url', [UrlExtensionRuntime::class, 'contentUrl']),
         ];
     }
 }

--- a/src/Twig/Runtime/UrlExtensionRuntime.php
+++ b/src/Twig/Runtime/UrlExtensionRuntime.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Twig\Runtime;
 
+use App\Entity\Contracts\ContentInterface;
 use App\Entity\Entry;
 use App\Entity\EntryComment;
 use App\Entity\Post;
@@ -304,5 +305,20 @@ class UrlExtensionRuntime implements RuntimeExtensionInterface
         }
 
         return $cursor;
+    }
+
+    public function contentUrl(ContentInterface $content): string
+    {
+        if ($content instanceof Entry) {
+            return $this->entryUrl($content);
+        } elseif ($content instanceof EntryComment) {
+            return $this->entryCommentViewUrl($content);
+        } elseif ($content instanceof Post) {
+            return $this->postUrl($content);
+        } elseif ($content instanceof PostComment) {
+            return $this->postUrl($content->post).'#post-comment-'.$content->getId();
+        }
+
+        return '#';
     }
 }

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -88,6 +88,9 @@
                         <div data-collapsable-target="content" class="content formatted">
                             {{ entry.body|markdown("entry")|raw }}
                         </div>
+                        {% if entry.poll is not same as null %}
+                            {{ component('poll', {poll: entry.poll, isExternal: entry.apId is not same as null}) }}
+                        {% endif %}
                         <div data-collapsable-target="button"></div>
                     </div>
                 {% endif %}

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -76,6 +76,9 @@
                     {% elseif(comment.visibility is same as 'soft_deleted') %}
                         <p class="text-muted">&lsqb;<i>{{ 'deleted_by_author'|trans }}</i>&rsqb;</p>
                     {% endif %}
+                    {% if comment.poll is not same as null %}
+                        {{ component('poll', {poll: comment.poll, isExternal: comment.apId is not same as null}) }}
+                    {% endif %}
                 </div>
                 <div data-collapsable-target="button"></div>
             </div>

--- a/templates/components/poll.html.twig
+++ b/templates/components/poll.html.twig
@@ -1,0 +1,56 @@
+<div class="poll">
+    {% if app.user and poll.hasUserVoted(app.user) is not same as true and poll.hasEnded() is not same as true %}
+        <form action="/poll/{{ poll.id }}/vote" method="get">
+            {% if poll.multipleChoice %}
+                {% for choice in poll.choices %}
+                    <div class="checkbox">
+                        <label for="choice_{{ choice.id }}">{{ choice.name }}</label>
+                        <input id="choice_{{ choice.id }}" type="checkbox" name="choice[]" value="{{ choice.name }}" />
+                    </div>
+                {% endfor %}
+            {% else %}
+                {% for choice in poll.choices %}
+                    <div class="checkbox">
+                        <label for="choice_{{ choice.id }}">{{ choice.name }}</label>
+                        <input id="choice_{{ choice.id }}" type="radio" name="choice[]" value="{{ choice.name }}" />
+                    </div>
+                {% endfor %}
+            {% endif %}
+            <div class="text-right">
+                <button id="poll_vote_submit" class="btn btn__primary" type="submit">{{ 'poll_vote'|trans }}</button>
+            </div>
+        </form>
+    {% else %}
+        <div class="poll-result">
+            {% for choice in poll.getResultData(app.user) %}
+                <div class="choice-result">
+                    <div class="choice-label">
+                        <span class="percentage">{{ choice['percentage'] }}%</span>
+                        <span class="name">
+                            {{ choice['name'] }}
+                            {% if choice['userVoted'] %}
+                                <i class="fa fa-check"></i>
+                            {% endif %}
+                        </span>
+                    </div>
+                    <div class="choice-bar" style="width: {{ choice['percentage'] }}%"></div>
+                </div>
+            {% endfor %}
+        </div>
+        <div class="flex">
+            <div class="flex-item">
+                <span class="text-muted">{{ poll.voterCount }} {{ 'poll_voters'|trans({'%count%': poll.voterCount}) }}</span>
+                {% if poll.hasEnded %}
+                    <span style="margin-left: 2rem;">{{ 'poll_ended'|trans }} {{ component('date', {date: poll.endDate}) }}</span>
+                {% else %}
+                    <span style="margin-left: 2rem;">{{ 'poll_ends'|trans }} {{ component('date', {date: poll.endDate}) }}</span>
+                {% endif %}
+            </div>
+            {% if isExternal %}
+                <div class="flex-item text-right">
+                    <a href="">{{ 'poll_update_results'|trans }}</a>
+                </div>
+            {% endif %}
+        </div>
+    {% endif %}
+</div>

--- a/templates/components/poll.html.twig
+++ b/templates/components/poll.html.twig
@@ -1,5 +1,6 @@
 <div class="poll">
-    {% if app.user and poll.hasUserVoted(app.user) is not same as true and poll.hasEnded() is not same as true %}
+    {% set forceResults = app.request.query.get('showResults')|bool %}
+    {% if app.user and poll.hasUserVoted(app.user) is not same as true and poll.hasEnded() is not same as true and forceResults is not same as true %}
         <form action="/poll/{{ poll.id }}/vote" method="get">
             {% if poll.multipleChoice %}
                 {% for choice in poll.choices %}
@@ -16,7 +17,8 @@
                     </div>
                 {% endfor %}
             {% endif %}
-            <div class="text-right">
+            <div class="text-right actions">
+                <a href="{{ options_url('showResults', true) }}">{{ 'poll_show_results'|trans }}</a>
                 <button id="poll_vote_submit" class="btn btn__primary" type="submit">{{ 'poll_vote'|trans }}</button>
             </div>
         </form>
@@ -46,11 +48,14 @@
                     <span style="margin-left: 2rem;">{{ 'poll_ends'|trans }} {{ component('date', {date: poll.endDate}) }}</span>
                 {% endif %}
             </div>
-            {% if isExternal %}
-                <div class="flex-item text-right">
-                    <a href="">{{ 'poll_update_results'|trans }}</a>
-                </div>
-            {% endif %}
+            <div class="flex-item text-right actions">
+                {% if forceResults %}
+                    <a href="{{ options_url('showResults', null) }}">{{ 'poll_hide_results'|trans }}</a>
+                {% endif %}
+                {% if isExternal %}
+                    <a href="{{ path('poll_refresh', {id: poll.id}) }}">{{ 'poll_update_results'|trans }}</a>
+                {% endif %}
+            </div>
         </div>
     {% endif %}
 </div>

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -64,6 +64,10 @@
                 <div data-collapsable-target="content" class="content">
                     {% if post.visibility in ['visible', 'private'] or (post.visibility is same as 'trashed' and this.canSeeTrashed) %}
                         {{ post.body|markdown("post")|raw }}
+
+                        {% if post.poll is not same as null %}
+                            {{ component('poll', {poll: post.poll, isExternal: post.apId is not same as null}) }}
+                        {% endif %}
                     {% elseif(post.visibility is same as 'trashed') %}
                         <p class="text-muted">&lsqb;<i>{{ 'deleted_by_moderator'|trans }}</i>&rsqb;</p>
                     {% elseif(post.visibility is same as 'soft_deleted') %}

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -73,6 +73,9 @@
                     {% elseif(comment.visibility is same as 'soft_deleted') %}
                         <p class="text-muted">&lsqb;<i>{{ 'deleted_by_author'|trans }}</i>&rsqb;</p>
                     {% endif %}
+                    {% if comment.poll is not same as null %}
+                        {{ component('poll', {poll: comment.poll, isExternal: comment.apId is not same as null}) }}
+                    {% endif %}
                 </div>
                 <div data-collapsable-target="button"></div>
             </div>

--- a/templates/entry/_form_edit.html.twig
+++ b/templates/entry/_form_edit.html.twig
@@ -33,6 +33,31 @@
     {{ form_row(form.magazine, {label: false}) }}
     {{ form_row(form.tags, {label: 'tags'}) }}
     {# form_row(form.badges, {label: 'badges'}) #}
+
+    {% if entry.poll is not same as null %}
+        <hr />
+        <h5>{{ 'poll'|trans }}</h5>
+        <p>{{ 'poll_edit_voters_reset'|trans }}</p>
+        <div class="sub-form">
+            {{ form_row(form.isMultipleChoicePoll, {row_attr: {class: 'checkbox'}}) }}
+            {{ form_row(form.pollEndsAt, {attr: {style: 'padding: 1rem .5rem;'}}) }}
+
+            {{ form_label(form.choices) }}
+            <div {{ stimulus_controller('form_collection') }} class="collection-container hide-index"
+                                                              data-form-collection-index-value="{{ form.choices|length > 0 ? form.choices|last.vars.name + 1 : 0 }}"
+                                                              data-form-collection-prototype-value="{{ form_widget(form.choices.vars.prototype)|e('html_attr') }}"
+            >
+                {{ form_widget(form.choices) }}
+                <div class="choices-container" {{ stimulus_target('form-collection', 'collectionContainer') }}>
+                </div>
+                <div style="text-align: center;">
+                    <button class="btn btn__primary" type="button" {{ stimulus_action('form-collection', 'addCollectionElement') }}>
+                        {{ '+' }}
+                    </button>
+                </div>
+            </div>
+        </div>
+    {% endif %}
 <div class="row params">
     {{ form_row(form.isAdult, {label: 'is_adult', row_attr: {class: 'checkbox'}}) }}
     {{ form_row(form.isOc, {label: 'oc', row_attr: {class: 'checkbox'}}) }}

--- a/templates/entry/_form_entry.html.twig
+++ b/templates/entry/_form_entry.html.twig
@@ -44,6 +44,7 @@
     {{ form_row(form.magazine, {label: false}) }}
     {{ form_row(form.tags, {label: 'tags'}) }}
     {# form_row(form.badges, {label: 'badges'}) #}
+    {{ include('form/_poll_form.html.twig') }}
     <div class="row params">
         {{ form_row(form.isAdult, {label: 'is_adult', row_attr: {class: 'checkbox'}}) }}
         {{ form_row(form.isOc, {label: 'oc', row_attr: {class: 'checkbox'}}) }}

--- a/templates/entry/comment/_form_comment.html.twig
+++ b/templates/entry/comment/_form_comment.html.twig
@@ -22,7 +22,11 @@
     'data-controller': 'input-length rich-textarea autogrow',
     'data-action' : 'input-length#updateDisplay',
     'data-input-length-max-value': constant('App\\DTO\\EntryCommentDto::MAX_BODY_LENGTH')
-}}) }}<div class="row actions">
+}}) }}
+
+{{ include('form/_poll_form.html.twig') }}
+
+<div class="row actions">
     <ul>
         {% if hasImage %}
             <img width="40"

--- a/templates/form/_poll_form.html.twig
+++ b/templates/form/_poll_form.html.twig
@@ -1,0 +1,22 @@
+<div class="poll-area">
+    {{ form_row(form.addPoll, {row_attr: {class: 'checkbox', style: 'float: left; margin-right: 1rem'}}) }}
+    <div class="sub-form">
+        {{ form_row(form.isMultipleChoicePoll, {row_attr: {class: 'checkbox'}}) }}
+        {{ form_row(form.pollEndsAt, {attr: {style: 'padding: 1rem .5rem;'}}) }}
+
+        {{ form_label(form.choices) }}
+        <div {{ stimulus_controller('form_collection') }} class="collection-container hide-index"
+                                                          data-form-collection-index-value="{{ form.choices|length > 0 ? form.choices|last.vars.name + 1 : 0 }}"
+                                                          data-form-collection-prototype-value="{{ form_widget(form.choices.vars.prototype)|e('html_attr') }}"
+        >
+            {{ form_widget(form.choices) }}
+            <div class="choices-container" {{ stimulus_target('form-collection', 'collectionContainer') }}>
+            </div>
+            <div style="text-align: center;">
+                <button class="btn btn__primary" type="button" {{ stimulus_action('form-collection', 'addCollectionElement') }}>
+                    {{ '+' }}
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/notifications/_blocks.html.twig
+++ b/templates/notifications/_blocks.html.twig
@@ -187,3 +187,13 @@
         </div>
     {% endif %}
 {% endblock %}
+
+{% block poll_ended %}
+    {{ 'notification_title_poll_ended'|trans }}:
+    <a href="{{ content_url(notification.poll.getSubject()) }}">{{ notification.poll.getSubject().shortTitle }}</a>
+{% endblock %}
+
+{% block poll_edited %}
+    {{ 'notification_title_poll_edited'|trans }}:
+    <a href="{{ content_url(notification.poll.getSubject()) }}">{{ notification.poll.getSubject().shortTitle }}</a>
+{% endblock %}

--- a/templates/post/_form_post.html.twig
+++ b/templates/post/_form_post.html.twig
@@ -29,6 +29,7 @@
         'data-input-length-max-value': constant('App\\DTO\\PostDto::MAX_BODY_LENGTH')
         }}) }}
 </div>
+{{ include('form/_poll_form.html.twig') }}
 <div class="row params">
     {{ form_row(form.isAdult, {label:'is_adult'}) }}
     {{ form_row(form.magazine, {label: false, attr: {placeholder: false}}) }}

--- a/templates/post/comment/_form_comment.html.twig
+++ b/templates/post/comment/_form_comment.html.twig
@@ -25,6 +25,9 @@
         'data-input-length-max-value': constant('App\\DTO\\PostCommentDto::MAX_BODY_LENGTH')
     }}) }}
 </div>
+
+{{ include('form/_poll_form.html.twig') }}
+
 <div class="row actions">
     <ul>
         {% if hasImage %}

--- a/tests/ActivityPubJsonDriver.php
+++ b/tests/ActivityPubJsonDriver.php
@@ -70,6 +70,10 @@ class ActivityPubJsonDriver extends JsonDriver
             $data['updated'] = 'SCRUBBED_DATE';
         }
 
+        if (isset($data['endTime'])) {
+            $data['endTime'] = 'SCRUBBED_DATE';
+        }
+
         if (isset($data['publicKey'])) {
             $data['publicKey'] = 'SCRUBBED_KEY';
         }
@@ -113,6 +117,10 @@ class ActivityPubJsonDriver extends JsonDriver
 
         if (isset($data->updated)) {
             $data->updated = 'SCRUBBED_DATE';
+        }
+
+        if (isset($data->endTime)) {
+            $data->endTime = 'SCRUBBED_DATE';
         }
 
         if (isset($data->publicKey)) {

--- a/tests/FactoryTrait.php
+++ b/tests/FactoryTrait.php
@@ -23,6 +23,8 @@ use App\Entity\Magazine;
 use App\Entity\Message;
 use App\Entity\MessageThread;
 use App\Entity\Notification;
+use App\Entity\Poll;
+use App\Entity\PollChoice;
 use App\Entity\Post;
 use App\Entity\PostComment;
 use App\Entity\Site;
@@ -638,5 +640,23 @@ trait FactoryTrait
         assertNotNull($dto->id);
 
         return $dto;
+    }
+
+    protected function createSimplePoll(bool $isMultipleChoice, bool $isRemote): Poll
+    {
+        $poll = new Poll();
+        $poll->multipleChoice = $isMultipleChoice;
+        $poll->isRemote = $isRemote;
+        $this->entityManager->persist($poll);
+        foreach (['A', 'B', 'C'] as $choiceName) {
+            $choice = new PollChoice();
+            $choice->name = $choiceName;
+            $choice->poll = $poll;
+            $poll->choices->add($choice);
+            $this->entityManager->persist($choice);
+        }
+        $this->entityManager->refresh($poll);
+
+        return $poll;
     }
 }

--- a/tests/Functional/ActivityPub/ActivityPubFunctionalTestCase.php
+++ b/tests/Functional/ActivityPub/ActivityPubFunctionalTestCase.php
@@ -12,6 +12,8 @@ use App\Entity\Entry;
 use App\Entity\EntryComment;
 use App\Entity\Magazine;
 use App\Entity\Message;
+use App\Entity\Poll;
+use App\Entity\PollVote;
 use App\Entity\Post;
 use App\Entity\PostComment;
 use App\Entity\User;
@@ -193,9 +195,13 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
     /**
      * @param callable(Entry $entry):void|null $entryCreateCallback
      */
-    protected function createRemoteEntryInRemoteMagazine(Magazine $magazine, User $user, ?callable $entryCreateCallback = null): array
+    protected function createRemoteEntryInRemoteMagazine(Magazine $magazine, User $user, ?callable $entryCreateCallback = null, bool $addPoll = false): array
     {
-        $entry = $this->getEntryByTitle('remote entry', magazine: $magazine, user: $user);
+        $entry = $this->getEntryByTitle('remote entry'.($addPoll ? ' with poll' : ''), magazine: $magazine, user: $user);
+        if ($addPoll) {
+            $entry->poll = $this->createSimplePoll(false, true);
+        }
+
         $json = $this->pageFactory->create($entry, $this->tagLinkRepository->getTagsOfContent($entry));
         $this->testingApHttpClient->activityObjects[$json['id']] = $json;
 
@@ -213,6 +219,9 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
 
         $this->entitiesToRemoveAfterSetup[] = $announceActivity;
         $this->entitiesToRemoveAfterSetup[] = $createActivity;
+        if ($addPoll) {
+            $this->entitiesToRemoveAfterSetup[] = $entry->poll;
+        }
         $this->entitiesToRemoveAfterSetup[] = $entry;
 
         return $announce;
@@ -221,11 +230,14 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
     /**
      * @param callable(EntryComment $entry):void|null $entryCommentCreateCallback
      */
-    protected function createRemoteEntryCommentInRemoteMagazine(Magazine $magazine, User $user, ?callable $entryCommentCreateCallback = null): array
+    protected function createRemoteEntryCommentInRemoteMagazine(Magazine $magazine, User $user, ?callable $entryCommentCreateCallback = null, bool $addPoll = false): array
     {
         $entries = array_filter($this->entitiesToRemoveAfterSetup, fn ($item) => $item instanceof Entry);
         $entry = $entries[array_key_first($entries)];
-        $comment = $this->createEntryComment('remote entry comment', $entry, $user);
+        $comment = $this->createEntryComment('remote entry comment'.($addPoll ? ' with poll' : ''), $entry, $user);
+        if ($addPoll) {
+            $comment->poll = $this->createSimplePoll(false, true);
+        }
         $json = $this->entryCommentNoteFactory->create($comment, $this->tagLinkRepository->getTagsOfContent($comment));
         $this->testingApHttpClient->activityObjects[$json['id']] = $json;
 
@@ -243,6 +255,9 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
 
         $this->entitiesToRemoveAfterSetup[] = $announceActivity;
         $this->entitiesToRemoveAfterSetup[] = $createActivity;
+        if ($addPoll) {
+            $this->entitiesToRemoveAfterSetup[] = $comment->poll;
+        }
         $this->entitiesToRemoveAfterSetup[] = $comment;
 
         return $announce;
@@ -251,9 +266,12 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
     /**
      * @param callable(Post $entry):void|null $postCreateCallback
      */
-    protected function createRemotePostInRemoteMagazine(Magazine $magazine, User $user, ?callable $postCreateCallback = null): array
+    protected function createRemotePostInRemoteMagazine(Magazine $magazine, User $user, ?callable $postCreateCallback = null, bool $addPoll = false): array
     {
-        $post = $this->createPost('remote post', magazine: $magazine, user: $user);
+        $post = $this->createPost('remote post'.($addPoll ? ' with poll' : ''), magazine: $magazine, user: $user);
+        if ($addPoll) {
+            $post->poll = $this->createSimplePoll(false, true);
+        }
         $json = $this->postNoteFactory->create($post, $this->tagLinkRepository->getTagsOfContent($post));
         $this->testingApHttpClient->activityObjects[$json['id']] = $json;
 
@@ -271,6 +289,9 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
 
         $this->entitiesToRemoveAfterSetup[] = $announceActivity;
         $this->entitiesToRemoveAfterSetup[] = $createActivity;
+        if ($addPoll) {
+            $this->entitiesToRemoveAfterSetup[] = $post->poll;
+        }
         $this->entitiesToRemoveAfterSetup[] = $post;
 
         return $announce;
@@ -279,11 +300,14 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
     /**
      * @param callable(PostComment $entry):void|null $postCommentCreateCallback
      */
-    protected function createRemotePostCommentInRemoteMagazine(Magazine $magazine, User $user, ?callable $postCommentCreateCallback = null): array
+    protected function createRemotePostCommentInRemoteMagazine(Magazine $magazine, User $user, ?callable $postCommentCreateCallback = null, bool $addPoll = false): array
     {
         $posts = array_filter($this->entitiesToRemoveAfterSetup, fn ($item) => $item instanceof Post);
         $post = $posts[array_key_first($posts)];
-        $comment = $this->createPostComment('remote post comment', $post, $user);
+        $comment = $this->createPostComment('remote post comment'.($addPoll ? ' with poll' : ''), $post, $user);
+        if ($addPoll) {
+            $comment->poll = $this->createSimplePoll(false, true);
+        }
         $json = $this->postCommentNoteFactory->create($comment, $this->tagLinkRepository->getTagsOfContent($comment));
         $this->testingApHttpClient->activityObjects[$json['id']] = $json;
 
@@ -301,6 +325,9 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
 
         $this->entitiesToRemoveAfterSetup[] = $announceActivity;
         $this->entitiesToRemoveAfterSetup[] = $createActivity;
+        if ($addPoll) {
+            $this->entitiesToRemoveAfterSetup[] = $comment->poll;
+        }
         $this->entitiesToRemoveAfterSetup[] = $comment;
 
         return $announce;
@@ -309,9 +336,12 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
     /**
      * @param callable(Entry $entry):void|null $entryCreateCallback
      */
-    protected function createRemoteEntryInLocalMagazine(Magazine $magazine, User $user, ?callable $entryCreateCallback = null): array
+    protected function createRemoteEntryInLocalMagazine(Magazine $magazine, User $user, ?callable $entryCreateCallback = null, bool $addPoll = false, $pollMultipleChoice = false): array
     {
-        $entry = $this->getEntryByTitle('remote entry in local', magazine: $magazine, user: $user);
+        $entry = $this->getEntryByTitle('remote entry in local'.($addPoll ? ' with poll' : ''), magazine: $magazine, user: $user);
+        if ($addPoll) {
+            $entry->poll = $this->createSimplePoll($pollMultipleChoice, true);
+        }
         $json = $this->pageFactory->create($entry, $this->tagLinkRepository->getTagsOfContent($entry));
         $this->testingApHttpClient->activityObjects[$json['id']] = $json;
 
@@ -326,6 +356,9 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
         }
 
         $this->entitiesToRemoveAfterSetup[] = $createActivity;
+        if ($addPoll) {
+            $this->entitiesToRemoveAfterSetup[] = $entry->poll;
+        }
         $this->entitiesToRemoveAfterSetup[] = $entry;
 
         return $create;
@@ -334,11 +367,14 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
     /**
      * @param callable(EntryComment $entry):void|null $entryCommentCreateCallback
      */
-    protected function createRemoteEntryCommentInLocalMagazine(Magazine $magazine, User $user, ?callable $entryCommentCreateCallback = null): array
+    protected function createRemoteEntryCommentInLocalMagazine(Magazine $magazine, User $user, ?callable $entryCommentCreateCallback = null, bool $addPoll = false): array
     {
         $entries = array_filter($this->entitiesToRemoveAfterSetup, fn ($item) => $item instanceof Entry && 'remote entry in local' === $item->title);
         $entry = $entries[array_key_first($entries)];
-        $comment = $this->createEntryComment('remote entry comment', $entry, $user);
+        $comment = $this->createEntryComment('remote entry comment'.($addPoll ? ' with poll' : ''), $entry, $user);
+        if ($addPoll) {
+            $comment->poll = $this->createSimplePoll(false, true);
+        }
         $json = $this->entryCommentNoteFactory->create($comment, $this->tagLinkRepository->getTagsOfContent($comment));
         $this->testingApHttpClient->activityObjects[$json['id']] = $json;
 
@@ -353,6 +389,9 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
         }
 
         $this->entitiesToRemoveAfterSetup[] = $createActivity;
+        if ($addPoll) {
+            $this->entitiesToRemoveAfterSetup[] = $comment->poll;
+        }
         $this->entitiesToRemoveAfterSetup[] = $comment;
 
         return $create;
@@ -361,9 +400,12 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
     /**
      * @param callable(Post $entry):void|null $postCreateCallback
      */
-    protected function createRemotePostInLocalMagazine(Magazine $magazine, User $user, ?callable $postCreateCallback = null): array
+    protected function createRemotePostInLocalMagazine(Magazine $magazine, User $user, ?callable $postCreateCallback = null, bool $addPoll = false): array
     {
-        $post = $this->createPost('remote post in local', magazine: $magazine, user: $user);
+        $post = $this->createPost('remote post in local'.($addPoll ? ' with poll' : ''), magazine: $magazine, user: $user);
+        if ($addPoll) {
+            $post->poll = $this->createSimplePoll(false, true);
+        }
         $json = $this->postNoteFactory->create($post, $this->tagLinkRepository->getTagsOfContent($post));
         $this->testingApHttpClient->activityObjects[$json['id']] = $json;
 
@@ -378,6 +420,9 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
         }
 
         $this->entitiesToRemoveAfterSetup[] = $createActivity;
+        if ($addPoll) {
+            $this->entitiesToRemoveAfterSetup[] = $post->poll;
+        }
         $this->entitiesToRemoveAfterSetup[] = $post;
 
         return $create;
@@ -386,11 +431,14 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
     /**
      * @param callable(PostComment $entry):void|null $postCommentCreateCallback
      */
-    protected function createRemotePostCommentInLocalMagazine(Magazine $magazine, User $user, ?callable $postCommentCreateCallback = null): array
+    protected function createRemotePostCommentInLocalMagazine(Magazine $magazine, User $user, ?callable $postCommentCreateCallback = null, bool $addPoll = false): array
     {
         $posts = array_filter($this->entitiesToRemoveAfterSetup, fn ($item) => $item instanceof Post && 'remote post in local' === $item->body);
         $post = $posts[array_key_first($posts)];
-        $comment = $this->createPostComment('remote post comment in local', $post, $user);
+        $comment = $this->createPostComment('remote post comment in local'.($addPoll ? ' with poll' : ''), $post, $user);
+        if ($addPoll) {
+            $comment->poll = $this->createSimplePoll(false, true);
+        }
         $json = $this->postCommentNoteFactory->create($comment, $this->tagLinkRepository->getTagsOfContent($comment));
         $this->testingApHttpClient->activityObjects[$json['id']] = $json;
 
@@ -405,6 +453,9 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
         }
 
         $this->entitiesToRemoveAfterSetup[] = $createActivity;
+        if ($addPoll) {
+            $this->entitiesToRemoveAfterSetup[] = $comment->poll;
+        }
         $this->entitiesToRemoveAfterSetup[] = $comment;
 
         return $create;
@@ -435,6 +486,29 @@ abstract class ActivityPubFunctionalTestCase extends ActivityPubTestCase
         }
 
         $this->entitiesToRemoveAfterSetup[] = $createActivity;
+
+        return $create;
+    }
+
+    public function createRemoteVoteOnLocalPoll(Poll $localPoll, User $remoteUser, string $choice): array
+    {
+        $vote = new PollVote();
+        $vote->poll = $localPoll;
+        $vote->voter = $remoteUser;
+        $vote->choice = $localPoll->findChoice($choice);
+        $this->entityManager->persist($vote);
+
+        $createActivity = $this->createWrapper->build($vote);
+        $create = $this->activityJsonBuilder->buildActivityJson($createActivity);
+        // replace current domain with previous one, because we are creating a remote object with the remote domain
+        // responding to a local object with a local domain and the local domain is the previous one
+        $create['object']['inReplyTo'] = str_replace($this->settingsManager->get('KBIN_DOMAIN'), $this->prev, $create['object']['inReplyTo']);
+        $create['to'][0] = str_replace($this->settingsManager->get('KBIN_DOMAIN'), $this->prev, $create['to'][0]);
+        $create['object']['to'][0] = str_replace($this->settingsManager->get('KBIN_DOMAIN'), $this->prev, $create['object']['to'][0]);
+        $this->testingApHttpClient->activityObjects[$create['id']] = $create;
+
+        $this->entitiesToRemoveAfterSetup[] = $createActivity;
+        $this->entitiesToRemoveAfterSetup[] = $vote;
 
         return $create;
     }

--- a/tests/Functional/ActivityPub/Inbox/CreateHandlerTest.php
+++ b/tests/Functional/ActivityPub/Inbox/CreateHandlerTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Functional\ActivityPub\Inbox;
 
 use App\Entity\Contracts\ActivityPubActivityInterface;
 use App\Entity\Contracts\VisibilityInterface;
+use App\Entity\Entry;
 use App\Entity\Magazine;
 use App\Entity\User;
 use App\Enums\EDirectMessageSettings;
@@ -24,6 +25,8 @@ class CreateHandlerTest extends ActivityPubFunctionalTestCase
     private array $announcePost;
     private array $announcePostComment;
     private array $createEntry;
+    private array $createEntryWithPoll;
+    private array $createEntryWithMultipleChoicePoll;
     private array $createEntryWithUrlAndImage;
     private array $createEntryComment;
     private array $createPost;
@@ -33,6 +36,10 @@ class CreateHandlerTest extends ActivityPubFunctionalTestCase
     private array $createMastodonPostWithMentionWithoutTagArray;
     private array $createPostWithPublicNS;
     private array $createPostWithPublicShortURL;
+    private Entry $localEntryWithPoll;
+    private array $remoteVoteOnLocalPoll;
+    private Entry $localEntryWithMultipleChoicePoll;
+    private array $remoteVoteOnLocalMultipleChoicePoll;
 
     public function setUpRemoteEntities(): void
     {
@@ -41,6 +48,8 @@ class CreateHandlerTest extends ActivityPubFunctionalTestCase
         $this->announcePost = $this->createRemotePostInRemoteMagazine($this->remoteMagazine, $this->remoteUser);
         $this->announcePostComment = $this->createRemotePostCommentInRemoteMagazine($this->remoteMagazine, $this->remoteUser);
         $this->createEntry = $this->createRemoteEntryInLocalMagazine($this->localMagazine, $this->remoteUser);
+        $this->createEntryWithPoll = $this->createRemoteEntryInLocalMagazine($this->localMagazine, $this->remoteUser, addPoll: true);
+        $this->createEntryWithMultipleChoicePoll = $this->createRemoteEntryInLocalMagazine($this->localMagazine, $this->remoteUser, addPoll: true, pollMultipleChoice: true);
         $this->createEntryWithUrlAndImage = $this->createRemoteEntryWithUrlAndImageInLocalMagazine($this->localMagazine, $this->remoteUser);
         $this->createEntryComment = $this->createRemoteEntryCommentInLocalMagazine($this->localMagazine, $this->remoteUser);
         $this->createPost = $this->createRemotePostInLocalMagazine($this->localMagazine, $this->remoteUser);
@@ -54,6 +63,16 @@ class CreateHandlerTest extends ActivityPubFunctionalTestCase
     public function setUpLocalEntities(): void
     {
         $this->setupRemoteActor();
+        $this->localEntryWithPoll = $this->getEntryByTitle('A local entry with a poll');
+        $this->localEntryWithPoll->poll = $this->createSimplePoll(false, false);
+        $this->localEntryWithMultipleChoicePoll = $this->getEntryByTitle('A local entry with a multiple choice poll');
+        $this->localEntryWithMultipleChoicePoll->poll = $this->createSimplePoll(true, false);
+    }
+
+    public function setUpLateRemoteEntities(): void
+    {
+        $this->remoteVoteOnLocalPoll = $this->createRemoteVoteOnLocalPoll($this->localEntryWithPoll->poll, $this->remoteUser, 'B');
+        $this->remoteVoteOnLocalMultipleChoicePoll = $this->createRemoteVoteOnLocalPoll($this->localEntryWithMultipleChoicePoll->poll, $this->remoteUser, 'A');
     }
 
     public function testCreateAnnouncedEntry(): void
@@ -129,6 +148,48 @@ class CreateHandlerTest extends ActivityPubFunctionalTestCase
         // the id of the 'Create' activity should be wrapped in a 'Announce' activity
         self::assertEquals($this->createEntry['id'], $postedObjects[0]['payload']['object']['id']);
         self::assertEquals($this->createEntry['object']['id'], $postedObjects[0]['payload']['object']['object']['id']);
+        self::assertEquals($this->remoteSubscriber->apInboxUrl, $postedObjects[0]['inboxUrl']);
+    }
+
+    public function testCreateEntryWithPoll(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createEntryWithPoll)));
+        $entry = $this->entryRepository->findOneBy(['apId' => $this->createEntryWithPoll['object']['id']]);
+        self::assertNotNull($entry);
+        self::assertNotNull($entry->poll);
+        self::assertFalse($entry->poll->multipleChoice);
+        self::assertTrue($entry->poll->isRemote);
+        $this->entityManager->refresh($entry->poll);
+        self::assertNotNull($entry->poll->findChoice('A'));
+        self::assertNotNull($entry->poll->findChoice('B'));
+        self::assertNotNull($entry->poll->findChoice('C'));
+        self::assertTrue($this->localMagazine->isSubscribed($this->remoteSubscriber));
+        $postedObjects = $this->testingApHttpClient->getPostedObjects();
+        self::assertNotEmpty($postedObjects);
+        // the id of the 'Create' activity should be wrapped in a 'Announce' activity
+        self::assertEquals($this->createEntryWithPoll['id'], $postedObjects[0]['payload']['object']['id']);
+        self::assertEquals($this->createEntryWithPoll['object']['id'], $postedObjects[0]['payload']['object']['object']['id']);
+        self::assertEquals($this->remoteSubscriber->apInboxUrl, $postedObjects[0]['inboxUrl']);
+    }
+
+    public function testCreateEntryWithMultipleChoicePoll(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->createEntryWithMultipleChoicePoll)));
+        $entry = $this->entryRepository->findOneBy(['apId' => $this->createEntryWithMultipleChoicePoll['object']['id']]);
+        self::assertNotNull($entry);
+        self::assertNotNull($entry->poll);
+        self::assertTrue($entry->poll->multipleChoice);
+        self::assertTrue($entry->poll->isRemote);
+        $this->entityManager->refresh($entry->poll);
+        self::assertNotNull($entry->poll->findChoice('A'));
+        self::assertNotNull($entry->poll->findChoice('B'));
+        self::assertNotNull($entry->poll->findChoice('C'));
+        self::assertTrue($this->localMagazine->isSubscribed($this->remoteSubscriber));
+        $postedObjects = $this->testingApHttpClient->getPostedObjects();
+        self::assertNotEmpty($postedObjects);
+        // the id of the 'Create' activity should be wrapped in a 'Announce' activity
+        self::assertEquals($this->createEntryWithMultipleChoicePoll['id'], $postedObjects[0]['payload']['object']['id']);
+        self::assertEquals($this->createEntryWithMultipleChoicePoll['object']['id'], $postedObjects[0]['payload']['object']['object']['id']);
         self::assertEquals($this->remoteSubscriber->apInboxUrl, $postedObjects[0]['inboxUrl']);
     }
 
@@ -264,6 +325,39 @@ class CreateHandlerTest extends ActivityPubFunctionalTestCase
         $this->bus->dispatch(new ActivityMessage(json_encode($this->createPostWithPublicShortURL)));
         $post = $this->postRepository->findOneBy(['apId' => $this->createPostWithPublicShortURL['object']['id']]);
         self::assertNotNull($post);
+    }
+
+    public function testRemoteVoteOnLocalEntryWithPoll(): void
+    {
+        $this->bus->dispatch(new ActivityMessage(json_encode($this->remoteVoteOnLocalPoll)));
+        $entry = $this->entryRepository->find($this->localEntryWithPoll->getId());
+        self::assertNotNull($entry);
+        self::assertNotNull($entry->poll);
+        self::assertEquals(1, $entry->poll->voterCount);
+        self::assertNotNull($entry->poll->findChoice('B'));
+        self::assertEquals(1, $entry->poll->findChoice('B')->voteCount);
+    }
+
+    public function testRemoteVotesOnLocalEntryWithMultipleChoicePoll(): void
+    {
+        $choiceA = $this->remoteVoteOnLocalMultipleChoicePoll;
+        $choiceB = $this->remoteVoteOnLocalMultipleChoicePoll;
+        $choiceB['object']['name'] = 'B';
+        $choiceC = $this->remoteVoteOnLocalMultipleChoicePoll;
+        $choiceC['object']['name'] = 'C';
+        $this->bus->dispatch(new ActivityMessage(json_encode($choiceA)));
+        $this->bus->dispatch(new ActivityMessage(json_encode($choiceB)));
+        $this->bus->dispatch(new ActivityMessage(json_encode($choiceC)));
+        $entry = $this->entryRepository->find($this->localEntryWithMultipleChoicePoll->getId());
+        self::assertNotNull($entry);
+        self::assertNotNull($entry->poll);
+        self::assertEquals(1, $entry->poll->voterCount);
+        self::assertNotNull($entry->poll->findChoice('A'));
+        self::assertEquals(1, $entry->poll->findChoice('A')->voteCount);
+        self::assertNotNull($entry->poll->findChoice('B'));
+        self::assertEquals(1, $entry->poll->findChoice('B')->voteCount);
+        self::assertNotNull($entry->poll->findChoice('C'));
+        self::assertEquals(1, $entry->poll->findChoice('C')->voteCount);
     }
 
     private function setupRemoteActor(): void

--- a/tests/Functional/Controller/Api/Magazine/Moderate/MagazineRetrieveBansApiTest.php
+++ b/tests/Functional/Controller/Api/Magazine/Moderate/MagazineRetrieveBansApiTest.php
@@ -5,13 +5,10 @@ declare(strict_types=1);
 namespace App\Tests\Functional\Controller\Api\Magazine\Moderate;
 
 use App\DTO\MagazineBanDto;
-use App\Tests\Functional\Controller\Api\Magazine\MagazineRetrieveApiTest;
 use App\Tests\WebTestCase;
 
 class MagazineRetrieveBansApiTest extends WebTestCase
 {
-    public const BAN_RESPONSE_KEYS = ['banId', 'reason', 'expired', 'expiredAt', 'bannedUser', 'bannedBy', 'magazine'];
-
     public function testApiCannotRetrieveMagazineBansAnonymous(): void
     {
         $magazine = $this->getMagazineByName('test');
@@ -77,7 +74,7 @@ class MagazineRetrieveBansApiTest extends WebTestCase
         self::assertCount(1, $jsonData['items']);
         self::assertArrayKeysMatch(self::BAN_RESPONSE_KEYS, $jsonData['items'][0]);
         self::assertEquals($ban->reason, $jsonData['items'][0]['reason']);
-        self::assertArrayKeysMatch(MagazineRetrieveApiTest::MAGAZINE_SMALL_RESPONSE_KEYS, $jsonData['items'][0]['magazine']);
+        self::assertArrayKeysMatch(WebTestCase::MAGAZINE_SMALL_RESPONSE_KEYS, $jsonData['items'][0]['magazine']);
         self::assertSame($magazine->getId(), $jsonData['items'][0]['magazine']['magazineId']);
         self::assertArrayKeysMatch(self::USER_SMALL_RESPONSE_KEYS, $jsonData['items'][0]['bannedUser']);
         self::assertSame($bannedUser->getId(), $jsonData['items'][0]['bannedUser']['userId']);

--- a/tests/Functional/Controller/Api/Poll/PollVoteControllerTest.php
+++ b/tests/Functional/Controller/Api/Poll/PollVoteControllerTest.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Controller\Api\Poll;
+
+use App\Tests\WebTestCase;
+use PHPUnit\Framework\Attributes\Depends;
+
+class PollVoteControllerTest extends WebTestCase
+{
+    public function testCannotVoteAnonymously(): void
+    {
+        $entry = $this->getEntryByTitle('Entry with poll');
+        $entry->poll = $this->createSimplePoll(false, false);
+        $this->entityManager->flush();
+
+        $this->client->request('PUT', "/api/entry/{$entry->getId()}/poll/vote?choices[]=B");
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testCannotVoteWithRead(): void
+    {
+        $user = $this->getUserByUsername('user');
+        $entry = $this->getEntryByTitle('Entry with poll');
+        $entry->poll = $this->createSimplePoll(false, false);
+        $this->entityManager->flush();
+
+        self::createOAuth2AuthCodeClient();
+        $this->client->loginUser($user);
+
+        $codes = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'read');
+        $token = $codes['token_type'].' '.$codes['access_token'];
+
+        $this->client->request('PUT', "/api/entry/{$entry->getId()}/poll/vote?choices[]=B", server: ['HTTP_AUTHORIZATION' => $token]);
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testCannotVoteWithWrongChoice(): void
+    {
+        $user = $this->getUserByUsername('user');
+        $entry = $this->getEntryByTitle('Entry with poll');
+        $entry->poll = $this->createSimplePoll(false, false);
+        $this->entityManager->flush();
+
+        self::createOAuth2AuthCodeClient();
+        $this->client->loginUser($user);
+
+        $codes = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'entry:vote');
+        $token = $codes['token_type'].' '.$codes['access_token'];
+
+        $this->client->request('PUT', "/api/entry/{$entry->getId()}/poll/vote?choices[]=D", server: ['HTTP_AUTHORIZATION' => $token]);
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testCannotVoteOnExpiredPoll(): void
+    {
+        $user = $this->getUserByUsername('user');
+        $entry = $this->getEntryByTitle('Entry with poll');
+        $entry->poll = $this->createSimplePoll(false, false);
+        $entry->poll->endDate = new \DateTimeImmutable('now - 1 day');
+        $this->entityManager->flush();
+
+        self::createOAuth2AuthCodeClient();
+        $this->client->loginUser($user);
+
+        $codes = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'entry:vote');
+        $token = $codes['token_type'].' '.$codes['access_token'];
+
+        $this->client->request('PUT', "/api/entry/{$entry->getId()}/poll/vote?choices[]=A", server: ['HTTP_AUTHORIZATION' => $token]);
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testVoteOnEntryPoll(): void
+    {
+        $user = $this->getUserByUsername('user');
+        $entry = $this->getEntryByTitle('Entry with poll');
+        $entry->poll = $this->createSimplePoll(false, false);
+        $this->entityManager->flush();
+
+        self::createOAuth2AuthCodeClient();
+        $this->client->loginUser($user);
+
+        $codes = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'entry:vote');
+        $token = $codes['token_type'].' '.$codes['access_token'];
+
+        $this->client->request('PUT', "/api/entry/{$entry->getId()}/poll/vote?choices[]=B", server: ['HTTP_AUTHORIZATION' => $token]);
+        self::assertResponseIsSuccessful();
+
+        $this->verifyPollResponse(['B']);
+    }
+
+    #[Depends('testVoteOnEntryPoll')]
+    public function testCannotVoteTwice(): void
+    {
+        $user = $this->getUserByUsername('user');
+        $entry = $this->getEntryByTitle('Entry with poll');
+        $entry->poll = $this->createSimplePoll(false, false);
+        $this->entityManager->flush();
+
+        self::createOAuth2AuthCodeClient();
+        $this->client->loginUser($user);
+
+        $codes = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'entry:vote');
+        $token = $codes['token_type'].' '.$codes['access_token'];
+
+        $this->client->request('PUT', "/api/entry/{$entry->getId()}/poll/vote?choices[]=B", server: ['HTTP_AUTHORIZATION' => $token]);
+        self::assertResponseIsSuccessful();
+
+        $this->verifyPollResponse(['B']);
+
+        $this->client->request('PUT', "/api/entry/{$entry->getId()}/poll/vote?choices[]=A", server: ['HTTP_AUTHORIZATION' => $token]);
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testVoteOnEntryMultipleChoicePoll(): void
+    {
+        $user = $this->getUserByUsername('user');
+        $entry = $this->getEntryByTitle('Entry with multiple choice poll');
+        $entry->poll = $this->createSimplePoll(true, false);
+        $this->entityManager->flush();
+
+        self::createOAuth2AuthCodeClient();
+        $this->client->loginUser($user);
+
+        $codes = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'entry:vote');
+        $token = $codes['token_type'].' '.$codes['access_token'];
+
+        $this->client->request('PUT', "/api/entry/{$entry->getId()}/poll/vote?choices[]=B&choices[]=C", server: ['HTTP_AUTHORIZATION' => $token]);
+        self::assertResponseIsSuccessful();
+
+        $this->verifyPollResponse(['B', 'C']);
+    }
+
+    public function testVoteOnEntryCommentPoll(): void
+    {
+        $user = $this->getUserByUsername('user');
+        $entry = $this->getEntryByTitle('Entry with comment');
+        $entryComment = $this->createEntryComment('comment with poll', $entry);
+        $entryComment->poll = $this->createSimplePoll(false, false);
+        $this->entityManager->flush();
+
+        self::createOAuth2AuthCodeClient();
+        $this->client->loginUser($user);
+
+        $codes = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'entry_comment:vote');
+        $token = $codes['token_type'].' '.$codes['access_token'];
+
+        $this->client->request('PUT', "/api/entry/{$entry->getId()}/comments/{$entryComment->getId()}/poll/vote?choices[]=B", server: ['HTTP_AUTHORIZATION' => $token]);
+        self::assertResponseIsSuccessful();
+
+        $this->verifyPollResponse(['B']);
+    }
+
+    public function testVoteOnEntryCommentMultipleChoicePoll(): void
+    {
+        $user = $this->getUserByUsername('user');
+        $entry = $this->getEntryByTitle('Entry with comment');
+        $entryComment = $this->createEntryComment('comment with poll', $entry);
+        $entryComment->poll = $this->createSimplePoll(true, false);
+        $this->entityManager->flush();
+
+        self::createOAuth2AuthCodeClient();
+        $this->client->loginUser($user);
+
+        $codes = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'entry_comment:vote');
+        $token = $codes['token_type'].' '.$codes['access_token'];
+
+        $this->client->request('PUT', "/api/entry/{$entry->getId()}/comments/{$entryComment->getId()}/poll/vote?choices[]=B&choices[]=A", server: ['HTTP_AUTHORIZATION' => $token]);
+        self::assertResponseIsSuccessful();
+
+        $this->verifyPollResponse(['B', 'A']);
+    }
+
+    public function testVoteOnPostPoll(): void
+    {
+        $user = $this->getUserByUsername('user');
+        $post = $this->createPost('Post with poll');
+        $post->poll = $this->createSimplePoll(false, false);
+        $this->entityManager->flush();
+
+        self::createOAuth2AuthCodeClient();
+        $this->client->loginUser($user);
+
+        $codes = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'post:vote');
+        $token = $codes['token_type'].' '.$codes['access_token'];
+
+        $this->client->request('PUT', "/api/post/{$post->getId()}/poll/vote?choices[]=B", server: ['HTTP_AUTHORIZATION' => $token]);
+        self::assertResponseIsSuccessful();
+
+        $this->verifyPollResponse(['B']);
+    }
+
+    public function testVoteOnPostMultipleChoicePoll(): void
+    {
+        $user = $this->getUserByUsername('user');
+        $post = $this->createPost('Post with poll');
+        $post->poll = $this->createSimplePoll(true, false);
+        $this->entityManager->flush();
+
+        self::createOAuth2AuthCodeClient();
+        $this->client->loginUser($user);
+
+        $codes = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'post:vote');
+        $token = $codes['token_type'].' '.$codes['access_token'];
+
+        $this->client->request('PUT', "/api/post/{$post->getId()}/poll/vote?choices[]=B&choices[]=A&choices[]=C", server: ['HTTP_AUTHORIZATION' => $token]);
+        self::assertResponseIsSuccessful();
+
+        $this->verifyPollResponse(['B', 'A', 'C']);
+    }
+
+    public function testVoteOnPostCommentPoll(): void
+    {
+        $user = $this->getUserByUsername('user');
+        $post = $this->createPost('Post with comment');
+        $postComment = $this->createPostComment('comment with poll', $post);
+        $postComment->poll = $this->createSimplePoll(false, false);
+        $this->entityManager->flush();
+
+        self::createOAuth2AuthCodeClient();
+        $this->client->loginUser($user);
+
+        $codes = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'post_comment:vote');
+        $token = $codes['token_type'].' '.$codes['access_token'];
+
+        $this->client->request('PUT', "/api/post/{$post->getId()}/comments/{$postComment->getId()}/poll/vote?choices[]=B", server: ['HTTP_AUTHORIZATION' => $token]);
+        self::assertResponseIsSuccessful();
+
+        $this->verifyPollResponse(['B']);
+    }
+
+    public function testVoteOnPostCommentMultipleChoicePoll(): void
+    {
+        $user = $this->getUserByUsername('user');
+        $post = $this->createPost('Post with comment');
+        $postComment = $this->createPostComment('comment with poll', $post);
+        $postComment->poll = $this->createSimplePoll(true, false);
+        $this->entityManager->flush();
+
+        self::createOAuth2AuthCodeClient();
+        $this->client->loginUser($user);
+
+        $codes = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'post_comment:vote');
+        $token = $codes['token_type'].' '.$codes['access_token'];
+
+        $this->client->request('PUT', "/api/post/{$post->getId()}/comments/{$postComment->getId()}/poll/vote?choices[]=B", server: ['HTTP_AUTHORIZATION' => $token]);
+        self::assertResponseIsSuccessful();
+
+        $this->verifyPollResponse(['B']);
+    }
+
+    private function verifyPollResponse(array $choices): void
+    {
+        $data = self::getJsonResponse($this->client);
+        self::assertArrayKeysMatch(WebTestCase::POLL_KEYS, $data);
+        self::assertIsArray($data['choices']);
+        self::assertCount(3, $data['choices']);
+        foreach ($data['choices'] as $choice) {
+            self::assertArrayKeysMatch(WebTestCase::POLL_CHOICE_KEYS, $choice);
+            if (\in_array($choice['name'], $choices)) {
+                self::assertEquals(1, $choice['voteCount']);
+                self::assertTrue($choice['currentUserHasVoted']);
+            } else {
+                self::assertEquals(0, $choice['voteCount']);
+                self::assertFalse($choice['currentUserHasVoted']);
+            }
+        }
+    }
+}

--- a/tests/Service/TestingApHttpClient.php
+++ b/tests/Service/TestingApHttpClient.php
@@ -103,6 +103,10 @@ class TestingApHttpClient implements ApHttpClientInterface
         return 'SOME_TESTING_CACHE_KEY';
     }
 
+    public function invalidateActivityObjectCache(string $url): void
+    {
+    }
+
     public function getInboxUrl(string $apProfileId): string
     {
         $actor = $this->getActorObject($apProfileId);

--- a/tests/Unit/ActivityPub/Outbox/CreateTest.php
+++ b/tests/Unit/ActivityPub/Outbox/CreateTest.php
@@ -26,9 +26,37 @@ class CreateTest extends ActivityPubTestCase
         $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
     }
 
+    public function testCreateEntryWithPoll(): void
+    {
+        $json = $this->activityJsonBuilder->buildActivityJson($this->getCreateEntryWithPollActivity());
+
+        $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
+    }
+
+    public function testCreateEntryWithMultipleChoicePoll(): void
+    {
+        $json = $this->activityJsonBuilder->buildActivityJson($this->getCreateEntryWithMultipleChoicePollActivity());
+
+        $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
+    }
+
     public function testCreateEntryComment(): void
     {
         $json = $this->activityJsonBuilder->buildActivityJson($this->getCreateEntryCommentActivity());
+
+        $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
+    }
+
+    public function testCreateEntryCommentWithPoll(): void
+    {
+        $json = $this->activityJsonBuilder->buildActivityJson($this->getCreateEntryCommentWithPollActivity());
+
+        $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
+    }
+
+    public function testCreateEntryCommentWithMultipleChoicePoll(): void
+    {
+        $json = $this->activityJsonBuilder->buildActivityJson($this->getCreateEntryCommentWithMultipleChoicePollActivity());
 
         $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
     }
@@ -40,9 +68,37 @@ class CreateTest extends ActivityPubTestCase
         $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
     }
 
+    public function testCreateNestedEntryCommentWithPoll(): void
+    {
+        $json = $this->activityJsonBuilder->buildActivityJson($this->getCreateNestedEntryCommentWithPollActivity());
+
+        $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
+    }
+
+    public function testCreateNestedEntryCommentWithMultipleChoicePoll(): void
+    {
+        $json = $this->activityJsonBuilder->buildActivityJson($this->getCreateNestedEntryCommentWithMultipleChoicePollActivity());
+
+        $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
+    }
+
     public function testCreatePost(): void
     {
         $json = $this->activityJsonBuilder->buildActivityJson($this->getCreatePostActivity());
+
+        $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
+    }
+
+    public function testCreatePostWithPoll(): void
+    {
+        $json = $this->activityJsonBuilder->buildActivityJson($this->getCreatePostActivityWithPoll());
+
+        $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
+    }
+
+    public function testCreatePostWithMultipleChoicePoll(): void
+    {
+        $json = $this->activityJsonBuilder->buildActivityJson($this->getCreatePostActivityWithMultipleChoicePoll());
 
         $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
     }
@@ -54,6 +110,20 @@ class CreateTest extends ActivityPubTestCase
         $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
     }
 
+    public function testCreatePostCommentWithPoll(): void
+    {
+        $json = $this->activityJsonBuilder->buildActivityJson($this->getCreatePostCommentActivityWithPoll());
+
+        $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
+    }
+
+    public function testCreatePostCommentWithMultipleChoicePoll(): void
+    {
+        $json = $this->activityJsonBuilder->buildActivityJson($this->getCreatePostCommentActivityWithMultipleChoicePoll());
+
+        $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
+    }
+
     public function testCreateNestedPostComment(): void
     {
         $json = $this->activityJsonBuilder->buildActivityJson($this->getCreateNestedPostCommentActivity());
@@ -61,9 +131,30 @@ class CreateTest extends ActivityPubTestCase
         $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
     }
 
+    public function testCreateNestedPostCommentWithPoll(): void
+    {
+        $json = $this->activityJsonBuilder->buildActivityJson($this->getCreateNestedPostCommentWithPollActivity());
+
+        $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
+    }
+
+    public function testCreateNestedPostCommentWithMultipleChoicePoll(): void
+    {
+        $json = $this->activityJsonBuilder->buildActivityJson($this->getCreateNestedPostCommentWithMultipleChoicePollActivity());
+
+        $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
+    }
+
     public function testCreateMessage(): void
     {
         $json = $this->activityJsonBuilder->buildActivityJson($this->getCreateMessageActivity());
+
+        $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
+    }
+
+    public function testCreatePollVote(): void
+    {
+        $json = $this->activityJsonBuilder->buildActivityJson($this->getCreatePollVoteActivity());
 
         $this->assertMatchesSnapshot($json, new ActivityPubJsonDriver());
     }

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateEntryCommentWithMultipleChoicePoll__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateEntryCommentWithMultipleChoicePoll__1.json
@@ -1,0 +1,82 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
+        "https://kbin.test/contexts"
+    ],
+    "id": "SCRUBBED_ID",
+    "type": "Create",
+    "actor": "https://kbin.test/u/user",
+    "published": "SCRUBBED_DATE",
+    "to": [
+        "https://www.w3.org/ns/activitystreams#Public",
+        "https://kbin.test/u/user"
+    ],
+    "cc": [
+        "https://kbin.test/m/test",
+        "https://kbin.test/u/user/followers"
+    ],
+    "object": {
+        "id": "SCRUBBED_ID",
+        "type": "Note",
+        "attributedTo": "https://kbin.test/u/user",
+        "inReplyTo": "SCRUBBED_ID",
+        "to": [
+            "https://www.w3.org/ns/activitystreams#Public",
+            "https://kbin.test/u/user"
+        ],
+        "cc": [
+            "https://kbin.test/m/test",
+            "https://kbin.test/u/user/followers"
+        ],
+        "audience": "https://kbin.test/m/test",
+        "sensitive": false,
+        "content": "<p>test</p>\n",
+        "mediaType": "text/html",
+        "source": {
+            "content": "test",
+            "mediaType": "text/markdown"
+        },
+        "url": "SCRUBBED_ID",
+        "tag": [
+            {
+                "type": "Hashtag",
+                "href": "https://kbin.test/tag/test",
+                "name": "#test"
+            }
+        ],
+        "published": "SCRUBBED_DATE",
+        "contentMap": {
+            "en": "<p>test</p>\n"
+        },
+        "votersCount": 0,
+        "endTime": "SCRUBBED_DATE",
+        "oneOf": [
+            {
+                "type": "Note",
+                "name": "A",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "B",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "C",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            }
+        ]
+    },
+    "audience": "https://kbin.test/m/test"
+}

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateEntryCommentWithPoll__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateEntryCommentWithPoll__1.json
@@ -1,0 +1,82 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
+        "https://kbin.test/contexts"
+    ],
+    "id": "SCRUBBED_ID",
+    "type": "Create",
+    "actor": "https://kbin.test/u/user",
+    "published": "SCRUBBED_DATE",
+    "to": [
+        "https://www.w3.org/ns/activitystreams#Public",
+        "https://kbin.test/u/user"
+    ],
+    "cc": [
+        "https://kbin.test/m/test",
+        "https://kbin.test/u/user/followers"
+    ],
+    "object": {
+        "id": "SCRUBBED_ID",
+        "type": "Note",
+        "attributedTo": "https://kbin.test/u/user",
+        "inReplyTo": "SCRUBBED_ID",
+        "to": [
+            "https://www.w3.org/ns/activitystreams#Public",
+            "https://kbin.test/u/user"
+        ],
+        "cc": [
+            "https://kbin.test/m/test",
+            "https://kbin.test/u/user/followers"
+        ],
+        "audience": "https://kbin.test/m/test",
+        "sensitive": false,
+        "content": "<p>test</p>\n",
+        "mediaType": "text/html",
+        "source": {
+            "content": "test",
+            "mediaType": "text/markdown"
+        },
+        "url": "SCRUBBED_ID",
+        "tag": [
+            {
+                "type": "Hashtag",
+                "href": "https://kbin.test/tag/test",
+                "name": "#test"
+            }
+        ],
+        "published": "SCRUBBED_DATE",
+        "contentMap": {
+            "en": "<p>test</p>\n"
+        },
+        "votersCount": 0,
+        "endTime": "SCRUBBED_DATE",
+        "oneOf": [
+            {
+                "type": "Note",
+                "name": "A",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "B",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "C",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            }
+        ]
+    },
+    "audience": "https://kbin.test/m/test"
+}

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateEntryWithMultipleChoicePoll__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateEntryWithMultipleChoicePoll__1.json
@@ -1,0 +1,80 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
+        "https://kbin.test/contexts"
+    ],
+    "id": "SCRUBBED_ID",
+    "type": "Create",
+    "actor": "https://kbin.test/u/user",
+    "published": "SCRUBBED_DATE",
+    "to": [
+        "https://kbin.test/m/test",
+        "https://www.w3.org/ns/activitystreams#Public"
+    ],
+    "cc": [
+        "https://kbin.test/u/user/followers"
+    ],
+    "object": {
+        "id": "SCRUBBED_ID",
+        "type": "Question",
+        "attributedTo": "https://kbin.test/u/user",
+        "inReplyTo": null,
+        "to": [
+            "https://kbin.test/m/test",
+            "https://www.w3.org/ns/activitystreams#Public"
+        ],
+        "cc": [
+            "https://kbin.test/u/user/followers"
+        ],
+        "name": "test",
+        "audience": "https://kbin.test/m/test",
+        "content": null,
+        "summary": "test #test",
+        "mediaType": "text/html",
+        "source": null,
+        "tag": [
+            {
+                "type": "Hashtag",
+                "href": "https://kbin.test/tag/test",
+                "name": "#test"
+            }
+        ],
+        "commentsEnabled": true,
+        "sensitive": false,
+        "stickied": false,
+        "published": "SCRUBBED_DATE",
+        "contentMap": {
+            "en": null
+        },
+        "votersCount": 0,
+        "endTime": "SCRUBBED_DATE",
+        "anyOf": [
+            {
+                "type": "Note",
+                "name": "A",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "B",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "C",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            }
+        ]
+    },
+    "audience": "https://kbin.test/m/test"
+}

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateEntryWithPoll__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateEntryWithPoll__1.json
@@ -1,0 +1,80 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
+        "https://kbin.test/contexts"
+    ],
+    "id": "SCRUBBED_ID",
+    "type": "Create",
+    "actor": "https://kbin.test/u/user",
+    "published": "SCRUBBED_DATE",
+    "to": [
+        "https://kbin.test/m/test",
+        "https://www.w3.org/ns/activitystreams#Public"
+    ],
+    "cc": [
+        "https://kbin.test/u/user/followers"
+    ],
+    "object": {
+        "id": "SCRUBBED_ID",
+        "type": "Question",
+        "attributedTo": "https://kbin.test/u/user",
+        "inReplyTo": null,
+        "to": [
+            "https://kbin.test/m/test",
+            "https://www.w3.org/ns/activitystreams#Public"
+        ],
+        "cc": [
+            "https://kbin.test/u/user/followers"
+        ],
+        "name": "test",
+        "audience": "https://kbin.test/m/test",
+        "content": null,
+        "summary": "test #test",
+        "mediaType": "text/html",
+        "source": null,
+        "tag": [
+            {
+                "type": "Hashtag",
+                "href": "https://kbin.test/tag/test",
+                "name": "#test"
+            }
+        ],
+        "commentsEnabled": true,
+        "sensitive": false,
+        "stickied": false,
+        "published": "SCRUBBED_DATE",
+        "contentMap": {
+            "en": null
+        },
+        "votersCount": 0,
+        "endTime": "SCRUBBED_DATE",
+        "oneOf": [
+            {
+                "type": "Note",
+                "name": "A",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "B",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "C",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            }
+        ]
+    },
+    "audience": "https://kbin.test/m/test"
+}

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateNestedEntryCommentWithMultipleChoicePoll__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateNestedEntryCommentWithMultipleChoicePoll__1.json
@@ -1,0 +1,82 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
+        "https://kbin.test/contexts"
+    ],
+    "id": "SCRUBBED_ID",
+    "type": "Create",
+    "actor": "https://kbin.test/u/user",
+    "published": "SCRUBBED_DATE",
+    "to": [
+        "https://www.w3.org/ns/activitystreams#Public",
+        "https://kbin.test/u/user"
+    ],
+    "cc": [
+        "https://kbin.test/m/test",
+        "https://kbin.test/u/user/followers"
+    ],
+    "object": {
+        "id": "SCRUBBED_ID",
+        "type": "Note",
+        "attributedTo": "https://kbin.test/u/user",
+        "inReplyTo": "SCRUBBED_ID",
+        "to": [
+            "https://www.w3.org/ns/activitystreams#Public",
+            "https://kbin.test/u/user"
+        ],
+        "cc": [
+            "https://kbin.test/m/test",
+            "https://kbin.test/u/user/followers"
+        ],
+        "audience": "https://kbin.test/m/test",
+        "sensitive": false,
+        "content": "<p>test</p>\n",
+        "mediaType": "text/html",
+        "source": {
+            "content": "test",
+            "mediaType": "text/markdown"
+        },
+        "url": "SCRUBBED_ID",
+        "tag": [
+            {
+                "type": "Hashtag",
+                "href": "https://kbin.test/tag/test",
+                "name": "#test"
+            }
+        ],
+        "published": "SCRUBBED_DATE",
+        "contentMap": {
+            "en": "<p>test</p>\n"
+        },
+        "votersCount": 0,
+        "endTime": "SCRUBBED_DATE",
+        "anyOf": [
+            {
+                "type": "Note",
+                "name": "A",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "B",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "C",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            }
+        ]
+    },
+    "audience": "https://kbin.test/m/test"
+}

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateNestedEntryCommentWithPoll__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateNestedEntryCommentWithPoll__1.json
@@ -1,0 +1,82 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
+        "https://kbin.test/contexts"
+    ],
+    "id": "SCRUBBED_ID",
+    "type": "Create",
+    "actor": "https://kbin.test/u/user",
+    "published": "SCRUBBED_DATE",
+    "to": [
+        "https://www.w3.org/ns/activitystreams#Public",
+        "https://kbin.test/u/user"
+    ],
+    "cc": [
+        "https://kbin.test/m/test",
+        "https://kbin.test/u/user/followers"
+    ],
+    "object": {
+        "id": "SCRUBBED_ID",
+        "type": "Note",
+        "attributedTo": "https://kbin.test/u/user",
+        "inReplyTo": "SCRUBBED_ID",
+        "to": [
+            "https://www.w3.org/ns/activitystreams#Public",
+            "https://kbin.test/u/user"
+        ],
+        "cc": [
+            "https://kbin.test/m/test",
+            "https://kbin.test/u/user/followers"
+        ],
+        "audience": "https://kbin.test/m/test",
+        "sensitive": false,
+        "content": "<p>test</p>\n",
+        "mediaType": "text/html",
+        "source": {
+            "content": "test",
+            "mediaType": "text/markdown"
+        },
+        "url": "SCRUBBED_ID",
+        "tag": [
+            {
+                "type": "Hashtag",
+                "href": "https://kbin.test/tag/test",
+                "name": "#test"
+            }
+        ],
+        "published": "SCRUBBED_DATE",
+        "contentMap": {
+            "en": "<p>test</p>\n"
+        },
+        "votersCount": 0,
+        "endTime": "SCRUBBED_DATE",
+        "oneOf": [
+            {
+                "type": "Note",
+                "name": "A",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "B",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "C",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            }
+        ]
+    },
+    "audience": "https://kbin.test/m/test"
+}

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateNestedPostCommentWithMultipleChoicePoll__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateNestedPostCommentWithMultipleChoicePoll__1.json
@@ -1,0 +1,82 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
+        "https://kbin.test/contexts"
+    ],
+    "id": "SCRUBBED_ID",
+    "type": "Create",
+    "actor": "https://kbin.test/u/user",
+    "published": "SCRUBBED_DATE",
+    "to": [
+        "https://www.w3.org/ns/activitystreams#Public",
+        "https://kbin.test/u/user"
+    ],
+    "cc": [
+        "https://kbin.test/m/test",
+        "https://kbin.test/u/user/followers"
+    ],
+    "object": {
+        "id": "SCRUBBED_ID",
+        "type": "Note",
+        "attributedTo": "https://kbin.test/u/user",
+        "inReplyTo": "SCRUBBED_ID",
+        "to": [
+            "https://www.w3.org/ns/activitystreams#Public",
+            "https://kbin.test/u/user"
+        ],
+        "cc": [
+            "https://kbin.test/m/test",
+            "https://kbin.test/u/user/followers"
+        ],
+        "audience": "https://kbin.test/m/test",
+        "sensitive": false,
+        "content": "<p>test</p>\n",
+        "mediaType": "text/html",
+        "source": {
+            "content": "test",
+            "mediaType": "text/markdown"
+        },
+        "url": "SCRUBBED_ID",
+        "tag": [
+            {
+                "type": "Hashtag",
+                "href": "https://kbin.test/tag/test",
+                "name": "#test"
+            }
+        ],
+        "published": "SCRUBBED_DATE",
+        "contentMap": {
+            "en": "<p>test</p>\n"
+        },
+        "votersCount": 0,
+        "endTime": "SCRUBBED_DATE",
+        "anyOf": [
+            {
+                "type": "Note",
+                "name": "A",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "B",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "C",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            }
+        ]
+    },
+    "audience": "https://kbin.test/m/test"
+}

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateNestedPostCommentWithPoll__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreateNestedPostCommentWithPoll__1.json
@@ -1,0 +1,82 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
+        "https://kbin.test/contexts"
+    ],
+    "id": "SCRUBBED_ID",
+    "type": "Create",
+    "actor": "https://kbin.test/u/user",
+    "published": "SCRUBBED_DATE",
+    "to": [
+        "https://www.w3.org/ns/activitystreams#Public",
+        "https://kbin.test/u/user"
+    ],
+    "cc": [
+        "https://kbin.test/m/test",
+        "https://kbin.test/u/user/followers"
+    ],
+    "object": {
+        "id": "SCRUBBED_ID",
+        "type": "Note",
+        "attributedTo": "https://kbin.test/u/user",
+        "inReplyTo": "SCRUBBED_ID",
+        "to": [
+            "https://www.w3.org/ns/activitystreams#Public",
+            "https://kbin.test/u/user"
+        ],
+        "cc": [
+            "https://kbin.test/m/test",
+            "https://kbin.test/u/user/followers"
+        ],
+        "audience": "https://kbin.test/m/test",
+        "sensitive": false,
+        "content": "<p>test</p>\n",
+        "mediaType": "text/html",
+        "source": {
+            "content": "test",
+            "mediaType": "text/markdown"
+        },
+        "url": "SCRUBBED_ID",
+        "tag": [
+            {
+                "type": "Hashtag",
+                "href": "https://kbin.test/tag/test",
+                "name": "#test"
+            }
+        ],
+        "published": "SCRUBBED_DATE",
+        "contentMap": {
+            "en": "<p>test</p>\n"
+        },
+        "votersCount": 0,
+        "endTime": "SCRUBBED_DATE",
+        "oneOf": [
+            {
+                "type": "Note",
+                "name": "A",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "B",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "C",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            }
+        ]
+    },
+    "audience": "https://kbin.test/m/test"
+}

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreatePollVote__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreatePollVote__1.json
@@ -1,0 +1,27 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
+        "https://kbin.test/contexts"
+    ],
+    "id": "SCRUBBED_ID",
+    "type": "Create",
+    "actor": "https://kbin.test/u/user2",
+    "published": "SCRUBBED_DATE",
+    "to": [
+        "https://kbin.test/u/user"
+    ],
+    "cc": [],
+    "object": {
+        "id": "SCRUBBED_ID",
+        "attributedTo": "https://kbin.test/u/user2",
+        "to": [
+            "https://kbin.test/u/user"
+        ],
+        "cc": [],
+        "type": "Note",
+        "published": "SCRUBBED_DATE",
+        "inReplyTo": "SCRUBBED_ID",
+        "name": "A"
+    }
+}

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreatePostCommentWithMultipleChoicePoll__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreatePostCommentWithMultipleChoicePoll__1.json
@@ -1,0 +1,82 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
+        "https://kbin.test/contexts"
+    ],
+    "id": "SCRUBBED_ID",
+    "type": "Create",
+    "actor": "https://kbin.test/u/user",
+    "published": "SCRUBBED_DATE",
+    "to": [
+        "https://www.w3.org/ns/activitystreams#Public",
+        "https://kbin.test/u/user"
+    ],
+    "cc": [
+        "https://kbin.test/m/test",
+        "https://kbin.test/u/user/followers"
+    ],
+    "object": {
+        "id": "SCRUBBED_ID",
+        "type": "Note",
+        "attributedTo": "https://kbin.test/u/user",
+        "inReplyTo": "SCRUBBED_ID",
+        "to": [
+            "https://www.w3.org/ns/activitystreams#Public",
+            "https://kbin.test/u/user"
+        ],
+        "cc": [
+            "https://kbin.test/m/test",
+            "https://kbin.test/u/user/followers"
+        ],
+        "audience": "https://kbin.test/m/test",
+        "sensitive": false,
+        "content": "<p>test</p>\n",
+        "mediaType": "text/html",
+        "source": {
+            "content": "test",
+            "mediaType": "text/markdown"
+        },
+        "url": "SCRUBBED_ID",
+        "tag": [
+            {
+                "type": "Hashtag",
+                "href": "https://kbin.test/tag/test",
+                "name": "#test"
+            }
+        ],
+        "published": "SCRUBBED_DATE",
+        "contentMap": {
+            "en": "<p>test</p>\n"
+        },
+        "votersCount": 0,
+        "endTime": "SCRUBBED_DATE",
+        "anyOf": [
+            {
+                "type": "Note",
+                "name": "A",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "B",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "C",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            }
+        ]
+    },
+    "audience": "https://kbin.test/m/test"
+}

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreatePostCommentWithPoll__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreatePostCommentWithPoll__1.json
@@ -1,0 +1,82 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
+        "https://kbin.test/contexts"
+    ],
+    "id": "SCRUBBED_ID",
+    "type": "Create",
+    "actor": "https://kbin.test/u/user",
+    "published": "SCRUBBED_DATE",
+    "to": [
+        "https://www.w3.org/ns/activitystreams#Public",
+        "https://kbin.test/u/user"
+    ],
+    "cc": [
+        "https://kbin.test/m/test",
+        "https://kbin.test/u/user/followers"
+    ],
+    "object": {
+        "id": "SCRUBBED_ID",
+        "type": "Note",
+        "attributedTo": "https://kbin.test/u/user",
+        "inReplyTo": "SCRUBBED_ID",
+        "to": [
+            "https://www.w3.org/ns/activitystreams#Public",
+            "https://kbin.test/u/user"
+        ],
+        "cc": [
+            "https://kbin.test/m/test",
+            "https://kbin.test/u/user/followers"
+        ],
+        "audience": "https://kbin.test/m/test",
+        "sensitive": false,
+        "content": "<p>test</p>\n",
+        "mediaType": "text/html",
+        "source": {
+            "content": "test",
+            "mediaType": "text/markdown"
+        },
+        "url": "SCRUBBED_ID",
+        "tag": [
+            {
+                "type": "Hashtag",
+                "href": "https://kbin.test/tag/test",
+                "name": "#test"
+            }
+        ],
+        "published": "SCRUBBED_DATE",
+        "contentMap": {
+            "en": "<p>test</p>\n"
+        },
+        "votersCount": 0,
+        "endTime": "SCRUBBED_DATE",
+        "oneOf": [
+            {
+                "type": "Note",
+                "name": "A",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "B",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "C",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            }
+        ]
+    },
+    "audience": "https://kbin.test/m/test"
+}

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreatePostWithMultipleChoicePoll__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreatePostWithMultipleChoicePoll__1.json
@@ -1,0 +1,82 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
+        "https://kbin.test/contexts"
+    ],
+    "id": "SCRUBBED_ID",
+    "type": "Create",
+    "actor": "https://kbin.test/u/user",
+    "published": "SCRUBBED_DATE",
+    "to": [
+        "https://kbin.test/m/test",
+        "https://www.w3.org/ns/activitystreams#Public"
+    ],
+    "cc": [
+        "https://kbin.test/u/user/followers"
+    ],
+    "object": {
+        "id": "SCRUBBED_ID",
+        "type": "Note",
+        "attributedTo": "https://kbin.test/u/user",
+        "inReplyTo": null,
+        "to": [
+            "https://kbin.test/m/test",
+            "https://www.w3.org/ns/activitystreams#Public"
+        ],
+        "cc": [
+            "https://kbin.test/u/user/followers"
+        ],
+        "audience": "https://kbin.test/m/test",
+        "sensitive": false,
+        "stickied": false,
+        "content": "<p>test</p>\n<p><a href=\"https://kbin.test/tag/test\">#test</a></p>\n",
+        "mediaType": "text/html",
+        "source": {
+            "content": "test\n\n #test",
+            "mediaType": "text/markdown"
+        },
+        "url": "SCRUBBED_ID",
+        "tag": [
+            {
+                "type": "Hashtag",
+                "href": "https://kbin.test/tag/test",
+                "name": "#test"
+            }
+        ],
+        "commentsEnabled": true,
+        "published": "SCRUBBED_DATE",
+        "contentMap": {
+            "en": "<p>test</p>\n<p><a href=\"https://kbin.test/tag/test\">#test</a></p>\n"
+        },
+        "votersCount": 0,
+        "endTime": "SCRUBBED_DATE",
+        "anyOf": [
+            {
+                "type": "Note",
+                "name": "A",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "B",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "C",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            }
+        ]
+    },
+    "audience": "https://kbin.test/m/test"
+}

--- a/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreatePostWithPoll__1.json
+++ b/tests/Unit/ActivityPub/Outbox/JsonSnapshots/CreateTest__testCreatePostWithPoll__1.json
@@ -1,0 +1,82 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
+        "https://kbin.test/contexts"
+    ],
+    "id": "SCRUBBED_ID",
+    "type": "Create",
+    "actor": "https://kbin.test/u/user",
+    "published": "SCRUBBED_DATE",
+    "to": [
+        "https://kbin.test/m/test",
+        "https://www.w3.org/ns/activitystreams#Public"
+    ],
+    "cc": [
+        "https://kbin.test/u/user/followers"
+    ],
+    "object": {
+        "id": "SCRUBBED_ID",
+        "type": "Note",
+        "attributedTo": "https://kbin.test/u/user",
+        "inReplyTo": null,
+        "to": [
+            "https://kbin.test/m/test",
+            "https://www.w3.org/ns/activitystreams#Public"
+        ],
+        "cc": [
+            "https://kbin.test/u/user/followers"
+        ],
+        "audience": "https://kbin.test/m/test",
+        "sensitive": false,
+        "stickied": false,
+        "content": "<p>test</p>\n<p><a href=\"https://kbin.test/tag/test\">#test</a></p>\n",
+        "mediaType": "text/html",
+        "source": {
+            "content": "test\n\n #test",
+            "mediaType": "text/markdown"
+        },
+        "url": "SCRUBBED_ID",
+        "tag": [
+            {
+                "type": "Hashtag",
+                "href": "https://kbin.test/tag/test",
+                "name": "#test"
+            }
+        ],
+        "commentsEnabled": true,
+        "published": "SCRUBBED_DATE",
+        "contentMap": {
+            "en": "<p>test</p>\n<p><a href=\"https://kbin.test/tag/test\">#test</a></p>\n"
+        },
+        "votersCount": 0,
+        "endTime": "SCRUBBED_DATE",
+        "oneOf": [
+            {
+                "type": "Note",
+                "name": "A",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "B",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            },
+            {
+                "type": "Note",
+                "name": "C",
+                "replies": {
+                    "type": "Collection",
+                    "totalItems": 0
+                }
+            }
+        ]
+    },
+    "audience": "https://kbin.test/m/test"
+}

--- a/tests/Unit/ActivityPub/Traits/CreateActivityGeneratorTrait.php
+++ b/tests/Unit/ActivityPub/Traits/CreateActivityGeneratorTrait.php
@@ -5,12 +5,29 @@ declare(strict_types=1);
 namespace App\Tests\Unit\ActivityPub\Traits;
 
 use App\Entity\Activity;
+use App\Entity\PollVote;
 
 trait CreateActivityGeneratorTrait
 {
     public function getCreateEntryActivity(): Activity
     {
         $entry = $this->getEntryByTitle('test', magazine: $this->magazine, user: $this->user);
+
+        return $this->createWrapper->build($entry);
+    }
+
+    public function getCreateEntryWithPollActivity(): Activity
+    {
+        $entry = $this->getEntryByTitle('test', magazine: $this->magazine, user: $this->user);
+        $entry->poll = $this->createSimplePoll(false, true);
+
+        return $this->createWrapper->build($entry);
+    }
+
+    public function getCreateEntryWithMultipleChoicePollActivity(): Activity
+    {
+        $entry = $this->getEntryByTitle('test', magazine: $this->magazine, user: $this->user);
+        $entry->poll = $this->createSimplePoll(true, true);
 
         return $this->createWrapper->build($entry);
     }
@@ -30,11 +47,49 @@ trait CreateActivityGeneratorTrait
         return $this->createWrapper->build($entryComment);
     }
 
+    public function getCreateEntryCommentWithPollActivity(): Activity
+    {
+        $entry = $this->getEntryByTitle('test', magazine: $this->magazine, user: $this->user);
+        $entryComment = $this->createEntryComment('test', entry: $entry, user: $this->user);
+        $entryComment->poll = $this->createSimplePoll(false, true);
+
+        return $this->createWrapper->build($entryComment);
+    }
+
+    public function getCreateEntryCommentWithMultipleChoicePollActivity(): Activity
+    {
+        $entry = $this->getEntryByTitle('test', magazine: $this->magazine, user: $this->user);
+        $entryComment = $this->createEntryComment('test', entry: $entry, user: $this->user);
+        $entryComment->poll = $this->createSimplePoll(false, true);
+
+        return $this->createWrapper->build($entryComment);
+    }
+
     public function getCreateNestedEntryCommentActivity(): Activity
     {
         $entry = $this->getEntryByTitle('test', magazine: $this->magazine, user: $this->user);
         $entryComment = $this->createEntryComment('test', entry: $entry, user: $this->user);
         $entryComment2 = $this->createEntryComment('test', entry: $entry, user: $this->user, parent: $entryComment);
+
+        return $this->createWrapper->build($entryComment2);
+    }
+
+    public function getCreateNestedEntryCommentWithPollActivity(): Activity
+    {
+        $entry = $this->getEntryByTitle('test', magazine: $this->magazine, user: $this->user);
+        $entryComment = $this->createEntryComment('test', entry: $entry, user: $this->user);
+        $entryComment2 = $this->createEntryComment('test', entry: $entry, user: $this->user, parent: $entryComment);
+        $entryComment2->poll = $this->createSimplePoll(false, true);
+
+        return $this->createWrapper->build($entryComment2);
+    }
+
+    public function getCreateNestedEntryCommentWithMultipleChoicePollActivity(): Activity
+    {
+        $entry = $this->getEntryByTitle('test', magazine: $this->magazine, user: $this->user);
+        $entryComment = $this->createEntryComment('test', entry: $entry, user: $this->user);
+        $entryComment2 = $this->createEntryComment('test', entry: $entry, user: $this->user, parent: $entryComment);
+        $entryComment2->poll = $this->createSimplePoll(true, true);
 
         return $this->createWrapper->build($entryComment2);
     }
@@ -46,10 +101,44 @@ trait CreateActivityGeneratorTrait
         return $this->createWrapper->build($post);
     }
 
+    public function getCreatePostActivityWithPoll(): Activity
+    {
+        $post = $this->createPost('test', magazine: $this->magazine, user: $this->user);
+        $post->poll = $this->createSimplePoll(false, true);
+
+        return $this->createWrapper->build($post);
+    }
+
+    public function getCreatePostActivityWithMultipleChoicePoll(): Activity
+    {
+        $post = $this->createPost('test', magazine: $this->magazine, user: $this->user);
+        $post->poll = $this->createSimplePoll(true, true);
+
+        return $this->createWrapper->build($post);
+    }
+
     public function getCreatePostCommentActivity(): Activity
     {
         $post = $this->createPost('test', magazine: $this->magazine, user: $this->user);
         $postComment = $this->createPostComment('test', post: $post, user: $this->user);
+
+        return $this->createWrapper->build($postComment);
+    }
+
+    public function getCreatePostCommentActivityWithPoll(): Activity
+    {
+        $post = $this->createPost('test', magazine: $this->magazine, user: $this->user);
+        $postComment = $this->createPostComment('test', post: $post, user: $this->user);
+        $postComment->poll = $this->createSimplePoll(false, true);
+
+        return $this->createWrapper->build($postComment);
+    }
+
+    public function getCreatePostCommentActivityWithMultipleChoicePoll(): Activity
+    {
+        $post = $this->createPost('test', magazine: $this->magazine, user: $this->user);
+        $postComment = $this->createPostComment('test', post: $post, user: $this->user);
+        $postComment->poll = $this->createSimplePoll(true, true);
 
         return $this->createWrapper->build($postComment);
     }
@@ -63,11 +152,46 @@ trait CreateActivityGeneratorTrait
         return $this->createWrapper->build($postComment2);
     }
 
+    public function getCreateNestedPostCommentWithPollActivity(): Activity
+    {
+        $post = $this->createPost('test', magazine: $this->magazine, user: $this->user);
+        $postComment = $this->createPostComment('test', post: $post, user: $this->user);
+        $postComment2 = $this->createPostComment('test', post: $post, user: $this->user, parent: $postComment);
+        $postComment2->poll = $this->createSimplePoll(false, true);
+
+        return $this->createWrapper->build($postComment2);
+    }
+
+    public function getCreateNestedPostCommentWithMultipleChoicePollActivity(): Activity
+    {
+        $post = $this->createPost('test', magazine: $this->magazine, user: $this->user);
+        $postComment = $this->createPostComment('test', post: $post, user: $this->user);
+        $postComment2 = $this->createPostComment('test', post: $post, user: $this->user, parent: $postComment);
+        $postComment2->poll = $this->createSimplePoll(true, true);
+
+        return $this->createWrapper->build($postComment2);
+    }
+
     public function getCreateMessageActivity(): Activity
     {
         $user2 = $this->getUserByUsername('user2');
         $message = $this->createMessage($user2, $this->user, 'some test message');
 
         return $this->createWrapper->build($message);
+    }
+
+    public function getCreatePollVoteActivity(): Activity
+    {
+        $user2 = $this->getUserByUsername('user2');
+        $entry = $this->getEntryByTitle('test', magazine: $this->magazine, user: $this->user);
+        $entry->poll = $this->createSimplePoll(false, false);
+
+        $vote = new PollVote();
+        $vote->poll = $entry->poll;
+        $vote->choice = $entry->poll->findChoice('A');
+        $vote->voter = $user2;
+        $this->entityManager->persist($vote);
+
+        return $this->createWrapper->build($vote);
     }
 }

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -50,6 +50,7 @@ use App\Service\MagazineManager;
 use App\Service\MentionManager;
 use App\Service\MessageManager;
 use App\Service\NotificationManager;
+use App\Service\PollManager;
 use App\Service\PostCommentManager;
 use App\Service\PostManager;
 use App\Service\ProjectInfoService;
@@ -86,24 +87,26 @@ abstract class WebTestCase extends BaseWebTestCase
     use OAuth2FlowTrait;
     use ValidationTrait;
 
-    protected const PAGINATED_KEYS = ['items', 'pagination'];
-    protected const PAGINATION_KEYS = ['count', 'currentPage', 'maxPage', 'perPage'];
-    protected const CURSOR_PAGINATION_KEYS = ['currentCursor', 'currentCursor2', 'nextCursor', 'nextCursor2', 'previousCursor', 'previousCursor2', 'perPage'];
-    protected const IMAGE_KEYS = ['filePath', 'sourceUrl', 'storageUrl', 'altText', 'width', 'height', 'blurHash'];
-    protected const MESSAGE_RESPONSE_KEYS = ['messageId', 'threadId', 'sender', 'body', 'status', 'createdAt'];
-    protected const USER_RESPONSE_KEYS = ['userId', 'username', 'about', 'avatar', 'cover', 'createdAt', 'followersCount', 'apId', 'apProfileId', 'isBot', 'isFollowedByUser', 'isFollowerOfUser', 'isBlockedByUser', 'isAdmin', 'isGlobalModerator', 'serverSoftware', 'serverSoftwareVersion', 'notificationStatus', 'reputationPoints', 'discoverable', 'indexable', 'title'];
-    protected const USER_SMALL_RESPONSE_KEYS = ['userId', 'username', 'isBot', 'isFollowedByUser', 'isFollowerOfUser', 'isBlockedByUser', 'avatar', 'apId', 'apProfileId', 'createdAt', 'isAdmin', 'isGlobalModerator', 'discoverable', 'indexable', 'title'];
-    protected const ENTRY_RESPONSE_KEYS = ['entryId', 'magazine', 'user', 'domain', 'title', 'url', 'image', 'body', 'lang', 'tags', 'badges', 'numComments', 'uv', 'dv', 'favourites', 'isFavourited', 'userVote', 'isOc', 'isAdult', 'isPinned', 'isLocked', 'createdAt', 'editedAt', 'lastActive', 'visibility', 'type', 'slug', 'apId', 'canAuthUserModerate', 'notificationStatus', 'bookmarks', 'crosspostedEntries', 'isAuthorModeratorInMagazine'];
-    protected const ENTRY_COMMENT_RESPONSE_KEYS = ['commentId', 'magazine', 'user', 'entryId', 'parentId', 'rootId', 'image', 'body', 'lang', 'isAdult', 'uv', 'dv', 'favourites', 'isFavourited', 'userVote', 'visibility', 'apId', 'mentions', 'tags', 'createdAt', 'editedAt', 'lastActive', 'childCount', 'children', 'canAuthUserModerate', 'bookmarks', 'isAuthorModeratorInMagazine'];
-    protected const POST_RESPONSE_KEYS = ['postId', 'user', 'magazine', 'image', 'body', 'lang', 'isAdult', 'isPinned', 'isLocked', 'comments', 'uv', 'dv', 'favourites', 'isFavourited', 'userVote', 'visibility', 'apId', 'tags', 'mentions', 'createdAt', 'editedAt', 'lastActive', 'slug', 'canAuthUserModerate', 'notificationStatus', 'bookmarks', 'isAuthorModeratorInMagazine'];
-    protected const POST_COMMENT_RESPONSE_KEYS = ['commentId', 'user', 'magazine', 'postId', 'parentId', 'rootId', 'image', 'body', 'lang', 'isAdult', 'uv', 'dv', 'favourites', 'isFavourited', 'userVote', 'visibility', 'apId', 'mentions', 'tags', 'createdAt', 'editedAt', 'lastActive', 'childCount', 'children', 'canAuthUserModerate', 'bookmarks', 'isAuthorModeratorInMagazine'];
-    protected const BAN_RESPONSE_KEYS = ['banId', 'reason', 'expired', 'expiredAt', 'bannedUser', 'bannedBy', 'magazine'];
-    protected const LOG_ENTRY_KEYS = ['type', 'createdAt', 'magazine', 'moderator', 'subject'];
-    protected const MAGAZINE_RESPONSE_KEYS = ['magazineId', 'owner', 'icon', 'banner', 'name', 'title', 'description', 'rules', 'subscriptionsCount', 'entryCount', 'entryCommentCount', 'postCount', 'postCommentCount', 'isAdult', 'isUserSubscribed', 'isBlockedByUser', 'tags', 'badges', 'moderators', 'apId', 'apProfileId', 'serverSoftware', 'serverSoftwareVersion', 'isPostingRestrictedToMods', 'localSubscribers', 'notificationStatus', 'discoverable', 'indexable'];
-    protected const MAGAZINE_SMALL_RESPONSE_KEYS = ['magazineId', 'name', 'icon', 'banner', 'isUserSubscribed', 'isBlockedByUser', 'apId', 'apProfileId', 'discoverable', 'indexable'];
-    protected const DOMAIN_RESPONSE_KEYS = ['domainId', 'name', 'entryCount', 'subscriptionsCount', 'isUserSubscribed', 'isBlockedByUser'];
+    protected const array PAGINATED_KEYS = ['items', 'pagination'];
+    protected const array PAGINATION_KEYS = ['count', 'currentPage', 'maxPage', 'perPage'];
+    protected const array CURSOR_PAGINATION_KEYS = ['currentCursor', 'currentCursor2', 'nextCursor', 'nextCursor2', 'previousCursor', 'previousCursor2', 'perPage'];
+    protected const array IMAGE_KEYS = ['filePath', 'sourceUrl', 'storageUrl', 'altText', 'width', 'height', 'blurHash'];
+    protected const array MESSAGE_RESPONSE_KEYS = ['messageId', 'threadId', 'sender', 'body', 'status', 'createdAt'];
+    protected const array USER_RESPONSE_KEYS = ['userId', 'username', 'about', 'avatar', 'cover', 'createdAt', 'followersCount', 'apId', 'apProfileId', 'isBot', 'isFollowedByUser', 'isFollowerOfUser', 'isBlockedByUser', 'isAdmin', 'isGlobalModerator', 'serverSoftware', 'serverSoftwareVersion', 'notificationStatus', 'reputationPoints', 'discoverable', 'indexable', 'title'];
+    protected const array USER_SMALL_RESPONSE_KEYS = ['userId', 'username', 'isBot', 'isFollowedByUser', 'isFollowerOfUser', 'isBlockedByUser', 'avatar', 'apId', 'apProfileId', 'createdAt', 'isAdmin', 'isGlobalModerator', 'discoverable', 'indexable', 'title'];
+    protected const array ENTRY_RESPONSE_KEYS = ['entryId', 'magazine', 'user', 'domain', 'title', 'url', 'image', 'body', 'lang', 'tags', 'badges', 'numComments', 'uv', 'dv', 'favourites', 'isFavourited', 'userVote', 'isOc', 'isAdult', 'isPinned', 'isLocked', 'createdAt', 'editedAt', 'lastActive', 'visibility', 'type', 'slug', 'apId', 'canAuthUserModerate', 'notificationStatus', 'bookmarks', 'crosspostedEntries', 'isAuthorModeratorInMagazine', 'poll'];
+    protected const array ENTRY_COMMENT_RESPONSE_KEYS = ['commentId', 'magazine', 'user', 'entryId', 'parentId', 'rootId', 'image', 'body', 'lang', 'isAdult', 'uv', 'dv', 'favourites', 'isFavourited', 'userVote', 'visibility', 'apId', 'mentions', 'tags', 'createdAt', 'editedAt', 'lastActive', 'childCount', 'children', 'canAuthUserModerate', 'bookmarks', 'isAuthorModeratorInMagazine', 'poll'];
+    protected const array POST_RESPONSE_KEYS = ['postId', 'user', 'magazine', 'image', 'body', 'lang', 'isAdult', 'isPinned', 'isLocked', 'comments', 'uv', 'dv', 'favourites', 'isFavourited', 'userVote', 'visibility', 'apId', 'tags', 'mentions', 'createdAt', 'editedAt', 'lastActive', 'slug', 'canAuthUserModerate', 'notificationStatus', 'bookmarks', 'isAuthorModeratorInMagazine', 'poll'];
+    protected const array POST_COMMENT_RESPONSE_KEYS = ['commentId', 'user', 'magazine', 'postId', 'parentId', 'rootId', 'image', 'body', 'lang', 'isAdult', 'uv', 'dv', 'favourites', 'isFavourited', 'userVote', 'visibility', 'apId', 'mentions', 'tags', 'createdAt', 'editedAt', 'lastActive', 'childCount', 'children', 'canAuthUserModerate', 'bookmarks', 'isAuthorModeratorInMagazine', 'poll'];
+    protected const array BAN_RESPONSE_KEYS = ['banId', 'reason', 'expired', 'expiredAt', 'bannedUser', 'bannedBy', 'magazine'];
+    protected const array LOG_ENTRY_KEYS = ['type', 'createdAt', 'magazine', 'moderator', 'subject'];
+    protected const array MAGAZINE_RESPONSE_KEYS = ['magazineId', 'owner', 'icon', 'banner', 'name', 'title', 'description', 'rules', 'subscriptionsCount', 'entryCount', 'entryCommentCount', 'postCount', 'postCommentCount', 'isAdult', 'isUserSubscribed', 'isBlockedByUser', 'tags', 'badges', 'moderators', 'apId', 'apProfileId', 'serverSoftware', 'serverSoftwareVersion', 'isPostingRestrictedToMods', 'localSubscribers', 'notificationStatus', 'discoverable', 'indexable'];
+    protected const array MAGAZINE_SMALL_RESPONSE_KEYS = ['magazineId', 'name', 'icon', 'banner', 'isUserSubscribed', 'isBlockedByUser', 'apId', 'apProfileId', 'discoverable', 'indexable'];
+    protected const array DOMAIN_RESPONSE_KEYS = ['domainId', 'name', 'entryCount', 'subscriptionsCount', 'isUserSubscribed', 'isBlockedByUser'];
+    protected const array POLL_KEYS = ['voterCount', 'currentUserHasVoted', 'choices'];
+    protected const array POLL_CHOICE_KEYS = ['name', 'voteCount', 'currentUserHasVoted'];
 
-    protected const KIBBY_PNG_URL_RESULT = 'a8/1c/a81cc2fea35eeb232cd28fcb109b3eb5a4e52c71bce95af6650d71876c1bcbb7.png';
+    protected const string KIBBY_PNG_URL_RESULT = 'a8/1c/a81cc2fea35eeb232cd28fcb109b3eb5a4e52c71bce95af6650d71876c1bcbb7.png';
 
     protected ArrayCollection $users;
     protected ArrayCollection $magazines;
@@ -162,6 +165,7 @@ abstract class WebTestCase extends BaseWebTestCase
     protected EntryPageFactory $pageFactory;
     protected TestingApHttpClient $testingApHttpClient;
     protected TestingImageManager $imageManager;
+    protected PollManager $pollManager;
 
     protected CreateWrapper $createWrapper;
     protected LikeWrapper $likeWrapper;
@@ -229,6 +233,7 @@ abstract class WebTestCase extends BaseWebTestCase
         $this->instanceManager = $this->getService(InstanceManager::class);
         $this->activityJsonBuilder = $this->getService(ActivityJsonBuilder::class);
         $this->mentionManager = $this->getService(MentionManager::class);
+        $this->pollManager = $this->getService(PollManager::class);
         $this->security = $this->getService(Security::class);
 
         $this->magazineRepository = $this->getService(MagazineRepository::class);

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -103,7 +103,7 @@ abstract class WebTestCase extends BaseWebTestCase
     protected const array MAGAZINE_RESPONSE_KEYS = ['magazineId', 'owner', 'icon', 'banner', 'name', 'title', 'description', 'rules', 'subscriptionsCount', 'entryCount', 'entryCommentCount', 'postCount', 'postCommentCount', 'isAdult', 'isUserSubscribed', 'isBlockedByUser', 'tags', 'badges', 'moderators', 'apId', 'apProfileId', 'serverSoftware', 'serverSoftwareVersion', 'isPostingRestrictedToMods', 'localSubscribers', 'notificationStatus', 'discoverable', 'indexable'];
     protected const array MAGAZINE_SMALL_RESPONSE_KEYS = ['magazineId', 'name', 'icon', 'banner', 'isUserSubscribed', 'isBlockedByUser', 'apId', 'apProfileId', 'discoverable', 'indexable'];
     protected const array DOMAIN_RESPONSE_KEYS = ['domainId', 'name', 'entryCount', 'subscriptionsCount', 'isUserSubscribed', 'isBlockedByUser'];
-    protected const array POLL_KEYS = ['voterCount', 'currentUserHasVoted', 'choices'];
+    protected const array POLL_KEYS = ['voterCount', 'endDate', 'currentUserHasVoted', 'choices'];
     protected const array POLL_CHOICE_KEYS = ['name', 'voteCount', 'currentUserHasVoted'];
 
     protected const string KIBBY_PNG_URL_RESULT = 'a8/1c/a81cc2fea35eeb232cd28fcb109b3eb5a4e52c71bce95af6650d71876c1bcbb7.png';

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -1226,3 +1226,15 @@ filter_lists_feeds_help: Filter words in threads, microblogs and comments in fee
 filter_lists_comments_help: Filter words while viewing a thread or microblog in the comment tree.
 filter_lists_profile_help: Filter words while viewing a users' profile in their content.
 expired: Expired
+poll: Poll
+poll_edit_voters_reset: All votes will be reset after editing!
+poll_ends_at: Poll ends at
+poll_choices: Choices
+poll_is_multiple_choice: Is multiple choice
+poll_vote: Vote
+poll_ends: Poll ends
+poll_ended: Poll ended
+poll_voters: '{0}Persons|{1}Person|]1,Inf[ Persons'
+poll_update_results: Update results
+notification_title_poll_ended: A poll you have voted in has ended
+notification_title_poll_edited: A poll you have voted in has been edited

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -1232,6 +1232,8 @@ poll_ends_at: Poll ends at
 poll_choices: Choices
 poll_is_multiple_choice: Is multiple choice
 poll_vote: Vote
+poll_show_results: Show results
+poll_hide_results: Hide results
 poll_ends: Poll ends
 poll_ended: Poll ended
 poll_voters: '{0}Persons|{1}Person|]1,Inf[ Persons'

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -1234,3 +1234,15 @@ block_instance_globally_short: Block Globally
 block_instance_globally_long: Block Instance for all Users
 unblock_instance_globally_short: Unblock Globally
 unblock_instance_globally_long: Unblock Instance for all Users
+poll: Poll
+poll_edit_voters_reset: All votes will be reset after editing!
+poll_ends_at: Poll ends at
+poll_choices: Choices
+poll_is_multiple_choice: Is multiple choice
+poll_vote: Vote
+poll_ends: Poll ends
+poll_ended: Poll ended
+poll_voters: '{0}Persons|{1}Person|]1,Inf[ Persons'
+poll_update_results: Update results
+notification_title_poll_ended: A poll you have voted in has ended
+notification_title_poll_edited: A poll you have voted in has been edited

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -1240,6 +1240,8 @@ poll_ends_at: Poll ends at
 poll_choices: Choices
 poll_is_multiple_choice: Is multiple choice
 poll_vote: Vote
+poll_show_results: Show results
+poll_hide_results: Hide results
 poll_ends: Poll ends
 poll_ended: Poll ended
 poll_voters: '{0}Persons|{1}Person|]1,Inf[ Persons'


### PR DESCRIPTION
- add the ability to add a poll to Entry, EntryComment, Post and PostComment
- Polls:
  - can be multiple choice
  - can contain an unlimited number of choices
  - can expire
- Add a hidden form for the poll to all create forms, the form appears when a checkbox is checked
- The ActivityPub implementation is the same as on Mastodon: https://docs.joinmastodon.org/spec/activitypub/#Question
- Add tests for the ActivityPub implementation and the Api controller
- The api had to be shifted a bit -> the `serialize...` functions in the base api take only the entity classes now instead of their dto variant -> touched a lot of api classes because of this

I will add images when this moves out of the draft phase :)

Closes #647 