### PR TITLE
Fix: video embed with unsupported media

### DIFF
--- a/src/DTO/EntryDto.php
+++ b/src/DTO/EntryDto.php
@@ -9,6 +9,7 @@ use App\Entity\Contracts\VisibilityInterface;
 use App\Entity\Entry;
 use App\Entity\Magazine;
 use App\Entity\User;
+use App\Service\VideoManager;
 use Doctrine\Common\Collections\Collection;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -143,15 +144,16 @@ class EntryDto implements ContentVisibilityInterface
     public function getType(): string
     {
         if ($this->url) {
+            if (VideoManager::isVideoUrl($this->url)) {
+                return Entry::ENTRY_TYPE_VIDEO;
+            }
             return Entry::ENTRY_TYPE_LINK;
         }
 
-        $type = Entry::ENTRY_TYPE_IMAGE;
-
         if ($this->body) {
-            $type = Entry::ENTRY_TYPE_ARTICLE;
+            return Entry::ENTRY_TYPE_ARTICLE;
         }
 
-        return $type;
+        return Entry::ENTRY_TYPE_IMAGE;
     }
 }

--- a/src/Service/EntryManager.php
+++ b/src/Service/EntryManager.php
@@ -165,6 +165,9 @@ class EntryManager implements ContentManagerInterface
             if (ImageManager::isImageUrl($dto->url)) {
                 $entry->type = Entry::ENTRY_TYPE_IMAGE;
                 $entry->hasEmbed = true;
+            } elseif (VideoManager::isVideoUrl($dto->url)) {
+                $entry->type = Entry::ENTRY_TYPE_VIDEO;
+                $entry->hasEmbed = true;
             } else {
                 $entry->type = Entry::ENTRY_TYPE_LINK;
             }
@@ -174,8 +177,6 @@ class EntryManager implements ContentManagerInterface
             $this->logger->warning('entry has neither image nor url nor body; defaulting to article');
             $entry->type = Entry::ENTRY_TYPE_ARTICLE;
         }
-
-        // TODO handle ENTRY_TYPE_VIDEO
 
         return $entry;
     }

--- a/src/Service/VideoManager.php
+++ b/src/Service/VideoManager.php
@@ -10,10 +10,26 @@ class VideoManager
 
     public static function isVideoUrl(string $url): bool
     {
-        $urlExt = pathinfo($url, PATHINFO_EXTENSION);
+        if (str_starts_with($url, 'data:')) {
+            return self::isSupportedVideoMimeType(substr($url, 5));
+        }
+
+        $path = (string) parse_url($url, PHP_URL_PATH);
+        $urlExt = strtolower(pathinfo($path, PATHINFO_EXTENSION));
 
         $types = array_map(fn ($type) => str_replace('video/', '', $type), self::VIDEO_MIMETYPES);
 
-        return \in_array($urlExt, $types);
+        return \in_array($urlExt, $types, false);
+    }
+
+    public static function isSupportedVideoMimeType(?string $mimeType): bool
+    {
+        if (null === $mimeType || '' === trim($mimeType)) {
+            return false;
+        }
+
+        $normalizedMimeType = strtolower(explode(';', trim($mimeType))[0]);
+
+        return \in_array($normalizedMimeType, self::VIDEO_MIMETYPES, true);
     }
 }

--- a/src/Utils/Embed.php
+++ b/src/Utils/Embed.php
@@ -9,6 +9,7 @@ use App\Event\ActivityPub\CurlRequestBeginningEvent;
 use App\Event\ActivityPub\CurlRequestFinishedEvent;
 use App\Service\ImageManager;
 use App\Service\SettingsManager;
+use App\Service\VideoManager;
 use Embed\Embed as BaseEmbed;
 use Embed\Extractor;
 use Psr\Log\LoggerInterface;
@@ -40,7 +41,7 @@ class Embed
         unset($this->dispatcher);
     }
 
