### PR TITLE
fix: show parent post for microblog comments in feed (Fixes #2190, #2191)

### DIFF
--- a/templates/layout/_subject.html.twig
+++ b/templates/layout/_subject.html.twig
@@ -45,7 +45,7 @@
     {% if forCombined is same as true %}
         {{ component('post_comment_combined', {comment: subject}|merge(attributes)|merge(postCommentAttributes)) }}
     {% else %}
-        {{ component('post_comment', {comment: subject}|merge(attributes)|merge(postCommentAttributes)) }}
+        {{ component('post_comment', {comment: subject, withPost: true}|merge(attributes)|merge(postCommentAttributes)) }}
     {% endif %}
 {% elseif subject is magazine %}
     {{ component('magazine_box', {magazine: subject}|merge(attributes, magazineAttributes)) }}


### PR DESCRIPTION
## Description

When boosted content is shown in the microblog feed (newest sort), post comments appear without their parent post. This causes two issues:

1. **Mixed designs** (#2190): Comments look different from regular posts because they lack the parent post context
2. **Missing thread context** (#2191): Users can't see what thread the comment belongs to

## Fix

In `templates/layout/_subject.html.twig`, pass `withPost: true` to the `post_comment` component when it's rendered in the non-combined (microblog) view. This causes the parent post to be rendered above the comment, providing thread context and making the visual design consistent.

The `PostCommentComponent` already supports the `withPost` boolean property (defaults to `false`). When set to `true`, it renders the parent post using the `post` component before the comment.

## Before

Comments in the microblog feed appear as standalone items without showing the parent post they belong to.

## After

Comments in the microblog feed show the parent post above the comment, providing full thread context and a consistent visual design.