### PR TITLE
Fix unverified users having access to the api

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -24,6 +24,7 @@ security:
             security: true
             stateless: true
             oauth2: true
+            user_checker: App\Security\UserChecker
         image_resolver:
             pattern: ^/media/cache/resolve
             security: false

--- a/tests/Functional/Controller/Api/ApiAccessTest.php
+++ b/tests/Functional/Controller/Api/ApiAccessTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Controller\Api;
+
+use App\Enums\EApplicationStatus;
+use App\Tests\WebTestCase;
+
+class ApiAccessTest extends WebTestCase
+{
+    public function testUnverifiedUserCannotAccessApiWithToken(): void
+    {
+        $unverifiedUser = $this->getUserByUsername('JohnDoe', active: false, addImage: false);
+        self::createOAuth2AuthCodeClient();
+        $this->client->loginUser($unverifiedUser);
+        $unverifiedTokenData = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'read write user');
+        $unverifiedToken = $unverifiedTokenData['token_type'].' '.$unverifiedTokenData['access_token'];
+
+        $this->client->request('GET', '/api/users/me', server: ['HTTP_AUTHORIZATION' => $unverifiedToken]);
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testUserWithApIdCannotAccessApi(): void
+    {
+        $user = $this->getUserByUsername('JohnDoe', addImage: false);
+        $user->apId = 'https://example.com/users/johndoe';
+
+        self::createOAuth2AuthCodeClient();
+        $this->client->loginUser($user);
+        $tokenData = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'read write user');
+        $token = $tokenData['token_type'].' '.$tokenData['access_token'];
+
+        $this->client->request('GET', '/api/users/me', server: ['HTTP_AUTHORIZATION' => $token]);
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testUserWithPendingApplicationCannotAccessApi(): void
+    {
+        $user = $this->getUserByUsername('JohnDoe', addImage: false);
+        $user->setApplicationStatus(EApplicationStatus::Pending);
+
+        self::createOAuth2AuthCodeClient();
+        $this->client->loginUser($user);
+        $tokenData = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'read write user');
+        $token = $tokenData['token_type'].' '.$tokenData['access_token'];
+
+        $this->client->request('GET', '/api/users/me', server: ['HTTP_AUTHORIZATION' => $token]);
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testUserWithRejectedApplicationCannotAccessApi(): void
+    {
+        $user = $this->getUserByUsername('JohnDoe', addImage: false);
+        $user->setApplicationStatus(EApplicationStatus::Rejected);
+
+        self::createOAuth2AuthCodeClient();
+        $this->client->loginUser($user);
+        $tokenData = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'read write user');
+        $token = $tokenData['token_type'].' '.$tokenData['access_token'];
+
+        $this->client->request('GET', '/api/users/me', server: ['HTTP_AUTHORIZATION' => $token]);
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testBannedUserCannotAccessApi(): void
+    {
+        $user = $this->getUserByUsername('JohnDoe', addImage: false);
+        $user->isBanned = true;
+
+        self::createOAuth2AuthCodeClient();
+        $this->client->loginUser($user);
+        $tokenData = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'read write user');
+        $token = $tokenData['token_type'].' '.$tokenData['access_token'];
+
+        $this->client->request('GET', '/api/users/me', server: ['HTTP_AUTHORIZATION' => $token]);
+        self::assertResponseStatusCodeSame(401);
+    }
+}

--- a/tests/Functional/Controller/Api/Instance/InstanceBlockApiTest.php
+++ b/tests/Functional/Controller/Api/Instance/InstanceBlockApiTest.php
@@ -270,7 +270,9 @@ class InstanceBlockApiTest extends WebTestCase
         $userDto->username = 'FreshlyManufactured';
         $userDto->plainPassword = '123';
         $userDto->email = 'newuser@example.com';
-        $user = $this->userManager->create($userDto);
+        $user = $this->userManager->create($userDto, verifyUserEmail: false);
+        $user->isVerified = true;
+        $this->entityManager->flush();
         $this->client->loginUser($user);
         $codes = self::getAuthorizationCodeTokenResponse($this->client, scopes: 'user:profile:edit');
 


### PR DESCRIPTION
- the user checker is now used to validate api access
- add a test for unverified, banned, approval-pending or -rejected users (all of which fail without the config change)