### PR TITLE
fix: emoji autocomplete inserts 'null' after colon + newline (Fixes #2151)

### DIFF
--- a/assets/controllers/rich_textarea_controller.js
+++ b/assets/controllers/rich_textarea_controller.js
@@ -64,8 +64,13 @@ export default class extends Controller {
                 this.markSelectedSuggestion();
                 event.preventDefault();
             } else if ('Enter' === key) {
-                this.replaceAutocompleteSearchString(this.getSelectedSuggestionReplacement());
-                event.preventDefault();
+                const replacement = this.getSelectedSuggestionReplacement();
+                if (null !== replacement) {
+                    this.replaceAutocompleteSearchString(replacement);
+                    event.preventDefault();
+                } else {
+                    this.clearAutocomplete();
+                }
             } else {
                 this.fetchAutocompleteResults(this.getAutocompleteSearchString(key));
             }
@@ -187,6 +192,9 @@ export default class extends Controller {
     }
 
     replaceAutocompleteSearchString(replaceText) {
+        if (null === replaceText) {
+            return;
+        }
         const [wordStart, wordEnd] = this.getAutocompleteSearchStringStartAndEnd();
         this.element.selectionStart = wordStart;
         this.element.selectionEnd = wordEnd+1;


### PR DESCRIPTION
Fixes #2151

## Root Cause
When a user types a word ending with `:` and presses Enter, the emoji autocomplete (`rich_textarea_controller.js`) attempts to replace the search string with the selected suggestion. If no emoji matches the typed text, `getSelectedSuggestionReplacement()` returns `null`, and `replaceAutocompleteSearchString(null)` calls `document.execCommand('insertText', false, null)` which inserts the literal string "null".

## Fix
1. Added null check in the `handleInput` Enter handler: only call `replaceAutocompleteSearchString` when there's a valid suggestion
2. Added defensive null check at the start of `replaceAutocompleteSearchString`

Both changes ensure that pressing Enter with no matching emoji suggestion simply clears the autocomplete and inserts a normal newline, as expected.