### PR TITLE
show a summary of the entry / post a comment is from when displaying it in Combined or Microblog

### DIFF
--- a/assets/styles/layout/_tools.scss
+++ b/assets/styles/layout/_tools.scss
@@ -72,3 +72,9 @@ a.link-muted:hover {
   border-radius: 20px;
   padding: .3rem;
 }
+
+.hrule {
+  border: var(--kbin-section-border);
+  height: 0;
+  margin: 2px 5px;
+}

--- a/src/Controller/User/UserFrontController.php
+++ b/src/Controller/User/UserFrontController.php
@@ -72,6 +72,7 @@ class UserFrontController extends AbstractController
                 'html' => $this->renderView(
                     'layout/_generic_subject_list.html.twig',
                     [
+                        'standaloneComments' => false,
                         'results' => $results,
                         'pagination' => $activity,
                     ]
@@ -82,6 +83,7 @@ class UserFrontController extends AbstractController
         return $this->render(
             'user/overview.html.twig',
             [
+                'standaloneComments' => false,
                 'user' => $user,
                 'results' => $results,
                 'pagination' => $activity,
@@ -424,6 +426,7 @@ class UserFrontController extends AbstractController
         return $this->render(
             'user/overview.html.twig',
             [
+                'standaloneComments' => true,
                 'user' => $user,
                 'results' => $activity->getCurrentPageResults(),
                 'pagination' => $activity,

--- a/src/Entity/Contracts/VisibilityInterface.php
+++ b/src/Entity/Contracts/VisibilityInterface.php
@@ -6,9 +6,13 @@ namespace App\Entity\Contracts;
 
 interface VisibilityInterface
 {
+    /** may be viewed by everyone */
     public const VISIBILITY_VISIBLE = 'visible';
+    /** removed by author; should not be viewed by anyone */
     public const VISIBILITY_SOFT_DELETED = 'soft_deleted';
+    /** removed by moderator; may be viewed by mods / admins */
     public const VISIBILITY_TRASHED = 'trashed';
+    /** may be viewed by followers of author */
     public const VISIBILITY_PRIVATE = 'private';
 
     public function getVisibility(): string;

--- a/src/Twig/Extension/SubjectExtension.php
+++ b/src/Twig/Extension/SubjectExtension.php
@@ -10,7 +10,9 @@ use App\Entity\Magazine;
 use App\Entity\Post;
 use App\Entity\PostComment;
 use App\Entity\User;
+use App\Twig\Runtime\SubjectExtensionRuntime;
 use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 use Twig\TwigTest;
 
 class SubjectExtension extends AbstractExtension
@@ -48,6 +50,14 @@ class SubjectExtension extends AbstractExtension
                     return $subject instanceof User;
                 }
             ),
+        ];
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('user_can_see_entry', [SubjectExtensionRuntime::class, 'userCanSeeEntry']),
+            new TwigFunction('user_can_see_post', [SubjectExtensionRuntime::class, 'userCanSeePost']),
         ];
     }
 }

--- a/src/Twig/Runtime/SubjectExtensionRuntime.php
+++ b/src/Twig/Runtime/SubjectExtensionRuntime.php
@@ -4,17 +4,72 @@ declare(strict_types=1);
 
 namespace App\Twig\Runtime;
 
+use App\Entity\Entry;
+use App\Entity\Post;
+use App\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
 use Twig\Extension\RuntimeExtensionInterface;
 
