### PR TITLE
Fix dry-run option missing

### DIFF
--- a/src/Command/CheckDuplicatesUsersMagazines.php
+++ b/src/Command/CheckDuplicatesUsersMagazines.php
@@ -20,6 +20,7 @@ use Psr\Cache\InvalidArgumentException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -45,7 +46,8 @@ class CheckDuplicatesUsersMagazines extends Command
     protected function configure(): void
     {
         $this
-            ->setDescription('Check for duplicate users and magazines with interactive deletion options.');
+            ->setDescription('Check for duplicate users and magazines with interactive deletion options.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Simulate actions without making any changes');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int


### PR DESCRIPTION
For some reason this was never tested I think, since the `addOption` for dry-run was missing. So even without using the `dry-run` parameter, you will get a fatal error:

```
$ php bin/console mbin:check:duplicates-users-magazines

Duplicate Users and Magazines Checker
=====================================

{"message":"Error thrown while running command \"mbin:check:duplicates-users-magazines\". Message: \"The \"dry-run\" option does not exist.\"","context":{"exception":{"class":"Symfony\\Component\\Console\\Exception\\InvalidArgumentException","message":"The \"dry-run\" option does not exist.","code":0,"file":"/var/www/kbin.melroy.org/html/vendor/symfony/console/Input/Input.php:127"},"command":"mbin:check:duplicates-users-magazines","message":"The \"dry-run\" option does not exist."},"level":500,"level_name":"CRITICAL","channel":"console","datetime":"2026-05-11T22:17:45.742024+00:00","extra":{}}
22:17:45 CRITICAL  [console] Error thrown while running command "mbin:check:duplicates-users-magazines". Message: "The "dry-run" option does not exist." ["exception" => Symfony\Component\Console\Exception\InvalidArgumentException^ { …},"command" => "mbin:check:duplicates-users-magazines","message" => "The "dry-run" option does not exist."]

                                        
  The "dry-run" option does not exist.  
                                        

mbin:check:duplicates-users-magazines
```

This should fix that.