### PR TITLE
Add the second cursor to the query

### DIFF
--- a/src/Controller/Entry/EntryFrontController.php
+++ b/src/Controller/Entry/EntryFrontController.php
@@ -44,6 +44,7 @@ class EntryFrontController extends AbstractController
         ?string $type,
         Request $request,
         #[MapQueryParameter] ?string $cursor = null,
+        #[MapQueryParameter] ?string $cursor2 = null,
     ): Response {
         $user = $this->getUser();
 
@@ -64,7 +65,9 @@ class EntryFrontController extends AbstractController
             $criteria->fetchCachedItems($this->sqlHelpers, $user);
         }
 
-        $entities = $this->contentRepository->findByCriteriaCursored($criteria, $this->getCursorByCriteria($criteria->sortOption, $cursor));
+        $cursorValue = $this->getCursorByCriteria($criteria->sortOption, $cursor);
+        $cursor2Value = $cursor2 ? $this->getCursorByCriteria(Criteria::SORT_NEW, $cursor2) : null;
+        $entities = $this->contentRepository->findByCriteriaCursored($criteria, $cursorValue, $cursor2Value);
         $templatePath = 'content/';
         $dataKey = 'results';
 

--- a/src/Pagination/Cursor/NativeQueryCursorAdapter.php
+++ b/src/Pagination/Cursor/NativeQueryCursorAdapter.php
@@ -94,6 +94,9 @@ class NativeQueryCursorAdapter implements CursorAdapterInterface
             $statement->bindValue('cursor2', $cursor2, SqlHelpers::getSqlType($cursor2));
         }
         $statement->bindValue('limit', $length);
+        if (str_contains($sql, ':innerLimit')) {
+            $statement->bindValue('innerLimit', $length * 3);
+        }
 
         return $this->transformer->transform($statement->executeQuery()->fetchAllAssociative());
     }

--- a/src/Repository/ContentRepository.php
+++ b/src/Repository/ContentRepository.php
@@ -473,7 +473,7 @@ class ContentRepository
             LEFT JOIN magazine m ON c.magazine_id = m.id
             $postCommentWhere";
 
-        $innerLimit = $addCursor ? 'LIMIT :limit' : '';
+        $innerLimit = $addCursor ? 'LIMIT :innerLimit' : '';
         $innerSql = '';
         if (Criteria::CONTENT_THREADS === $criteria->content) {
             if ($includeEntryComments) {


### PR DESCRIPTION
- We have a second cursor to resolve "ties" in values, this one was missing from the default feeds (it is present in the magazine feeds)
- Add a different inner limit for cursored queries so the outer query can filter things away and still have enough items to fill a page