### PR TITLE
Order content by boost date in Combined if boosted content should be included

### DIFF
--- a/migrations/Version20260526175316.php
+++ b/migrations/Version20260526175316.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260526175316 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'adds last_boosted_at with default value to entry, entry_comment, post and post_comment';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE entry ADD last_boosted_at TIMESTAMP(0) WITH TIME ZONE NOT NULL DEFAULT to_timestamp(0)::date');
+        $this->addSql('CREATE INDEX entry_last_boosted_at_idx ON entry (last_boosted_at)');
+        $this->addSql('ALTER TABLE entry_comment ADD last_boosted_at TIMESTAMP(0) WITH TIME ZONE NOT NULL DEFAULT to_timestamp(0)::date');
+        $this->addSql('CREATE INDEX entry_comment_last_boosted_at_idx ON entry_comment (last_boosted_at)');
+        $this->addSql('ALTER TABLE post ADD last_boosted_at TIMESTAMP(0) WITH TIME ZONE NOT NULL DEFAULT to_timestamp(0)::date');
+        $this->addSql('CREATE INDEX post_last_boosted_at_idx ON post (last_boosted_at)');
+        $this->addSql('ALTER TABLE post_comment ADD last_boosted_at TIMESTAMP(0) WITH TIME ZONE NOT NULL DEFAULT to_timestamp(0)::date');
+        $this->addSql('CREATE INDEX post_comment_last_boosted_at_idx ON post_comment (last_boosted_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX entry_last_boosted_at_idx');
+        $this->addSql('ALTER TABLE entry DROP last_boosted_at');
+        $this->addSql('DROP INDEX entry_comment_last_boosted_at_idx');
+        $this->addSql('ALTER TABLE entry_comment DROP last_boosted_at');
+        $this->addSql('DROP INDEX post_last_boosted_at_idx');
+        $this->addSql('ALTER TABLE post DROP last_boosted_at');
+        $this->addSql('DROP INDEX post_comment_last_boosted_at_idx');
+        $this->addSql('ALTER TABLE post_comment DROP last_boosted_at');
+    }
+
+    public function postUp(Schema $schema): void
+    {
+        $this->connection->transactional(function (): void {
+            $sqlTpl = 'UPDATE $e SET last_boosted_at = greatest((SELECT $e_vote.created_at FROM $e_vote WHERE $e_vote.$fk = $e.id ORDER BY $e_vote.created_at DESC LIMIT 1), created_at);';
+            $this->connection->executeStatement(str_replace('$e', 'entry', str_replace('$fk', 'entry_id', $sqlTpl)));
+            $this->connection->executeStatement(str_replace('$e', 'entry_comment', str_replace('$fk', 'comment_id', $sqlTpl)));
+            $this->connection->executeStatement(str_replace('$e', 'post', str_replace('$fk', 'post_id', $sqlTpl)));
+            $this->connection->executeStatement(str_replace('$e', 'post_comment', str_replace('$fk', 'comment_id', $sqlTpl)));
+        });
+    }
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="4"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
+    findUnusedVariablesAndParams="false"
+>
+    <projectFiles>
+        <directory name="src"/>
+        <ignoreFiles>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <PossiblyUnusedReturnValue errorLevel="suppress" />
+    </issueHandlers>
+</psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -19,5 +19,6 @@
 
     <issueHandlers>
         <PossiblyUnusedReturnValue errorLevel="suppress" />
+        <!-- <MissingAbstractPureAnnotation errorLevel="suppress" /> -->
     </issueHandlers>
 </psalm>

--- a/src/Controller/Entry/EntryFrontController.php
+++ b/src/Controller/Entry/EntryFrontController.php
@@ -65,9 +65,9 @@ class EntryFrontController extends AbstractController
             $criteria->fetchCachedItems($this->sqlHelpers, $user);
         }
 
-        $cursorValue = $this->getCursorByCriteria($criteria->sortOption, $cursor);
-        $cursor2Value = $cursor2 ? $this->getCursorByCriteria(Criteria::SORT_NEW, $cursor2) : null;
-        $entities = $this->contentRepository->findByCriteriaCursored($criteria, $cursorValue, $cursor2Value);
+        //$cursorValue = $this->getCursorByCriteria($criteria->sortOption, $cursor);
+        //$cursor2Value = $cursor2 ? $this->getCursorByCriteria(Criteria::SORT_NEW, $cursor2) : null;
+        $entities = $this->contentRepository->findByCriteria($criteria);
         $templatePath = 'content/';
         $dataKey = 'results';
 
@@ -136,9 +136,10 @@ class EntryFrontController extends AbstractController
         if (null !== $user) {
             $criteria->fetchCachedItems($this->sqlHelpers, $user);
         }
-        $cursorValue = $this->getCursorByCriteria($criteria->sortOption, $cursor);
-        $cursor2Value = $cursor2 ? $this->getCursorByCriteria(Criteria::SORT_NEW, $cursor2) : null;
-        $results = $this->contentRepository->findByCriteriaCursored($criteria, $cursorValue, $cursor2Value);
+        #$cursorValue = $this->getCursorByCriteria($criteria->sortOption, $cursor);
+        #$cursor2Value = $cursor2 ? $this->getCursorByCriteria(Criteria::SORT_NEW, $cursor2) : null;
+        #$results = $this->contentRepository->findByCriteriaCursored($criteria, $cursorValue, $cursor2Value);
+        $results = $this->contentRepository->findByCriteria($criteria);
 
         return $this->renderResponse(
             $request,

--- a/src/Controller/Entry/EntryFrontController.php
+++ b/src/Controller/Entry/EntryFrontController.php
@@ -65,9 +65,9 @@ class EntryFrontController extends AbstractController
             $criteria->fetchCachedItems($this->sqlHelpers, $user);
         }
 
