### PR TITLE
Fix typo in monitoring_duration_twig_render

### DIFF
--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -1175,7 +1175,7 @@ monitoring_route_overview_description: This graph shows the summed milliseconds 
   being computed
 monitoring_duration_overall: Other
 monitoring_duration_query: Query
-monitoring_duration_twig_render: Twit Render
+monitoring_duration_twig_render: Twig Render
 monitoring_duration_curl_request: Curl Request
 monitoring_duration_sending_response: Sending Response
 monitoring_dont_format_query: don't format query


### PR DESCRIPTION
 Fix typo in main translation (English)

