### PR TITLE
Fix command only working halfway through

### DIFF
--- a/src/Command/RemoveRemoteMediaCommand.php
+++ b/src/Command/RemoveRemoteMediaCommand.php
@@ -60,7 +60,7 @@ class RemoveRemoteMediaCommand extends Command
         $totalDeletedFiles = 0;
         $totalDeletedSize = 0;
 
-        for ($i = 0; $i < $images->getNbPages(); ++$i) {
+        for ($i = 0; \sizeof($images); ++$i) {
             $progressBar->setMessage(\sprintf('Fetching images %s - %s', ($i * $batchSize) + 1, ($i + 1) * $batchSize));
             $progressBar->display();
             foreach ($images->getCurrentPageResults() as $image) {
@@ -81,7 +81,9 @@ class RemoveRemoteMediaCommand extends Command
                 }
             }
             if ($images->hasNextPage()) {
-                $images->setCurrentPage($images->getNextPage());
+                $images = $this->imageRepository->findOldRemoteMediaPaginated($days, $batchSize);
+            } else {
+                $images = [];
             }
         }
         $io->writeln('');


### PR DESCRIPTION
The problem was the pagination. About halfway through it tries to refetch the images, but the result set is now half the size, because the images it already deleted will not appear in the results anymore. Fix that by just fetching again without the offset if there is a next page and if not just set it to an empty array