-        //$cursorValue = $this->getCursorByCriteria($criteria->sortOption, $cursor);
-        //$cursor2Value = $cursor2 ? $this->getCursorByCriteria(Criteria::SORT_NEW, $cursor2) : null;
-        $entities = $this->contentRepository->findByCriteria($criteria);
+        $cursorValue = $this->getCursorByCriteria($criteria->sortOption, $cursor);
+        $cursor2Value = $cursor2 ? $this->getCursorByCriteria(Criteria::SORT_NEW, $cursor2) : null;
+        $entities = $this->contentRepository->findByCriteriaCursored($criteria, $cursorValue, $cursor2Value);
         $templatePath = 'content/';
         $dataKey = 'results';
 
@@ -136,10 +136,9 @@ class EntryFrontController extends AbstractController
         if (null !== $user) {
             $criteria->fetchCachedItems($this->sqlHelpers, $user);
         }
-        #$cursorValue = $this->getCursorByCriteria($criteria->sortOption, $cursor);
-        #$cursor2Value = $cursor2 ? $this->getCursorByCriteria(Criteria::SORT_NEW, $cursor2) : null;
-        #$results = $this->contentRepository->findByCriteriaCursored($criteria, $cursorValue, $cursor2Value);
-        $results = $this->contentRepository->findByCriteria($criteria);
+        $cursorValue = $this->getCursorByCriteria($criteria->sortOption, $cursor);
+        $cursor2Value = $cursor2 ? $this->getCursorByCriteria(Criteria::SORT_NEW, $cursor2) : null;
+        $results = $this->contentRepository->findByCriteriaCursored($criteria, $cursorValue, $cursor2Value);
 
         return $this->renderResponse(
             $request,

--- a/src/Entity/Contracts/VotableInterface.php
+++ b/src/Entity/Contracts/VotableInterface.php
@@ -39,5 +39,8 @@ interface VotableInterface
 
     public function getUserVote(User $user): ?Vote;
 
+    /**
+     * @psalm-external-mutation-free
+     */
     public function updateLastBoostDate(): self;
 }

--- a/src/Entity/Contracts/VotableInterface.php
+++ b/src/Entity/Contracts/VotableInterface.php
@@ -38,4 +38,6 @@ interface VotableInterface
     public function getUserChoice(User $user): int;
 
     public function getUserVote(User $user): ?Vote;
+
+    public function updateLastBoostDate(): self;
 }

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -176,6 +176,7 @@ class Entry implements VotableInterface, CommentInterface, DomainInterface, Visi
         $this->createdAtTraitConstruct();
         $this->updateLastActive();
 
+        /* @psalm-suppress UninitializedProperty */
         $this->lastBoostedAt = $this->createdAt;
     }
 

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -43,6 +43,7 @@ use Webmozart\Assert\Assert;
 #[Index(columns: ['comment_count'], name: 'entry_comment_count_idx')]
 #[Index(columns: ['created_at'], name: 'entry_created_at_idx')]
 #[Index(columns: ['last_active'], name: 'entry_last_active_at_idx')]
+#[Index(columns: ['last_boosted_at'], name: 'entry_last_boosted_at_idx')]
 #[Index(columns: ['body_ts'], name: 'entry_body_ts_idx')]
 #[Index(columns: ['title_ts'], name: 'entry_title_ts_idx')]
 class Entry implements VotableInterface, CommentInterface, DomainInterface, VisibilityInterface, RankingInterface, ReportInterface, FavouriteInterface, ActivityPubActivityInterface, ContentVisibilityInterface
@@ -173,8 +174,9 @@ class Entry implements VotableInterface, CommentInterface, DomainInterface, Visi
         $user->addEntry($this);
 
         $this->createdAtTraitConstruct();
-
         $this->updateLastActive();
+
+        $this->lastBoostedAt = $this->createdAt;
     }
 
     public function updateLastActive(): void

--- a/src/Entity/EntryComment.php
+++ b/src/Entity/EntryComment.php
@@ -129,6 +129,7 @@ class EntryComment implements VotableInterface, VisibilityInterface, ReportInter
         $this->createdAtTraitConstruct();
         $this->updateLastActive();
 
+        /* @psalm-suppress UninitializedProperty */
         $this->lastBoostedAt = $this->createdAt;
     }
 

--- a/src/Entity/EntryComment.php
+++ b/src/Entity/EntryComment.php
@@ -37,6 +37,7 @@ use Webmozart\Assert\Assert;
 #[Index(columns: ['up_votes'], name: 'entry_comment_up_votes_idx')]
 #[Index(columns: ['last_active'], name: 'entry_comment_last_active_at_idx')]
 #[Index(columns: ['created_at'], name: 'entry_comment_created_at_idx')]
+#[Index(columns: ['last_boosted_at'], name: 'entry_comment_last_boosted_at_idx')]
 #[Index(columns: ['body_ts'], name: 'entry_comment_body_ts_idx')]
 class EntryComment implements VotableInterface, VisibilityInterface, ReportInterface, FavouriteInterface, ActivityPubActivityInterface
 {
@@ -127,6 +128,8 @@ class EntryComment implements VotableInterface, VisibilityInterface, ReportInter
 
         $this->createdAtTraitConstruct();
         $this->updateLastActive();
+
+        $this->lastBoostedAt = $this->createdAt;
     }
 
     public function updateLastActive(): void

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -40,6 +40,7 @@ use Webmozart\Assert\Assert;
 #[Index(columns: ['comment_count'], name: 'post_comment_count_idx')]
 #[Index(columns: ['created_at'], name: 'post_created_at_idx')]
 #[Index(columns: ['last_active'], name: 'post_last_active_at_idx')]
+#[Index(columns: ['last_boosted_at'], name: 'post_last_boosted_at_idx')]
 #[Index(columns: ['body_ts'], name: 'post_body_ts_idx')]
 class Post implements VotableInterface, CommentInterface, VisibilityInterface, RankingInterface, ReportInterface, FavouriteInterface, ActivityPubActivityInterface
 {
@@ -127,6 +128,8 @@ class Post implements VotableInterface, CommentInterface, VisibilityInterface, R
 
         $this->createdAtTraitConstruct();
         $this->updateLastActive();
+
+        $this->lastBoostedAt = $this->createdAt;
     }
 
     public function updateLastActive(): void

