### PR TITLE
Update Docker login action to v4

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -330,7 +330,7 @@ jobs:
 
       - name: Login to ghcr
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
# Summary

Updates `docker/login-action` from the Node.js 20-based v3 major to the current v4 major in the main CI workflow. This removes the forced Node.js 24 compatibility warning from the `build-and-publish-docker-image` job and aligns it with the pipeline-image workflow.


The v4 action manifest uses the Node.js 24 runtime.