-class SubjectExtensionRuntime implements RuntimeExtensionInterface
+readonly class SubjectExtensionRuntime implements RuntimeExtensionInterface
 {
-    public function __construct()
-    {
-        // Inject dependencies if needed
+    public function __construct(
+        private Security $security,
+    ) {
     }
 
-    public function doSomething($value)
+    public function userCanSeeEntry(Entry $entry): bool
     {
-        // ...
+        /* @var ?User $user */
+        $user = $this->security->getUser();
+
+        if (null !== $user) {
+            if ($user->isBlocked($entry->user)
+                || $user->isBlockedMagazine($entry->getMagazine())
+                || (null !== $entry->domain && $user->isBlockedDomain($entry->domain))) {
+                return false;
+            }
+        }
+
+        if ($entry->isVisible() && $entry->user->isVisible()) {
+            return true;
+        }
+
+        if (null !== $user) {
+            if ($user->isAdmin() || $user->isModerator()) {
+                return true;
+            }
+            if ($entry->getMagazine()->userIsModerator($user)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function userCanSeePost(Post $post): bool
+    {
+        /* @var ?User $user */
+        $user = $this->security->getUser();
+
+        if (null !== $user) {
+            if ($user->isBlocked($post->user) || $user->isBlockedMagazine($post->getMagazine())) {
+                return false;
+            }
+        }
+
+        if ($post->isVisible() && $post->user->isVisible()) {
+            return true;
+        }
+
+        if (null !== $user) {
+            if ($user->isAdmin() || $user->isModerator()) {
+                return true;
+            }
+            if ($post->getMagazine()->userIsModerator($user)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Twig/Runtime/SubjectExtensionRuntime.php
+++ b/src/Twig/Runtime/SubjectExtensionRuntime.php
@@ -36,6 +36,12 @@ readonly class SubjectExtensionRuntime implements RuntimeExtensionInterface
     {
         $author = $content->user;
 
+        // don't show deleted content
+        if($content->isSoftDeleted() || $author->isSoftDeleted() || $author->isDeleted) {
+            return false;
+        }
+
+        // handle user blocks
         if (null !== $user) {
             if ($user->isBlocked($author)
                 || $user->isBlockedMagazine($content->getMagazine())
@@ -48,6 +54,7 @@ readonly class SubjectExtensionRuntime implements RuntimeExtensionInterface
             }
         }
 
+        // show visible or allowed private content
         if ($content->isVisible() && $author->isVisible()) {
             return true;
         }
@@ -55,6 +62,7 @@ readonly class SubjectExtensionRuntime implements RuntimeExtensionInterface
             return true;
         }
 
+        // admins and moderators may see everything (except deleted)
         if (null !== $user) {
             if ($user->isAdmin() || $user->isModerator()) {
                 return true;

--- a/src/Twig/Runtime/SubjectExtensionRuntime.php
+++ b/src/Twig/Runtime/SubjectExtensionRuntime.php
@@ -37,7 +37,7 @@ readonly class SubjectExtensionRuntime implements RuntimeExtensionInterface
         $author = $content->user;
 
         // don't show deleted content
-        if($content->isSoftDeleted() || $author->isSoftDeleted() || $author->isDeleted) {
+        if ($content->isSoftDeleted() || $author->isSoftDeleted() || $author->isDeleted) {
             return false;
         }
 

--- a/src/Twig/Runtime/SubjectExtensionRuntime.php
+++ b/src/Twig/Runtime/SubjectExtensionRuntime.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Twig\Runtime;
 
+use App\Entity\Domain;
 use App\Entity\Entry;
 use App\Entity\Post;
 use App\Entity\User;
@@ -21,43 +22,36 @@ readonly class SubjectExtensionRuntime implements RuntimeExtensionInterface
     {
         /* @var ?User $user */
         $user = $this->security->getUser();
-
-        if (null !== $user) {
-            if ($user->isBlocked($entry->user)
-                || $user->isBlockedMagazine($entry->getMagazine())
-                || (null !== $entry->domain && $user->isBlockedDomain($entry->domain))) {
-                return false;
-            }
-        }
-
-        if ($entry->isVisible() && $entry->user->isVisible()) {
-            return true;
-        }
-
-        if (null !== $user) {
-            if ($user->isAdmin() || $user->isModerator()) {
-                return true;
-            }
-            if ($entry->getMagazine()->userIsModerator($user)) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->userCanSeeEntryPost($entry, $user, $entry->domain);
     }
 
     public function userCanSeePost(Post $post): bool
     {
         /* @var ?User $user */
         $user = $this->security->getUser();
+        return $this->userCanSeeEntryPost($post, $user);
+    }
+
+    private function userCanSeeEntryPost(Entry|Post $content, ?User $user, ?Domain $domain = null): bool
+    {
+        $author = $content->user;
 
         if (null !== $user) {
-            if ($user->isBlocked($post->user) || $user->isBlockedMagazine($post->getMagazine())) {
+            if ($user->isBlocked($author)
+                || $user->isBlockedMagazine($content->getMagazine())
+                || (null !== $domain && $user->isBlockedDomain($domain))) {
+                return false;
+            }
+
+            if ($user->hideAdult && $content->isAdult()) {
                 return false;
             }
         }
 
-        if ($post->isVisible() && $post->user->isVisible()) {
+        if ($content->isVisible() && $author->isVisible()) {
+            return true;
+        }
+        if (($content->isPrivate() || $author->isPrivate()) && $user->isFollowing($author)) {
             return true;
         }
 
@@ -65,7 +59,7 @@ readonly class SubjectExtensionRuntime implements RuntimeExtensionInterface
             if ($user->isAdmin() || $user->isModerator()) {
                 return true;
             }
-            if ($post->getMagazine()->userIsModerator($user)) {
+            if ($content->getMagazine()->userIsModerator($user)) {
                 return true;
             }
         }

--- a/templates/components/boost.html.twig
+++ b/templates/components/boost.html.twig
@@ -6,6 +6,6 @@
             type="submit"
             data-action="subject#favourite">
         {{ 'up_vote'|trans }} <span class="{{ html_classes({'hidden': not subject.apShareCount and not subject.countUpvotes}) }}"
-                                          data-subject-target="upvoteCounter">({{ (subject.apShareCount ?? subject.countUpvotes)|abbreviateNumber }})</span>
+                                          data-subject-target="upvoteCounter">({{ subject.countUpvotes|abbreviateNumber }})</span>
     </button>
 </form>

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -11,6 +11,12 @@
 {% if showLevel is not defined %}
     {% set showLevel = true %}
 {% endif %}
+{% if noIndention is not defined %}
+    {% set noIndention = false %}
+{% endif %}
+{% if attachToTop is not defined %}
+    {% set attachToTop = false %}
+{% endif %}
 
 {% if not app.user or (app.user and not app.user.isBlocked(comment.user)) %}
     {% if comment.visibility is same as 'private' and (not app.user or not app.user.isFollower(comment.user)) %}
@@ -25,6 +31,7 @@
                 'author': showLevel and comment.isAuthor(comment.entry.user),
                 'show-preview': SHOW_PREVIEW is same as V_TRUE and not comment.isAdult,
             })}).without('id') }}
+                style="{% if noIndention %}margin-left: 0;{% endif %} {% if attachToTop %}margin-top: -0.5rem;{% endif %}"
                 id="entry-comment-{{ comment.id }}"
                 data-controller="comment subject mentions comment-collapse html-refresh"
                 data-comment-collapse-depth-value="{{ level }}"

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -8,6 +8,10 @@
 {%- set SHOW_USER_FULLNAME = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::MBIN_SHOW_USER_DOMAIN'), V_FALSE)  -%}
 {%- set SHOW_MAGAZINE_FULLNAME = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::MBIN_SHOW_MAGAZINE_DOMAIN'), V_FALSE)  -%}
 
+{% if showLevel is not defined %}
+    {% set showLevel = true %}
+{% endif %}
+
 {% if not app.user or (app.user and not app.user.isBlocked(comment.user)) %}
     {% if comment.visibility is same as 'private' and (not app.user or not app.user.isFollower(comment.user)) %}
         <div class="section section--small {{ 'comment-level--' ~ this.getLevel() }}">
@@ -15,9 +19,10 @@
         </div>
     {% else %}
         <blockquote{{ attributes.defaults({
-            class: html_classes('section comment entry-comment subject', 'comment-level--' ~ this.getLevel(), {
-                'own': app.user and comment.isAuthor(app.user),
-                'author': comment.isAuthor(comment.entry.user),
+            class: html_classes('section comment entry-comment subject', {
+                ('comment-level--' ~ this.getLevel()): showLevel,
+                'own': showLevel and app.user and comment.isAuthor(app.user),
+                'author': showLevel and comment.isAuthor(comment.entry.user),
                 'show-preview': SHOW_PREVIEW is same as V_TRUE and not comment.isAdult,
             })}).without('id') }}
                 id="entry-comment-{{ comment.id }}"
@@ -26,6 +31,13 @@
                 data-subject-parent-value="{{ comment.parent ? comment.parent.id : '' }}"
                 data-action="{{- DYNAMIC_LISTS is same as V_TRUE ? 'notifications:Notification@window->subject#notification' : '' -}}">
             <header>
+                {% if withContext is defined and withContext %}
+                    <div class="mb-1">
+                        {% include "entry/comment/context.html.twig" %}
+                        <div class="hrule"></div>
+                    </div>
+                {% endif %}
+
                 {% if comment.isAdult %}<span class="badge danger">18+</span>{% endif %}
                 {{ component('user_inline', {user: comment.user, showAvatar: false, showNewIcon: true, fullName: SHOW_USER_FULLNAME is same as V_TRUE}) }}
 

--- a/templates/components/entry_comment_combined.html.twig
+++ b/templates/components/entry_comment_combined.html.twig
@@ -36,11 +36,11 @@
                         <small>
                             {% if isAdult %}<small class="badge danger">18+</small>{% endif %}
 
-                            {{ 'in'|trans }} {{ component('entry_inline', {entry: comment.entry}) }}
-
                             {% if hasLang %}
                                 <small class="badge-lang kbin-bg">{{ comment.lang|language_name }}</small>
                             {% endif %}
+
+                            {% include 'entry/comment/context.html.twig' %}
                         </small>
                     {% elseif isModDeleted %}
                         <p class="text-muted">&lsqb;<i>{{ 'deleted_by_moderator'|trans }}</i>&rsqb;</p>

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -10,6 +10,12 @@
 {% if showLevel is not defined %}
     {% set showLevel = true %}
 {% endif %}
+{% if noIndention is not defined %}
+    {% set noIndention = false %}
+{% endif %}
+{% if attachToTop is not defined %}
+    {% set attachToTop = false %}
+{% endif %}
 
 {% if withPost %}
     {{ component('post', {post: comment.post}) }}
@@ -27,6 +33,7 @@
                 'author': showLevel and comment.isAuthor(comment.post.user),
                 'show-preview': SHOW_PREVIEW is same as V_TRUE and not comment.isAdult,
             })}).without('id') }}
+                style="{% if noIndention %}margin-left: 0;{% endif %} {% if attachToTop %}margin-top: -1rem;{% endif %}"
                 id="post-comment-{{ comment.id }}"
                 data-controller="comment subject mentions comment-collapse html-refresh"
                 data-comment-collapse-depth-value="{{ level }}"

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -5,6 +5,11 @@
 {%- set SHOW_PREVIEW = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_PREVIEW'), V_FALSE) -%}
 {%- set VIEW_STYLE = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::POST_COMMENTS_VIEW'), V_TREE) -%}
 {%- set SHOW_USER_FULLNAME = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::MBIN_SHOW_USER_DOMAIN'), V_FALSE) -%}
+{%- set SHOW_MAGAZINE_FULLNAME = app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::MBIN_SHOW_MAGAZINE_DOMAIN'), V_FALSE)  -%}
+
+{% if showLevel is not defined %}
+    {% set showLevel = true %}
+{% endif %}
 
 {% if withPost %}
     {{ component('post', {post: comment.post}) }}
@@ -16,9 +21,10 @@
         </div>
     {% else %}
         <blockquote{{ attributes.defaults({
-            class: html_classes('section comment post-comment subject', 'comment-level--' ~ this.getLevel(), {
-                'own': app.user and comment.isAuthor(app.user),
-                'author': comment.isAuthor(comment.post.user),
+            class: html_classes('section comment post-comment subject', {
+                ('comment-level--' ~ this.getLevel()): showLevel,
+                'own': showLevel and app.user and comment.isAuthor(app.user),
+                'author': showLevel and comment.isAuthor(comment.post.user),
                 'show-preview': SHOW_PREVIEW is same as V_TRUE and not comment.isAdult,
             })}).without('id') }}
                 id="post-comment-{{ comment.id }}"
@@ -27,6 +33,13 @@
                 data-subject-parent-value="{{ comment.parent ? comment.parent.id : '' }}"
                 data-action="notifications:Notification@window->subject#notification">
             <header>
+                {% if withContext is defined and withContext %}
+                    <div class="mb-1">
+                        {% include "post/comment/context.html.twig" %}
+                        <div class="hrule"></div>
+                    </div>
+                {% endif %}
+
                 {% if comment.isAdult %}<span class="badge danger">18+</span>{% endif %}
                 {{ component('user_inline', {user: comment.user, showAvatar: false, showNewIcon: true, fullName: SHOW_USER_FULLNAME is same as V_TRUE}) }}
 

--- a/templates/components/post_comment_combined.html.twig
+++ b/templates/components/post_comment_combined.html.twig
@@ -31,17 +31,18 @@
                 {% set hasLang = comment.lang is not same as app.request.locale and comment.lang is not same as kbin_default_lang() %}
                 {% set isModDeleted = comment.visibility is same as 'trashed' %}
                 {% set isUserDeleted = comment.visibility is same as 'soft_deleted' %}
-                {% set needsHeader = (hasTitle and (isAdult or hasLang)) or isModDeleted or isUserDeleted %}
 
-                <header {% if not needsHeader %} style="margin: 0 0 var(--kbin-entry-element-spacing) 0;" {% endif %}>
+                <header>
                     {% if hasTitle %}
-                        <h2>
+                        <small>
                             {% if isAdult %}<small class="badge danger">18+</small>{% endif %}
 
                             {% if hasLang %}
                                 <small class="badge-lang kbin-bg">{{ comment.lang|language_name }}</small>
                             {% endif %}
-                        </h2>
+
+                            {% include 'post/comment/context.html.twig' %}
+                        </small>
                     {% elseif isModDeleted %}
                         <p class="text-muted">&lsqb;<i>{{ 'deleted_by_moderator'|trans }}</i>&rsqb;</p>
                     {% elseif isUserDeleted %}

--- a/templates/content/_list.html.twig
+++ b/templates/content/_list.html.twig
@@ -24,8 +24,8 @@
      }) }}"
      data-action="{{- data_action -}}">
     {% if magazine is defined and magazine %}
-        {% include 'layout/_subject_list.html.twig' with {postAttributes: {showMagazineName: false}, entryAttributes: {showMagazineName: false}} %}
+        {% include 'layout/_subject_list.html.twig' with {postAttributes: {showMagazineName: false}, entryAttributes: {showMagazineName: false}, postCommentAttributes: {withContext: true, showLevel: false}, entryCommentAttributes: {withContext: true, showLevel: false}} %}
     {% else %}
-        {% include 'layout/_subject_list.html.twig' %}
+        {% include 'layout/_subject_list.html.twig' with {postCommentAttributes: {withContext: true, showLevel: false}, entryCommentAttributes: {withContext: true, showLevel: false}} %}
     {% endif %}
 </div>

--- a/templates/content/_list.html.twig
+++ b/templates/content/_list.html.twig
@@ -24,8 +24,8 @@
      }) }}"
      data-action="{{- data_action -}}">
     {% if magazine is defined and magazine %}
-        {% include 'layout/_subject_list.html.twig' with {postAttributes: {showMagazineName: false}, entryAttributes: {showMagazineName: false}, postCommentAttributes: {withContext: true, showLevel: false}, entryCommentAttributes: {withContext: true, showLevel: false}} %}
+        {% include 'layout/_subject_list.html.twig' with {postAttributes: {showMagazineName: false}, entryAttributes: {showMagazineName: false}, postCommentAttributes: {withContext: true, showLevel: false, noIndention: true}, entryCommentAttributes: {withContext: true, showLevel: false, noIndention: true}} %}
     {% else %}
-        {% include 'layout/_subject_list.html.twig' with {postCommentAttributes: {withContext: true, showLevel: false}, entryCommentAttributes: {withContext: true, showLevel: false}} %}
+        {% include 'layout/_subject_list.html.twig' with {postCommentAttributes: {withContext: true, showLevel: false, noIndention: true}, entryCommentAttributes: {withContext: true, showLevel: false, noIndention: true}} %}
     {% endif %}
 </div>

--- a/templates/entry/comment/context.html.twig
+++ b/templates/entry/comment/context.html.twig
@@ -1,0 +1,18 @@
+<span>
+    {{ 'in_reply_to'|trans }}
+    {% with {entry: comment.entry} %}
+    <span>
+        {{ component('user_inline', {user: entry.user, fullName: SHOW_USER_FULLNAME is same as V_TRUE, showNewIcon: true}) }}:
+        <a href="{{ path('entry_single', {magazine_name: entry.magazine.name, entry_id: entry.id, slug: entry.slug|length ? entry.slug : '-'}) }}">
+            {% if entry.image is not same as null %}
+                <i class="fa-solid fa-photo-film"></i>
+            {% endif %}
+            {{ entry.title }}
+        </a>
+        {% if entry.magazine.name is not same as 'random' %}
+            {{ 'in'|trans }}
+            {{ component('magazine_inline', {magazine: entry.magazine, fullName: SHOW_MAGAZINE_FULLNAME is same as V_TRUE, showNewIcon: true}) }}
+        {% endif %}
+    </span>
+    {% endwith %}
+</span>

--- a/templates/entry/comment/context.html.twig
+++ b/templates/entry/comment/context.html.twig
@@ -3,15 +3,19 @@
     {% with {entry: comment.entry} %}
     <span>
         {{ component('user_inline', {user: entry.user, fullName: SHOW_USER_FULLNAME is same as V_TRUE, showNewIcon: true}) }}:
-        <a href="{{ path('entry_single', {magazine_name: entry.magazine.name, entry_id: entry.id, slug: entry.slug|length ? entry.slug : '-'}) }}">
-            {% if entry.image is not same as null %}
-                <i class="fa-solid fa-photo-film"></i>
+        {% if user_can_see_entry(entry) %}
+            <a href="{{ path('entry_single', {magazine_name: entry.magazine.name, entry_id: entry.id, slug: entry.slug|length ? entry.slug : '-'}) }}">
+                {% if entry.image is not same as null %}
+                    <i class="fa-solid fa-photo-film"></i>
+                {% endif %}
+                {{ entry.title }}
+            </a>
+            {% if entry.magazine.name is not same as 'random' %}
+                {{ 'in'|trans }}
+                {{ component('magazine_inline', {magazine: entry.magazine, fullName: SHOW_MAGAZINE_FULLNAME is same as V_TRUE, showNewIcon: true}) }}
             {% endif %}
-            {{ entry.title }}
-        </a>
-        {% if entry.magazine.name is not same as 'random' %}
-            {{ 'in'|trans }}
-            {{ component('magazine_inline', {magazine: entry.magazine, fullName: SHOW_MAGAZINE_FULLNAME is same as V_TRUE, showNewIcon: true}) }}
+        {% else %}
+            <span class="text-muted">{{ 'invisible_or_deleted'|trans }}</span>
         {% endif %}
     </span>
     {% endwith %}

--- a/templates/layout/_generic_subject_list.html.twig
+++ b/templates/layout/_generic_subject_list.html.twig
@@ -1,3 +1,17 @@
+{% if entryCommentAttributes is not defined %}
+    {% set entryCommentAttributes = {} %}
+{% endif %}
+{% if postCommentAttributes is not defined %}
+    {% set postCommentAttributes = {} %}
+{% endif %}
+{% if standaloneComments is defined and standaloneComments is same as true %}
+    {% set entryCommentAttributes = entryCommentAttributes|merge({withContext: true, showLevel: false, noIndention: true}) %}
+    {% set postCommentAttributes = postCommentAttributes|merge({withContext: true, showLevel: false, noIndention: true}) %}
+{% else %}
+    {% set entryCommentAttributes = entryCommentAttributes|merge({attachToTop: true}) %}
+    {% set postCommentAttributes = postCommentAttributes|merge({attachToTop: true}) %}
+{% endif %}
+
 <div data-controller="subject-list">
     {{ include('layout/_subject_list.html.twig') }}
 </div>

--- a/templates/post/comment/context.html.twig
+++ b/templates/post/comment/context.html.twig
@@ -1,0 +1,18 @@
+<span>
+    {{ 'in_reply_to'|trans }}
+    {% with {post: comment.post} %}
+    <span>
+        {{ component('user_inline', {user: post.user, fullName: SHOW_USER_FULLNAME is same as V_TRUE, showNewIcon: true}) }}:
+        <a href="{{ path('post_single', {magazine_name: post.magazine.name, post_id: post.id, slug: post.slug|length ? post.slug : '-'}) }}">
+            {% if post.image is not same as null %}
+                <i class="fa-solid fa-photo-film"></i>
+            {% endif %}
+            {{ post.getShortTitle() }}
+        </a>
+        {% if post.magazine.name is not same as 'random' %}
+            {{ 'in'|trans }}
+            {{ component('magazine_inline', {magazine: post.magazine, fullName: SHOW_MAGAZINE_FULLNAME is same as V_TRUE}) }}
+        {% endif %}
+    </span>
+    {% endwith %}
+</span>

--- a/templates/post/comment/context.html.twig
+++ b/templates/post/comment/context.html.twig
@@ -3,15 +3,19 @@
     {% with {post: comment.post} %}
     <span>
         {{ component('user_inline', {user: post.user, fullName: SHOW_USER_FULLNAME is same as V_TRUE, showNewIcon: true}) }}:
-        <a href="{{ path('post_single', {magazine_name: post.magazine.name, post_id: post.id, slug: post.slug|length ? post.slug : '-'}) }}">
-            {% if post.image is not same as null %}
-                <i class="fa-solid fa-photo-film"></i>
+        {% if user_can_see_post(post) %}
+            <a href="{{ path('post_single', {magazine_name: post.magazine.name, post_id: post.id, slug: post.slug|length ? post.slug : '-'}) }}">
+                {% if post.image is not same as null %}
+                    <i class="fa-solid fa-photo-film"></i>
+                {% endif %}
+                {{ post.getShortTitle() }}
+            </a>
+            {% if post.magazine.name is not same as 'random' %}
+                {{ 'in'|trans }}
+                {{ component('magazine_inline', {magazine: post.magazine, fullName: SHOW_MAGAZINE_FULLNAME is same as V_TRUE}) }}
             {% endif %}
-            {{ post.getShortTitle() }}
-        </a>
-        {% if post.magazine.name is not same as 'random' %}
-            {{ 'in'|trans }}
-            {{ component('magazine_inline', {magazine: post.magazine, fullName: SHOW_MAGAZINE_FULLNAME is same as V_TRUE}) }}
+        {% else %}
+            <span class="text-muted">{{ 'invisible_or_deleted'|trans }}</span>
         {% endif %}
     </span>
     {% endwith %}

--- a/templates/user/_boost_list.html.twig
+++ b/templates/user/_boost_list.html.twig
@@ -1,3 +1,5 @@
+{% set commentAttributes = {withContext: true, showLevel: false, noIndention: true} %}
+
 <div data-controller="subject-list">
-    {% include 'layout/_subject_list.html.twig' with {entryCommentAttributes: {showMagazineName: false}} %}
+    {% include 'layout/_subject_list.html.twig' with {entryCommentAttributes: commentAttributes|merge({showMagazineName: false}), postCommentAttributes: commentAttributes} %}
 </div>

--- a/templates/user/overview.html.twig
+++ b/templates/user/overview.html.twig
@@ -27,11 +27,17 @@
     {% include('user/_federated_info.html.twig') %}
 
     {% if user.visibility is same as 'visible' or is_granted('ROLE_ADMIN') or is_granted('ROLE_MODERATOR') %}
+        {% if standaloneComments %}
+            {% set commentAttributes = {withContext: true, showLevel: false, noIndention: true} %}
+        {% else %}
+            {% set commentAttributes = {attachToTop: true} %}
+        {% endif %}
+
         <div id="content" class="{{ html_classes('overview subjects comments-tree comments', {
             'show-comment-avatar': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_COMMENTS_SHOW_USER_AVATAR')) is same as 'true' or not app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_COMMENTS_SHOW_USER_AVATAR')),
             'show-post-avatar': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_USERS_AVATARS')) is same as 'true' or not app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_USERS_AVATARS'))
         }) }}">