--- a/src/Entity/PostComment.php
+++ b/src/Entity/PostComment.php
@@ -37,6 +37,7 @@ use Webmozart\Assert\Assert;
 #[Index(columns: ['up_votes'], name: 'post_comment_up_votes_idx')]
 #[Index(columns: ['last_active'], name: 'post_comment_last_active_at_idx')]
 #[Index(columns: ['created_at'], name: 'post_comment_created_at_idx')]
+#[Index(columns: ['last_boosted_at'], name: 'post_comment_last_boosted_at_idx')]
 #[Index(columns: ['body_ts'], name: 'post_comment_body_ts_idx')]
 class PostComment implements VotableInterface, VisibilityInterface, ReportInterface, FavouriteInterface, ActivityPubActivityInterface
 {
@@ -123,6 +124,8 @@ class PostComment implements VotableInterface, VisibilityInterface, ReportInterf
 
         $this->createdAtTraitConstruct();
         $this->updateLastActive();
+
+        $this->lastBoostedAt = $this->createdAt;
     }
 
     public function updateLastActive(): void

--- a/src/Entity/Traits/VotableTrait.php
+++ b/src/Entity/Traits/VotableTrait.php
@@ -28,6 +28,9 @@ trait VotableTrait
     #[Column(type: 'integer', nullable: true)]
     public ?int $apShareCount = null;
 
+    #[Column(type: 'datetimetz_immutable', nullable: false)]
+    public ?\DateTimeImmutable $lastBoostedAt;
+
     public function countUpVotes(): int
     {
         return $this->apShareCount ?? $this->upVotes;
@@ -62,6 +65,13 @@ trait VotableTrait
     {
         $this->upVotes = $this->getUpVotes()->count();
         $this->downVotes = $this->getDownVotes()->count();
+
+        return $this;
+    }
+
+    public function updateLastBoostDate(): self
+    {
+        $this->lastBoostedAt = new \DateTimeImmutable();
 
         return $this;
     }

--- a/src/Repository/ContentRepository.php
+++ b/src/Repository/ContentRepository.php
@@ -461,17 +461,17 @@ class ContentRepository
         // only join domain if we are explicitly looking at one
         $domainJoin = $criteria->domain ? 'LEFT JOIN domain d ON d.id = c.domain_id' : '';
 
-        $entrySql = "SELECT c.id, 'entry' as type, c.type as content_type, c.created_at, c.ranking, c.score, c.comment_count, c.sticky, c.last_active, c.user_id FROM entry c
+        $entrySql = "SELECT c.id, 'entry' as type, c.type as content_type, c.created_at, c.last_boosted_at, c.ranking, c.score, c.comment_count, c.sticky, c.last_active, c.user_id FROM entry c
             LEFT JOIN magazine m ON c.magazine_id = m.id
             $domainJoin
             $entryWhere";
-        $postSql = "SELECT c.id, 'post' as type, 'microblog' as content_type, c.created_at, c.ranking, c.score, c.comment_count, c.sticky, c.last_active, c.user_id FROM post c
+        $postSql = "SELECT c.id, 'post' as type, 'microblog' as content_type, c.created_at, c.last_boosted_at, c.ranking, c.score, c.comment_count, c.sticky, c.last_active, c.user_id FROM post c
             LEFT JOIN magazine m ON c.magazine_id = m.id
             $postWhere";
-        $entryCommentSql = "SELECT c.id, 'entry_comment' as type, 'microblog' as content_type, c.created_at, 0 as ranking, 0 as score, 0 as comment_count, false as sticky, c.last_active, c.user_id FROM entry_comment c
+        $entryCommentSql = "SELECT c.id, 'entry_comment' as type, 'microblog' as content_type, c.created_at, c.last_boosted_at, 0 as ranking, 0 as score, 0 as comment_count, false as sticky, c.last_active, c.user_id FROM entry_comment c
             LEFT JOIN magazine m ON c.magazine_id = m.id
             $entryCommentWhere";
-        $postCommentSql = "SELECT c.id, 'post_comment' as type, 'microblog' as content_type, c.created_at, 0 as ranking, 0 as score, 0 as comment_count, false as sticky, c.last_active, c.user_id FROM post_comment c
+        $postCommentSql = "SELECT c.id, 'post_comment' as type, 'microblog' as content_type, c.created_at, c.last_boosted_at, 0 as ranking, 0 as score, 0 as comment_count, false as sticky, c.last_active, c.user_id FROM post_comment c
             LEFT JOIN magazine m ON c.magazine_id = m.id
             $postCommentWhere";
 
@@ -523,7 +523,7 @@ class ContentRepository
             Criteria::SORT_HOT => 'ranking',
             Criteria::SORT_COMMENTED => 'commentCount',
             Criteria::SORT_ACTIVE => 'lastActive',
-            default => 'createdAt',
+            default => $criteria->includeBoosts ? 'lastBoostedAt' : 'createdAt',
         };
     }
 
@@ -534,8 +534,8 @@ class ContentRepository
             Criteria::SORT_HOT => 'c.ranking < :cursor',
             Criteria::SORT_COMMENTED => 'c.comment_count < :cursor',
             Criteria::SORT_ACTIVE => 'c.last_active < :cursor',
-            Criteria::SORT_OLD => 'c.created_at > :cursor',
-            default => 'c.created_at < :cursor',
+            Criteria::SORT_OLD => $criteria->includeBoosts ? 'c.last_boosted_at > :cursor' : 'c.created_at > :cursor',
+            default => $criteria->includeBoosts ? 'c.last_boosted_at < :cursor' : 'c.created_at < :cursor',
         };
     }
 
@@ -546,8 +546,8 @@ class ContentRepository
             Criteria::SORT_HOT => 'c.ranking > :cursor',
             Criteria::SORT_COMMENTED => 'c.comment_count > :cursor',
             Criteria::SORT_ACTIVE => 'c.last_active > :cursor',
