### PR TITLE
show who boosted content in feed

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -62,5 +62,6 @@
 @use 'themes/solarized';
 @use 'themes/tokyo-night';
 @use 'components/tag';
+@use 'widgets/boosted_by';
 
 @import 'glightbox/dist/css/glightbox.min.css';

--- a/assets/styles/widgets/boosted_by.scss
+++ b/assets/styles/widgets/boosted_by.scss
@@ -1,0 +1,4 @@
+.boosted-by {
+  font-size: 0.8rem;
+  max-height: 2lh;
+}

--- a/assets/styles/widgets/boosted_by.scss
+++ b/assets/styles/widgets/boosted_by.scss
@@ -1,4 +1,5 @@
 .boosted-by {
   font-size: 0.8rem;
   max-height: 2lh;
+  overflow: hidden;
 }

--- a/src/Controller/Api/Combined/CombinedRetrieveApi.php
+++ b/src/Controller/Api/Combined/CombinedRetrieveApi.php
@@ -831,6 +831,7 @@ class CombinedRetrieveApi extends BaseApi
     private function createContentResponse(Entry|EntryComment|Post|PostComment $item): ContentResponseDto
     {
         $this->handlePrivateContent($item);
+
         $boostedBy = null;
         if (isset($item->extendedContentProperties['boostUsers'])) {
             $boostedBy = array_map(

--- a/src/Controller/Api/Combined/CombinedRetrieveApi.php
+++ b/src/Controller/Api/Combined/CombinedRetrieveApi.php
@@ -6,6 +6,7 @@ namespace App\Controller\Api\Combined;
 
 use App\Controller\Api\BaseApi;
 use App\Controller\Traits\PrivateContentTrait;
+use App\DTO\ContentBoostResponseDto;
 use App\DTO\ContentResponseDto;
 use App\Entity\Entry;
 use App\Entity\EntryComment;
@@ -811,19 +812,7 @@ class CombinedRetrieveApi extends BaseApi
     {
         $result = [];
         foreach ($content as $item) {
-            if ($item instanceof Entry) {
-                $this->handlePrivateContent($item);
-                $result[] = new ContentResponseDto(entry: $this->serializeEntry($this->entryFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
-            } elseif ($item instanceof Post) {
-                $this->handlePrivateContent($item);
-                $result[] = new ContentResponseDto(post: $this->serializePost($this->postFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
-            } elseif ($item instanceof EntryComment) {
-                $this->handlePrivateContent($item);
-                $result[] = new ContentResponseDto(entryComment: $this->serializeEntryComment($this->entryCommentFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
-            } elseif ($item instanceof PostComment) {
-                $this->handlePrivateContent($item);
-                $result[] = new ContentResponseDto(postComment: $this->serializePostComment($this->postCommentFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
-            }
+            $result[] = $this->createContentResponse($item);
         }
 
         return new JsonResponse($this->serializePaginated($result, $content), headers: $headers);
@@ -833,16 +822,44 @@ class CombinedRetrieveApi extends BaseApi
     {
         $result = [];
         foreach ($content as $item) {
-            if ($item instanceof Entry) {
-                $this->handlePrivateContent($item);
-                $result[] = new ContentResponseDto(entry: $this->serializeEntry($this->entryFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
-            } elseif ($item instanceof Post) {
-                $this->handlePrivateContent($item);
-                $result[] = new ContentResponseDto(post: $this->serializePost($this->postFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)));
-            }
+            $result[] = $this->createContentResponse($item);
         }
 
         return new JsonResponse($this->serializeCursorPaginated($result, $content), headers: $headers);
+    }
+
+    private function createContentResponse(Entry|EntryComment|Post|PostComment $item): ContentResponseDto
+    {
+        $this->handlePrivateContent($item);
+        $boostedBy = null;
+        if (isset($item->extendedContentProperties['boostUsers'])) {
+            $boostedBy = array_map(
+                fn (array $boost): ContentBoostResponseDto => new ContentBoostResponseDto(
+                    $this->userFactory->createSmallDto($boost['user']),
+                    $boost['time'],
+                ),
+                $item->extendedContentProperties['boostUsers'],
+            );
+        }
+
+        return match (true) {
+            $item instanceof Entry => new ContentResponseDto(
+                entry: $this->serializeEntry($this->entryFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)),
+                boostedBy: $boostedBy,
+            ),
+            $item instanceof Post => new ContentResponseDto(
+                post: $this->serializePost($this->postFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)),
+                boostedBy: $boostedBy,
+            ),
+            $item instanceof EntryComment => new ContentResponseDto(
+                entryComment: $this->serializeEntryComment($this->entryCommentFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)),
+                boostedBy: $boostedBy,
+            ),
+            $item instanceof PostComment => new ContentResponseDto(
+                postComment: $this->serializePostComment($this->postCommentFactory->createDto($item), $this->tagLinkRepository->getTagsOfContent($item)),
+                boostedBy: $boostedBy,
+            ),
+        };
     }
 
     private function getCursor(ContentRepository $contentRepository, string $sortOption, ?string $cursor): int|\DateTime|\DateTimeImmutable

--- a/src/DTO/ContentBoostResponseDto.php
+++ b/src/DTO/ContentBoostResponseDto.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO;
+
+use Nelmio\ApiDocBundle\Attribute\Model;
+use OpenApi\Attributes as OA;
+
+#[OA\Schema()]
+class ContentBoostResponseDto implements \JsonSerializable
+{
+    public function __construct(
+        #[OA\Property(ref: new Model(type: UserSmallResponseDto::class))]
+        public UserSmallResponseDto $user,
+        public \DateTimeImmutable $boostedAt,
+    ) {
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return [
+            'user' => $this->user,
+            'boostedAt' => $this->boostedAt->format(\DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/src/DTO/ContentResponseDto.php
+++ b/src/DTO/ContentResponseDto.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\DTO;
 
+use Nelmio\ApiDocBundle\Attribute\Model;
 use OpenApi\Attributes as OA;
 
 /**
@@ -17,6 +18,9 @@ class ContentResponseDto
         public ?PostResponseDto $post = null,
         public ?EntryCommentResponseDto $entryComment = null,
         public ?PostCommentResponseDto $postComment = null,
+        /** @var ContentBoostResponseDto[]|null */
+        #[OA\Property(type: 'array', nullable: true, items: new OA\Items(ref: new Model(type: ContentBoostResponseDto::class)))]
+        public ?array $boostedBy = null,
     ) {
     }
 }

--- a/src/DTO/SettingsDto.php
+++ b/src/DTO/SettingsDto.php
@@ -38,6 +38,8 @@ class SettingsDto implements \JsonSerializable
         public string $MBIN_DOWNVOTES_MODE,
         public bool $MBIN_NEW_USERS_NEED_APPROVAL,
         public bool $MBIN_USE_FEDERATION_ALLOW_LIST,
+        public bool $MBIN_FEED_ALLOW_ENTRY_COMMENTS,
+        public bool $MBIN_FEED_ALLOW_POST_COMMENTS,
     ) {
     }
 
@@ -71,6 +73,8 @@ class SettingsDto implements \JsonSerializable
         $dto->MBIN_DOWNVOTES_MODE = $this->MBIN_DOWNVOTES_MODE ?? $dto->MBIN_DOWNVOTES_MODE;
         $dto->MBIN_NEW_USERS_NEED_APPROVAL = $this->MBIN_NEW_USERS_NEED_APPROVAL ?? $dto->MBIN_NEW_USERS_NEED_APPROVAL;
         $dto->MBIN_USE_FEDERATION_ALLOW_LIST = $this->MBIN_USE_FEDERATION_ALLOW_LIST ?? $dto->MBIN_USE_FEDERATION_ALLOW_LIST;
+        $dto->MBIN_FEED_ALLOW_ENTRY_COMMENTS = $this->MBIN_FEED_ALLOW_ENTRY_COMMENTS ?? $dto->MBIN_FEED_ALLOW_ENTRY_COMMENTS;
+        $dto->MBIN_FEED_ALLOW_POST_COMMENTS = $this->MBIN_FEED_ALLOW_POST_COMMENTS ?? $dto->MBIN_FEED_ALLOW_POST_COMMENTS;
 
         return $dto;
     }
@@ -106,6 +110,8 @@ class SettingsDto implements \JsonSerializable
             'MBIN_DOWNVOTES_MODE' => $this->MBIN_DOWNVOTES_MODE,
             'MBIN_NEW_USERS_NEED_APPROVAL' => $this->MBIN_NEW_USERS_NEED_APPROVAL,
             'MBIN_USE_FEDERATION_ALLOW_LIST' => $this->MBIN_USE_FEDERATION_ALLOW_LIST,
+            'MBIN_FEED_ALLOW_ENTRY_COMMENTS' => $this->MBIN_FEED_ALLOW_ENTRY_COMMENTS,
+            'MBIN_FEED_ALLOW_POST_COMMENTS' => $this->MBIN_FEED_ALLOW_POST_COMMENTS,
         ];
     }
 }

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -16,6 +16,7 @@ use App\Entity\Contracts\VotableInterface;
 use App\Entity\Traits\ActivityPubActivityTrait;
 use App\Entity\Traits\CreatedAtTrait;
 use App\Entity\Traits\EditedAtTrait;
+use App\Entity\Traits\ExtendedContentTrait;
 use App\Entity\Traits\RankingTrait;
 use App\Entity\Traits\VisibilityTrait;
 use App\Entity\Traits\VotableTrait;
@@ -56,6 +57,7 @@ class Entry implements VotableInterface, CommentInterface, DomainInterface, Visi
     use CreatedAtTrait {
         CreatedAtTrait::__construct as createdAtTraitConstruct;
     }
+    use ExtendedContentTrait;
 
     public const ENTRY_TYPE_ARTICLE = 'article';
     public const ENTRY_TYPE_LINK = 'link';

--- a/src/Entity/EntryComment.php
+++ b/src/Entity/EntryComment.php
@@ -13,6 +13,7 @@ use App\Entity\Contracts\VotableInterface;
 use App\Entity\Traits\ActivityPubActivityTrait;
 use App\Entity\Traits\CreatedAtTrait;
 use App\Entity\Traits\EditedAtTrait;
+use App\Entity\Traits\ExtendedContentTrait;
 use App\Entity\Traits\VisibilityTrait;
 use App\Entity\Traits\VotableTrait;
 use App\Repository\Criteria as MbinCriteria;
@@ -48,6 +49,7 @@ class EntryComment implements VotableInterface, VisibilityInterface, ReportInter
     use CreatedAtTrait {
         CreatedAtTrait::__construct as createdAtTraitConstruct;
     }
+    use ExtendedContentTrait;
 
     #[ManyToOne(targetEntity: User::class, inversedBy: 'entryComments')]
     #[JoinColumn(nullable: false, onDelete: 'CASCADE')]

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -14,6 +14,7 @@ use App\Entity\Contracts\VotableInterface;
 use App\Entity\Traits\ActivityPubActivityTrait;
 use App\Entity\Traits\CreatedAtTrait;
 use App\Entity\Traits\EditedAtTrait;
+use App\Entity\Traits\ExtendedContentTrait;
 use App\Entity\Traits\RankingTrait;
 use App\Entity\Traits\VisibilityTrait;
 use App\Entity\Traits\VotableTrait;
@@ -52,6 +53,7 @@ class Post implements VotableInterface, CommentInterface, VisibilityInterface, R
     use CreatedAtTrait {
         CreatedAtTrait::__construct as createdAtTraitConstruct;
     }
+    use ExtendedContentTrait;
 
     #[ManyToOne(targetEntity: User::class, inversedBy: 'posts')]
     #[JoinColumn(nullable: false, onDelete: 'CASCADE')]

--- a/src/Entity/PostComment.php
+++ b/src/Entity/PostComment.php
@@ -13,6 +13,7 @@ use App\Entity\Contracts\VotableInterface;
 use App\Entity\Traits\ActivityPubActivityTrait;
 use App\Entity\Traits\CreatedAtTrait;
 use App\Entity\Traits\EditedAtTrait;
+use App\Entity\Traits\ExtendedContentTrait;
 use App\Entity\Traits\VisibilityTrait;
 use App\Entity\Traits\VotableTrait;
 use App\Repository\Criteria as MbinCriteria;
@@ -48,6 +49,7 @@ class PostComment implements VotableInterface, VisibilityInterface, ReportInterf
     use CreatedAtTrait {
         CreatedAtTrait::__construct as createdAtTraitConstruct;
     }
+    use ExtendedContentTrait;
 
     #[ManyToOne(targetEntity: User::class, inversedBy: 'postComments')]
     #[JoinColumn(nullable: false, onDelete: 'CASCADE')]

--- a/src/Entity/Traits/ExtendedContentTrait.php
+++ b/src/Entity/Traits/ExtendedContentTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Entity\Traits;
 
@@ -6,10 +7,10 @@ trait ExtendedContentTrait
 {
     /**
      * @var array<string, mixed>
-     * May contain the following properties:
-     *   - boostUsers:
-     *     - desc: list of (followed) users who boosted this item + when it was boosted
-     *     - value: ['user' => User, 'time' => DateTimeImmutable][]
+     *                           May contain the following properties:
+     *                           - boostUsers:
+     *                           - desc: list of (followed) users who boosted this item + when it was boosted
+     *                           - value: ['user' => User, 'time' => DateTimeImmutable][]
      */
     public array $extendedContentProperties = [];
 }

--- a/src/Entity/Traits/ExtendedContentTrait.php
+++ b/src/Entity/Traits/ExtendedContentTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Entity\Traits;
+
+trait ExtendedContentTrait
+{
+    /**
+     * @var array<string, mixed>
+     * May contain the following properties:
+     *   - boostUsers:
+     *     - desc: list of (followed) users who boosted this item + when it was boosted
+     *     - value: ['user' => User, 'time' => DateTimeImmutable][]
+     */
+    public array $extendedContentProperties = [];
+}

--- a/src/Factory/ExtendedContentPopulationTransformerFactory.php
+++ b/src/Factory/ExtendedContentPopulationTransformerFactory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Factory;
 
@@ -10,13 +11,14 @@ use Doctrine\ORM\EntityManagerInterface;
 
 readonly class ExtendedContentPopulationTransformerFactory
 {
-
     public function __construct(
         private EntityManagerInterface $entityManager,
         private UserRepository $userRepository,
-    ){}
+    ) {
+    }
 
-    public function create(Criteria $criteria, ?User $loggedInUser): ExtendedContentPopulationTransformer {
+    public function create(Criteria $criteria, ?User $loggedInUser): ExtendedContentPopulationTransformer
+    {
         return new ExtendedContentPopulationTransformer(
             $this->entityManager,
             $this->userRepository,

--- a/src/Factory/ExtendedContentPopulationTransformerFactory.php
+++ b/src/Factory/ExtendedContentPopulationTransformerFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Factory;
+
+use App\Entity\User;
+use App\Pagination\Transformation\ExtendedContentPopulationTransformer;
+use App\Repository\Criteria;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+readonly class ExtendedContentPopulationTransformerFactory
+{
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private UserRepository $userRepository,
+    ){}
+
+    public function create(Criteria $criteria, ?User $loggedInUser): ExtendedContentPopulationTransformer {
+        return new ExtendedContentPopulationTransformer(
+            $this->entityManager,
+            $this->userRepository,
+            $criteria,
+            $loggedInUser,
+        );
+    }
+}

--- a/src/Form/SettingsType.php
+++ b/src/Form/SettingsType.php
@@ -50,6 +50,8 @@ class SettingsType extends AbstractType
             ->add('KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN', CheckboxType::class, ['required' => false])
             ->add('MBIN_SIDEBAR_SECTIONS_RANDOM_LOCAL_ONLY', CheckboxType::class, ['required' => false])
             ->add('MBIN_SIDEBAR_SECTIONS_USERS_LOCAL_ONLY', CheckboxType::class, ['required' => false])
+            ->add('MBIN_FEED_ALLOW_ENTRY_COMMENTS', CheckboxType::class, ['required' => false])
+            ->add('MBIN_FEED_ALLOW_POST_COMMENTS', CheckboxType::class, ['required' => false])
             ->add('MBIN_RESTRICT_MAGAZINE_CREATION', CheckboxType::class, ['required' => false])
             ->add('MBIN_SSO_SHOW_FIRST', CheckboxType::class, ['required' => false])
             ->add('MBIN_DOWNVOTES_MODE', ChoiceType::class, [

--- a/src/Pagination/Transformation/ContentPopulationTransformer.php
+++ b/src/Pagination/Transformation/ContentPopulationTransformer.php
@@ -14,10 +14,10 @@ use App\Entity\User;
 use App\Utils\SqlHelpers;
 use Doctrine\ORM\EntityManagerInterface;
 
-class ContentPopulationTransformer implements ResultTransformer
+readonly class ContentPopulationTransformer implements ResultTransformer
 {
     public function __construct(
-        private readonly EntityManagerInterface $entityManager,
+        protected EntityManagerInterface $entityManager,
     ) {
     }
 

--- a/src/Pagination/Transformation/ExtendedContentPopulationTransformer.php
+++ b/src/Pagination/Transformation/ExtendedContentPopulationTransformer.php
@@ -11,7 +11,6 @@ use App\Entity\User;
 use App\Repository\Criteria;
 use App\Repository\UserRepository;
 use App\Utils\SqlHelpers;
-use Doctrine\DBAL\ParameterType;
 use Doctrine\ORM\EntityManagerInterface;
 
 readonly class ExtendedContentPopulationTransformer extends ContentPopulationTransformer
@@ -44,32 +43,85 @@ readonly class ExtendedContentPopulationTransformer extends ContentPopulationTra
         \assert(\count($rows) === \count($items));
 
         $hasUser = null !== $this->loggedInUser;
+
+        if ($hasUser) {
+            $this->extendItemsBoostList($rows, $items);
+        }
+    }
+
+    /**
+     * @param array<Entry|EntryComment|Post|PostComment> $items
+     */
+    private function extendItemsBoostList(array $rows, array $items): void
+    {
+        $boostedEntries = [];
+        $boostedPosts = [];
+        $boostedEntryComments = [];
+        $boostedPostComments = [];
+
         foreach ($items as $i => $item) {
             $row = $rows[$i];
             \assert($row['id'] === $item->getId());
 
-            if ($hasUser && isset($row['was_boosted']) && true === $row['was_boosted']) {
-                $this->extendItemBoostList($item);
+            if (isset($row['was_boosted']) && true === $row['was_boosted']) {
+                match (true) {
+                    $item instanceof Entry => $boostedEntries[$item->getId()] = $item,
+                    $item instanceof Post => $boostedPosts[$item->getId()] = $item,
+                    $item instanceof EntryComment => $boostedEntryComments[$item->getId()] = $item,
+                    $item instanceof PostComment => $boostedPostComments[$item->getId()] = $item,
+                    default => throw new \LogicException('unreachable'),
+                };
+            }
+        }
+
+        $userCache = [];
+        if (\count($boostedEntries) > 0) {
+            $boostInfos = $this->queryBoostInfo(array_keys($boostedEntries), 'Entry', $userCache);
+            foreach ($boostInfos as $id => $boosts) {
+                $boostedEntries[$id]->extendedContentProperties['boostUsers'] = $boosts;
+            }
+        }
+        if (\count($boostedPosts) > 0) {
+            $boostInfos = $this->queryBoostInfo(array_keys($boostedPosts), 'Post', $userCache);
+            foreach ($boostInfos as $id => $boosts) {
+                $boostedPosts[$id]->extendedContentProperties['boostUsers'] = $boosts;
+            }
+        }
+        if (\count($boostedEntryComments) > 0) {
+            $boostInfos = $this->queryBoostInfo(array_keys($boostedEntryComments), 'EntryComment', $userCache);
+            foreach ($boostInfos as $id => $boosts) {
+                $boostedEntryComments[$id]->extendedContentProperties['boostUsers'] = $boosts;
+            }
+        }
+        if (\count($boostedPostComments) > 0) {
+            $boostInfos = $this->queryBoostInfo(array_keys($boostedPostComments), 'PostComment', $userCache);
+            foreach ($boostInfos as $id => $boosts) {
+                $boostedPostComments[$id]->extendedContentProperties['boostUsers'] = $boosts;
             }
         }
     }
 
-    private function extendItemBoostList(Entry|EntryComment|Post|PostComment $item): void
+    /**
+     * @param array<int, User> $userCache
+     *
+     * @return array [contentId => [user => User, time => DateTimeImmutable][]]
+     */
+    private function queryBoostInfo(array $contentIds, string $contentType, array $userCache): array
     {
-        switch (\get_class($item)) {
-            case Entry::class:
+        switch ($contentType) {
+            case 'Entry':
                 $vType = 'entry';
                 $fkType = 'entry';
                 break;
-            case Post::class:
+            case 'Post':
                 $vType = 'post';
                 $fkType = 'post';
                 break;
-            case EntryComment::class:
+            case 'EntryComment':
                 $vType = 'entry_comment';
                 $fkType = 'comment';
                 break;
-            case PostComment::class:
+            case 'PostComment':
                 $vType = 'post_comment';
                 $fkType = 'comment';
                 break;
@@ -78,17 +130,25 @@ readonly class ExtendedContentPopulationTransformer extends ContentPopulationTra
         }
 
         if (null === $this->criteria->cachedUserFollows) {
-            $sql = 'SELECT v.user_id, v.created_at FROM user_follow uf RIGHT OUTER JOIN %v_type%_vote v ON uf.following_id = v.user_id WHERE v.%fk_type%_id = :itemId AND (uf.follower_id = :loggedInUser OR v.user_id = :loggedInUser) AND v.choice = 1';
+            $sql = 'SELECT v.%fk_type%_id AS item_id, v.user_id, v.created_at FROM user_follow uf RIGHT OUTER JOIN %v_type%_vote v ON uf.following_id = v.user_id WHERE v.%fk_type%_id IN (:itemIds) AND (uf.follower_id = :loggedInUser OR v.user_id = :loggedInUser) AND v.choice = 1';
             $sql = str_replace('%v_type%', $vType, str_replace('%fk_type%', $fkType, $sql));
 
-            $boostsQuery = $this->entityManager->getConnection()->prepare($sql);
-            $boostsQuery->bindValue('itemId', $item->getId(), ParameterType::INTEGER);
-            $boostsQuery->bindValue('loggedInUser', $this->loggedInUser->getId(), ParameterType::INTEGER);
-        } else {
-            $sql = 'SELECT v.user_id, v.created_at FROM %v_type%_vote v WHERE :itemId = v.%fk_type%_id AND (v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser) AND v.choice = 1';
-            $sql = str_replace('%v_type%', $vType, str_replace('%fk_type%', $fkType, $sql));
             $parameters = [
-                'itemId' => $item->getId(),
+                'itemIds' => $contentIds,
+                'loggedInUser' => $this->loggedInUser->getId(),
+            ];
+            $rewritten = SqlHelpers::rewriteArrayParameters($parameters, $sql);
+
+            $boostsQuery = $this->entityManager->getConnection()->prepare($rewritten['sql']);
+            foreach ($rewritten['parameters'] as $key => $value) {
+                $boostsQuery->bindValue($key, $value, SqlHelpers::getSqlType($value));
+            }
+        } else {
+            $sql = 'SELECT v.%fk_type%_id AS item_id, v.user_id, v.created_at FROM %v_type%_vote v WHERE v.%fk_type%_id IN (:itemIds) AND (v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser) AND v.choice = 1';
+            $sql = str_replace('%v_type%', $vType, str_replace('%fk_type%', $fkType, $sql));
+
+            $parameters = [
+                'itemIds' => $contentIds,
                 'loggedInUser' => $this->loggedInUser->getId(),
                 'cachedUserFollows' => $this->criteria->cachedUserFollows,
             ];
@@ -100,16 +160,45 @@ readonly class ExtendedContentPopulationTransformer extends ContentPopulationTra
             }
         }
 
-        $boostInfo = $boostsQuery->executeQuery()->fetchAllAssociative();
-        $boostUsers = $this->userRepository->findBy(['id' => array_map(fn ($row) => $row['user_id'], $boostInfo)]);
+        $boostsInfo = $boostsQuery->executeQuery()->fetchAllAssociative();
+        $boostExtensions = [];
+        $usersToFetch = [];
+        $itemsToFix = [];
+        foreach ($boostsInfo as $row) {
+            $user = $row['user_id'];
+            if (isset($userCache[$user])) {
+                $user = $userCache[$user];
+                $fetchUser = false;
+            } else {
+                $usersToFetch[] = $user;
+                $fetchUser = true;
+            }
 
-        $boostExtension = [];
-        foreach ($boostUsers as $boostUser) {
-            $boostTime = array_find($boostInfo, fn ($row) => $row['user_id'] === $boostUser->getId())['created_at'];
-            $boostExtension[] = ['user' => $boostUser, 'time' => new \DateTimeImmutable($boostTime)];
+            $item = ['user' => $user, 'time' => new \DateTimeImmutable($row['created_at'])];
+            $boostExtensions[$row['item_id']][] = &$item;
+
+            if ($fetchUser) {
+                $itemsToFix[] = &$item;
+            }
         }
-        usort($boostExtension, fn ($a, $b) => $a['time'] <=> $b['time']);
 
-        $item->extendedContentProperties['boostUsers'] = $boostExtension;
+        if (\count($usersToFetch) > 0) {
+            $users = $this->userRepository->findBy(['id' => $usersToFetch]);
+            foreach ($users as $user) {
+                $userCache[$user->getId()] = $user;
+
+                foreach ($itemsToFix as $item) {
+                    if ($item['user'] === $user->getId()) {
+                        $item['user'] = $user;
+                    }
+                }
+            }
+        }
+
+        foreach ($boostExtensions as $boosts) {
+            usort($boosts, fn ($a, $b) => $a['time'] <=> $b['time']);
+        }
+
+        return $boostExtensions;
     }
 }

--- a/src/Pagination/Transformation/ExtendedContentPopulationTransformer.php
+++ b/src/Pagination/Transformation/ExtendedContentPopulationTransformer.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Pagination\Transformation;
+
+use App\Entity\Entry;
+use App\Entity\EntryComment;
+use App\Entity\Post;
+use App\Entity\PostComment;
+use App\Entity\User;
+use App\Repository\Criteria;
+use App\Repository\UserRepository;
+use App\Utils\SqlHelpers;
+use DateTimeImmutable;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\ORM\EntityManagerInterface;
+
+readonly class ExtendedContentPopulationTransformer extends ContentPopulationTransformer
+{
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        private UserRepository $userRepository,
+        private Criteria $criteria,
+        private ?User $loggedInUser,
+    ) {
+        parent::__construct($entityManager);
+    }
+
+    public function transform(iterable $input): iterable
+    {
+        $items = parent::transform($input);
+
+        assert(is_array($input));
+        assert(is_array($items));
+        $this->extendItems($input, $items);
+
+        return $items;
+    }
+
+    /**
+     * @param array $rows
+     * @param array<Entry|EntryComment|Post|PostComment> $items
+     * @return void
+     */
+    private function extendItems(array $rows, array $items): void {
+        assert(count($rows) === count($items));
+
+        $hasUser = $this->loggedInUser !== null;
+        foreach ($items as $i => $item) {
+            $row = $rows[$i];
+            assert($row['id'] === $item->getId());
+
+            if($hasUser && isset($row['was_boosted']) && true === $row['was_boosted']){
+                $this->extendItemBoostList($item);
+            }
+        }
+    }
+
+    private function extendItemBoostList(Entry|EntryComment|Post|PostComment $item): void
+    {
+        switch (get_class($item)) {
+            case Entry::class:
+                $vType = 'entry';
+                $fkType = 'entry';
+                break;
+            case Post::class:
+                $vType = 'post';
+                $fkType = 'post';
+                break;
+            case EntryComment::class:
+                $vType = 'entry_comment';
+                $fkType = 'comment';
+                break;
+            case PostComment::class:
+                $vType = 'post_comment';
+                $fkType = 'comment';
+                break;
+            default:
+                throw new \LogicException('unreachable');
+        }
+
+        if(null === $this->criteria->cachedUserFollows) {
+            $sql = 'SELECT v.user_id, v.created_at FROM user_follow uf RIGHT OUTER JOIN %v_type%_vote v ON uf.following_id = v.user_id WHERE v.%fk_type%_id = :itemId AND (uf.follower_id = :loggedInUser OR v.user_id = :loggedInUser) AND v.choice = 1';
+            $sql = str_replace('%v_type%', $vType, str_replace('%fk_type%', $fkType, $sql));
+
+            $boostsQuery = $this->entityManager->getConnection()->prepare($sql);
+            $boostsQuery->bindValue('itemId', $item->getId(), ParameterType::INTEGER);
+            $boostsQuery->bindValue('loggedInUser', $this->loggedInUser->getId(), ParameterType::INTEGER);
+        } else {
+            $sql = 'SELECT v.user_id, v.created_at FROM %v_type%_vote v WHERE :itemId = v.%fk_type%_id AND (v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser) AND v.choice = 1';
+            $sql = str_replace('%v_type%', $vType, str_replace('%fk_type%', $fkType, $sql));
+            $parameters = [
+                'itemId' => $item->getId(),
+                'loggedInUser' => $this->loggedInUser->getId(),
+                'cachedUserFollows' => $this->criteria->cachedUserFollows,
+            ];
+            $rewritten = SqlHelpers::rewriteArrayParameters($parameters, $sql);
+
+            $boostsQuery = $this->entityManager->getConnection()->prepare($rewritten['sql']);
+            foreach ($rewritten['parameters'] as $key => $value) {
+                $boostsQuery->bindValue($key, $value, SqlHelpers::getSqlType($value));
+            }
+        }
+
+        $boostInfo = $boostsQuery->executeQuery()->fetchAllAssociative();
+        $boostUsers = $this->userRepository->findBy(['id' => array_map(fn($row) => $row['user_id'], $boostInfo)]);
+
+        $boostExtension = [];
+        foreach ($boostUsers as $boostUser) {
+            $boostTime = array_find($boostInfo, fn($row) => $row['user_id'] === $boostUser->getId())['created_at'];
+            $boostExtension[] = ['user' => $boostUser, 'time' => new DateTimeImmutable($boostTime)];
+        }
+        usort($boostExtension, fn($a, $b) => $a['time'] <=> $b['time']);
+
+        $item->extendedContentProperties['boostUsers'] = $boostExtension;
+    }
+}

--- a/src/Pagination/Transformation/ExtendedContentPopulationTransformer.php
+++ b/src/Pagination/Transformation/ExtendedContentPopulationTransformer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Pagination\Transformation;
 
@@ -10,7 +11,6 @@ use App\Entity\User;
 use App\Repository\Criteria;
 use App\Repository\UserRepository;
 use App\Utils\SqlHelpers;
-use DateTimeImmutable;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -29,27 +29,26 @@ readonly class ExtendedContentPopulationTransformer extends ContentPopulationTra
     {
         $items = parent::transform($input);
 
-        assert(is_array($input));
-        assert(is_array($items));
+        \assert(\is_array($input));
+        \assert(\is_array($items));
         $this->extendItems($input, $items);
 
         return $items;
     }
 
     /**
-     * @param array $rows
      * @param array<Entry|EntryComment|Post|PostComment> $items
-     * @return void
      */
-    private function extendItems(array $rows, array $items): void {
-        assert(count($rows) === count($items));
+    private function extendItems(array $rows, array $items): void
+    {
+        \assert(\count($rows) === \count($items));
 
-        $hasUser = $this->loggedInUser !== null;
+        $hasUser = null !== $this->loggedInUser;
         foreach ($items as $i => $item) {
             $row = $rows[$i];
-            assert($row['id'] === $item->getId());
+            \assert($row['id'] === $item->getId());
 
-            if($hasUser && isset($row['was_boosted']) && true === $row['was_boosted']){
+            if ($hasUser && isset($row['was_boosted']) && true === $row['was_boosted']) {
                 $this->extendItemBoostList($item);
             }
         }
@@ -57,7 +56,7 @@ readonly class ExtendedContentPopulationTransformer extends ContentPopulationTra
 
     private function extendItemBoostList(Entry|EntryComment|Post|PostComment $item): void
     {
-        switch (get_class($item)) {
+        switch (\get_class($item)) {
             case Entry::class:
                 $vType = 'entry';
                 $fkType = 'entry';
@@ -78,7 +77,7 @@ readonly class ExtendedContentPopulationTransformer extends ContentPopulationTra
                 throw new \LogicException('unreachable');
         }
 
-        if(null === $this->criteria->cachedUserFollows) {
+        if (null === $this->criteria->cachedUserFollows) {
             $sql = 'SELECT v.user_id, v.created_at FROM user_follow uf RIGHT OUTER JOIN %v_type%_vote v ON uf.following_id = v.user_id WHERE v.%fk_type%_id = :itemId AND (uf.follower_id = :loggedInUser OR v.user_id = :loggedInUser) AND v.choice = 1';
             $sql = str_replace('%v_type%', $vType, str_replace('%fk_type%', $fkType, $sql));
 
@@ -102,14 +101,14 @@ readonly class ExtendedContentPopulationTransformer extends ContentPopulationTra
         }
 
         $boostInfo = $boostsQuery->executeQuery()->fetchAllAssociative();
-        $boostUsers = $this->userRepository->findBy(['id' => array_map(fn($row) => $row['user_id'], $boostInfo)]);
+        $boostUsers = $this->userRepository->findBy(['id' => array_map(fn ($row) => $row['user_id'], $boostInfo)]);
 
         $boostExtension = [];
         foreach ($boostUsers as $boostUser) {
-            $boostTime = array_find($boostInfo, fn($row) => $row['user_id'] === $boostUser->getId())['created_at'];
-            $boostExtension[] = ['user' => $boostUser, 'time' => new DateTimeImmutable($boostTime)];
+            $boostTime = array_find($boostInfo, fn ($row) => $row['user_id'] === $boostUser->getId())['created_at'];
+            $boostExtension[] = ['user' => $boostUser, 'time' => new \DateTimeImmutable($boostTime)];
         }
-        usort($boostExtension, fn($a, $b) => $a['time'] <=> $b['time']);
+        usort($boostExtension, fn ($a, $b) => $a['time'] <=> $b['time']);
 
         $item->extendedContentProperties['boostUsers'] = $boostExtension;
     }

--- a/src/Repository/ContentRepository.php
+++ b/src/Repository/ContentRepository.php
@@ -8,12 +8,14 @@ use App\Entity\Contracts\VisibilityInterface;
 use App\Entity\Entry;
 use App\Entity\Post;
 use App\Entity\User;
+use App\Factory\ExtendedContentPopulationTransformerFactory;
 use App\Pagination\Cursor\CursorPagination;
 use App\Pagination\Cursor\CursorPaginationInterface;
 use App\Pagination\Cursor\NativeQueryCursorAdapter;
 use App\Pagination\NativeQueryAdapter;
 use App\Pagination\Pagerfanta;
 use App\Pagination\Transformation\ContentPopulationTransformer;
+use App\Pagination\Transformation\ExtendedContentPopulationTransformer;
 use App\Utils\SqlHelpers;
 use Doctrine\DBAL\Exception;
 use Doctrine\ORM\EntityManagerInterface;
@@ -30,7 +32,7 @@ class ContentRepository
     public function __construct(
         private readonly Security $security,
         private readonly EntityManagerInterface $entityManager,
-        private readonly ContentPopulationTransformer $contentPopulationTransformer,
+        private readonly ExtendedContentPopulationTransformerFactory $contentPopulationTransformerFactory,
         private readonly CacheInterface $cache,
         private readonly LoggerInterface $logger,
         private readonly KernelInterface $kernel,
@@ -47,7 +49,14 @@ class ContentRepository
             // pre-set the results to 1000 pages for queries not very limited by the parameters so the count query is not being executed
             $numResults = 1000 * ($criteria->perPage ?? self::PER_PAGE);
         }
-        $fanta = new Pagerfanta(new NativeQueryAdapter($conn, $query['sql'], $query['parameters'], numOfResults: $numResults, transformer: $this->contentPopulationTransformer, cache: $this->cache));
+        $fanta = new Pagerfanta(new NativeQueryAdapter(
+            $conn,
+            $query['sql'],
+            $query['parameters'],
+            numOfResults: $numResults,
+            transformer: $this->contentPopulationTransformerFactory->create($criteria, $this->security->getUser()),
+            cache: $this->cache
+        ));
         $fanta->setMaxPerPage($criteria->perPage ?? self::PER_PAGE);
         $fanta->setCurrentPage($criteria->page);
 
@@ -84,7 +93,7 @@ class ContentRepository
                 $this->getSecondaryCursorWhereFromCriteriaInverted($criteria),
                 'c.created_at DESC',
                 'c.created_at',
-                transformer: $this->contentPopulationTransformer,
+                transformer: $this->contentPopulationTransformerFactory->create($criteria, $this->security->getUser()),
             ),
             $this->getCursorFieldFromCriteria($criteria),
             $criteria->perPage ?? self::PER_PAGE,
@@ -194,6 +203,10 @@ class ContentRepository
         $subClauseEntry = '';
         $subClauseEntryComment = '';
         $subClausePostComment = '';
+        $selectPostBoosted = '';
+        $selectEntryBoosted = '';
+        $selectPostCommentBoosted = '';
+        $selectEntryCommentBoosted = '';
         if ($user && $criteria->subscribed) {
             $subClausePost = 'c.user_id = :loggedInUser'
                 .(null === $criteria->cachedUserSubscribedMagazines ?
@@ -213,23 +226,20 @@ class ContentRepository
                         ' OR EXISTS (SELECT 1 FROM user_follow uf WHERE uf.follower_id = :loggedInUser AND uf.following_id = c.user_id)' :
                         ' OR c.user_id IN (:cachedUserFollows)');
 
-                $subClauseEntryComment = $repliesCommonWhere.
-                    (null === $criteria->cachedUserFollows ?
-                        ' OR EXISTS (SELECT 1 FROM user_follow uf RIGHT OUTER JOIN entry_comment_vote v ON uf.following_id = v.user_id WHERE c.id = v.comment_id AND (uf.follower_id = :loggedInUser OR v.user_id = :loggedInUser) AND v.choice = 1)' :
-                        ' OR EXISTS (SELECT 1 FROM entry_comment_vote v WHERE c.id = v.comment_id AND (v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser) AND v.choice = 1)');
-                $subClausePostComment = $repliesCommonWhere.
-                    (null === $criteria->cachedUserFollows ?
-                        ' OR EXISTS (SELECT 1 FROM user_follow uf RIGHT OUTER JOIN post_comment_vote v ON uf.following_id = v.user_id WHERE c.id = v.comment_id AND (uf.follower_id = :loggedInUser OR v.user_id = :loggedInUser) AND v.choice = 1)' :
-                        ' OR EXISTS (SELECT 1 FROM post_comment_vote v WHERE c.id = v.comment_id AND (v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser) AND v.choice = 1)');
+                $boostCheckTpl = null === $criteria->cachedUserFollows ?
+                    'EXISTS (SELECT 1 FROM user_follow uf RIGHT OUTER JOIN %v_type%_vote v ON uf.following_id = v.user_id WHERE c.id = v.%fk_type%_id AND (uf.follower_id = :loggedInUser OR v.user_id = :loggedInUser) AND v.choice = 1)' :
+                    'EXISTS (SELECT 1 FROM %v_type%_vote v WHERE c.id = v.%fk_type%_id AND (v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser) AND v.choice = 1)';
 
-                $subClausePost = $subClausePost
-                    .(null === $criteria->cachedUserFollows ?
-                        ' OR EXISTS (SELECT 1 FROM user_follow uf RIGHT OUTER JOIN post_vote v ON uf.following_id = v.user_id WHERE c.id = v.post_id AND (uf.follower_id = :loggedInUser OR v.user_id = :loggedInUser) AND v.choice = 1)' :
-                        ' OR EXISTS (SELECT 1 FROM post_vote v WHERE c.id = v.post_id AND (v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser) AND v.choice = 1)');
-                $subClauseEntry = $subClauseEntry
-                    .(null === $criteria->cachedUserFollows ?
-                        ' OR EXISTS (SELECT 1 FROM user_follow uf RIGHT OUTER JOIN entry_vote v ON uf.following_id = v.user_id WHERE c.id = v.entry_id AND (uf.follower_id = :loggedInUser OR v.user_id = :loggedInUser) AND v.choice = 1)' :
-                        ' OR EXISTS (SELECT 1 FROM entry_vote v WHERE c.id = v.entry_id AND (v.user_id IN (:cachedUserFollows) OR v.user_id = :loggedInUser) AND v.choice = 1)');
+                $subClauseEntryComment = $repliesCommonWhere.' OR '.str_replace('%v_type%', 'entry_comment', str_replace('%fk_type%', 'comment', $boostCheckTpl));
+                $subClausePostComment = $repliesCommonWhere.' OR '.str_replace('%v_type%', 'post_comment', str_replace('%fk_type%', 'comment', $boostCheckTpl));
+
+                $subClausePost = $subClausePost.' OR '.str_replace('%v_type%', 'post', str_replace('%fk_type%', 'post', $boostCheckTpl));
+                $subClauseEntry = $subClauseEntry.' OR '.str_replace('%v_type%', 'entry', str_replace('%fk_type%', 'entry', $boostCheckTpl));
+
+                $selectPostBoosted = ', '.str_replace('%v_type%', 'post', str_replace('%fk_type%', 'post', $boostCheckTpl)).' AS was_boosted';
+                $selectEntryBoosted = ', '.str_replace('%v_type%', 'entry', str_replace('%fk_type%', 'entry', $boostCheckTpl)).' AS was_boosted';
+                $selectPostCommentBoosted = ', '.str_replace('%v_type%', 'post_comment', str_replace('%fk_type%', 'comment', $boostCheckTpl)).' AS was_boosted';
+                $selectEntryCommentBoosted = ', '.str_replace('%v_type%', 'entry_comment', str_replace('%fk_type%', 'comment', $boostCheckTpl)).' AS was_boosted';
             }
 
             if (null !== $criteria->cachedUserSubscribedMagazines) {
@@ -481,17 +491,17 @@ class ContentRepository
         // only join domain if we are explicitly looking at one
         $domainJoin = $criteria->domain ? 'LEFT JOIN domain d ON d.id = c.domain_id' : '';
 
-        $entrySql = "SELECT c.id, 'entry' as type, c.type as content_type, c.created_at, c.last_boosted_at, c.ranking, c.score, c.comment_count, c.sticky, c.last_active, c.user_id FROM entry c
+        $entrySql = "SELECT c.id, 'entry' as type, c.type as content_type, c.created_at, c.last_boosted_at, c.ranking, c.score, c.comment_count, c.sticky, c.last_active, c.user_id $selectEntryBoosted FROM entry c
             LEFT JOIN magazine m ON c.magazine_id = m.id
             $domainJoin
             $entryWhere";
-        $postSql = "SELECT c.id, 'post' as type, 'microblog' as content_type, c.created_at, c.last_boosted_at, c.ranking, c.score, c.comment_count, c.sticky, c.last_active, c.user_id FROM post c
+        $postSql = "SELECT c.id, 'post' as type, 'microblog' as content_type, c.created_at, c.last_boosted_at, c.ranking, c.score, c.comment_count, c.sticky, c.last_active, c.user_id $selectPostBoosted FROM post c
             LEFT JOIN magazine m ON c.magazine_id = m.id
             $postWhere";
-        $entryCommentSql = "SELECT c.id, 'entry_comment' as type, 'microblog' as content_type, c.created_at, c.last_boosted_at, 0 as ranking, 0 as score, 0 as comment_count, false as sticky, c.last_active, c.user_id FROM entry_comment c
+        $entryCommentSql = "SELECT c.id, 'entry_comment' as type, 'microblog' as content_type, c.created_at, c.last_boosted_at, 0 as ranking, 0 as score, 0 as comment_count, false as sticky, c.last_active, c.user_id $selectEntryCommentBoosted FROM entry_comment c
             LEFT JOIN magazine m ON c.magazine_id = m.id
             $entryCommentWhere";
-        $postCommentSql = "SELECT c.id, 'post_comment' as type, 'microblog' as content_type, c.created_at, c.last_boosted_at, 0 as ranking, 0 as score, 0 as comment_count, false as sticky, c.last_active, c.user_id FROM post_comment c
+        $postCommentSql = "SELECT c.id, 'post_comment' as type, 'microblog' as content_type, c.created_at, c.last_boosted_at, 0 as ranking, 0 as score, 0 as comment_count, false as sticky, c.last_active, c.user_id $selectPostCommentBoosted FROM post_comment c
             LEFT JOIN magazine m ON c.magazine_id = m.id
             $postCommentWhere";
 

--- a/src/Repository/ContentRepository.php
+++ b/src/Repository/ContentRepository.php
@@ -16,6 +16,7 @@ use App\Pagination\NativeQueryAdapter;
 use App\Pagination\Pagerfanta;
 use App\Pagination\Transformation\ContentPopulationTransformer;
 use App\Pagination\Transformation\ExtendedContentPopulationTransformer;
+use App\Service\SettingsManager;
 use App\Utils\SqlHelpers;
 use Doctrine\DBAL\Exception;
 use Doctrine\ORM\EntityManagerInterface;
@@ -33,6 +34,7 @@ class ContentRepository
         private readonly Security $security,
         private readonly EntityManagerInterface $entityManager,
         private readonly ExtendedContentPopulationTransformerFactory $contentPopulationTransformerFactory,
+        private readonly SettingsManager $settingsManager,
         private readonly CacheInterface $cache,
         private readonly LoggerInterface $logger,
         private readonly KernelInterface $kernel,
@@ -111,8 +113,8 @@ class ContentRepository
     private function getQueryAndParameters(Criteria $criteria, bool $addCursor): array
     {
         $includeEntries = Criteria::CONTENT_COMBINED === $criteria->content || Criteria::CONTENT_THREADS === $criteria->content;
-        $includeEntryComments = $criteria->subscribed && Criteria::CONTENT_COMBINED === $criteria->content && $criteria->includeBoosts;
-        $includePostComments = $criteria->subscribed && (Criteria::CONTENT_COMBINED === $criteria->content || Criteria::CONTENT_MICROBLOG === $criteria->content) && $criteria->includeBoosts;
+        $includeEntryComments = $this->settingsManager->getDto()->MBIN_FEED_ALLOW_ENTRY_COMMENTS && $criteria->subscribed && Criteria::CONTENT_COMBINED === $criteria->content && $criteria->includeBoosts;
+        $includePostComments = $this->settingsManager->getDto()->MBIN_FEED_ALLOW_POST_COMMENTS && $criteria->subscribed && (Criteria::CONTENT_COMBINED === $criteria->content || Criteria::CONTENT_MICROBLOG === $criteria->content) && $criteria->includeBoosts;
 
         $parameters = [
             'visible' => VisibilityInterface::VISIBILITY_VISIBLE,

--- a/src/Repository/ContentRepository.php
+++ b/src/Repository/ContentRepository.php
@@ -14,8 +14,6 @@ use App\Pagination\Cursor\CursorPaginationInterface;
 use App\Pagination\Cursor\NativeQueryCursorAdapter;
 use App\Pagination\NativeQueryAdapter;
 use App\Pagination\Pagerfanta;
-use App\Pagination\Transformation\ContentPopulationTransformer;
-use App\Pagination\Transformation\ExtendedContentPopulationTransformer;
 use App\Service\SettingsManager;
 use App\Utils\SqlHelpers;
 use Doctrine\DBAL\Exception;

--- a/src/Service/SettingsManager.php
+++ b/src/Service/SettingsManager.php
@@ -102,6 +102,8 @@ class SettingsManager
                 $this->find($results, 'MBIN_DOWNVOTES_MODE') ?? $this->mbinDownvotesMode->value,
                 $newUsersNeedApprovalEdited,
                 $this->find($results, 'MBIN_USE_FEDERATION_ALLOW_LIST', FILTER_VALIDATE_BOOLEAN) ?? $this->mbinUseFederationAllowList,
+                $this->find($results, 'MBIN_FEED_ALLOW_ENTRY_COMMENTS', FILTER_VALIDATE_BOOLEAN) ?? true,
+                $this->find($results, 'MBIN_FEED_ALLOW_POST_COMMENTS', FILTER_VALIDATE_BOOLEAN) ?? true,
             );
             $this->instanceDto = $dto;
         } else {

--- a/templates/admin/settings.html.twig
+++ b/templates/admin/settings.html.twig
@@ -87,6 +87,16 @@
                 {{ form_widget(form.MBIN_SIDEBAR_SECTIONS_USERS_LOCAL_ONLY) }}
             </div>
             <div class="checkbox">
+                {{ form_label(form.MBIN_FEED_ALLOW_ENTRY_COMMENTS, 'feed_allow_entry_comments') }}
+                {{ form_widget(form.MBIN_FEED_ALLOW_ENTRY_COMMENTS) }}
+            </div>
+            <div style="font-size: 0.8rem; margin-top: -0.5rem; margin-left: 2rem;">{{ 'feed_allow_comments_hint'|trans }}</div>
+            <div class="checkbox">
+                {{ form_label(form.MBIN_FEED_ALLOW_POST_COMMENTS, 'feed_allow_post_comments') }}
+                {{ form_widget(form.MBIN_FEED_ALLOW_POST_COMMENTS) }}
+            </div>
+            <div style="font-size: 0.8rem; margin-top: -0.5rem; margin-left: 2rem;">{{ 'feed_allow_comments_hint'|trans }}</div>
+            <div class="checkbox">
                 {{ form_label(form.MBIN_RESTRICT_MAGAZINE_CREATION, 'restrict_magazine_creation') }}
                 {{ form_widget(form.MBIN_RESTRICT_MAGAZINE_CREATION) }}
             </div>

--- a/templates/components/entry.html.twig
+++ b/templates/components/entry.html.twig
@@ -203,6 +203,8 @@
                             </div>
                         </li>
                     </menu>
+
+                    {{ include('widget/boosted_by.html.twig', {subject: entry}) }}
                 {% elseif (entry.visibility is same as 'trashed' and this.canSeeTrashed) %}
                     <menu>
                         <li>

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -156,6 +156,9 @@
                         </li>
                     </menu>
                 {% endif %}
+
+                {{ include('widget/boosted_by.html.twig', {subject: comment}) }}
+
                 <div data-subject-target="container" class="js-container">
                 </div>
             </footer>

--- a/templates/components/entry_comment_combined.html.twig
+++ b/templates/components/entry_comment_combined.html.twig
@@ -178,6 +178,9 @@
                         </li>
                     </menu>
                 {% endif %}
+
+                {{ include('widget/boosted_by.html.twig', {subject: comment}) }}
+
                 <div data-subject-target="container" class="js-container">
                 </div>
             </footer>

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -141,11 +141,17 @@
                             </div>
                         </li>
                     </menu>
+
+                {% if post.extendedContentProperties.boostUsers is defined %}
+                    {{ include('widget/boosted_by.html.twig', {subject: post}) }}
+                {% else %}
                     {{ component('voters_inline', {
                         subject: post,
                         url: post_voters_url(post, 'up'),
                         'data-post-target': 'voters'
                     }) }}
+                {% endif %}
+
                 {% elseif(post.visibility is same as 'trashed' and this.canSeeTrashed) %}
                     <menu>
                         <li>

--- a/templates/components/post_combined.html.twig
+++ b/templates/components/post_combined.html.twig
@@ -176,6 +176,9 @@
                         </li>
                     </menu>
                 {% endif %}
+
+                {{ include('widget/boosted_by.html.twig', {subject: post}) }}
+
                 <div data-subject-target="container" class="js-container">
                 </div>
             </footer>

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -155,10 +155,16 @@
                         </li>
                     </menu>
                 {% endif %}
-                {{ component('voters_inline', {
-                    subject: comment,
-                    url: post_comment_voters_url(comment, 'up')
-                }) }}
+
+                {% if comment.extendedContentProperties.boostUsers is defined %}
+                    {{ include('widget/boosted_by.html.twig', {subject: comment}) }}
+                {% else %}
+                    {{ component('voters_inline', {
+                        subject: comment,
+                        url: post_comment_voters_url(comment, 'up')
+                    }) }}
+                {% endif %}
+
                 <div data-subject-target="container" class="js-container">
                 </div>
             </footer>

--- a/templates/components/post_comment_combined.html.twig
+++ b/templates/components/post_comment_combined.html.twig
@@ -170,6 +170,9 @@
                         </li>
                     </menu>
                 {% endif %}
+
+                {{ include('widget/boosted_by.html.twig', {subject: comment}) }}
+
                 <div data-subject-target="container" class="js-container">
                 </div>
             </footer>

--- a/templates/widget/boosted_by.html.twig
+++ b/templates/widget/boosted_by.html.twig
@@ -1,0 +1,14 @@
+{% with {boosts: subject.extendedContentProperties.boostUsers|default([])} %}
+    {% if boosts|length > 0 %}
+        <div class="boosted-by">
+            <span aria-label="{{ 'boosts'|trans }}">{{ 'boosted_by'|trans }}</span>
+            {% for boost in boosts %}
+                <a href="{{ path('user_overview', {username: boost.user.username}) }}">
+                    {{ boost.user.username|username }}
+                    ({{ component('date', {date: boost.time}) }})
+                </a>
+                {%- if not loop.last %},{% endif %}
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endwith %}

--- a/tests/Functional/Controller/Api/Combined/CombinedRetrieveApiTest.php
+++ b/tests/Functional/Controller/Api/Combined/CombinedRetrieveApiTest.php
@@ -54,6 +54,27 @@ class CombinedRetrieveApiTest extends WebTestCase
         self::assertArrayKeysMatch(self::PAGINATION_KEYS, $jsonData['pagination']);
         self::assertSame(8, $jsonData['pagination']['count']);
 
+        $boostedContentIds = [
+            'post' => $postBoosted->getId(),
+            'postComment' => $postCommentBoosted->getId(),
+            'entry' => $entryBoosted->getId(),
+            'entryComment' => $entryCommentBoosted->getId(),
+        ];
+        $boostedContentSeen = [];
+        foreach ($jsonData['items'] as $item) {
+            foreach ($boostedContentIds as $type => $boostedContentId) {
+                $idKey = str_ends_with($type, 'Comment') ? 'commentId' : $type.'Id';
+                if (($item[$type][$idKey] ?? null) === $boostedContentId) {
+                    self::assertCount(1, $item['boostedBy']);
+                    self::assertSame($userFollowing->getId(), $item['boostedBy'][0]['user']['userId']);
+                    self::assertSame($userFollowing->username, $item['boostedBy'][0]['user']['username']);
+                    self::assertNotFalse(\DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, $item['boostedBy'][0]['boostedAt']));
+                    $boostedContentSeen[] = $type;
+                }
+            }
+        }
+        self::assertEqualsCanonicalizing(array_keys($boostedContentIds), $boostedContentSeen);
+
         $retrievedPostIds = array_map(function ($item) {
             if (null !== $item['post']) {
                 self::assertArrayKeysMatch(self::POST_RESPONSE_KEYS, $item['post']);

--- a/tests/Functional/Controller/Api/Instance/Admin/InstanceSettingsRetrieveApiTest.php
+++ b/tests/Functional/Controller/Api/Instance/Admin/InstanceSettingsRetrieveApiTest.php
@@ -8,7 +8,7 @@ use App\Tests\WebTestCase;
 
 class InstanceSettingsRetrieveApiTest extends WebTestCase
 {
-    public const INSTANCE_SETTINGS_RESPONSE_KEYS = [
+    public const array INSTANCE_SETTINGS_RESPONSE_KEYS = [
         'KBIN_DOMAIN',
         'KBIN_TITLE',
         'KBIN_META_TITLE',
@@ -37,6 +37,8 @@ class InstanceSettingsRetrieveApiTest extends WebTestCase
         'MBIN_SSO_SHOW_FIRST',
         'MBIN_NEW_USERS_NEED_APPROVAL',
         'MBIN_USE_FEDERATION_ALLOW_LIST',
+        'MBIN_FEED_ALLOW_ENTRY_COMMENTS',
+        'MBIN_FEED_ALLOW_POST_COMMENTS',
     ];
 
     public function testApiCannotRetrieveInstanceSettingsAnonymous(): void

--- a/tests/Functional/Controller/Api/Instance/Admin/InstanceSettingsUpdateApiTest.php
+++ b/tests/Functional/Controller/Api/Instance/Admin/InstanceSettingsUpdateApiTest.php
@@ -10,37 +10,6 @@ use App\Utils\DownvotesMode;
 
 class InstanceSettingsUpdateApiTest extends WebTestCase
 {
-    public const INSTANCE_SETTINGS_RESPONSE_KEYS = [
-        'KBIN_DOMAIN',
-        'KBIN_TITLE',
-        'KBIN_META_TITLE',
-        'KBIN_META_KEYWORDS',
-        'KBIN_META_DESCRIPTION',
-        'KBIN_DEFAULT_LANG',
-        'KBIN_CONTACT_EMAIL',
-        'KBIN_SENDER_EMAIL',
-        'MBIN_DEFAULT_THEME',
-        'KBIN_JS_ENABLED',
-        'KBIN_FEDERATION_ENABLED',
-        'KBIN_REGISTRATIONS_ENABLED',
-        'KBIN_HEADER_LOGO',
-        'KBIN_CAPTCHA_ENABLED',
-        'KBIN_MERCURE_ENABLED',
-        'KBIN_FEDERATION_PAGE_ENABLED',
-        'KBIN_ADMIN_ONLY_OAUTH_CLIENTS',
-        'MBIN_PRIVATE_INSTANCE',
-        'KBIN_FEDERATED_SEARCH_ONLY_LOGGEDIN',
-        'MBIN_SIDEBAR_SECTIONS_RANDOM_LOCAL_ONLY',
-        'MBIN_SIDEBAR_SECTIONS_USERS_LOCAL_ONLY',
-        'MBIN_SSO_REGISTRATIONS_ENABLED',
-        'MBIN_RESTRICT_MAGAZINE_CREATION',
-        'MBIN_DOWNVOTES_MODE',
-        'MBIN_SSO_ONLY_MODE',
-        'MBIN_SSO_SHOW_FIRST',
-        'MBIN_NEW_USERS_NEED_APPROVAL',
-        'MBIN_USE_FEDERATION_ALLOW_LIST',
-    ];
-
     public function testApiCannotUpdateInstanceSettingsAnonymous(): void
     {
         $this->client->request('PUT', '/api/instance/settings');
@@ -114,6 +83,8 @@ class InstanceSettingsUpdateApiTest extends WebTestCase
             'MBIN_SSO_SHOW_FIRST' => false,
             'MBIN_NEW_USERS_NEED_APPROVAL' => false,
             'MBIN_USE_FEDERATION_ALLOW_LIST' => false,
+            'MBIN_FEED_ALLOW_ENTRY_COMMENTS' => true,
+            'MBIN_FEED_ALLOW_POST_COMMENTS' => true,
         ];
 
         $this->client->jsonRequest('PUT', '/api/instance/settings', $settings, server: ['HTTP_AUTHORIZATION' => $token]);
@@ -121,7 +92,7 @@ class InstanceSettingsUpdateApiTest extends WebTestCase
         self::assertResponseIsSuccessful();
         $jsonData = self::getJsonResponse($this->client);
 
-        self::assertArrayKeysMatch(self::INSTANCE_SETTINGS_RESPONSE_KEYS, $jsonData);
+        self::assertArrayKeysMatch(InstanceSettingsRetrieveApiTest::INSTANCE_SETTINGS_RESPONSE_KEYS, $jsonData);
         foreach ($jsonData as $key => $value) {
             self::assertEquals($settings[$key], $value, "$key did not match!");
         }
@@ -155,6 +126,8 @@ class InstanceSettingsUpdateApiTest extends WebTestCase
             'MBIN_SSO_SHOW_FIRST' => true,
             'MBIN_NEW_USERS_NEED_APPROVAL' => false,
             'MBIN_USE_FEDERATION_ALLOW_LIST' => false,
+            'MBIN_FEED_ALLOW_ENTRY_COMMENTS' => false,
+            'MBIN_FEED_ALLOW_POST_COMMENTS' => false,
         ];
 
         $this->client->jsonRequest('PUT', '/api/instance/settings', $settings, server: ['HTTP_AUTHORIZATION' => $token]);
@@ -162,7 +135,7 @@ class InstanceSettingsUpdateApiTest extends WebTestCase
         self::assertResponseIsSuccessful();
         $jsonData = self::getJsonResponse($this->client);
 
-        self::assertArrayKeysMatch(self::INSTANCE_SETTINGS_RESPONSE_KEYS, $jsonData);
+        self::assertArrayKeysMatch(InstanceSettingsRetrieveApiTest::INSTANCE_SETTINGS_RESPONSE_KEYS, $jsonData);
         foreach ($jsonData as $key => $value) {
             self::assertEquals($settings[$key], $value, "$key did not match!");
         }

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -1116,6 +1116,9 @@ combined: Combined
 sidebar_sections_random_local_only: Restrict "Random Threads/Posts" sidebar sections to local only
 sidebar_sections_users_local_only: Restrict "Active people" sidebar section to local only
 random_local_only_performance_warning: Enabling "Random local only" may cause SQL performance impact.
+feed_allow_entry_comments: Include comments of threads in Combined feed
+feed_allow_post_comments: Include comments of posts in Combined feed
+feed_allow_comments_hint: (might result in slow loading)
 discoverable: Discoverable
 user_discoverable_help: If this is enabled, your profile, threads, microblogs and comments can be found
   through search and the random panels. Your profile might also appear in the active user panel and on the people page.

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -249,6 +249,7 @@ solarized_auto: Solarized (Auto Detect)
 font_size: Font size
 size: Size
 boosts: Boosts
+boosted_by: Boosted by
 show_users_avatars: 'Show users’ avatars'
 yes: Yes
 no: No


### PR DESCRIPTION
If content gets included in the feed (Combined + Subscribed + Newest), then show who of the followees boosted it.
<img width="1212" height="876" alt="img" src="https://github.com/user-attachments/assets/ca89de9a-697f-41bf-bebd-a0d7ec43047f" />

This is currently only for the UI. If you have an idea how this info can be included in API responses, please let me know (@jwr1).

As the content-query can become white heavy when including comments, this PR also adds a setting for the admins to disable comments in the feed.

Closes #2192