### PR TITLE
optimize some queries

### DIFF
--- a/src/Repository/ContentRepository.php
+++ b/src/Repository/ContentRepository.php
@@ -197,8 +197,8 @@ class ContentRepository
         if ($user && $criteria->subscribed) {
             $subClausePost = 'c.user_id = :loggedInUser'
                 .(null === $criteria->cachedUserSubscribedMagazines ?
-                    ' OR EXISTS (SELECT 1 FROM magazine_subscription ms WHERE ms.user_id = :loggedInUser AND ms.magazine_id = m.id)' :
-                    ' OR m.id IN (:cachedUserSubscribedMagazines)')
+                    ' OR EXISTS (SELECT 1 FROM magazine_subscription ms WHERE ms.user_id = :loggedInUser AND ms.magazine_id = c.magazine_id)' :
+                    ' OR c.magazine_id IN (:cachedUserSubscribedMagazines)')
                 .(null === $criteria->cachedUserFollows ?
                     ' OR EXISTS (SELECT 1 FROM user_follow uf WHERE uf.follower_id = :loggedInUser AND uf.following_id = c.user_id)' :
                     ' OR c.user_id IN (:cachedUserFollows)');
@@ -243,9 +243,9 @@ class ContentRepository
         $modClause = '';
         if ($user && $criteria->moderated) {
             if (null === $criteria->cachedUserModeratedMagazines) {
-                $modClause = 'EXISTS (SELECT * FROM moderator mod WHERE mod.magazine_id = m.id AND mod.user_id = :loggedInUser)';
+                $modClause = 'EXISTS (SELECT * FROM moderator mod WHERE mod.magazine_id = c.magazine_id AND mod.user_id = :loggedInUser)';
             } else {
-                $modClause = 'm.id IN (:cachedUserModeratedMagazines)';
+                $modClause = 'c.magazine_id IN (:cachedUserModeratedMagazines)';
                 $parameters['cachedUserModeratedMagazines'] = $criteria->cachedUserModeratedMagazines;
             }
         }
@@ -281,9 +281,9 @@ class ContentRepository
 
             if (!$criteria->domain) {
                 if (null === $criteria->cachedUserBlockedMagazines) {
-                    $blockingClausePost .= ' AND NOT EXISTS (SELECT * FROM magazine_block mb WHERE mb.magazine_id = m.id AND mb.user_id = :loggedInUser)';
+                    $blockingClausePost .= ' AND NOT EXISTS (SELECT * FROM magazine_block mb WHERE mb.magazine_id = c.magazine_id AND mb.user_id = :loggedInUser)';
                 } else {
-                    $blockingClausePost .= ' AND (m IS NULL OR m.id NOT IN (:cachedUserBlockedMagazines))';
+                    $blockingClausePost .= ' AND (m IS NULL OR c.magazine_id NOT IN (:cachedUserBlockedMagazines))';
                     $parameters['cachedUserBlockedMagazines'] = $criteria->cachedUserBlockedMagazines;
                 }
             }

--- a/src/Repository/SearchRepository.php
+++ b/src/Repository/SearchRepository.php
@@ -187,54 +187,54 @@ class SearchRepository
         $blockMagazineAndUserResult = null !== $authorId || null !== $magazineId ? 'AND false' : '';
         $conn = $this->entityManager->getConnection();
         $sqlEntry = "SELECT e.id, e.created_at, e.visibility, 2 * ts_rank_cd(e.title_ts, plainto_tsquery(:tsLang, :query)) + ts_rank_cd(e.body_ts, plainto_tsquery(:tsLang, :query)) as rank, 'entry' AS type FROM entry e
-            INNER JOIN public.user u ON u.id = user_id
+            INNER JOIN public.user u ON u.id = e.user_id
             INNER JOIN magazine m ON e.magazine_id = m.id
             WHERE (e.body_ts @@ plainto_tsquery( :tsLang, :query ) = true OR e.title_ts @@ plainto_tsquery( :tsLang, :query ) = true OR e.title LIKE :likeQuery)
                 AND e.visibility = :visibility
                 AND u.is_deleted = false
                 AND (u.ap_discoverable = true OR u.ap_discoverable IS NULL)
                 AND (m.ap_discoverable = true OR m.ap_discoverable IS NULL)
-                AND NOT EXISTS (SELECT id FROM user_block ub WHERE ub.blocked_id = u.id AND ub.blocker_id = :queryingUser)
-                AND NOT EXISTS (SELECT id FROM magazine_block mb WHERE mb.magazine_id = m.id AND mb.user_id = :queryingUser)
+                AND NOT EXISTS (SELECT id FROM user_block ub WHERE ub.blocked_id = e.user_id AND ub.blocker_id = :queryingUser)
+                AND NOT EXISTS (SELECT id FROM magazine_block mb WHERE mb.magazine_id = e.magazine_id AND mb.user_id = :queryingUser)
                 AND NOT EXISTS (SELECT hl.id FROM hashtag_link hl INNER JOIN hashtag h ON h.id = hl.hashtag_id AND h.banned = true WHERE hl.entry_id = e.id)
                 $authorWhere $magazineWhere $createdWhere
         UNION ALL
         SELECT e.id, e.created_at, e.visibility, 3 * ts_rank_cd(e.body_ts, plainto_tsquery(:tsLang, :query)) as rank, 'entry_comment' AS type FROM entry_comment e