-            Criteria::SORT_OLD => 'c.created_at < :cursor',
-            default => 'c.created_at >= :cursor',
+            Criteria::SORT_OLD => $criteria->includeBoosts ? 'c.last_boosted_at < :cursor' : 'c.created_at < :cursor',
+            default => $criteria->includeBoosts ? 'c.last_boosted_at >= :cursor' : 'c.created_at >= :cursor',
         };
     }
 
@@ -608,11 +608,11 @@ class ContentRepository
 
         switch ($criteria->sortOption) {
             case Criteria::SORT_OLD:
-                $orderings[] = 'created_at ASC';
+                $orderings[] = $criteria->includeBoosts ? 'last_boosted_at ASC' : 'created_at ASC';
                 break;
             case Criteria::SORT_NEW:
             default:
-                $orderings[] = 'created_at DESC';
+                $orderings[] = $criteria->includeBoosts ? 'last_boosted_at DESC' : 'created_at DESC';
         }
 
         return $orderings;

--- a/src/Repository/ContentRepository.php
+++ b/src/Repository/ContentRepository.php
@@ -82,8 +82,8 @@ class ContentRepository
                 $query['parameters'],
                 $this->getSecondaryCursorWhereFromCriteria($criteria),
                 $this->getSecondaryCursorWhereFromCriteriaInverted($criteria),
-                'sort_date DESC',
-                'sort_date',
+                'c.created_at DESC',
+                'c.created_at',
                 transformer: $this->contentPopulationTransformer,
             ),
             $this->getCursorFieldFromCriteria($criteria),
@@ -215,21 +215,21 @@ class ContentRepository
 
                 $subClauseEntryComment = $repliesCommonWhere.
                     (null === $criteria->cachedUserFollows ?
-                        ' OR EXISTS (SELECT 1 FROM user_follow uf WHERE uf.follower_id = :loggedInUser AND uf.following_id = v.user_id) OR v.user_id = :loggedInUser' :
-                        ' OR v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser');
+                        ' OR EXISTS (SELECT 1 FROM user_follow uf RIGHT OUTER JOIN entry_comment_vote v ON uf.following_id = v.user_id WHERE c.id = v.comment_id AND (uf.follower_id = :loggedInUser OR v.user_id = :loggedInUser) AND v.choice = 1)' :
+                        ' OR EXISTS (SELECT 1 FROM entry_comment_vote v WHERE c.id = v.comment_id AND (v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser) AND v.choice = 1)');
                 $subClausePostComment = $repliesCommonWhere.
                     (null === $criteria->cachedUserFollows ?
-                        ' OR EXISTS (SELECT 1 FROM user_follow uf WHERE uf.follower_id = :loggedInUser AND uf.following_id = v.user_id) OR v.user_id = :loggedInUser' :
-                        ' OR v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser');
+                        ' OR EXISTS (SELECT 1 FROM user_follow uf RIGHT OUTER JOIN post_comment_vote v ON uf.following_id = v.user_id WHERE c.id = v.comment_id AND (uf.follower_id = :loggedInUser OR v.user_id = :loggedInUser) AND v.choice = 1)' :
+                        ' OR EXISTS (SELECT 1 FROM post_comment_vote v WHERE c.id = v.comment_id AND (v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser) AND v.choice = 1)');
 
                 $subClausePost = $subClausePost
                     .(null === $criteria->cachedUserFollows ?
-                        ' OR EXISTS (SELECT 1 FROM user_follow uf WHERE uf.follower_id = :loggedInUser AND uf.following_id = v.user_id) OR v.user_id = :loggedInUser' :
-                        ' OR v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser');
+                        ' OR EXISTS (SELECT 1 FROM user_follow uf RIGHT OUTER JOIN post_vote v ON uf.following_id = v.user_id WHERE c.id = v.post_id AND (uf.follower_id = :loggedInUser OR v.user_id = :loggedInUser) AND v.choice = 1)' :
+                        ' OR EXISTS (SELECT 1 FROM post_vote v WHERE c.id = v.post_id AND (v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser) AND v.choice = 1)');
                 $subClauseEntry = $subClauseEntry
                     .(null === $criteria->cachedUserFollows ?
-                        ' OR EXISTS (SELECT 1 FROM user_follow uf WHERE uf.follower_id = :loggedInUser AND uf.following_id = v.user_id) OR v.user_id = :loggedInUser' :
-                        ' OR v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser');
+                        ' OR EXISTS (SELECT 1 FROM user_follow uf RIGHT OUTER JOIN entry_vote v ON uf.following_id = v.user_id WHERE c.id = v.entry_id AND (uf.follower_id = :loggedInUser OR v.user_id = :loggedInUser) AND v.choice = 1)' :
+                        ' OR EXISTS (SELECT 1 FROM entry_vote v WHERE c.id = v.entry_id AND (v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser) AND v.choice = 1)');
             }
 
             if (null !== $criteria->cachedUserSubscribedMagazines) {
@@ -379,7 +379,7 @@ class ContentRepository
             $visibilityClauseM,
             $visibilityClauseC,
             $allClause,
-            $addCursor && !$criteria->includeBoosts ? '%cursor% OR (%cursor2%)' : '',
+            $addCursor ? '%cursor% OR (%cursor2%)' : '',
             $filterClauseEntry,
         ]);
 
@@ -401,7 +401,7 @@ class ContentRepository
             $visibilityClauseM,
             $visibilityClauseC,
             $allClause,
-            $addCursor && !$criteria->includeBoosts ? '%cursor% OR (%cursor2%)' : '',
+            $addCursor ? '%cursor% OR (%cursor2%)' : '',
             $filterClausePost,
         ]);
 
@@ -422,7 +422,7 @@ class ContentRepository
             $visibilityClauseM,
             $visibilityClauseC,
             $allClause,
