### PR TITLE
Make query of AP user case-sensitive

### DIFF
--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -264,10 +264,10 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
         $this->getEntityManager()->flush();
     }
 
-    public function findOneByUsername(string $username): ?User
+    public function findOneByUsername(string $username, bool $caseInsensitive = false): ?User
     {
         return $this->createQueryBuilder('u')
-            ->Where('LOWER(u.username) = LOWER(:username)')
+            ->Where($caseInsensitive ? 'LOWER(u.username) = LOWER(:username)' : 'u.username = :username')
             ->andWhere('u.applicationStatus = :status')
             ->setParameter('status', EApplicationStatus::Approved->value)
             ->setParameter('username', $username)

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -413,26 +413,7 @@ class ActivityPubManager
             $user->apDiscoverable = $actor['discoverable'] ?? null;
             $user->apIndexable = $actor['indexable'] ?? null;
             $user->apManuallyApprovesFollowers = $actor['manuallyApprovesFollowers'] ?? false;
-            $actorUrlValue = $actor['url'] ?? $actorUrl;
-            if (\is_array($actorUrlValue)) {
-                // Pick the link with the fewest path segments as the most canonical profile URL.
-                // Fall back to $actorUrl if no valid href is found.
-                $best = null;
-                $bestCount = PHP_INT_MAX;
-                foreach ($actorUrlValue as $link) {
-                    $href = \is_array($link) ? ($link['href'] ?? null) : (string) $link;
-                    if (null === $href) {
-                        continue;
-                    }
-                    $pathSegments = \count(array_filter(explode('/', parse_url($href, PHP_URL_PATH) ?? '')));
-                    if ($pathSegments < $bestCount) {
-                        $bestCount = $pathSegments;
-                        $best = $href;
-                    }
-                }
-                $actorUrlValue = $best ?? $actorUrl;
-            }
-            $user->apPublicUrl = \is_string($actorUrlValue) ? $actorUrlValue : $actorUrl;
+            $user->apPublicUrl = $this->findBestActorUrl($actorUrl, $actor['url'] ?? null);
             $user->apDeletedAt = null;
             $user->apTimeoutAt = null;
             $user->apFetchedAt = new \DateTime();
@@ -712,7 +693,7 @@ class ActivityPubManager
             $magazine->apFeaturedUrl = $actor['featured'] ?? null;
             $magazine->apPreferredUsername = $actor['preferredUsername'] ?? null;
             $magazine->apDiscoverable = $actor['discoverable'] ?? null;
-            $magazine->apPublicUrl = $actor['url'] ?? $actorUrl;
+            $magazine->apPublicUrl = $this->findBestActorUrl($actorUrl, $actor['url'] ?? null);
             $magazine->apDeletedAt = null;
             $magazine->apTimeoutAt = null;
             $magazine->apFetchedAt = new \DateTime();
@@ -1319,5 +1300,34 @@ class ActivityPubManager
         }
 
         return null;
+    }
+
+    private function findBestActorUrl(string $actorUrl, mixed $actorUrlValue): string
+    {
+        if (null === $actorUrlValue) {
+            return $actorUrl;
+        } elseif (\is_string($actorUrlValue)) {
+            return $actorUrlValue;
+        } elseif (\is_array($actorUrlValue)) {
+            // Pick the link with the fewest path segments as the most canonical profile URL.
+            // Fall back to $actorUrl if no valid href is found.
+            $best = null;
+            $bestCount = PHP_INT_MAX;
+            foreach ($actorUrlValue as $link) {
+                $href = \is_array($link) ? ($link['href'] ?? null) : (string) $link;
+                if (null === $href) {
+                    continue;
+                }
+                $pathSegments = \count(array_filter(explode('/', parse_url($href, PHP_URL_PATH) ?? '')));
+                if ($pathSegments > 0 && $pathSegments < $bestCount) {
+                    $bestCount = $pathSegments;
+                    $best = $href;
+                }
+            }
+            return $best ?? $actorUrl;
+        } else {
+            $this->logger->warning('[ActivityPubManager::getEntityObject] got an actorUrlValue which was neither a string, array nor null: {o}', ['o' => $actorUrlValue]);
+            return $actorUrl;
+        }
     }
 }

--- a/src/Service/ActivityPubManager.php
+++ b/src/Service/ActivityPubManager.php
@@ -1306,9 +1306,13 @@ class ActivityPubManager
     {
         if (null === $actorUrlValue) {
             return $actorUrl;
-        } elseif (\is_string($actorUrlValue)) {
+        }
+
+        if (\is_string($actorUrlValue)) {
             return $actorUrlValue;
-        } elseif (\is_array($actorUrlValue)) {
+        }
+
+        if (\is_array($actorUrlValue)) {
             // Pick the link with the fewest path segments as the most canonical profile URL.
             // Fall back to $actorUrl if no valid href is found.
             $best = null;
@@ -1325,9 +1329,9 @@ class ActivityPubManager
                 }
             }
             return $best ?? $actorUrl;
-        } else {
-            $this->logger->warning('[ActivityPubManager::getEntityObject] got an actorUrlValue which was neither a string, array nor null: {o}', ['o' => $actorUrlValue]);
-            return $actorUrl;
         }
+
+        $this->logger->warning('[ActivityPubManager::getEntityObject] got an actorUrlValue which was neither a string, array nor null: {o}', ['o' => $actorUrlValue]);
+        return $actorUrl;
     }
 }


### PR DESCRIPTION
AP handles are mostly handled case-sensitive, so Mbin should do so too. \
This will fix the "more than one row was returned ..." error in the UI.

The `$caseInsensitive` parameter was added to allow quick reverts to the original behavior on locations where it might be needed.