-            {% include 'layout/_subject_list.html.twig' with {entryCommentAttributes: {showMagazineName: false, withContext: true, showLevel: false}, postCommentAttributes: {withContext: true, showLevel: false}} %}
+            {% include 'layout/_subject_list.html.twig' with {entryCommentAttributes: commentAttributes|merge({showMagazineName: false}), postCommentAttributes: commentAttributes} %}
         </div>
     {% endif %}
 {% endblock %}

--- a/templates/user/overview.html.twig
+++ b/templates/user/overview.html.twig
@@ -31,7 +31,7 @@
             'show-comment-avatar': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_COMMENTS_SHOW_USER_AVATAR')) is same as 'true' or not app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_COMMENTS_SHOW_USER_AVATAR')),
             'show-post-avatar': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_USERS_AVATARS')) is same as 'true' or not app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_USERS_AVATARS'))
         }) }}">
-            {% include 'layout/_subject_list.html.twig' with {entryCommentAttributes: {showMagazineName: false}} %}
+            {% include 'layout/_subject_list.html.twig' with {entryCommentAttributes: {showMagazineName: false, withContext: true, showLevel: false}, postCommentAttributes: {withContext: true, showLevel: false}} %}
         </div>
     {% endif %}
 {% endblock %}

--- a/templates/user/replies.html.twig
+++ b/templates/user/replies.html.twig
@@ -30,7 +30,7 @@
             'show-comment-avatar': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_COMMENTS_SHOW_USER_AVATAR')) is same as 'true' or not app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_COMMENTS_SHOW_USER_AVATAR')),
             'show-post-avatar': app.request.cookies.get(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_USERS_AVATARS')) is same as 'true' or not app.request.cookies.has(constant('App\\Controller\\User\\ThemeSettingsController::KBIN_POSTS_SHOW_USERS_AVATARS'))
         }) }}">