-            $addCursor && !$criteria->includeBoosts ? '%cursor% OR (%cursor2%)' : '',
+            $addCursor ? '%cursor% OR (%cursor2%)' : '',
             $filterClauseComments,
         ]);
 
@@ -444,7 +444,7 @@ class ContentRepository
             $visibilityClauseM,
             $visibilityClauseC,
             $allClause,
-            $addCursor && !$criteria->includeBoosts ? '%cursor% OR (%cursor2%)' : '',
+            $addCursor ? '%cursor% OR (%cursor2%)' : '',
             $filterClauseComments,
         ]);
 
@@ -461,53 +461,19 @@ class ContentRepository
         // only join domain if we are explicitly looking at one
         $domainJoin = $criteria->domain ? 'LEFT JOIN domain d ON d.id = c.domain_id' : '';
 
-        if($criteria->includeBoosts) {
-            $boostJoinEntry = 'LEFT JOIN entry_vote v ON (c.id = v.entry_id AND v.choice = 1)';
-            $boostJoinEntryComment = 'LEFT JOIN entry_comment_vote v ON (c.id = v.comment_id AND v.choice = 1)';
-            $boostJoinPost = 'LEFT JOIN post_vote v ON (c.id = v.post_id AND v.choice = 1)';
-            $boostJoinPostComment = 'LEFT JOIN post_comment_vote v ON (c.id = v.comment_id AND v.choice = 1)';
-
-            $sortDateSelect = 'greatest(max(c.created_at), max(v.created_at)) AS sort_date';
-        } else {
-            $boostJoinEntry = '';
-            $boostJoinEntryComment = '';
-            $boostJoinPost = '';
-            $boostJoinPostComment = '';
-
-            $sortDateSelect = 'c.created_at AS sort_date';
-        }
-
-        $entrySql = "SELECT c.id, 'entry' as type, c.type as content_type, c.created_at, c.ranking, c.score, c.comment_count, c.sticky, c.last_active, c.user_id, $sortDateSelect FROM entry c
+        $entrySql = "SELECT c.id, 'entry' as type, c.type as content_type, c.created_at, c.ranking, c.score, c.comment_count, c.sticky, c.last_active, c.user_id FROM entry c
             LEFT JOIN magazine m ON c.magazine_id = m.id
             $domainJoin
-            $boostJoinEntry
             $entryWhere";
-        $postSql = "SELECT c.id, 'post' as type, 'microblog' as content_type, c.created_at, c.ranking, c.score, c.comment_count, c.sticky, c.last_active, c.user_id, $sortDateSelect FROM post c
+        $postSql = "SELECT c.id, 'post' as type, 'microblog' as content_type, c.created_at, c.ranking, c.score, c.comment_count, c.sticky, c.last_active, c.user_id FROM post c
             LEFT JOIN magazine m ON c.magazine_id = m.id
-            $boostJoinPost
             $postWhere";
-        $entryCommentSql = "SELECT c.id, 'entry_comment' as type, 'microblog' as content_type, c.created_at, 0 as ranking, 0 as score, 0 as comment_count, false as sticky, c.last_active, c.user_id, $sortDateSelect FROM entry_comment c
+        $entryCommentSql = "SELECT c.id, 'entry_comment' as type, 'microblog' as content_type, c.created_at, 0 as ranking, 0 as score, 0 as comment_count, false as sticky, c.last_active, c.user_id FROM entry_comment c
             LEFT JOIN magazine m ON c.magazine_id = m.id
-            $boostJoinEntryComment
             $entryCommentWhere";
-        $postCommentSql = "SELECT c.id, 'post_comment' as type, 'microblog' as content_type, c.created_at, 0 as ranking, 0 as score, 0 as comment_count, false as sticky, c.last_active, c.user_id, $sortDateSelect FROM post_comment c
+        $postCommentSql = "SELECT c.id, 'post_comment' as type, 'microblog' as content_type, c.created_at, 0 as ranking, 0 as score, 0 as comment_count, false as sticky, c.last_active, c.user_id FROM post_comment c
             LEFT JOIN magazine m ON c.magazine_id = m.id
-            $boostJoinPostComment
             $postCommentWhere";
-
-        if($criteria->includeBoosts) {
-            $entrySql = $entrySql.' GROUP BY c.id';
-            $postSql = $postSql.' GROUP BY c.id';
-            $entryCommentSql = $entryCommentSql.' GROUP BY c.id';
-            $postCommentSql = $postCommentSql.' GROUP BY c.id';
-
-            if($addCursor) {
-                $entrySql = $entrySql.' WHERE %cursor% OR (%cursor2%)';
-                $postSql = $postSql.' WHERE %cursor% OR (%cursor2%)';
-                $entryCommentSql = $entryCommentSql.' WHERE %cursor% OR (%cursor2%)';
-                $postCommentSql = $postCommentSql.' WHERE %cursor% OR (%cursor2%)';
-            }
-        }
 
         $innerLimit = $addCursor ? 'LIMIT :innerLimit' : '';
         $innerSql = '';
@@ -557,7 +523,7 @@ class ContentRepository
             Criteria::SORT_HOT => 'ranking',
             Criteria::SORT_COMMENTED => 'commentCount',
             Criteria::SORT_ACTIVE => 'lastActive',
-            default => 'sort_date',
+            default => 'createdAt',
         };
     }
 
@@ -568,8 +534,8 @@ class ContentRepository
             Criteria::SORT_HOT => 'c.ranking < :cursor',
             Criteria::SORT_COMMENTED => 'c.comment_count < :cursor',
             Criteria::SORT_ACTIVE => 'c.last_active < :cursor',
-            Criteria::SORT_OLD => 'sort_date > :cursor',
-            default => 'sort_date < :cursor',
+            Criteria::SORT_OLD => 'c.created_at > :cursor',
+            default => 'c.created_at < :cursor',
         };
     }
 
@@ -580,18 +546,18 @@ class ContentRepository
             Criteria::SORT_HOT => 'c.ranking > :cursor',
             Criteria::SORT_COMMENTED => 'c.comment_count > :cursor',
             Criteria::SORT_ACTIVE => 'c.last_active > :cursor',
