### PR TITLE
Fix abandoned magazine ordering test flake

### DIFF
--- a/tests/Functional/Controller/Api/Magazine/MagazineRetrieveApiTest.php
+++ b/tests/Functional/Controller/Api/Magazine/MagazineRetrieveApiTest.php
@@ -579,8 +579,11 @@ class MagazineRetrieveApiTest extends WebTestCase
         self::assertIsArray($jsonData['items']);
         self::assertCount(2, $jsonData['items']);
         self::assertArrayKeysMatch(self::MAGAZINE_RESPONSE_KEYS, $jsonData['items'][0]);
-        self::assertSame($magazine1->getId(), $jsonData['items'][0]['magazineId']);
-        self::assertSame($magazine2->getId(), $jsonData['items'][1]['magazineId']);
+        self::assertArrayKeysMatch(self::MAGAZINE_RESPONSE_KEYS, $jsonData['items'][1]);
+        self::assertEqualsCanonicalizing(
+            [$magazine1->getId(), $magazine2->getId()],
+            array_column($jsonData['items'], 'magazineId'),
+        );
     }
 
     public function testApiCanRetrieveAbandonedMagazineSortedByOwner(): void

--- a/tests/Functional/Controller/Api/Magazine/MagazineRetrieveApiTest.php
+++ b/tests/Functional/Controller/Api/Magazine/MagazineRetrieveApiTest.php
@@ -560,6 +560,7 @@ class MagazineRetrieveApiTest extends WebTestCase
         $magazine1 = $this->getMagazineByName('test1', $abandoningUser);
         $magazine2 = $this->getMagazineByName('test2', $abandoningUser);
         $magazine3 = $this->getMagazineByName('test3', $activeUser);
+        $this->magazineManager->subscribe($magazine1, $activeUser);
 
         $abandoningUser->lastActive = new \DateTime('-6 months');
         $activeUser->lastActive = new \DateTime('-2 days');
@@ -579,11 +580,8 @@ class MagazineRetrieveApiTest extends WebTestCase
         self::assertIsArray($jsonData['items']);
         self::assertCount(2, $jsonData['items']);
         self::assertArrayKeysMatch(self::MAGAZINE_RESPONSE_KEYS, $jsonData['items'][0]);
-        self::assertArrayKeysMatch(self::MAGAZINE_RESPONSE_KEYS, $jsonData['items'][1]);
-        self::assertEqualsCanonicalizing(
-            [$magazine1->getId(), $magazine2->getId()],
-            array_column($jsonData['items'], 'magazineId'),
-        );
+        self::assertSame($magazine1->getId(), $jsonData['items'][0]['magazineId']);
+        self::assertSame($magazine2->getId(), $jsonData['items'][1]['magazineId']);
     }
 
     public function testApiCanRetrieveAbandonedMagazineSortedByOwner(): void


### PR DESCRIPTION
## Summary

- give one abandoned magazine a subscriber so the default `subscriptionsCount DESC` ordering is deterministic
- preserve the original positional assertions and default-sort coverage
- leave the explicit `ownerLastActive` ordering test unchanged

## Cause

The test created two abandoned magazines with equal subscription counts, then assumed a stable order. PostgreSQL may return tied rows in either order because the query has no secondary ordering, producing the intermittent failure seen in [this workflow run](https://github.com/MbinOrg/mbin/actions/runs/34353636142/job/102472724588).

The fixture now gives `magazine1` one subscriber, removing the tie while continuing to verify the endpoint’s documented default sort.
