### PR TITLE
Fix CI failure when main advances during tests

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -23,6 +23,8 @@ jobs:
       image: ghcr.io/mbinorg/mbin-pipeline-image:latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
 
       - name: Get NPM cache directory path
         id: npm-cache-dir-path
@@ -75,6 +77,8 @@ jobs:
       image: ghcr.io/mbinorg/mbin-pipeline-image:latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
 
       - name: Add GITHUB_WORKSPACE as a safe directory
         run: git config --global --add safe.directory $GITHUB_WORKSPACE

--- a/ci/skipOnExcluded.sh
+++ b/ci/skipOnExcluded.sh
@@ -7,9 +7,6 @@ git config --global --add safe.directory "$(realpath "$GITHUB_WORKSPACE")"
 
 ignoredPatterns="$(cat "$GITHUB_WORKSPACE"/ci/ignoredPaths.txt)"
 if [[ "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" == 'main' ]]; then
-    # Compare the commit checked out for this run with its parent. Fetching the
-    # moving origin/main ref here can make the checked-out commit the shallow
-    # boundary when main advances during the workflow, leaving main^ unknown.
     changedFiles="$(git diff --name-only HEAD^ HEAD)"
 else
     git fetch origin main:main --depth 1

--- a/ci/skipOnExcluded.sh
+++ b/ci/skipOnExcluded.sh
@@ -7,8 +7,10 @@ git config --global --add safe.directory "$(realpath "$GITHUB_WORKSPACE")"
 
 ignoredPatterns="$(cat "$GITHUB_WORKSPACE"/ci/ignoredPaths.txt)"
 if [[ "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" == 'main' ]]; then
-    git fetch origin main --depth 2
-    changedFiles="$(git diff --name-only main^ HEAD)"
+    # Compare the commit checked out for this run with its parent. Fetching the
+    # moving origin/main ref here can make the checked-out commit the shallow
+    # boundary when main advances during the workflow, leaving main^ unknown.
+    changedFiles="$(git diff --name-only HEAD^ HEAD)"
 else
     git fetch origin main:main --depth 1
     changedFiles="$(git diff --name-only main)"


### PR DESCRIPTION
## Summary

Fix the CI helper failure seen when `main` advances while a workflow is running.

The helper used `git diff --name-only main^ HEAD` after fetching the moving `origin/main` ref. With the checkout's shallow history, a concurrent commit could leave the tested commit as the shallow boundary, causing `main^` to fail before the thread-safe integration tests started.

This changes the main-branch path to compare the checked-out commit (`HEAD^..HEAD`) and configures the build and automated-test checkouts with `fetch-depth: 2`.

## Failing job addressed

This is the failure being resolved:
https://github.com/MbinOrg/mbin/actions/runs/34630637289/job/103366325277

The job passed unit tests and non-thread-safe integration tests, then failed with:

```text
fatal: ambiguous argument 'main^': unknown revision or path not in the working tree.
```