-            Criteria::SORT_OLD => 'sort_date < :cursor',
-            default => 'sort_date >= :cursor',
+            Criteria::SORT_OLD => 'c.created_at < :cursor',
+            default => 'c.created_at >= :cursor',
         };
     }
 
     private function getSecondaryCursorWhereFromCriteria(Criteria $criteria): string
     {
         return match ($criteria->sortOption) {
-            Criteria::SORT_TOP => 'c.score = :cursor AND sort_date < :cursor2',
-            Criteria::SORT_HOT => 'c.ranking = :cursor AND sort_date < :cursor2',
-            Criteria::SORT_COMMENTED => 'c.comment_count = :cursor AND sort_date < :cursor2',
-            Criteria::SORT_ACTIVE => 'c.last_active = :cursor AND sort_date < :cursor2',
+            Criteria::SORT_TOP => 'c.score = :cursor AND c.created_at < :cursor2',
+            Criteria::SORT_HOT => 'c.ranking = :cursor AND c.created_at < :cursor2',
+            Criteria::SORT_COMMENTED => 'c.comment_count = :cursor AND c.created_at < :cursor2',
+            Criteria::SORT_ACTIVE => 'c.last_active = :cursor AND c.created_at < :cursor2',
             default => 'FALSE',
         };
     }
@@ -599,10 +565,10 @@ class ContentRepository
     private function getSecondaryCursorWhereFromCriteriaInverted(Criteria $criteria): string
     {
         return match ($criteria->sortOption) {
-            Criteria::SORT_TOP => 'c.score = :cursor AND sort_date >= :cursor2',
-            Criteria::SORT_HOT => 'c.ranking = :cursor AND sort_date >= :cursor2',
-            Criteria::SORT_COMMENTED => 'c.comment_count = :cursor AND sort_date >= :cursor2',
-            Criteria::SORT_ACTIVE => 'c.last_active = :cursor AND sort_date >= :cursor2',
+            Criteria::SORT_TOP => 'c.score = :cursor AND c.created_at >= :cursor2',
+            Criteria::SORT_HOT => 'c.ranking = :cursor AND c.created_at >= :cursor2',
+            Criteria::SORT_COMMENTED => 'c.comment_count = :cursor AND c.created_at >= :cursor2',
+            Criteria::SORT_ACTIVE => 'c.last_active = :cursor AND c.created_at >= :cursor2',
             default => 'FALSE',
         };
     }
@@ -642,11 +608,11 @@ class ContentRepository
 
         switch ($criteria->sortOption) {
             case Criteria::SORT_OLD:
-                $orderings[] = 'sort_date ASC';
+                $orderings[] = 'created_at ASC';
                 break;
             case Criteria::SORT_NEW:
             default:
-                $orderings[] = 'sort_date DESC';
+                $orderings[] = 'created_at DESC';
         }
 
         return $orderings;

--- a/src/Repository/ContentRepository.php
+++ b/src/Repository/ContentRepository.php
@@ -82,8 +82,8 @@ class ContentRepository
                 $query['parameters'],
                 $this->getSecondaryCursorWhereFromCriteria($criteria),
                 $this->getSecondaryCursorWhereFromCriteriaInverted($criteria),
-                'c.created_at DESC',
-                'c.created_at',
+                'sort_date DESC',
+                'sort_date',
                 transformer: $this->contentPopulationTransformer,
             ),
             $this->getCursorFieldFromCriteria($criteria),
@@ -215,21 +215,21 @@ class ContentRepository
 
                 $subClauseEntryComment = $repliesCommonWhere.
                     (null === $criteria->cachedUserFollows ?
-                        ' OR EXISTS (SELECT 1 FROM user_follow uf RIGHT OUTER JOIN entry_comment_vote v ON uf.following_id = v.user_id WHERE c.id = v.comment_id AND (uf.follower_id = :loggedInUser OR v.user_id = :loggedInUser) AND v.choice = 1)' :
-                        ' OR EXISTS (SELECT 1 FROM entry_comment_vote v WHERE c.id = v.comment_id AND (v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser) AND v.choice = 1)');
+                        ' OR EXISTS (SELECT 1 FROM user_follow uf WHERE uf.follower_id = :loggedInUser AND uf.following_id = v.user_id) OR v.user_id = :loggedInUser' :
+                        ' OR v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser');
                 $subClausePostComment = $repliesCommonWhere.
                     (null === $criteria->cachedUserFollows ?
-                        ' OR EXISTS (SELECT 1 FROM user_follow uf RIGHT OUTER JOIN post_comment_vote v ON uf.following_id = v.user_id WHERE c.id = v.comment_id AND (uf.follower_id = :loggedInUser OR v.user_id = :loggedInUser) AND v.choice = 1)' :
-                        ' OR EXISTS (SELECT 1 FROM post_comment_vote v WHERE c.id = v.comment_id AND (v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser) AND v.choice = 1)');
+                        ' OR EXISTS (SELECT 1 FROM user_follow uf WHERE uf.follower_id = :loggedInUser AND uf.following_id = v.user_id) OR v.user_id = :loggedInUser' :
+                        ' OR v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser');
 
                 $subClausePost = $subClausePost
                     .(null === $criteria->cachedUserFollows ?
-                        ' OR EXISTS (SELECT 1 FROM user_follow uf RIGHT OUTER JOIN post_vote v ON uf.following_id = v.user_id WHERE c.id = v.post_id AND (uf.follower_id = :loggedInUser OR v.user_id = :loggedInUser) AND v.choice = 1)' :
-                        ' OR EXISTS (SELECT 1 FROM post_vote v WHERE c.id = v.post_id AND (v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser) AND v.choice = 1)');
+                        ' OR EXISTS (SELECT 1 FROM user_follow uf WHERE uf.follower_id = :loggedInUser AND uf.following_id = v.user_id) OR v.user_id = :loggedInUser' :
+                        ' OR v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser');
                 $subClauseEntry = $subClauseEntry
                     .(null === $criteria->cachedUserFollows ?
-                        ' OR EXISTS (SELECT 1 FROM user_follow uf RIGHT OUTER JOIN entry_vote v ON uf.following_id = v.user_id WHERE c.id = v.entry_id AND (uf.follower_id = :loggedInUser OR v.user_id = :loggedInUser) AND v.choice = 1)' :
-                        ' OR EXISTS (SELECT 1 FROM entry_vote v WHERE c.id = v.entry_id AND (v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser) AND v.choice = 1)');
+                        ' OR EXISTS (SELECT 1 FROM user_follow uf WHERE uf.follower_id = :loggedInUser AND uf.following_id = v.user_id) OR v.user_id = :loggedInUser' :
+                        ' OR v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser');
             }
 
             if (null !== $criteria->cachedUserSubscribedMagazines) {
@@ -379,7 +379,7 @@ class ContentRepository
             $visibilityClauseM,
             $visibilityClauseC,
             $allClause,
-            $addCursor ? '%cursor% OR (%cursor2%)' : '',
+            $addCursor && !$criteria->includeBoosts ? '%cursor% OR (%cursor2%)' : '',
             $filterClauseEntry,
         ]);
 
