### PR TITLE
fix ImageManager::compressUntilSize()

### DIFF
--- a/docs/02-admin/03-optional-features/09-image-compression.md
+++ b/docs/02-admin/03-optional-features/09-image-compression.md
@@ -3,7 +3,7 @@
 You can enable compression of images uploaded to mbin by users or downloaded from remote instances, 
 for increased compatibility, to save on size and for a better user experience.
 
-To enable image compression set `MBIN_IMAGE_COMPRESSION_QUALITY` in your `.env` file to a value between 0.1 and 0.95.
+To enable image compression set `MBIN_IMAGE_COMPRESSION_QUALITY` in your `.env` file to a value between 0.3 and 0.95.
 This setting is used as a starting point to compress the image. It is gradually lowered (in 0.05 steps) until the maximum size is no longer exceeded.
 
 > [!TIP]

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -107,7 +107,7 @@ class ImageManager implements ImageManagerInterface
         $tempPath = "{$filePath}_temp_compress.$extension";
         $compressed = false;
         $quality = 0.9;
-        if (0.1 <= $this->imageCompressionQuality && 1 > $this->imageCompressionQuality) {
+        if (0.3 <= $this->imageCompressionQuality && 1 > $this->imageCompressionQuality) {
             $quality = $this->imageCompressionQuality;
         }
         while ($bytes > $maxBytes && $quality > 0.3) {

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -95,7 +95,7 @@ class ImageManager implements ImageManagerInterface
      */
     public function compressUntilSize(string $filePath, string $extension, int $maxBytes): bool
     {
-        if (-1 === (int)$this->imageCompressionQuality || filesize($filePath) <= $maxBytes) {
+        if (-1 === (int) $this->imageCompressionQuality || filesize($filePath) <= $maxBytes) {
             // don't compress images if disabled or smaller than max bytes
             return false;
         }

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -95,7 +95,7 @@ class ImageManager implements ImageManagerInterface
      */
     public function compressUntilSize(string $filePath, string $extension, int $maxBytes): bool
     {
-        if (-1 === $this->imageCompressionQuality || filesize($filePath) <= $maxBytes) {
+        if (-1 === (int)$this->imageCompressionQuality || filesize($filePath) <= $maxBytes) {
             // don't compress images if disabled or smaller than max bytes
             return false;
         }
@@ -103,13 +103,14 @@ class ImageManager implements ImageManagerInterface
         $image = $imagine->open($filePath);
         $bytes = filesize($filePath);
         $initialBytes = $bytes;
+        $lastBytes = $bytes;
         $tempPath = "{$filePath}_temp_compress.$extension";
         $compressed = false;
         $quality = 0.9;
         if (0.1 <= $this->imageCompressionQuality && 1 > $this->imageCompressionQuality) {
             $quality = $this->imageCompressionQuality;
         }
-        while ($bytes > $maxBytes && $quality > 0.1) {
+        while ($bytes > $maxBytes && $quality > 0.3) {
             $this->logger->debug('[ImageManager::compressUntilSize] Trying to compress "{path}" with {q}% quality', ['path' => $tempPath, 'q' => $quality * 100]);
             $image->save($tempPath, [
                 'jpeg_quality' => $quality * 100, // jpeg max value is 100
@@ -117,11 +118,12 @@ class ImageManager implements ImageManagerInterface
                 'webp_quality' => $quality * 100, // webp quality max is 100
             ]);
             $bytes = filesize($tempPath);
-            if ($initialBytes === $bytes) {
+            if ($lastBytes === $bytes) {
                 // there were no changes, so maybe it is in a format that cannot be compressed...
                 break;
             }
             $compressed = true;
+            $lastBytes = $bytes;
             $quality -= 0.05;
         }
         $copied = false;


### PR DESCRIPTION
The loop checks if the compression had any effect, but it does so with the original file size. If the image got compressed in the first iteration, the condition then would always be false.