### PR TITLE
update docker build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,7 +156,7 @@ POSTGRES_DB=mbin
 POSTGRES_USER=mbin
 POSTGRES_PASSWORD=!ChangeThisPostgresPass!
 # IMPORTANT: You MUST configure your PostgreSQL server version!
-POSTGRES_VERSION=17
+POSTGRES_VERSION=18
 DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:5432/${POSTGRES_DB}?serverVersion=${POSTGRES_VERSION}&charset=utf8"
 # Or when using the PostgreSQL socket file (when folder is: /var/run/postgresql):
 #DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@%%2fvar%%2frun%%2fpostgresql/${POSTGRES_DB}?serverVersion=${POSTGRES_VERSION}&charset=utf8"

--- a/.env.example_docker
+++ b/.env.example_docker
@@ -156,7 +156,7 @@ POSTGRES_DB=mbin
 POSTGRES_USER=mbin
 POSTGRES_PASSWORD=!ChangeThisPostgresPass!
 # IMPORTANT: You MUST configure your PostgreSQL server version!
-POSTGRES_VERSION=17
+POSTGRES_VERSION=18
 DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?serverVersion=${POSTGRES_VERSION}&charset=utf8"
 ###< doctrine/doctrine-bundle ###
 

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -24,7 +24,7 @@ services:
         tty: true
 
     node:
-        image: node:24-trixie-slim
+        image: docker.io/library/node:26-trixie-slim
         user: ${MBIN_USER}
         volumes:
             - ./:/app

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,11 +11,11 @@ services:
             MERCURE_PUBLISHER_JWT_KEY: ${MERCURE_JWT_SECRET}
             MERCURE_SUBSCRIBER_JWT_KEY: ${MERCURE_JWT_SECRET}
         volumes:
-            - ./storage/caddy_config:/config
-            - ./storage/caddy_data:/data
-            - ./storage/media:/app/public/media
-            - ./storage/oauth:/app/config/oauth2
-            - ./storage/php_logs:/app/var/log
+            - ./storage/caddy_config:/config:rw,Z
+            - ./storage/caddy_data:/data:rw,Z
+            - ./storage/media:/app/public/media:rw,z
+            - ./storage/oauth:/app/config/oauth2:ro,Z
+            - ./storage/php_logs:/app/var/log:rw,z
         ports:
             - 80:80
             - 443:443
@@ -37,8 +37,8 @@ services:
             test: ['CMD-SHELL', "ps aux | grep 'messenger[:]consume' || exit 1"]
         env_file: .env
         volumes:
-            - ./storage/media:/app/public/media
-            - ./storage/messenger_logs:/app/var/log
+            - ./storage/media:/app/public/media:rw,z
+            - ./storage/messenger_logs:/app/var/log:rw,z
         depends_on:
             - amqproxy
             - postgres
@@ -48,7 +48,7 @@ services:
             replicas: 6
 
     amqproxy:
-        image: cloudamqp/amqproxy
+        image: docker.io/cloudamqp/amqproxy
         restart: unless-stopped
         user: ${MBIN_USER}
         command: amqp://rabbitmq:5672
@@ -57,22 +57,22 @@ services:
                 condition: service_healthy
 
     rabbitmq:
-        image: rabbitmq:3-management-alpine
+        image: docker.io/library/rabbitmq:3-management-alpine
         restart: unless-stopped
         user: ${MBIN_USER}
         healthcheck:
             test: ['CMD', 'rabbitmq-diagnostics', 'check_port_connectivity']
         env_file: .env
         volumes:
-            - ./storage/rabbitmq_data:/var/lib/rabbitmq
-            - ./storage/rabbitmq_logs:/var/log/rabbitmq
+            - ./storage/rabbitmq_data:/var/lib/rabbitmq:rw,Z
+            - ./storage/rabbitmq_logs:/var/log/rabbitmq:rw,z
         ports:
             - 15672:15672
         # Hostname specified to ensure persistent data: https://stackoverflow.com/questions/41330514
         hostname: rabbitmq
 
     postgres:
-        image: postgres:${POSTGRES_VERSION}-trixie
+        image: docker.io/library/postgres:${POSTGRES_VERSION}-trixie
         restart: unless-stopped
         user: ${MBIN_USER}
         shm_size: '2gb'
@@ -80,14 +80,14 @@ services:
             test: ['CMD', 'pg_isready']
         env_file: .env
         volumes:
-            - ./storage/postgres:/var/lib/postgresql/data
+            - ./storage/postgres:/var/lib/postgresql:rw,Z
 
     valkey:
-        image: valkey/valkey:trixie
+        image: docker.io/valkey/valkey:trixie
         restart: unless-stopped
         user: ${MBIN_USER}
         command: valkey-server /valkey.conf --requirepass ${VALKEY_PASSWORD}
         healthcheck:
             test: ['CMD', 'valkey-cli', 'ping']
         volumes:
-            - ./docker/valkey.conf:/valkey.conf
+            - ./docker/valkey.conf:/valkey.conf:ro,Z

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 
 
 # Base FrankenPHP image
-FROM dunglas/frankenphp:1-php8.4-trixie AS base
+FROM docker.io/dunglas/frankenphp:1-php8.5-trixie AS base
 
 WORKDIR /app
 
@@ -38,6 +38,8 @@ RUN set -eux; \
 		pcntl \
 		exif \
 		zip \
+        bz2 \
+        mbstring \
 	;
 
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
@@ -86,7 +88,7 @@ RUN set -eux; \
 
 
 # Node assets builder
-FROM node:24-trixie-slim AS prod_node
+FROM docker.io/library/node:26-trixie-slim AS prod_node
 
 RUN mkdir /app
 WORKDIR /app

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -134,3 +134,4 @@ openssl rsa -in ./storage/oauth/private.pem --outform PEM -pubout -out ./storage
 echo
 echo "Mbin environment setup complete!"
 echo "Please refer back to the documentation for finishing touches."
+echo "If you use rootless Podman, you have to run 'chmod 777 storage/* && chmod 666 storage/oauth/*'!"

--- a/docker/tests/compose.yaml
+++ b/docker/tests/compose.yaml
@@ -1,6 +1,6 @@
 services:
     db:
-        image: postgres:${POSTGRES_VERSION:-17}-trixie
+        image: postgres:${POSTGRES_VERSION:-18}-trixie
         container_name: mbin-tests-db
         shm_size: 128mb
         restart: unless-stopped

--- a/docs/02-admin/01-installation/01-bare_metal.md
+++ b/docs/02-admin/01-installation/01-bare_metal.md
@@ -221,7 +221,7 @@ MERCURE_JWT_SECRET="{!SECRET!!KEY!-32_3-!}"
 KBIN_STORAGE_URL=https://domain.tld/media
 
 # Ubuntu 22.04 installs PostgreSQL v14 by default, Debian 12 PostgreSQL v15 is the default
-POSTGRES_VERSION=14
+POSTGRES_VERSION=18
 
 # Configure email, eg. using SMTP
 MAILER_DSN=smtp://127.0.0.1 # When you have a local SMTP server listening


### PR DESCRIPTION
- use PHP 8.5
- use Node 26
- use Postgresql 18
- expand compatibility of compose settings and image URLs to Podman

**Attention:** the change to Postgresql 18 changes the mounts of the database files and requires a DB upgrade for existing deployments.