@@ -401,7 +401,7 @@ class ContentRepository
             $visibilityClauseM,
             $visibilityClauseC,
             $allClause,
-            $addCursor ? '%cursor% OR (%cursor2%)' : '',
+            $addCursor && !$criteria->includeBoosts ? '%cursor% OR (%cursor2%)' : '',
             $filterClausePost,
         ]);
 
@@ -422,7 +422,7 @@ class ContentRepository
             $visibilityClauseM,
             $visibilityClauseC,
             $allClause,
-            $addCursor ? '%cursor% OR (%cursor2%)' : '',
+            $addCursor && !$criteria->includeBoosts ? '%cursor% OR (%cursor2%)' : '',
             $filterClauseComments,
         ]);
 
@@ -444,7 +444,7 @@ class ContentRepository
             $visibilityClauseM,
             $visibilityClauseC,
             $allClause,
-            $addCursor ? '%cursor% OR (%cursor2%)' : '',
+            $addCursor && !$criteria->includeBoosts ? '%cursor% OR (%cursor2%)' : '',
             $filterClauseComments,
         ]);
 
@@ -461,19 +461,53 @@ class ContentRepository
         // only join domain if we are explicitly looking at one
         $domainJoin = $criteria->domain ? 'LEFT JOIN domain d ON d.id = c.domain_id' : '';
 
-        $entrySql = "SELECT c.id, 'entry' as type, c.type as content_type, c.created_at, c.ranking, c.score, c.comment_count, c.sticky, c.last_active, c.user_id FROM entry c
+        if($criteria->includeBoosts) {
+            $boostJoinEntry = 'LEFT JOIN entry_vote v ON (c.id = v.entry_id AND v.choice = 1)';
+            $boostJoinEntryComment = 'LEFT JOIN entry_comment_vote v ON (c.id = v.comment_id AND v.choice = 1)';
+            $boostJoinPost = 'LEFT JOIN post_vote v ON (c.id = v.post_id AND v.choice = 1)';
+            $boostJoinPostComment = 'LEFT JOIN post_comment_vote v ON (c.id = v.comment_id AND v.choice = 1)';
+
+            $sortDateSelect = 'greatest(max(c.created_at), max(v.created_at)) AS sort_date';
+        } else {
+            $boostJoinEntry = '';
+            $boostJoinEntryComment = '';
+            $boostJoinPost = '';
+            $boostJoinPostComment = '';
+
+            $sortDateSelect = 'c.created_at AS sort_date';
+        }
+
+        $entrySql = "SELECT c.id, 'entry' as type, c.type as content_type, c.created_at, c.ranking, c.score, c.comment_count, c.sticky, c.last_active, c.user_id, $sortDateSelect FROM entry c
             LEFT JOIN magazine m ON c.magazine_id = m.id
             $domainJoin
+            $boostJoinEntry
             $entryWhere";
-        $postSql = "SELECT c.id, 'post' as type, 'microblog' as content_type, c.created_at, c.ranking, c.score, c.comment_count, c.sticky, c.last_active, c.user_id FROM post c
+        $postSql = "SELECT c.id, 'post' as type, 'microblog' as content_type, c.created_at, c.ranking, c.score, c.comment_count, c.sticky, c.last_active, c.user_id, $sortDateSelect FROM post c
             LEFT JOIN magazine m ON c.magazine_id = m.id
+            $boostJoinPost
             $postWhere";
-        $entryCommentSql = "SELECT c.id, 'entry_comment' as type, 'microblog' as content_type, c.created_at, 0 as ranking, 0 as score, 0 as comment_count, false as sticky, c.last_active, c.user_id FROM entry_comment c
+        $entryCommentSql = "SELECT c.id, 'entry_comment' as type, 'microblog' as content_type, c.created_at, 0 as ranking, 0 as score, 0 as comment_count, false as sticky, c.last_active, c.user_id, $sortDateSelect FROM entry_comment c
             LEFT JOIN magazine m ON c.magazine_id = m.id
+            $boostJoinEntryComment
             $entryCommentWhere";
-        $postCommentSql = "SELECT c.id, 'post_comment' as type, 'microblog' as content_type, c.created_at, 0 as ranking, 0 as score, 0 as comment_count, false as sticky, c.last_active, c.user_id FROM post_comment c
+        $postCommentSql = "SELECT c.id, 'post_comment' as type, 'microblog' as content_type, c.created_at, 0 as ranking, 0 as score, 0 as comment_count, false as sticky, c.last_active, c.user_id, $sortDateSelect FROM post_comment c
             LEFT JOIN magazine m ON c.magazine_id = m.id
+            $boostJoinPostComment
             $postCommentWhere";