-            INNER JOIN public.user u ON u.id = user_id
+            INNER JOIN public.user u ON u.id = e.user_id
             INNER JOIN magazine m ON e.magazine_id = m.id
             WHERE (e.body_ts @@ plainto_tsquery( :tsLang, :query ) = true)
                 AND e.visibility = :visibility
                 AND u.is_deleted = false
                 AND (u.ap_discoverable = true OR u.ap_discoverable IS NULL)
                 AND (m.ap_discoverable = true OR m.ap_discoverable IS NULL)
-                AND NOT EXISTS (SELECT id FROM user_block ub WHERE ub.blocked_id = u.id AND ub.blocker_id = :queryingUser)
-                AND NOT EXISTS (SELECT id FROM magazine_block mb WHERE mb.magazine_id = m.id AND mb.user_id = :queryingUser)
+                AND NOT EXISTS (SELECT id FROM user_block ub WHERE ub.blocked_id = e.user_id AND ub.blocker_id = :queryingUser)
+                AND NOT EXISTS (SELECT id FROM magazine_block mb WHERE mb.magazine_id = e.magazine_id AND mb.user_id = :queryingUser)
                 AND NOT EXISTS (SELECT hl.id FROM hashtag_link hl INNER JOIN hashtag h ON h.id = hl.hashtag_id AND h.banned = true WHERE hl.entry_comment_id = e.id)
                 $authorWhere $magazineWhere $createdWhere
         ";
         $sqlPost = "SELECT e.id, e.created_at, e.visibility, 3 * ts_rank_cd(e.body_ts, plainto_tsquery(:tsLang, :query)) as rank, 'post' AS type FROM post e
-            INNER JOIN public.user u ON u.id = user_id
+            INNER JOIN public.user u ON u.id = e.user_id
             INNER JOIN magazine m ON e.magazine_id = m.id
             WHERE (e.body_ts @@ plainto_tsquery( :tsLang, :query ) = true)
                 AND e.visibility = :visibility
                 AND u.is_deleted = false
                 AND (u.ap_discoverable = true OR u.ap_discoverable IS NULL)
                 AND (m.ap_discoverable = true OR m.ap_discoverable IS NULL)
-                AND NOT EXISTS (SELECT id FROM user_block ub WHERE ub.blocked_id = u.id AND ub.blocker_id = :queryingUser)
-                AND NOT EXISTS (SELECT id FROM magazine_block mb WHERE mb.magazine_id = m.id AND mb.user_id = :queryingUser)
+                AND NOT EXISTS (SELECT id FROM user_block ub WHERE ub.blocked_id = e.user_id AND ub.blocker_id = :queryingUser)
+                AND NOT EXISTS (SELECT id FROM magazine_block mb WHERE mb.magazine_id = e.magazine_id AND mb.user_id = :queryingUser)
                 AND NOT EXISTS (SELECT hl.id FROM hashtag_link hl INNER JOIN hashtag h ON h.id = hl.hashtag_id AND h.banned = true WHERE hl.post_id = e.id)
                 $authorWhere $magazineWhere $createdWhere
         UNION ALL
         SELECT e.id, e.created_at, e.visibility, 3 * ts_rank_cd(e.body_ts, plainto_tsquery(:tsLang, :query)) as rank, 'post_comment' AS type FROM post_comment e
-            INNER JOIN public.user u ON u.id = user_id
+            INNER JOIN public.user u ON u.id = e.user_id
             INNER JOIN magazine m ON e.magazine_id = m.id
             WHERE (e.body_ts @@ plainto_tsquery( :tsLang, :query ) = true)
                 AND e.visibility = :visibility
                 AND u.is_deleted = false
                 AND (u.ap_discoverable = true OR u.ap_discoverable IS NULL)
                 AND (m.ap_discoverable = true OR m.ap_discoverable IS NULL)
-                AND NOT EXISTS (SELECT id FROM user_block ub WHERE ub.blocked_id = u.id AND ub.blocker_id = :queryingUser)
-                AND NOT EXISTS (SELECT id FROM magazine_block mb WHERE mb.magazine_id = m.id AND mb.user_id = :queryingUser)
+                AND NOT EXISTS (SELECT id FROM user_block ub WHERE ub.blocked_id = e.user_id AND ub.blocker_id = :queryingUser)
+                AND NOT EXISTS (SELECT id FROM magazine_block mb WHERE mb.magazine_id = e.magazine_id AND mb.user_id = :queryingUser)
                 AND NOT EXISTS (SELECT hl.id FROM hashtag_link hl INNER JOIN hashtag h ON h.id = hl.hashtag_id AND h.banned = true WHERE hl.post_comment_id = e.id)
                 $authorWhere $magazineWhere $createdWhere
         ";


### PR DESCRIPTION
When joining with `JOIN magazine m ON magazine_id = m.id` and then filtering by `m.id ...` Postgres will use an index-lookup on the magazine index instead of just filter by the equal `magazine_id` which is very inperformant. This PR changes filters to use `magazine_id` and the like directly in the WHERE clause.