### PR TITLE
Tune autovacuum thresholds for high-churn tables

### DIFF
--- a/docs/02-admin/02-configuration/04-postgresql.md
+++ b/docs/02-admin/02-configuration/04-postgresql.md
@@ -12,7 +12,7 @@ sudo nano /etc/postgresql/16/main/postgresql.conf
 
 These settings below are more **an indication and heavily depends on your server specifications**. As well as if you are running other services on the same server.
 
-However, the following settings are a good starting point when your serve is around 12 vCPUs and 32GB of RAM. Be sure to fune-tune these settings to your needs.
+However, the following settings are a good starting point when your server is around 12 vCPUs and 32GB of RAM. Be sure to fine-tune these settings to your needs.
 
 ```ini
 # Increase max connections
@@ -29,6 +29,9 @@ huge_pages = on
 work_mem = 15MB
 # Increase maintenance work memory
 maintenance_work_mem = 2GB
+# Limit memory used by each autovacuum worker separately. This avoids up to
+# autovacuum_max_workers workers inheriting the larger maintenance_work_mem value.
+autovacuum_work_mem = 512MB
 
 # Should be posix under Linux anyway, just to be sure...
 dynamic_shared_memory_type = posix
@@ -48,12 +51,13 @@ max_parallel_maintenance_workers = 4
 # You should *not* increase this value more than max_worker_processes
 max_parallel_workers = 16
 
-# Boost transaction speeds and reduce I/O wait for writes (with the risk of losing un-flushed data in case of a crash)
-# If you do not want to take that risk, keep it to: "on".
-synchronous_commit = off
+# Preserve acknowledged transactions during a crash. Set this to "off" only
+# after deciding that losing recent acknowledged writes is acceptable.
+synchronous_commit = on
 
-# Group write commits to combine multiple transactions by a single flush (this is a time delay in μs)
-commit_delay = 300
+# Keep the default unless a production benchmark demonstrates that a delay
+# improves throughput for your concurrent write workload.
+commit_delay = 0
 
 # Increase the checkpoint timeout (time between two checkpoints) to reduce the disk I/O
 # This will significantly reduce the disk I/O and speed-up the write times to disk. The only downside is time needed for crash recovery.
@@ -71,6 +75,35 @@ random_page_cost = 1.1
 # Increase the cache size, increasing the likelihood of index scans (if we have enough RAM memory)
 # Try to aim for: RAM size * 0.8 (on a dedicated DB server)
 effective_cache_size = 24GB
+```
+
+## Routine maintenance and autovacuum
+
+PostgreSQL reuses space from updated and deleted rows through regular vacuuming.
+Keep `autovacuum` enabled and use `VACUUM (ANALYZE)` for exceptional maintenance,
+such as after a large retention cleanup. Do not use `VACUUM FULL` as routine
+maintenance: it rewrites a table and blocks normal access while it runs.
+
+The global autovacuum scale factors are suitable for many tables, but large
+high-churn tables can otherwise accumulate millions of changed or dead rows
+before they are maintained. Mbin configures conservative per-table thresholds
+for `favourite` and `entry_comment` through its database migrations. These
+overrides leave the instance-wide autovacuum worker and I/O policy under the
+administrator's control.
+
+Use the following query to inspect the maintenance history and estimated dead
+rows for the largest tables:
+
+```sql
+SELECT relname,
+       n_live_tup,
+       n_dead_tup,
+       last_vacuum,
+       last_autovacuum,
+       last_analyze,
+       last_autoanalyze
+FROM pg_stat_user_tables
+ORDER BY n_dead_tup DESC;
 ```
 
 For reference check out [PGTune](https://pgtune.leopard.in.ua/) (this tool will **not** cover all the settings mentioned above, so be aware of that).

--- a/docs/02-admin/02-configuration/04-postgresql.md
+++ b/docs/02-admin/02-configuration/04-postgresql.md
@@ -51,13 +51,12 @@ max_parallel_maintenance_workers = 4
 # You should *not* increase this value more than max_worker_processes
 max_parallel_workers = 16
 
-# Preserve acknowledged transactions during a crash. Set this to "off" only
-# after deciding that losing recent acknowledged writes is acceptable.
-synchronous_commit = on
+# Boost transaction speeds and reduce I/O wait for writes (with the risk of losing un-flushed data in case of a crash)
+# If you do not want to take that risk, keep it to: "on".
+synchronous_commit = off
 
-# Keep the default unless a production benchmark demonstrates that a delay
-# improves throughput for your concurrent write workload.
-commit_delay = 0
+# Group write commits to combine multiple transactions by a single flush (this is a time delay in μs)
+commit_delay = 300
 
 # Increase the checkpoint timeout (time between two checkpoints) to reduce the disk I/O
 # This will significantly reduce the disk I/O and speed-up the write times to disk. The only downside is time needed for crash recovery.

--- a/docs/02-admin/02-configuration/04-postgresql.md
+++ b/docs/02-admin/02-configuration/04-postgresql.md
@@ -31,7 +31,7 @@ work_mem = 15MB
 maintenance_work_mem = 2GB
 # Limit memory used by each autovacuum worker separately. This avoids up to
 # autovacuum_max_workers workers inheriting the larger maintenance_work_mem value.
-autovacuum_work_mem = 512MB
+autovacuum_work_mem = 1GB
 
 # Should be posix under Linux anyway, just to be sure...
 dynamic_shared_memory_type = posix

--- a/docs/02-admin/02-configuration/04-postgresql.md
+++ b/docs/02-admin/02-configuration/04-postgresql.md
@@ -77,35 +77,6 @@ random_page_cost = 1.1
 effective_cache_size = 24GB
 ```
 
-## Routine maintenance and autovacuum
-
-PostgreSQL reuses space from updated and deleted rows through regular vacuuming.
-Keep `autovacuum` enabled and use `VACUUM (ANALYZE)` for exceptional maintenance,
-such as after a large retention cleanup. Do not use `VACUUM FULL` as routine
-maintenance: it rewrites a table and blocks normal access while it runs.
-
-The global autovacuum scale factors are suitable for many tables, but large
-high-churn tables can otherwise accumulate millions of changed or dead rows
-before they are maintained. Mbin configures conservative per-table thresholds
-for `favourite` and `entry_comment` through its database migrations. These
-overrides leave the instance-wide autovacuum worker and I/O policy under the
-administrator's control.
-
-Use the following query to inspect the maintenance history and estimated dead
-rows for the largest tables:
-
-```sql
-SELECT relname,
-       n_live_tup,
-       n_dead_tup,
-       last_vacuum,
-       last_autovacuum,
-       last_analyze,
-       last_autoanalyze
-FROM pg_stat_user_tables
-ORDER BY n_dead_tup DESC;
-```
-
 For reference check out [PGTune](https://pgtune.leopard.in.ua/) (this tool will **not** cover all the settings mentioned above, so be aware of that).
 
 > [!NOTE]

--- a/migrations/Version20260910011700.php
+++ b/migrations/Version20260910011700.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260910011700 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Tune autovacuum thresholds for high-churn content tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE favourite SET (
+            autovacuum_vacuum_threshold = 50000,
+            autovacuum_vacuum_scale_factor = 0.005,
+            autovacuum_analyze_threshold = 50000,
+            autovacuum_analyze_scale_factor = 0.005
+        )');
+        $this->addSql('ALTER TABLE entry_comment SET (
+            autovacuum_vacuum_threshold = 20000,
+            autovacuum_vacuum_scale_factor = 0.02,
+            autovacuum_analyze_threshold = 20000,
+            autovacuum_analyze_scale_factor = 0.02
+        )');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE favourite RESET (
+            autovacuum_vacuum_threshold,
+            autovacuum_vacuum_scale_factor,
+            autovacuum_analyze_threshold,
+            autovacuum_analyze_scale_factor
+        )');
+        $this->addSql('ALTER TABLE entry_comment RESET (
+            autovacuum_vacuum_threshold,
+            autovacuum_vacuum_scale_factor,
+            autovacuum_analyze_threshold,
+            autovacuum_analyze_scale_factor
+        )');
+    }
+}


### PR DESCRIPTION
## Problem

On large Mbin instances, the global `autovacuum_vacuum_scale_factor = 0.2` lets high-churn tables accumulate millions of changed or dead rows before PostgreSQL schedules routine maintenance. This delays space reuse and leaves planner statistics stale longer than needed.

For example, a `favourite` table with roughly 190 million rows (on kbin.melroy.org) would wait for about 38 million changed/dead rows under the global default.

The production PostgreSQL guide also sets `maintenance_work_mem = 2GB` without setting `autovacuum_work_mem`. Since autovacuum inherits that value by default, several workers could each reserve the larger amount.

## Change

Add a PostgreSQL migration with conservative per-table autovacuum settings:

- `favourite`: vacuum and analyze at 50,000 rows plus 0.5% of table size (about 1 million rows at 190 million rows).
- `entry_comment`: vacuum and analyze at 20,000 rows plus 2% of table size.

The migration affects only table storage parameters. It does not run a vacuum, rewrite tables, change schema columns, or modify global PostgreSQL settings. Its down migration resets the overrides so an instance returns to its own global policy.

Update the PostgreSQL guide to cap each autovacuum worker at `1GB` while retaining `2GB` for manual maintenance.

## Why a migration

These are PostgreSQL-specific storage parameters, rather than Doctrine ORM mapping. Shipping them in a Doctrine migration gives every upgraded Mbin instance the same sensible defaults while preserving administrators' global worker, I/O, and resource policies.

