### PR TITLE
use more EXTRA_LAZY collections in entities

### DIFF
--- a/src/Entity/Domain.php
+++ b/src/Entity/Domain.php
@@ -23,7 +23,7 @@ use Doctrine\ORM\Mapping\Table;
 #[ORM\UniqueConstraint(name: 'domain_name_idx', columns: ['name'])]
 class Domain
 {
-    #[OneToMany(mappedBy: 'domain', targetEntity: Entry::class)]
+    #[OneToMany(mappedBy: 'domain', targetEntity: Entry::class, fetch: 'EXTRA_LAZY')]
     public Collection $entries;
     #[Column(type: 'string', nullable: false)]
     public string $name;
@@ -31,7 +31,7 @@ class Domain
     public int $entryCount = 0;
     #[Column(type: 'integer', options: ['default' => 0])]
     public int $subscriptionsCount = 0;
-    #[OneToMany(mappedBy: 'domain', targetEntity: DomainSubscription::class, cascade: [
+    #[OneToMany(mappedBy: 'domain', targetEntity: DomainSubscription::class, fetch: 'EXTRA_LAZY', cascade: [
         'persist',
         'remove',
     ], orphanRemoval: true)]

--- a/src/Entity/Magazine.php
+++ b/src/Entity/Magazine.php
@@ -94,13 +94,13 @@ class Magazine implements VisibilityInterface, ActivityPubActorInterface, ApiRes
     public Collection $ownershipRequests;
     #[OneToMany(mappedBy: 'magazine', targetEntity: ModeratorRequest::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
     public Collection $moderatorRequests;
-    #[OneToMany(mappedBy: 'magazine', targetEntity: Entry::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
+    #[OneToMany(mappedBy: 'magazine', targetEntity: Entry::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     public Collection $entries;
-    #[OneToMany(mappedBy: 'magazine', targetEntity: Post::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
+    #[OneToMany(mappedBy: 'magazine', targetEntity: Post::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     public Collection $posts;
-    #[OneToMany(mappedBy: 'magazine', targetEntity: MagazineSubscription::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
+    #[OneToMany(mappedBy: 'magazine', targetEntity: MagazineSubscription::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     public Collection $subscriptions;
-    #[OneToMany(mappedBy: 'magazine', targetEntity: MagazineBan::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
+    #[OneToMany(mappedBy: 'magazine', targetEntity: MagazineBan::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     public Collection $bans;
     #[OneToMany(mappedBy: 'magazine', targetEntity: Report::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     #[OrderBy(['createdAt' => 'DESC'])]

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -85,7 +85,7 @@ class Post implements VotableInterface, CommentInterface, VisibilityInterface, R
     public ?string $ip = null;
     #[Column(type: Types::JSONB, nullable: true)]
     public ?array $mentions = null;
-    #[OneToMany(mappedBy: 'post', targetEntity: PostComment::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
+    #[OneToMany(mappedBy: 'post', targetEntity: PostComment::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     public Collection $comments;
     #[OneToMany(mappedBy: 'post', targetEntity: PostVote::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     public Collection $votes;
@@ -177,7 +177,7 @@ class Post implements VotableInterface, CommentInterface, VisibilityInterface, R
         return new ArrayCollection(iterator_to_array($iterator));
     }
 
-    private function handlePrivateComments(ArrayCollection $comments, ?User $user): ArrayCollection
+    private function handlePrivateComments(Collection $comments, ?User $user): Collection
     {
         return $comments->filter(function (PostComment $val) use ($user) {
             if ($user && VisibilityInterface::VISIBILITY_PRIVATE === $val->visibility) {

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -194,7 +194,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Visibil
     public Collection $magazineOwnershipRequests;
     #[OneToMany(mappedBy: 'user', targetEntity: ModeratorRequest::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
     public Collection $moderatorRequests;
-    #[OneToMany(mappedBy: 'user', targetEntity: Entry::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
+    #[OneToMany(mappedBy: 'user', targetEntity: Entry::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     public Collection $entries;
     #[OneToMany(mappedBy: 'user', targetEntity: EntryVote::class, cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
     public Collection $entryVotes;


### PR DESCRIPTION
This lowers memory consumption of Messengers significantly as before some code paths would load all elements of a huge collection into memory.