### PR TITLE
call gc_collect_cycles() for every message

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,6 +9,8 @@ $finder = (new PhpCsFixer\Finder())
         'node_modules',
         'vendor',
         'docker',
+        'public',
+        'storage',
     ])
 ;
 

--- a/src/MessageHandler/MbinMessageHandler.php
+++ b/src/MessageHandler/MbinMessageHandler.php
@@ -23,18 +23,20 @@ abstract class MbinMessageHandler
      */
     public function workWrapper(MessageInterface $message): void
     {
-        gc_collect_cycles();
+        try {
+            // when we are in the test environment this would throw: ConnectionException: There is no active transaction.
+            if ('test' !== $this->kernel->getEnvironment()) {
+                $conn = $this->entityManager->getConnection();
+                $conn->getNativeConnection(); // calls connect() internally
 
-        // when we are in the test environment this would throw: ConnectionException: There is no active transaction.
-        if ('test' !== $this->kernel->getEnvironment()) {
-            $conn = $this->entityManager->getConnection();
-            $conn->getNativeConnection(); // calls connect() internally
+                $conn->transactional(fn() => $this->doWork($message));
 
-            $conn->transactional(fn () => $this->doWork($message));
-
-            $conn->close();
-        } else {
-            $this->doWork($message);
+                $conn->close();
+            } else {
+                $this->doWork($message);
+            }
+        } finally {
+            gc_collect_cycles();
         }
     }
 

--- a/src/MessageHandler/MbinMessageHandler.php
+++ b/src/MessageHandler/MbinMessageHandler.php
@@ -29,7 +29,7 @@ abstract class MbinMessageHandler
                 $conn = $this->entityManager->getConnection();
                 $conn->getNativeConnection(); // calls connect() internally
 
-                $conn->transactional(fn() => $this->doWork($message));
+                $conn->transactional(fn () => $this->doWork($message));
 
                 $conn->close();
             } else {

--- a/src/MessageHandler/MbinMessageHandler.php
+++ b/src/MessageHandler/MbinMessageHandler.php
@@ -23,6 +23,8 @@ abstract class MbinMessageHandler
      */
     public function workWrapper(MessageInterface $message): void
     {
+        gc_collect_cycles();
+
         // when we are in the test environment this would throw: ConnectionException: There is no active transaction.
         if ('test' !== $this->kernel->getEnvironment()) {
             $conn = $this->entityManager->getConnection();


### PR DESCRIPTION
This might help keeping the memory-consumption of the messengers low. It might also not help, but the worst it can do is add a few milliseconds of delay to the processing of every message.

As far as I checked it helped on some message type and on others it did not lower the overall memory consumption. If this is worth merging is up to you.