### PR TITLE
fix empty image embed link text

### DIFF
--- a/src/Controller/AjaxController.php
+++ b/src/Controller/AjaxController.php
@@ -91,10 +91,14 @@ class AjaxController extends AbstractController
         $data = $embed->fetch($request->get('url'));
         // only wrap embed link for image embed as it doesn't make much sense for any other type for embed
         if ($data->isImageUrl()) {
+            $text = $data->html;
+            if (null === $text || '' === $text) {
+                $text = $this->translator->trans('original_image');
+            }
             $html = \sprintf(
                 '<a href="%s" class="embed-link">%s</a>',
                 $data->url,
-                $data->html
+                $text
             );
         } else {
             $html = $data->html;

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -1234,3 +1234,4 @@ block_instance_globally_short: Block Globally
 block_instance_globally_long: Block Instance for all Users
 unblock_instance_globally_short: Unblock Globally
 unblock_instance_globally_long: Unblock Instance for all Users
+original_image: Original image


### PR DESCRIPTION
In some instances the `<a>` tag of an image embed has no text when the image is not local. This sets a default text.