+
+        if($criteria->includeBoosts) {
+            $entrySql = $entrySql.' GROUP BY c.id';
+            $postSql = $postSql.' GROUP BY c.id';
+            $entryCommentSql = $entryCommentSql.' GROUP BY c.id';
+            $postCommentSql = $postCommentSql.' GROUP BY c.id';
+
+            if($addCursor) {
+                $entrySql = $entrySql.' WHERE %cursor% OR (%cursor2%)';
+                $postSql = $postSql.' WHERE %cursor% OR (%cursor2%)';
+                $entryCommentSql = $entryCommentSql.' WHERE %cursor% OR (%cursor2%)';
+                $postCommentSql = $postCommentSql.' WHERE %cursor% OR (%cursor2%)';
+            }
+        }
 
         $innerLimit = $addCursor ? 'LIMIT :innerLimit' : '';
         $innerSql = '';
@@ -523,7 +557,7 @@ class ContentRepository
             Criteria::SORT_HOT => 'ranking',
             Criteria::SORT_COMMENTED => 'commentCount',
             Criteria::SORT_ACTIVE => 'lastActive',
-            default => 'createdAt',
+            default => 'sort_date',
         };
     }
 
@@ -534,8 +568,8 @@ class ContentRepository
             Criteria::SORT_HOT => 'c.ranking < :cursor',
             Criteria::SORT_COMMENTED => 'c.comment_count < :cursor',
             Criteria::SORT_ACTIVE => 'c.last_active < :cursor',
-            Criteria::SORT_OLD => 'c.created_at > :cursor',
-            default => 'c.created_at < :cursor',
+            Criteria::SORT_OLD => 'sort_date > :cursor',
+            default => 'sort_date < :cursor',
         };
     }
 
@@ -546,18 +580,18 @@ class ContentRepository
             Criteria::SORT_HOT => 'c.ranking > :cursor',
             Criteria::SORT_COMMENTED => 'c.comment_count > :cursor',
             Criteria::SORT_ACTIVE => 'c.last_active > :cursor',
-            Criteria::SORT_OLD => 'c.created_at < :cursor',
-            default => 'c.created_at >= :cursor',
+            Criteria::SORT_OLD => 'sort_date < :cursor',
+            default => 'sort_date >= :cursor',
         };
     }
 
     private function getSecondaryCursorWhereFromCriteria(Criteria $criteria): string
     {
         return match ($criteria->sortOption) {
-            Criteria::SORT_TOP => 'c.score = :cursor AND c.created_at < :cursor2',
-            Criteria::SORT_HOT => 'c.ranking = :cursor AND c.created_at < :cursor2',
-            Criteria::SORT_COMMENTED => 'c.comment_count = :cursor AND c.created_at < :cursor2',
-            Criteria::SORT_ACTIVE => 'c.last_active = :cursor AND c.created_at < :cursor2',
+            Criteria::SORT_TOP => 'c.score = :cursor AND sort_date < :cursor2',
+            Criteria::SORT_HOT => 'c.ranking = :cursor AND sort_date < :cursor2',
+            Criteria::SORT_COMMENTED => 'c.comment_count = :cursor AND sort_date < :cursor2',
+            Criteria::SORT_ACTIVE => 'c.last_active = :cursor AND sort_date < :cursor2',
             default => 'FALSE',
         };
     }
@@ -565,10 +599,10 @@ class ContentRepository
     private function getSecondaryCursorWhereFromCriteriaInverted(Criteria $criteria): string
     {
         return match ($criteria->sortOption) {
-            Criteria::SORT_TOP => 'c.score = :cursor AND c.created_at >= :cursor2',
-            Criteria::SORT_HOT => 'c.ranking = :cursor AND c.created_at >= :cursor2',
-            Criteria::SORT_COMMENTED => 'c.comment_count = :cursor AND c.created_at >= :cursor2',
-            Criteria::SORT_ACTIVE => 'c.last_active = :cursor AND c.created_at >= :cursor2',
+            Criteria::SORT_TOP => 'c.score = :cursor AND sort_date >= :cursor2',
+            Criteria::SORT_HOT => 'c.ranking = :cursor AND sort_date >= :cursor2',
+            Criteria::SORT_COMMENTED => 'c.comment_count = :cursor AND sort_date >= :cursor2',
+            Criteria::SORT_ACTIVE => 'c.last_active = :cursor AND sort_date >= :cursor2',
             default => 'FALSE',
         };
     }
@@ -608,11 +642,11 @@ class ContentRepository
 
         switch ($criteria->sortOption) {
             case Criteria::SORT_OLD:
-                $orderings[] = 'created_at ASC';
+                $orderings[] = 'sort_date ASC';
                 break;
             case Criteria::SORT_NEW:
             default:
-                $orderings[] = 'created_at DESC';
+                $orderings[] = 'sort_date DESC';
         }
 
         return $orderings;

--- a/src/Service/VoteManager.php
+++ b/src/Service/VoteManager.php
@@ -64,6 +64,7 @@ class VoteManager
 
                 if (VotableInterface::VOTE_UP === $choice && null !== $votable->apShareCount) {
                     ++$votable->apShareCount;
+                    $votable->updateLastBoostDate();
                 } elseif (VotableInterface::VOTE_DOWN === $choice && null !== $votable->apDislikeCount) {
                     ++$votable->apDislikeCount;
                 }
@@ -132,6 +133,7 @@ class VoteManager
 
         $votable->updateVoteCounts();
 
+        $votable->updateLastBoostDate();
         $votable->lastActive = new \DateTime();
 
         if ($votable instanceof PostComment) {


### PR DESCRIPTION
Currently, the *Combined* timeline is sorted by `createdAt`. This is a problem when boosted content is included, as it might be quite old and so the user will not see newly boosted content without scrolling far down regularly.

This solution is not perfect, as only the global most recent boost time is recorded, which means that content can move on top even if it was not boosted by any of the users followees.

I hope I didn't miss locations in the code where boost are created.