### PR TITLE
fix overflow handling when a post or comment contains an overly wide table

### DIFF
--- a/assets/styles/components/_comment.scss
+++ b/assets/styles/components/_comment.scss
@@ -71,6 +71,16 @@ $comment-margin-sm: .3rem;
     }
   }
 
+  .content-container {
+    grid-area: body;
+    display: grid;
+
+    p {
+      margin-top: 0;
+      margin-bottom: 0.5rem;
+    }
+  }
+
   .content {
     p:last-child {
       margin-bottom: 0;
@@ -95,15 +105,6 @@ $comment-margin-sm: .3rem;
 
   .expand-label {
     display: none;
-  }
-
-  div {
-    grid-area: body;
-
-    p {
-      margin-top: 0;
-      margin-bottom: 0.5rem;
-    }
   }
 
   > figure {

--- a/assets/styles/components/_post.scss
+++ b/assets/styles/components/_post.scss
@@ -74,6 +74,15 @@ blockquote.post {
     }
   }
 
+  .content-container {
+    grid-area: body;
+    display: grid;
+
+    p {
+      margin-top: 0
+    }
+  }
+
   .content {
     p:last-child {
       margin-bottom: 0;
@@ -82,14 +91,6 @@ blockquote.post {
 
   aside:not(.notification-switch) {
     grid-area: vote;
-  }
-
-  div {
-    grid-area: body;
-
-    p {
-      margin-top: 0
-    }
   }
 
   > figure {

--- a/assets/styles/layout/_layout.scss
+++ b/assets/styles/layout/_layout.scss
@@ -82,6 +82,7 @@ body {
     grid-area: main;
     padding: 0 .5rem;
     position: relative;
+    min-width: 0;
 
     @include b.media-breakpoint-down(md) {
       overflow-x: clip;

--- a/assets/styles/layout/_tools.scss
+++ b/assets/styles/layout/_tools.scss
@@ -61,6 +61,7 @@ a.link-muted:hover {
   display: block;
   overflow-x: auto;
   white-space: pre-wrap;
+  word-break: normal;
 }
 
 .badge {

--- a/templates/components/entry_comment.html.twig
+++ b/templates/components/entry_comment.html.twig
@@ -67,7 +67,7 @@
                 asLink: true
             }) }}
 
-            <div data-controller="collapsable">
+            <div data-controller="collapsable" class="content-container">
                 <div data-collapsable-target="content" class="content">
                     {% if comment.visibility in ['visible', 'private'] or (comment.visibility is same as 'trashed' and this.canSeeTrashed) %}
                         {{ comment.body|markdown("entry")|raw }}

--- a/templates/components/post.html.twig
+++ b/templates/components/post.html.twig
@@ -60,7 +60,7 @@
             </header>
 
             <!-- body -->
-            <div data-controller="collapsable">
+            <div data-controller="collapsable" class="content-container">
                 <div data-collapsable-target="content" class="content">
                     {% if post.visibility in ['visible', 'private'] or (post.visibility is same as 'trashed' and this.canSeeTrashed) %}
                         {{ post.body|markdown("post")|raw }}

--- a/templates/components/post_comment.html.twig
+++ b/templates/components/post_comment.html.twig
@@ -64,7 +64,7 @@
                 height: 40,
                 asLink: true
             }) }}
-            <div data-controller="collapsable">
+            <div data-controller="collapsable" class="content-container">
                 <div data-collapsable-target="content" class="content">
                     {% if comment.visibility in ['visible', 'private'] or (comment.visibility is same as 'trashed' and this.canSeeTrashed) %}
                         {{ comment.body|markdown("post")|raw }}


### PR DESCRIPTION
Before the text in the table would be extremely squeezed (wrapped) or partly invisible. Now the table scrolls while the surrounding content keeps it width.