### PR TITLE
fix search filter when no type is set in SearchRetrieveApi request

### DIFF
--- a/src/Controller/Api/Search/SearchRetrieveApi.php
+++ b/src/Controller/Api/Search/SearchRetrieveApi.php
@@ -162,6 +162,9 @@ class SearchRetrieveApi extends BaseApi
         if ('entry' !== $type && 'post' !== $type && null !== $type) {
             throw new BadRequestHttpException();
         }
+        if (null === $type) {
+            $type = 'entry+post';
+        }
 
         $items = $manager->findPaginated($this->getUser(), $q, $page, $perPage, authorId: $authorId, magazineId: $magazineId, specificType: $type);
         $dtos = [];


### PR DESCRIPTION
Null means return all types for the search repo, but the code expects only Posts and Entries (+ comments).