-    public function fetch($url): self
+    public function fetch(string $url): self
     {
         if ($this->settings->isLocalUrl($url)) {
             if (ImageManager::isImageUrl($url)) {
@@ -147,6 +148,44 @@ class Embed
             return null;
         }
 
+        $dom = new \DOMDocument();
+        libxml_use_internal_errors(true);
+        $dom->loadHTML('<?xml encoding="UTF-8">'.$html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        libxml_clear_errors();
+
+        $videoElements = $dom->getElementsByTagName('video');
+
+        foreach ($videoElements as $videoElement) {
+            $sourceUrl = $videoElement->getAttribute('src');
+            $sourceMimeType = $videoElement->getAttribute('type');
+
+            if (
+                ($sourceUrl && VideoManager::isVideoUrl($sourceUrl))
+                || ($sourceMimeType && VideoManager::isSupportedVideoMimeType($sourceMimeType))
+            ) {
+                continue; // supported video source, no need to check this one further
+            }
+
+            $isSupported = false;
+
+            foreach ($videoElement->getElementsByTagName('source') as $sourceElement) {
+                $sourceUrl = $sourceElement->getAttribute('src');
+                $sourceMimeType = $sourceElement->getAttribute('type');
+
+                if (
+                    ($sourceUrl && VideoManager::isVideoUrl($sourceUrl))
+                    || ($sourceMimeType && VideoManager::isSupportedVideoMimeType($sourceMimeType))
+                ) {
+                    $isSupported = true;
+                    break;
+                }
+            }
+
+            if (!$isSupported) {
+                return null;
+            }
+        }
+
         return $html;
     }
 
@@ -166,7 +205,7 @@ class Embed
         }
 
         if ($this->isVideoUrl()) {
-            return Entry::ENTRY_TYPE_IMAGE;
+            return Entry::ENTRY_TYPE_VIDEO;
         }
 
         if ($this->isVideoEmbed()) {
@@ -187,7 +226,11 @@ class Embed
 
     private function isVideoUrl(): bool
     {
-        return false;
+        if (!$this->url) {
+            return false;
+        }
+
+        return VideoManager::isVideoUrl($this->url);
     }
 
     private function isVideoEmbed(): bool

--- a/tests/Unit/Utils/EmbedTest.php
+++ b/tests/Unit/Utils/EmbedTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Utils;
+
+use App\Service\SettingsManager;
+use App\Utils\Embed;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+
+class EmbedTest extends TestCase
+{
+    public function testUnsupportedVideoSourceHtmlIsRejected(): void
+    {
+        $embed = $this->createEmbed();
+        $method = new \ReflectionMethod(Embed::class, 'cleanIframe');
+
+        $html = '<div><video controls><source src="https://example.com/master.m3u8" type="application/vnd.apple.mpegurl"></video></div>';
+
+        self::assertNull($method->invoke($embed, $html));
+    }
+
+    public function testSupportedVideoSourceHtmlIsKept(): void
+    {
+        $embed = $this->createEmbed();
+        $method = new \ReflectionMethod(Embed::class, 'cleanIframe');
+
+        $html = '<div><video controls><source src="https://example.com/video.mp4" type="video/mp4"></video></div>';
+
+        self::assertSame($html, $method->invoke($embed, $html));
+    }
+
+    public function testDataUriVideoSourceHtmlIsKept(): void
+    {
+        $embed = $this->createEmbed();
+        $method = new \ReflectionMethod(Embed::class, 'cleanIframe');
+
+        $html = '<div><video controls src="data:video/mp4;base64,AAAA"></video></div>';
+
+        self::assertSame($html, $method->invoke($embed, $html));
+    }
+
+    public function testUnsupportedVideoContentWithOtherMarkupIsRejected(): void
+    {
+        $embed = $this->createEmbed();
+        $method = new \ReflectionMethod(Embed::class, 'cleanIframe');
+
+        $html = '<div><p>Preview content</p><video controls><source src="https://example.com/master.m3u8" type="application/vnd.apple.mpegurl"></video></div>';
+
+        self::assertNull($method->invoke($embed, $html));
+    }
+
+    private function createEmbed(): Embed
+    {
+        return new Embed(
+            $this->createMock(CacheInterface::class),
+            $this->createMock(SettingsManager::class),
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(EventDispatcherInterface::class),
+        );
+    }
+}


### PR DESCRIPTION
Closes #487 

Before, preview embeds that contained unsupported media URLs could load when the preview button is clicked, leading to direct download of the media file.

With this change, unsupported media will return a null embed, which should solve it.