-            {% include 'layout/_subject_list.html.twig' with {'postCommentAttributes': {'showNested': false, 'withPost': true}} %}
+            {% include 'layout/_subject_list.html.twig' with {'postCommentAttributes': {'showNested': false, 'withPost': false, 'withContext': true, 'showLevel': false, 'noIndention': true}} %}
         </div>
     </div>
     {% endif %}

--- a/tests/Functional/Controller/User/UserFrontControllerTest.php
+++ b/tests/Functional/Controller/User/UserFrontControllerTest.php
@@ -70,7 +70,7 @@ class UserFrontControllerTest extends WebTestCase
 
         $this->assertSelectorTextContains('.options.options--top .active', 'Replies (2)');
         $this->assertEquals(2, $crawler->filter('#main .post-comment')->count());
-        $this->assertEquals(2, $crawler->filter('#main .post')->count());
+        $this->assertEquals(0, $crawler->filter('#main .post')->count());
     }
 
     public function createSubscriptionsPage()

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -1236,3 +1236,4 @@ unblock_instance_globally_short: Unblock Globally
 unblock_instance_globally_long: Unblock Instance for all Users
 in_reply_to: in reply to
 original_image: Original image
+invisible_or_deleted: invisible or deleted

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -1234,3 +1234,4 @@ block_instance_globally_short: Block Globally
 block_instance_globally_long: Block Instance for all Users
 unblock_instance_globally_short: Unblock Globally
 unblock_instance_globally_long: Unblock Instance for all Users
+in_reply_to: in reply to


### PR DESCRIPTION
<img width="1229" height="720" alt="microblog" src="https://github.com/user-attachments/assets/ed3e2c9a-1588-448f-ba29-72f050e58f75" />
<img width="1229" height="489" alt="combined" src="https://github.com/user-attachments/assets/6b265137-441a-40be-ac88-0833abb9d504" />
<img width="1199" height="755" alt="boosts" src="https://github.com/user-attachments/assets/243ab0f5-a9cc-4112-9724-73d235cc9195" />

Mobile is a bit "squished"
<img width="444" height="954" alt="mobile" src="https://github.com/user-attachments/assets/7f71c779-831b-497e-9bb1-068bbef3fcf7" />

Comments in the *User Overview* are now attached to their parents
<img width="1216" height="1001" alt="overview" src="https://github.com/user-attachments/assets/d0a811ff-7eeb-495c-8ef1-d56b076338b6" />



Closes #2191 and #2190 (somewhat)